### PR TITLE
fix: prevent swiping messages when editing tasks

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -790,7 +790,7 @@ $("document").ready(function () {
     function isInputElementInFocus() {
         //return $(document.activeElement).is(":input");
         var focused = $(':focus');
-        if (focused.is('input') || focused.is('textarea') || focused.attr('contenteditable') == 'true') {
+        if (focused.is('input') || focused.is('textarea') || focused.prop('contenteditable') == 'true') {
             if (focused.attr('id') === 'send_textarea') {
                 return false;
             }


### PR DESCRIPTION
Messed up my previous PR quite a bit, here we go again:

Currently, if you edit a single task/objective and use the arrow keys while it's focused, the swipes event handler is triggered. This causes swipes to be triggered and potentially new messages to be generated when you only want to edit a task description. The code to handle the swipe hotkeys will already bail when an input is focused: 

https://github.com/SillyTavern/SillyTavern/blob/c890da2877cfe6d3b31c953aab0e3d598931b40c/public/scripts/RossAscends-mods.js#L790-L800

However, the task list is added dynamically and the `.attr()` check will fail on these. This PR changed this behavior and checks for the `contenteditable` prop instead. This will return true for elements that existed in the html source as well as elements inserted using the DOM.