### PR TITLE
Improve NovelAI configuration, move more to UI, clean up config handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -276,6 +276,81 @@
                                         </div>
                                     </div>
                                 </div>
+                                <div class="range-block">
+                                    <div class="range-block-title">
+                                        Rep. Pen. Range.
+                                    </div>
+                                    <div class="range-block-range-and-counter">
+                                        <div class="range-block-range">
+                                            <input type="range" id="rep_pen_size_novel" name="volume" min="0" max="2048" step="1">
+                                        </div>
+                                        <div class="range-block-counter">
+                                            <div contenteditable="true" data-for="rep_pen_size_novel" id="rep_pen_size_counter_novel">
+                                                select
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="range-block">
+                                    <div class="range-block-title">
+                                        Rep. Pen. Slope
+                                    </div>
+                                    <div class="range-block-range-and-counter">
+                                        <div class="range-block-range">
+                                            <input type="range" id="rep_pen_slope_novel" name="volume" min="0" max="10" step="0.01">
+                                        </div>
+                                        <div class="range-block-counter">
+                                            <div contenteditable="true" data-for="rep_pen_slope_novel" id="rep_pen_slope_counter_novel">
+                                                select
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="range-block">
+                                    <div class="range-block-title">
+                                        Rep. Pen. Freq.
+                                    </div>
+                                    <div class="range-block-range-and-counter">
+                                        <div class="range-block-range">
+                                            <input type="range" id="rep_pen_freq_novel" name="volume" min="0" max="1" step="0.00001">
+                                        </div>
+                                        <div class="range-block-counter">
+                                            <div contenteditable="true" data-for="rep_pen_freq_novel" id="rep_pen_freq_counter_novel">
+                                                select
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="range-block">
+                                    <div class="range-block-title">
+                                        Rep. Pen. Presence
+                                    </div>
+                                    <div class="range-block-range-and-counter">
+                                        <div class="range-block-range">
+                                            <input type="range" id="rep_pen_presence_novel" name="volume" min="0" max="1" step="0.001">
+                                        </div>
+                                        <div class="range-block-counter">
+                                            <div contenteditable="true" data-for="rep_pen_presence_novel" id="rep_pen_presence_counter_novel">
+                                                select
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="range-block">
+                                    <div class="range-block-title">
+                                        Tail Free Sampling
+                                    </div>
+                                    <div class="range-block-range-and-counter">
+                                        <div class="range-block-range">
+                                            <input type="range" id="tail_free_sampling_novel" name="volume" min="0" max="1" step="0.001">
+                                        </div>
+                                        <div class="range-block-counter">
+                                            <div contenteditable="true" data-for="tail_free_sampling_novel" id="tail_free_sampling_counter_novel">
+                                                select
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div id="range_block_textgenerationwebui">
                                 <div class="range-block">

--- a/public/script.js
+++ b/public/script.js
@@ -3018,14 +3018,16 @@ function getNovelGenerationData(finalPromt, this_settings, this_amount_gen) {
         "temperature": parseFloat(nai_settings.temp_novel),
         "max_length": this_amount_gen, // this_settings.max_length, // <= why?
         "min_length": this_settings.min_length,
-        "tail_free_sampling": this_settings.tail_free_sampling,
+        "tail_free_sampling": parseFloat(nai_settings.tail_free_sampling_novel),
         "repetition_penalty": parseFloat(nai_settings.rep_pen_novel),
         "repetition_penalty_range": parseInt(nai_settings.rep_pen_size_novel),
-        "repetition_penalty_frequency": this_settings.repetition_penalty_frequency,
-        "repetition_penalty_presence": this_settings.repetition_penalty_presence,
+        "repetition_penalty_slope": parseFloat(nai_settings.rep_pen_slope_novel),
+        "repetition_penalty_frequency": parseFloat(nai_settings.rep_pen_freq_novel),
+        "repetition_penalty_presence": parseFloat(nai_settings.rep_pen_presence_novel),
         "top_a": this_settings.top_a,
         "top_p": this_settings.top_p,
         "top_k": this_settings.top_k,
+        "typical_p": this_settings.typical_p,
         //"stop_sequences": {{187}},
         //bad_words_ids = {{50256}, {0}, {1}};
         //generate_until_sentence = true;
@@ -6158,6 +6160,8 @@ $(document).ready(function () {
 
         const preset = novelai_settings[novelai_setting_names[nai_settings.preset_settings_novel]];
         loadNovelPreset(preset);
+        amount_gen = parseInt($("#amount_gen").val());
+        max_context = parseInt($("#max_context").val());
 
         saveSettingsDebounced();
     });

--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -13,6 +13,10 @@ const nai_settings = {
     temp_novel: 0.5,
     rep_pen_novel: 1,
     rep_pen_size_novel: 100,
+    rep_pen_slope_novel: 0,
+    rep_pen_freq_novel: 0,
+    rep_pen_presence_novel: 0,
+    tail_free_sampling_novel: 0.68,
     model_novel: "euterpe-v2",
     preset_settings_novel: "Classic-Euterpe",
 };
@@ -29,17 +33,24 @@ function getNovelTier(tier) {
 }
 
 function loadNovelPreset(preset) {
+    $("#amount_gen").val(preset.max_length);
+    $("#amount_gen_counter").text(`${preset.max_length}`);
+    if (((preset.max_context > 2048) && (!$("#max_context_unlocked")[0].checked)) ||
+        ((preset.max_context <= 2048) && ($("#max_context_unlocked")[0].checked))) {
+        $("#max_context_unlocked").click();
+    }
+    $("#max_context").val(preset.max_context);
+    $("#max_context_counter").text(`${preset.max_context}`);
+    $("#rep_pen_size_novel").attr('max', preset.max_context);
+
     nai_settings.temp_novel = preset.temperature;
     nai_settings.rep_pen_novel = preset.repetition_penalty;
     nai_settings.rep_pen_size_novel = preset.repetition_penalty_range;
-    $("#temp_novel").val(nai_settings.temp_novel);
-    $("#temp_counter_novel").html(nai_settings.temp_novel);
-
-    $("#rep_pen_novel").val(nai_settings.rep_pen_novel);
-    $("#rep_pen_counter_novel").html(nai_settings.rep_pen_novel);
-
-    $("#rep_pen_size_novel").val(nai_settings.rep_pen_size_novel);
-    $("#rep_pen_size_counter_novel").html(`${nai_settings.rep_pen_size_novel}`);
+    nai_settings.rep_pen_slope_novel = preset.repetition_penalty_slope;
+    nai_settings.rep_pen_freq_novel = preset.repetition_penalty_frequency;
+    nai_settings.rep_pen_presence_novel = preset.repetition_penalty_presence;
+    nai_settings.tail_free_sampling_novel = preset.tail_free_sampling;
+    loadNovelSettingsUi(nai_settings);
 }
 
 function loadNovelSettings(settings) {
@@ -50,15 +61,28 @@ function loadNovelSettings(settings) {
     nai_settings.temp_novel = settings.temp_novel;
     nai_settings.rep_pen_novel = settings.rep_pen_novel;
     nai_settings.rep_pen_size_novel = settings.rep_pen_size_novel;
+    nai_settings.rep_pen_slope_novel = settings.rep_pen_slope_novel;
+    nai_settings.rep_pen_freq_novel = settings.rep_pen_freq_novel;
+    nai_settings.rep_pen_presence_novel = settings.rep_pen_presence_novel;
+    nai_settings.tail_free_sampling_novel = settings.tail_free_sampling_novel;
+    loadNovelSettingsUi(nai_settings);
+}
 
-    $("#temp_novel").val(nai_settings.temp_novel);
-    $("#temp_counter_novel").text(Number(nai_settings.temp_novel).toFixed(2));
-
-    $("#rep_pen_novel").val(nai_settings.rep_pen_novel);
-    $("#rep_pen_counter_novel").text(Number(nai_settings.rep_pen_novel).toFixed(2));
-
-    $("#rep_pen_size_novel").val(nai_settings.rep_pen_size_novel);
-    $("#rep_pen_size_counter_novel").text(`${nai_settings.rep_pen_size_novel}`);
+function loadNovelSettingsUi(ui_settings) {
+    $("#temp_novel").val(ui_settings.temp_novel);
+    $("#temp_counter_novel").html(Number(ui_settings.temp_novel).toFixed(2));
+    $("#rep_pen_novel").val(ui_settings.rep_pen_novel);
+    $("#rep_pen_counter_novel").html(Number(ui_settings.rep_pen_novel).toFixed(2));
+    $("#rep_pen_size_novel").val(ui_settings.rep_pen_size_novel);
+    $("#rep_pen_size_counter_novel").html(Number(ui_settings.rep_pen_size_novel).toFixed(0));
+    $("#rep_pen_slope_novel").val(ui_settings.rep_pen_slope_novel);
+    $("#rep_pen_slope_counter_novel").html(Number(`${ui_settings.rep_pen_slope_novel}`).toFixed(2));
+    $("#rep_pen_freq_novel").val(ui_settings.rep_pen_freq_novel);
+    $("#rep_pen_freq_counter_novel").html(Number(ui_settings.rep_pen_freq_novel).toFixed(5));
+    $("#rep_pen_presence_novel").val(ui_settings.rep_pen_presence_novel);
+    $("#rep_pen_presence_counter_novel").html(Number(ui_settings.rep_pen_presence_novel).toFixed(3));
+    $("#tail_free_sampling_novel").val(ui_settings.tail_free_sampling_novel);
+    $("#tail_free_sampling_counter_novel").html(Number(ui_settings.tail_free_sampling_novel).toFixed(3));
 }
 
 const sliders = [
@@ -66,19 +90,43 @@ const sliders = [
         sliderId: "#temp_novel",
         counterId: "#temp_counter_novel",
         format: (val) => Number(val).toFixed(2),
-        setValue: (val) => { nai_settings.temp_novel = Number(val); },
+        setValue: (val) => { nai_settings.temp_novel = Number(val).toFixed(2); },
     },
     {
         sliderId: "#rep_pen_novel",
         counterId: "#rep_pen_counter_novel",
         format: (val) => Number(val).toFixed(2),
-        setValue: (val) => { nai_settings.rep_pen_novel = Number(val); },
+        setValue: (val) => { nai_settings.rep_pen_novel = Number(val).toFixed(2); },
     },
     {
         sliderId: "#rep_pen_size_novel",
         counterId: "#rep_pen_size_counter_novel",
         format: (val) => `${val}`,
-        setValue: (val) => { nai_settings.rep_pen_size_novel = Number(val); },
+        setValue: (val) => { nai_settings.rep_pen_size_novel = Number(val).toFixed(0); },
+    },
+    {
+        sliderId: "#rep_pen_slope_novel",
+        counterId: "#rep_pen_slope_counter_novel",
+        format: (val) => `${val}`,
+        setValue: (val) => { nai_settings.rep_pen_slope_novel = Number(val).toFixed(2); },
+    },
+    {
+        sliderId: "#rep_pen_freq_novel",
+        counterId: "#rep_pen_freq_counter_novel",
+        format: (val) => `${val}`,
+        setValue: (val) => { nai_settings.rep_pen_freq_novel = Number(val).toFixed(5); },
+    },
+    {
+        sliderId: "#rep_pen_presence_novel",
+        counterId: "#rep_pen_presence_counter_novel",
+        format: (val) => `${val}`,
+        setValue: (val) => { nai_settings.rep_pen_presence_novel = Number(val).toFixed(3); },
+    },
+    {
+        sliderId: "#tail_free_sampling_novel",
+        counterId: "#tail_free_sampling_counter_novel",
+        format: (val) => `${val}`,
+        setValue: (val) => { nai_settings.tail_free_sampling_novel = Number(val).toFixed(3); },
     },
 ];
 

--- a/server.js
+++ b/server.js
@@ -1330,11 +1330,13 @@ app.post("/generate_novelai", jsonParser, async function (request, response_gene
             "tail_free_sampling": request.body.tail_free_sampling,
             "repetition_penalty": request.body.repetition_penalty,
             "repetition_penalty_range": request.body.repetition_penalty_range,
+            "repetition_penalty_slope": request.body.repetition_penalty_slope,
             "repetition_penalty_frequency": request.body.repetition_penalty_frequency,
             "repetition_penalty_presence": request.body.repetition_penalty_presence,
             "top_a": request.body.top_a,
             "top_p": request.body.top_p,
             "top_k": request.body.top_k,
+            "typical_p": request.body.typical_p,
             //"stop_sequences": {{187}},
             //bad_words_ids = {{50256}, {0}, {1}};
             //generate_until_sentence = true;


### PR DESCRIPTION
Pretty much what it says on the tin. Shifts most of the config for NovelAI parameters to the UI, cleans up so that max_content is also properly passed along (in dev you already made it so amount_gen was properly pulled, but max_content and amount_gen still weren't actually retrieved from the novelAI config initially). Note, loading max_context from the config is most relevant given Clio supports a different context size from the others.