### PR TITLE
Fix the i18n translation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@
                 $("[data-i18n]").each(function () {
                     //read the translation from the language data
                     const key = $(this).data("i18n");
-                    const text = data?.language?.key;
+                    const text = data?.[language]?.[key];    // Ensure that the translated text is loaded correctly.
                     if (text) {
                         $(this).text(text);
                     }


### PR DESCRIPTION
changed the i18n translation text load method to ensure it could be loaded correctly.
in the last edition, 'text' would always get 'undefined'
I suspect that the reason is because the architecture of the json file has changed.
