### PR TITLE
Add Prompt Arena presets from TextGenWebUi

### DIFF
--- a/public/TextGen Settings/Beam Search.settings
+++ b/public/TextGen Settings/Beam Search.settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 4.5,
     "no_repeat_ngram_size": 2,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/Contrastive Search.settings
+++ b/public/TextGen Settings/Contrastive Search.settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0.6,

--- a/public/TextGen Settings/Default.settings
+++ b/public/TextGen Settings/Default.settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.2,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/Deterministic.settings
+++ b/public/TextGen Settings/Deterministic.settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/Kobold (Godlike).settings
+++ b/public/TextGen Settings/Kobold (Godlike).settings
@@ -5,6 +5,8 @@
     "typical_p": 0.19,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.1,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/Kobold (Liminal Drift).settings
+++ b/public/TextGen Settings/Kobold (Liminal Drift).settings
@@ -5,6 +5,8 @@
     "typical_p": 0.6,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.1,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/LLaMa-Precise.settings
+++ b/public/TextGen Settings/LLaMa-Precise.settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.18,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/Naive.settings
+++ b/public/TextGen Settings/Naive.settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/NovelAI (Best Guess).settings
+++ b/public/TextGen Settings/NovelAI (Best Guess).settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.15,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/NovelAI (Decadence).settings
+++ b/public/TextGen Settings/NovelAI (Decadence).settings
@@ -6,6 +6,8 @@
     "rep_pen": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,
     "num_beams": 1,

--- a/public/TextGen Settings/NovelAI (Genesis).settings
+++ b/public/TextGen Settings/NovelAI (Genesis).settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.05,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/NovelAI (Lycaenidae).settings
+++ b/public/TextGen Settings/NovelAI (Lycaenidae).settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.15,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/NovelAI (Ouroboros).settings
+++ b/public/TextGen Settings/NovelAI (Ouroboros).settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.05,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/NovelAI (Pleasing Results).settings
+++ b/public/TextGen Settings/NovelAI (Pleasing Results).settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.15,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/NovelAI (Sphinx Moth).settings
+++ b/public/TextGen Settings/NovelAI (Sphinx Moth).settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.15,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/NovelAI (Storywriter).settings
+++ b/public/TextGen Settings/NovelAI (Storywriter).settings
@@ -5,6 +5,8 @@
     "typical_p": 1,
     "top_a": 0,
     "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
     "rep_pen": 1.1,
     "no_repeat_ngram_size": 0,
     "penalty_alpha": 0,

--- a/public/TextGen Settings/Prompt Arena (Asterism).settings
+++ b/public/TextGen Settings/Prompt Arena (Asterism).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 1.68,
+    "top_p": 0.17,
+    "top_k": 77,
+    "typical_p": 1,
+    "top_a": 0.42,
+    "tfs": 0.97,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
+    "rep_pen": 1.02,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (Big O).settings
+++ b/public/TextGen Settings/Prompt Arena (Big O).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 0.87,
+    "top_p": 0.99,
+    "top_k": 85,
+    "typical_p": 0.68,
+    "top_a": 0,
+    "tfs": 0.68,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
+    "rep_pen": 1.01,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (Divine Intellect).settings
+++ b/public/TextGen Settings/Prompt Arena (Divine Intellect).settings
@@ -1,0 +1,20 @@
+{
+
+    "temp": 1.31,
+    "top_p": 0.14,
+    "top_k": 49,
+    "typical_p": 1,
+    "top_a": 0.52,
+    "tfs": 1,
+    "epsilon_cutoff": 1.49,
+    "eta_cutoff": 10.42,
+    "rep_pen": 1.17,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (Midnight Enigma).settings
+++ b/public/TextGen Settings/Prompt Arena (Midnight Enigma).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 0.98,
+    "top_p": 0.37,
+    "top_k": 100,
+    "typical_p": 1,
+    "top_a": 0,
+    "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
+    "rep_pen": 1.18,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (Shortwave).settings
+++ b/public/TextGen Settings/Prompt Arena (Shortwave).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 1.53,
+    "top_p": 0.64,
+    "top_k": 33,
+    "typical_p": 1,
+    "top_a": 0.04,
+    "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
+    "rep_pen": 1.07,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (Space Alien).settings
+++ b/public/TextGen Settings/Prompt Arena (Space Alien).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 1.31,
+    "top_p": 0.29,
+    "top_k": 72,
+    "typical_p": 1,
+    "top_a": 0,
+    "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
+    "rep_pen": 1.09,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (StarChat).settings
+++ b/public/TextGen Settings/Prompt Arena (StarChat).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 0.02,
+    "top_p": 0.95,
+    "top_k": 50,
+    "typical_p": 1,
+    "top_a": 0,
+    "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
+    "rep_pen": 1,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (Titanic).settings
+++ b/public/TextGen Settings/Prompt Arena (Titanic).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 1.01,
+    "top_p": 0.21,
+    "top_k": 91,
+    "typical_p": 1,
+    "top_a": 0.75,
+    "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 10.78,
+    "rep_pen": 1.21,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1.07,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (Yara).settings
+++ b/public/TextGen Settings/Prompt Arena (Yara).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 0.82,
+    "top_p": 0.21,
+    "top_k": 72,
+    "typical_p": 1,
+    "top_a": 0,
+    "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
+    "rep_pen": 1.19,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (simple-1).settings
+++ b/public/TextGen Settings/Prompt Arena (simple-1).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 0.7,
+    "top_p": 0.9,
+    "top_k": 20,
+    "typical_p": 1,
+    "top_a": 0.75,
+    "tfs": 1,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
+    "rep_pen": 1.15,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}

--- a/public/TextGen Settings/Prompt Arena (tfs-with-top-a).settings
+++ b/public/TextGen Settings/Prompt Arena (tfs-with-top-a).settings
@@ -1,0 +1,19 @@
+{
+    "temp": 0.7,
+    "top_p": 1,
+    "top_k": 0,
+    "typical_p": 1,
+    "top_a": 0.2,
+    "tfs": 0.95,
+    "epsilon_cutoff": 0,
+    "eta_cutoff": 0,
+    "rep_pen": 1.15,
+    "no_repeat_ngram_size": 0,
+    "penalty_alpha": 0,
+    "num_beams": 1,
+    "length_penalty": 1,
+    "min_length": 0,
+    "encoder_rep_pen": 1,
+    "do_sample": true,
+    "early_stopping": false
+}


### PR DESCRIPTION
Added the presets selected to for TextGenWebUI as found in [Oobabooga's prompt arena results](https://github.com/oobabooga/oobabooga.github.io/blob/main/arena/results.md).

All other presets have had `epsilon_cutoff` and `eta_cutoff` parameters added to set them for 0 to prevent unexpected behavior if someone swaps to one of those presets without zeroing out the values manually.

With the exception of `Kobold (Godlike)` and `Contrastive Search`, which were both selected to remain as TextGenWebUI presets (and have not changed), the rest have been removed from the base TextGenWebUI webapp. They've been left here in case anyone using ST wishes to continue using them, but I'll leave it up to the key developers to decide if they'll be retired at a later date to save on clutter.