### PR TITLE
Add preset setting to avoid sending empty messages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1017,6 +1017,19 @@
                                                 if you use quotes manually for speech.</span>
                                         </div>
                                     </div>
+                                    <div class="range-block">
+                                        <div class="range-block-title justifyLeft">
+                                            Replace empty message
+                                        </div>
+                                        <div class="toggle-description justifyLeft">
+                                            <span data-i18n="Send this text instead of nothing when the text box is empty.">
+                                                Send this text instead of nothing when the text box is empty.
+                                            </span>
+                                        </div>
+                                        <div class="wide100p">
+                                            <textarea id="send_if_empty_textarea" class="text_pole textarea_compact" name="send_if_empty" rows="1" placeholder=""></textarea>
+                                        </div>
+                                    </div>
                                 </div>
                                 <br>
                                 <div class="range-block">

--- a/public/script.js
+++ b/public/script.js
@@ -1915,6 +1915,10 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                 await sendMessageAsUser(textareaText, messageBias);
             }
         }
+        else if (textareaText == "" && !automatic_trigger && type !== 'quiet' && main_api == 'openai' && oai_settings.send_if_empty.trim().length > 0) {
+            await sendMessageAsUser(oai_settings.send_if_empty.trim(), messageBias);
+        }
+
         ////////////////////////////////////
         const scenarioText = chat_metadata['scenario'] || characters[this_chid].scenario;
         let charDescription = baseChatReplace(characters[this_chid].description.trim(), name1, name2);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -111,6 +111,7 @@ const default_settings = {
     nsfw_toggle: true,
     enhance_definitions: false,
     wrap_in_quotes: false,
+    send_if_empty: '',
     nsfw_first: false,
     main_prompt: default_main_prompt,
     nsfw_prompt: default_nsfw_prompt,
@@ -143,6 +144,7 @@ const oai_settings = {
     nsfw_toggle: true,
     enhance_definitions: false,
     wrap_in_quotes: false,
+    send_if_empty: '',
     nsfw_first: false,
     main_prompt: default_main_prompt,
     nsfw_prompt: default_nsfw_prompt,
@@ -970,6 +972,7 @@ function loadOpenAISettings(data, settings) {
     oai_settings.legacy_streaming = settings.legacy_streaming ?? default_settings.legacy_streaming;
     oai_settings.max_context_unlocked = settings.max_context_unlocked ?? default_settings.max_context_unlocked;
     oai_settings.nsfw_avoidance_prompt = settings.nsfw_avoidance_prompt ?? default_settings.nsfw_avoidance_prompt;
+    oai_settings.send_if_empty = settings.send_if_empty ?? default_settings.send_if_empty;
     oai_settings.wi_format = settings.wi_format ?? default_settings.wi_format;
     oai_settings.claude_model = settings.claude_model ?? default_settings.claude_model;
     oai_settings.windowai_model = settings.windowai_model ?? default_settings.windowai_model;
@@ -1011,6 +1014,7 @@ function loadOpenAISettings(data, settings) {
     $('#impersonation_prompt_textarea').val(oai_settings.impersonation_prompt);
     $('#nsfw_avoidance_prompt_textarea').val(oai_settings.nsfw_avoidance_prompt);
     $('#wi_format_textarea').val(oai_settings.wi_format);
+    $('#send_if_empty_textarea').val(oai_settings.send_if_empty);
 
     $('#temp_openai').val(oai_settings.temp_openai);
     $('#temp_counter_openai').text(Number(oai_settings.temp_openai).toFixed(2));
@@ -1150,6 +1154,7 @@ async function saveOpenAIPreset(name, settings) {
         nsfw_toggle: settings.nsfw_toggle,
         enhance_definitions: settings.enhance_definitions,
         wrap_in_quotes: settings.wrap_in_quotes,
+        send_if_empty: settings.send_if_empty,
         nsfw_first: settings.nsfw_first,
         main_prompt: settings.main_prompt,
         nsfw_prompt: settings.nsfw_prompt,
@@ -1427,6 +1432,7 @@ function onSettingsPresetChange() {
         nsfw_toggle: ['#nsfw_toggle', 'nsfw_toggle', true],
         enhance_definitions: ['#enhance_definitions', 'enhance_definitions', true],
         wrap_in_quotes: ['#wrap_in_quotes', 'wrap_in_quotes', true],
+        send_if_empty: ['#send_if_empty_textarea', 'send_if_empty', false],
         nsfw_first: ['#nsfw_first', 'nsfw_first', true],
         jailbreak_system: ['#jailbreak_system', 'jailbreak_system', true],
         main_prompt: ['#main_prompt_textarea', 'main_prompt', false],
@@ -1715,6 +1721,11 @@ $(document).ready(function () {
 
     $('#wrap_in_quotes').on('change', function () {
         oai_settings.wrap_in_quotes = !!$('#wrap_in_quotes').prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $("#send_if_empty_textarea").on('input', function () {
+        oai_settings.send_if_empty = $('#send_if_empty_textarea').val();
         saveSettingsDebounced();
     });
 


### PR DESCRIPTION
## What

This adds the following textbox to the *AI Response Configuration* panel.

![pic](https://github.com/SillyTavern/SillyTavern/assets/136247862/1452560e-80c6-4112-8ebc-a055e1216296)

If it's not empty and the user sends an empty message, send this text instead of doing nothing.

## Why

Claude behaves undesirably when you skip your turn in a conversation. It sees the repeating `A:` (Assistant) `H:` (Human) pattern in the context and tries to autocomplete the missing `H:`. This usually turns out badly: Claude either goes OOC, prints out random summaries or decides the roleplay is over.

Sending a simple "[Continue.]" or equivalent message is enough to prevent this from happening.

## Comments

- I made this an OAI preset setting because *Wrap user messages in quotes* is also an OAI preset setting, and both modify the message sent.
- `onSettingsPresetChange()` doesn't default undefined settings, so values stick around until you resave all presets. Changing this behavior is beyond the scope of the PR.
