### PR TITLE
Avoid memory on most recent chat

### DIFF
--- a/public/scripts/extensions/memory/index.js
+++ b/public/scripts/extensions/memory/index.js
@@ -305,8 +305,9 @@ function setMemoryContext(value, saveToMessage) {
     context.setExtensionPrompt(MODULE_NAME, formatMemoryValue(value), extension_prompt_types.AFTER_SCENARIO);
     $('#memory_contents').val(value);
 
-    if (saveToMessage && context.chat.length > 1) {
-        const mes = context.chat[context.chat.length - 2];
+    if (saveToMessage && context.chat.length) {
+        const idx = context.chat.length - 2;
+        const mes = context.chat[idx < 0 ? 0 : idx];
 
         if (!mes.extra) {
             mes.extra = {};


### PR DESCRIPTION
When using swipes, I kept running into an issue where each swipe response was responding very similarly to the previous response that I tried to swipe away. After looking at the memory context, I noticed that it mentioned the information I tried to swipe away and that was being sent as context for the next swipe response. This PR tries to avoid that by avoiding the most recent chat for memory, unless only one chat exists.

The main issue was the value in `SillyTavern.getContext().extensionPrompts['1_memory'].value` would be used and it wasn't reset to previous memory before generation. At first I was going to make sure the value in `extensionPrompts` was the previous memory value, when swiping, but if the user manual modified the memory context then it was the summary that included the most recent chat that may get swiped away. I just decided that avoiding the most recent chat in the summary was the safest option, but there may be cases I am not considering.