### PR TITLE
Optional delete message confirmation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2344,6 +2344,9 @@
                             <label for="import_card_tags"><input id="import_card_tags" type="checkbox" />
                                 <span data-i18n="Import Card Tags">Import Card Tags</span>
                             </label>
+                            <label for="confirm_message_delete"><input id="confirm_message_delete" type="checkbox" />
+                                <span data-i18n="Confirm message deletion">Confirm message deletion</span>
+                            </label>
 
                             <div class="inline-drawer wide100p flexFlowColumn">
                                 <div class="inline-drawer-toggle inline-drawer-header">

--- a/public/script.js
+++ b/public/script.js
@@ -7672,9 +7672,11 @@ $(document).ready(function () {
 
 
     $(document).on("click", ".mes_edit_delete", async function () {
-        const confirmation = await callPopup("Are you sure you want to delete this message?", 'confirm');
-        if (!confirmation) {
-            return;
+        if (power_user.confirm_message_delete) {
+            const confirmation = await callPopup("Are you sure you want to delete this message?", 'confirm');
+            if (!confirmation) {
+                return;
+            }
         }
 
         const mes = $(this).closest(".mes");

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -632,6 +632,7 @@ function loadPowerUserSettings(settings, data) {
     $(`#pygmalion_formatting option[value=${power_user.pygmalion_formatting}]`).attr("selected", true);
     $(`#send_on_enter option[value=${power_user.send_on_enter}]`).attr("selected", true);
     $("#import_card_tags").prop("checked", power_user.import_card_tags);
+    $("#confirm_message_delete").prop("checked", power_user.confirm_message_delete !== undefined ? !!power_user.confirm_message_delete : true);
     $("#collapse-newlines-checkbox").prop("checked", power_user.collapse_newlines);
     $("#pin-examples-checkbox").prop("checked", power_user.pin_examples);
     $("#disable-description-formatting-checkbox").prop("checked", power_user.disable_description_formatting);
@@ -1694,6 +1695,11 @@ $(document).ready(() => {
 
     $("#import_card_tags").on('input', function () {
         power_user.import_card_tags = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $("#confirm_message_delete").on('input', function () {
+        power_user.confirm_message_delete = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 


### PR DESCRIPTION
Adds a power user option for the "Are you sure you want to delete this message?" confirmation when deleting single messages in message edit mode. On by default if undefined in config.json to preserve existing behaviour.