### PR TITLE
Display avatar name in card list

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3151,7 +3151,7 @@
                 <img src="">
             </div>
             <div class="flex-container wide100pLess70px">
-                <div class="ch_name"></div>
+                <div class="wide100p"><span class="ch_name"></span> <i class="ch_avatar_url"></i></div>
                 <i class="ch_fav_icon fa-solid fa-star"></i>
                 <input class="ch_fav" value="" hidden />
                 <div class="ch_description"></div>

--- a/public/script.js
+++ b/public/script.js
@@ -803,6 +803,7 @@ async function printCharacters() {
         template.find('img').attr('src', this_avatar);
         template.find('.avatar').attr('title', item.avatar);
         template.find('.ch_name').text(item.name);
+        template.find('.ch_avatar_url').text(item.avatar);
         template.find('.ch_fav_icon').css("display", 'none');
         template.toggleClass('is_fav', item.fav || item.fav == 'true');
         template.find('.ch_fav').val(item.fav);

--- a/public/style.css
+++ b/public/style.css
@@ -1353,6 +1353,10 @@ input[type=search]:focus::-webkit-search-cancel-button {
     font-weight: bolder;
 }
 
+.ch_avatar_url {
+    float: right;
+}
+
 .character_select .avatar {
     align-self: center;
 }


### PR DESCRIPTION
I deal with a lot of slight edits of cards, and this would make it much easier to deal with them.
(A better answer would be to separate the concept of 'Card Name' from 'Character Name', but that's not an easy UI fix)

![firefox_RUX8A4ayVj](https://github.com/SillyTavern/SillyTavern/assets/136940546/7fcb9aad-7e9b-4c63-9cc0-b1585455cfbd)