### PR TITLE
Draw zoomed avatar over chat on mobile

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7837,15 +7837,6 @@ $(document).ready(function () {
     });
 
     $(document).on('click', '.mes .avatar', function () {
-
-        console.log(isMobile());
-        console.log($('body').hasClass('waifuMode'));
-
-        if (isMobile() === true && !$('body').hasClass('waifuMode')) {
-            console.debug('saw mobile regular mode, returning');
-            return;
-        } else { console.debug('saw valid env for zoomed display') }
-
         let thumbURL = $(this).children('img').attr('src');
         let charsPath = '/characters/'
         let targetAvatarImg = thumbURL.substring(thumbURL.lastIndexOf("=") + 1);

--- a/public/style.css
+++ b/public/style.css
@@ -4476,15 +4476,15 @@ body.waifuMode .zoomed_avatar {
     }
 
     .zoomed_avatar {
-        min-width: 100px;
+        min-width: 210px;
         min-height: 100px;
         max-height: 90vh;
-        max-width: 90vh;
-        width: calc((100vw - var(--sheldWidth)) /2);
+        max-width: 35vh;
+        width: calc((100vw - var(--sheldWidth)/4));
         position: absolute;
         padding: 0;
         filter: drop-shadow(2px 2px 2px #51515199);
-        z-index: 2;
+        z-index: 30;
         overflow: hidden;
         display: none;
         left: 0;


### PR DESCRIPTION
the zoomed avatars were being displayed behind the chat when active on mobile and vertical monitors
![image](https://github.com/SillyTavern/SillyTavern/assets/39929221/0e8579d4-480e-4b30-bac9-a0d13872a432)

So I pushed it over the chat like it used to be a few days ago.

![Peek 2023-06-29 21-52](https://github.com/SillyTavern/SillyTavern/assets/39929221/8a017d74-e2e4-44e3-a431-23749ab110d1)


