### PR TITLE
Objectives: Manual task Add/Remove. Manual Task check.

### DIFF
--- a/public/scripts/extensions/objective/index.js
+++ b/public/scripts/extensions/objective/index.js
@@ -61,7 +61,7 @@ async function generateQuietPrompt(quiet_prompt) {
 
 // Accepts optional position. Defaults to adding to end of list.
 function addTask(description, position = null) {
-    position = position ? position != null : position = globalTasks.length
+    position = position != null ? position: position = globalTasks.length
     globalTasks.splice(position, 0, {
         "description": description,
         "completed": false
@@ -78,10 +78,16 @@ function getTask(index = null, taskDescription = null) {
         task = globalObjective[index]
     } else if (taskDescription != null) {
         task = globalTasks.find(task => {
-            return true ? task.description == description : false
+            return task.description == description ? true: false
         })
     }
     return task
+}
+
+function deleteTask(index){
+    globalTasks.splice(index, 1)
+    setCurrentTask()
+    updateUiTaskList()
 }
 
 // Complete the current task, setting next task to next incomplete task
@@ -90,7 +96,6 @@ function completeTask(task) {
     console.info(`Task successfully completed: ${JSON.stringify(task)}`)
     setCurrentTask()
     updateUiTaskList()
-    saveState()
 }
 
 // Call Quiet Generate to create task list using character context, then convert to tasks. Should not be called much.
@@ -227,9 +232,11 @@ function addUiTask(taskIndex, taskComplete, taskDescription) {
           <span>${taskIndex}</span>
           <input id="objective-task-complete-${taskIndex}" type="checkbox">
           <span class="text_pole" style="display: block" id="objective-task-description-${taskIndex}" contenteditable>${taskDescription}</span>
+          <div id="objective-task-delete-${taskIndex}" class="objective-task-button fa-solid fa-xmark fa-2x" title="Delete Task"></div>
+          <div id="objective-task-add-${taskIndex}" class="objective-task-button fa-solid fa-plus fa-2x" title="Add Task"></div>
       </div><br>
     `;
-
+    
     // Add the filled out template
     $('#objective-tasks').append(template);
 
@@ -244,17 +251,40 @@ function addUiTask(taskIndex, taskComplete, taskDescription) {
         const index = Number(event.target.id.split('-').pop());
         globalTasks[index].description = event.target.textContent;
     });
+    $(`#objective-task-delete-${taskIndex}`).on('click', event => {
+        const index = Number(event.target.id.split('-').pop());
+        deleteTask(index)        
+    });
+    $(`#objective-task-add-${taskIndex}`).on('click', event => {
+        const index = Number(event.target.id.split('-').pop()) + 1;
+        addTask("", index)
+        setCurrentTask()
+        updateUiTaskList()
+    });
 }
 
 // Populate UI task list
 function updateUiTaskList() {
     $('#objective-tasks').empty()
-    for (const index in globalTasks) {
-        addUiTask(
-            index,
-            globalTasks[index].completed,
-            globalTasks[index].description
-        )
+    // Show tasks if there are any
+    if (globalTasks.length > 0){
+        for (const index in globalTasks) {
+            addUiTask(
+                index,
+                globalTasks[index].completed,
+                globalTasks[index].description
+            )
+        }
+    } else {
+    // Show button to add tasks if there are none
+        $('#objective-tasks').append(`
+        <input id="objective-task-add-first" type="button" class="menu_button" value="Add Task">
+        `)
+        $("#objective-task-add-first").on('click', () => {
+            addTask("")
+            setCurrentTask()
+            updateUiTaskList()
+        })
     }
 }
 

--- a/public/scripts/extensions/objective/index.js
+++ b/public/scripts/extensions/objective/index.js
@@ -307,6 +307,8 @@ function onChatDepthInput() {
 
 // Update how often we check for task completion
 function onCheckFrequencyInput() {
+    checkCounter =  $("#objective-check-frequency").val()
+    $('#objective-counter').text(checkCounter)
     saveState()
 }
 
@@ -402,10 +404,9 @@ jQuery(() => {
         }
         if ($("#objective-check-frequency").val() > 0) {
             // Check only at specified interval
-            if (checkCounter > 0) {
-                return
+            if (checkCounter <= 0) {
+                checkTaskCompleted();
             }
-            checkTaskCompleted();
             checkCounter -= 1
         }
         setCurrentTask();

--- a/public/scripts/extensions/objective/index.js
+++ b/public/scripts/extensions/objective/index.js
@@ -120,13 +120,8 @@ async function generateTasks() {
 
 // Call Quiet Generate to check if a task is completed
 async function checkTaskCompleted() {
-    // Make sure there are tasks and check is enabled
-    if (Object.keys(currentTask).length == 0 || $('#objective-check-frequency').val() == 0) {
-        return
-    }
-
-    // Check only at specified interval
-    if (checkCounter > 0) {
+    // Make sure there are tasks 
+    if (Object.keys(currentTask).length == 0) {
         return
     }
     checkCounter = $('#objective-check-frequency').val()
@@ -288,6 +283,15 @@ function updateUiTaskList() {
     }
 }
 
+function addManualTaskCheck() {
+    $('#extensionsMenu').prepend(`
+        <div id="objective-task-manual-check-menu-item" class="list-group-item flex-container flexGap5">
+            <div id="objective-task-manual-check" class="extensionsMenuExtensionButton fa-regular fa-square-check"/></div>
+            Manual Task Check
+        </div>`)
+    $('#objective-task-manual-check-menu-item').attr('title', 'Trigger AI check of completed tasks').on('click', checkTaskCompleted)
+}
+
 // Trigger creation of new tasks with given objective.
 async function onGenerateObjectiveClick() {
     globalObjective = $('#objective-text').val()
@@ -380,6 +384,7 @@ jQuery(() => {
         </div>
     </div>`;
 
+    addManualTaskCheck()
     $('#extensions_settings').append(settingsHtml);
     $('#objective-generate').on('click', onGenerateObjectiveClick)
     $('#objective-chat-depth').on('input', onChatDepthInput)
@@ -396,6 +401,10 @@ jQuery(() => {
             return
         }
         if ($("#objective-check-frequency").val() > 0) {
+            // Check only at specified interval
+            if (checkCounter > 0) {
+                return
+            }
             checkTaskCompleted();
             checkCounter -= 1
         }

--- a/public/scripts/extensions/objective/style.css
+++ b/public/scripts/extensions/objective/style.css
@@ -14,3 +14,23 @@
 .objective_block_control label {
     width: max-content;
 }
+
+.objective-task-button {
+    margin: 0;
+    outline: none;
+    border: none;
+    cursor: pointer;
+    transition: 0.3s;
+    opacity: 0.7;
+    align-items: center;
+    justify-content: center;
+    
+}
+
+.objective-task-button:hover {
+    opacity: 1;
+}
+
+[id^=objective-task-delete-] {
+    color: #da3f3f;
+}


### PR DESCRIPTION
## What's in the PR?
The ability to add and remove tasks, including from blank slate without having to trigger task gen from an objective. 
Added Manual Task Check action in the Extensions palette. 

## Bugs fixed:
Bad ternary construction in addTask
checkCounter now updates/resets when  objective-check-frequency is updated.

## Under the hood
checkCounter logic removed from Task check function and added to MESSAGE_RECEIVED event handler.
deleteTask function added
