### PR TITLE
Overwrite swipe text on edit

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3263,6 +3263,9 @@ function messageEditAuto(div) {
     var text = mesBlock.find(".edit_textarea").val().trim();
     const bias = extractMessageBias(text);
     chat[this_edit_mes_id]["mes"] = text;
+    if (chat[this_edit_mes_id]["swipe_id"] !== undefined) {
+        chat[this_edit_mes_id]["swipes"][chat[this_edit_mes_id]["swipe_id"]] = text;
+    }
 
     // editing old messages
     if (!chat[this_edit_mes_id]["extra"]) {
@@ -3284,6 +3287,9 @@ function messageEditDone(div) {
     var text = mesBlock.find(".edit_textarea").val().trim();
     const bias = extractMessageBias(text);
     chat[this_edit_mes_id]["mes"] = text;
+    if (chat[this_edit_mes_id]["swipe_id"] !== undefined) {
+        chat[this_edit_mes_id]["swipes"][chat[this_edit_mes_id]["swipe_id"]] = text;
+    }
 
     // editing old messages
     if (!chat[this_edit_mes_id]["extra"]) {


### PR DESCRIPTION
This was reported by a user on Discord (https://discord.com/channels/1100685673633153084/1100814383891877888/1104210264666153101). I am submitting this PR that should fix it, unless I am missing something else that needs to change, but I don't know if this is the change that should be made.

This should overwrite the text in the `swipes` array for the chat. This eliminates the ability to roll back to the original text, but there isn't an **undo** button that I know of so maybe it is not important to preserve the original text.

I don't like how this change is duplicating the same thing in two places, but I didn't want to unnecessarily refactor those functions. If that would be better, I can do that instead.