### PR TITLE
Limit the character list sysnopsis to the first line of Creator's Notes

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -812,7 +812,7 @@ async function printCharacters() {
         template.toggleClass('is_fav', item.fav || item.fav == 'true');
         template.find('.ch_fav').val(item.fav);
 
-        const description = item.data?.creator_notes || '';
+        const description = item.data?.creator_notes.split('\n', 1)[0] || '';
         if (description) {
             template.find('.ch_description').text(description);
         }


### PR DESCRIPTION
Limits the description on the character list to the first line while leaving the rest to be used as actual notes.

![image](https://github.com/SillyTavern/SillyTavern/assets/39929221/ed48e4d9-0ff6-4399-9d31-3724284b11cd)

@malfoyslastname
Honestly a synopsis field should be considered for the spec.