### PR TITLE
Fixed possible error with hosting on port 80 or 443

### DIFF
--- a/server.js
+++ b/server.js
@@ -2743,7 +2743,7 @@ if (listen && !config.whitelistMode && !config.basicAuthMode) {
         process.exit(1);
     }
 }
-
+// tavernURL.port is empty if port == 443 on HTTPS or port == 80 on HTTP. This causes createServer().listen() to error. To observe error, change port in config.conf to 80 or 443. See https://nodejs.org/api/url.html#urlport. Of course, the user will have to allow node.js to bind to privileged ports before they can host SillyTavern on these ports. I understand if the chosen solution is different, this is simply a proposal.
 if (true === cliArguments.ssl)
     https.createServer(
         {
@@ -2751,13 +2751,13 @@ if (true === cliArguments.ssl)
             key: fs.readFileSync(cliArguments.keyPath)
         }, app)
         .listen(
-            tavernUrl.port,
+            tavernUrl.port || 443,
             tavernUrl.hostname,
             setupTasks
         );
 else
     http.createServer(app).listen(
-        tavernUrl.port,
+        tavernUrl.port || 80,
         tavernUrl.hostname,
         setupTasks
     );

--- a/server.js
+++ b/server.js
@@ -2743,7 +2743,6 @@ if (listen && !config.whitelistMode && !config.basicAuthMode) {
         process.exit(1);
     }
 }
-// tavernURL.port is empty if port == 443 on HTTPS or port == 80 on HTTP. This causes createServer().listen() to error. To observe error, change port in config.conf to 80 or 443. See https://nodejs.org/api/url.html#urlport. Of course, the user will have to allow node.js to bind to privileged ports before they can host SillyTavern on these ports. I understand if the chosen solution is different, this is simply a proposal.
 if (true === cliArguments.ssl)
     https.createServer(
         {


### PR DESCRIPTION
tavernURL.port is empty if port == 443 on HTTPS or port == 80 on HTTP. This causes createServer().listen() to error. To observe error, change port in config.conf to 80 or 443. See https://nodejs.org/api/url.html#urlport. Of course, the user might have to allow node.js to bind to privileged ports before they can actually host SillyTavern on these ports. I understand if the chosen solution is different, this is simply a proposal.