### PR TITLE
Cancel KoboldAI generation if streaming option conflicts.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1949,7 +1949,7 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
     }
 
     if (main_api == 'kobold' && kai_settings.streaming_kobold && !kai_settings.can_use_streaming) {
-        toastr.warning('Streaming is enabled, but the version of Kobold used does not support token streaming.', undefined, { timeOut: 10000, preventDuplicates: true, });
+        toastr.error('Streaming is enabled, but the version of Kobold used does not support token streaming.', undefined, { timeOut: 10000, preventDuplicates: true, });
         is_send_press = false;
         return;
     }

--- a/public/script.js
+++ b/public/script.js
@@ -1950,6 +1950,8 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
 
     if (main_api == 'kobold' && kai_settings.streaming_kobold && !kai_settings.can_use_streaming) {
         toastr.warning('Streaming is enabled, but the version of Kobold used does not support token streaming.', undefined, { timeOut: 10000, preventDuplicates: true, });
+        is_send_press = false;
+        return;
     }
 
     if (main_api == 'kobold' && kai_settings.streaming_kobold && power_user.multigen) {


### PR DESCRIPTION
Trivial change to block generation on KoboldAI if 'streaming' is enabled but ST can't confirm its availability.

All the other option-mismatch popups will cancel the generate, but this instead starts generating an unknown number of tokens.
It happens enough to be aggravating, especially because it's usually due to connection issues that mean abort attempts will fail (in my experience, at least) and you cannot set up multi-gen as a fallback.