### PR TITLE
Ouoertheo/empty tts bugfix

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -1,3 +1,4 @@
+import { config } from 'yargs'
 import { callPopup, cancelTtsPlay, isMultigenEnabled, is_send_press, saveSettingsDebounced } from '../../../script.js'
 import { extension_settings, getContext } from '../../extensions.js'
 import { getStringHash } from '../../utils.js'
@@ -174,6 +175,7 @@ function debugTtsPlayback() {
             "audioQueueProcessorReady": audioQueueProcessorReady,
             "ttsJobQueue": ttsJobQueue,
             "currentTtsJob": currentTtsJob,
+            "ttsConfig": extension_settings.tts
         }
     ))
 }
@@ -372,6 +374,7 @@ async function processTtsQueue() {
     try {
         if (!text) {
             console.warn('Got empty text in TTS queue job.');
+            completeTtsJob()
             return;
         }
 

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -1,4 +1,3 @@
-import { config } from 'yargs'
 import { callPopup, cancelTtsPlay, isMultigenEnabled, is_send_press, saveSettingsDebounced } from '../../../script.js'
 import { extension_settings, getContext } from '../../extensions.js'
 import { getStringHash } from '../../utils.js'


### PR DESCRIPTION
This PR fixes entering a bad state when generation text is empty after being submitted to the TTS queue. completeTtsJob() was not being called to clean up the current TTS job.