### PR TITLE
Fix swipes etc when send_if_empty is set

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1915,7 +1915,8 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                 await sendMessageAsUser(textareaText, messageBias);
             }
         }
-        else if (textareaText == "" && !automatic_trigger && type !== 'quiet' && main_api == 'openai' && oai_settings.send_if_empty.trim().length > 0) {
+        else if (textareaText == "" && !automatic_trigger && type === undefined && main_api == 'openai' && oai_settings.send_if_empty.trim().length > 0) {
+            // Use send_if_empty if set and the user message is empty. Only when sending messages normally
             await sendMessageAsUser(oai_settings.send_if_empty.trim(), messageBias);
         }
 


### PR DESCRIPTION
Made an oops, only use `send_if_empty` when sending normally, otherwise it produces extra messages on swipes etc.