### PR TITLE
Mismatch between file and character names prevents chat logs from being deleted.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -938,7 +938,7 @@ async function delChat(chatfile) {
         headers: getRequestHeaders(),
         body: JSON.stringify({
             chatfile: chatfile,
-            id: characters[this_chid].name
+            avatar_url: characters[this_chid].avatar,
         }),
     });
     if (response.ok === true) {

--- a/server.js
+++ b/server.js
@@ -578,7 +578,7 @@ app.post("/savechat", jsonParser, function (request, response) {
         var dir_name = String(request.body.avatar_url).replace('.png', '');
         let chat_data = request.body.chat;
         let jsonlData = chat_data.map(JSON.stringify).join('\n');
-        fs.writeFileSync(`${chatsPath + dir_name}/${sanitize(String(request.body.file_name))}.jsonl`, jsonlData, 'utf8');
+        fs.writeFileSync(`${chatsPath + sanitize(dir_name)}/${sanitize(String(request.body.file_name))}.jsonl`, jsonlData, 'utf8');
         return response.send({ result: "ok" });
     } catch (error) {
         response.send(error);
@@ -1198,9 +1198,10 @@ app.post("/delchat", jsonParser, function (request, response) {
         return response.sendStatus(403);
     }
 
-    const fileName = path.join(directories.chats, '/', sanitize(request.body.id), '/', sanitize(request.body.chatfile));
+	var dirName = String(request.body.avatar_url).replace('.png', '');
+    const fileName = path.join(directories.chats, '/', sanitize(dirName), '/', sanitize(request.body.chatfile));
     if (!fs.existsSync(fileName)) {
-        console.log('Chat file not found');
+        console.log(`Chat file not found '${fileName}'`);
         return response.sendStatus(400);
     } else {
         console.log('found the chat file: ' + fileName);


### PR DESCRIPTION
When a card's name and filename do not match (ie, "Chatbot" vs "Chatbot.card.png"), chat histories cannot be deleted.

- By comparison with /savechat endpoint, the fix appears simple?
- Added attempted filename to /delchat failure logging
- Included bonus sanitization for /savechat