### PR TITLE
Add keyboard shortcut to accept message edits

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -831,9 +831,12 @@ $("document").ready(function () {
             }, 300);
         }
 
-        // Ctrl+Enter for Regeneration Last Response
+        // Ctrl+Enter for Regeneration Last Response. If editing, accept the edits instead
         if (event.ctrlKey && event.key == "Enter") {
-            if (is_send_press == false) {
+            const editMesDone = document.querySelector(".mes_edit_buttons[style='display: inline-flex;'] > .mes_edit_done") ;
+            if (editMesDone !== null) {
+                $(editMesDone).click();
+            } else if (is_send_press == false) {
                 $('#option_regenerate').click();
                 $('#options').hide();
             }


### PR DESCRIPTION
Keyboard shortcuts to edit messages are handy but there was currently no way to accept the edits using keyboard only (unless using `auto_save_msg_edits`)