### PR TITLE
Regex: fix multiple script bug

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1137,10 +1137,7 @@ function messageFormatting(mes, ch_name, isSystem, isUser) {
         mes = mes.replaceAll(substituteParams(power_user.user_prompt_bias), "");
     }
 
-    const regexResult = getRegexedString(mes, regex_placement.MD_DISPLAY);
-    if (regexResult) {
-        mes = regexResult;
-    }
+    mes = getRegexedString(mes, regex_placement.MD_DISPLAY);
 
     if (power_user.auto_fix_generated_markdown) {
         mes = fixMarkdown(mes);
@@ -2956,10 +2953,7 @@ export function replaceBiasMarkup(str) {
 }
 
 export async function sendMessageAsUser(textareaText, messageBias) {
-    const regexResult = getRegexedString(textareaText, regex_placement.USER_INPUT);
-    if (regexResult) {
-        textareaText = regexResult;
-    }
+    textareaText = getRegexedString(textareaText, regex_placement.USER_INPUT);
 
     chat[chat.length] = {};
     chat[chat.length - 1]['name'] = name1;
@@ -3551,10 +3545,7 @@ function cleanUpMessage(getMessage, isImpersonate, displayIncompleteSentences = 
     }
 
     // Regex uses vars, so add before formatting
-    const regexResult = getRegexedString(getMessage, isImpersonate ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT);
-    if (regexResult) {
-        getMessage = regexResult;
-    }
+    getMessage = getRegexedString(getMessage, isImpersonate ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT);
 
     if (!displayIncompleteSentences && power_user.trim_sentences) {
         getMessage = end_trim_to_sentence(getMessage, power_user.include_newline);
@@ -4985,16 +4976,13 @@ function updateMessage(div) {
         regexPlacement = regex_placement.SYSTEM;
     }
 
-    const regexResult = getRegexedString(
+    text = getRegexedString(
         text,
         regexPlacement,
         {
             characterOverride: regexPlacement === regex_placement.SENDAS ? mes.name : undefined
         }
     );
-    if (regexResult) {
-        text = regexResult;
-    }
 
     if (power_user.trim_spaces) {
         text = text.trim();
@@ -6113,10 +6101,7 @@ async function createOrEditCharacter(e) {
                     ) {
                         // MARK - kingbri: Regex on character greeting message
                         // May need to be placed somewhere else
-                        const regexResult = getRegexedString(this_ch_mes, regex_placement.AI_OUTPUT);
-                        if (regexResult) {
-                            this_ch_mes = regexResult;
-                        }
+                        this_ch_mes = getRegexedString(this_ch_mes, regex_placement.AI_OUTPUT);
 
                         clearChat();
                         chat.length = 0;

--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -39,14 +39,14 @@ function regexFromString(input) {
 
 // Parent function to fetch a regexed version of a raw string
 function getRegexedString(rawString, placement, { characterOverride } = {}) {
+    let finalString = rawString;
     if (extension_settings.disabledExtensions.includes("regex") || !rawString || placement === undefined) {
-        return;
+        return finalString;
     }
 
-    let finalString;
     extension_settings.regex.forEach((script) => {
         if (script.placement.includes(placement)) {
-            finalString = runRegexScript(script, rawString, { characterOverride });
+            finalString = runRegexScript(script, finalString, { characterOverride });
         }
     });
 
@@ -55,17 +55,17 @@ function getRegexedString(rawString, placement, { characterOverride } = {}) {
 
 // Runs the provided regex script on the given string
 function runRegexScript(regexScript, rawString, { characterOverride } = {}) {
+    let newString = rawString;
     if (!regexScript || !!(regexScript.disabled) || !regexScript?.findRegex || !rawString) {
-        return;
+        return newString;
     }
 
     let match;
-    let newString;
     const findRegex = regexFromString(regexScript.substituteRegex ? substituteParams(regexScript.findRegex) : regexScript.findRegex);
 
     // The user skill issued. Return with nothing.
     if (!findRegex) {
-        return;
+        return newString;
     }
 
     while ((match = findRegex.exec(rawString)) !== null) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -226,10 +226,7 @@ async function sendMessageAs(_, text) {
 
     const name = parts.shift().trim();
     let mesText = parts.join('\n').trim();
-    const regexResult = getRegexedString(mesText, regex_placement.SENDAS, { characterOverride: name });
-    if (regexResult) {
-        mesText = regexResult;
-    }
+    mesText = getRegexedString(mesText, regex_placement.SENDAS, { characterOverride: name });
 
     // Messages that do nothing but set bias will be hidden from the context
     const bias = extractMessageBias(mesText);
@@ -273,10 +270,7 @@ async function sendNarratorMessage(_, text) {
         return;
     }
 
-    const regexResult = getRegexedString(text, regex_placement.SYSTEM);
-    if (regexResult) {
-        text = regexResult;
-    }
+    text = getRegexedString(text, regex_placement.SYSTEM);
 
     const name = chat_metadata[NARRATOR_NAME_KEY] || NARRATOR_NAME_DEFAULT;
     // Messages that do nothing but set bias will be hidden from the context


### PR DESCRIPTION
If there are multiple scripts for the same placement, don't mess up string gen. Currently avoids an O(n) comparison, but may be needed if there are more errors (see commit message).