### PR TITLE
Revert to the not evals.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6494,7 +6494,12 @@ const swipe_right = () => {
 }
 
 export function updateCharacterCount(characterSelector) {
-    const visibleCharacters = $(characterSelector).filter(":visible");
+    const visibleCharacters = $(characterSelector)
+        .not(".hiddenBySearch")
+        .not(".hiddenByTag")
+        .not(".hiddenByGroup")
+        .not(".hiddenByGroupMember")
+        .not(".hiddenByFav");
     const visibleCharacterCount = visibleCharacters.length;
     const totalCharacterCount = $(characterSelector).length;
 


### PR DESCRIPTION
The :visible class isn't available fast enough on the getCharacters call leading to 0 / whatever characters on first evaluation. 
I'm open to other ways to time the :visible check better, but for now, I don't think we're losing too much with this (despite it being less pretty). 