### PR TITLE
Fix code blocks style

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -223,7 +223,9 @@ table.responsiveTable {
 
 .mes_text pre code {
     position: relative;
-    padding-right: 30px;
+    display: block;
+    overflow-x: auto;
+    padding: 1em;
 }
 
 .mes .mes_timer {


### PR DESCRIPTION
If language in code block is unsupporded by hljs, it'll display weird.
![image](https://github.com/SillyTavern/SillyTavern/assets/48323879/a9558db7-c2c0-4da6-8fa9-664743eed7ea)

This PR fixes this