### PR TITLE
Add new Replacement Macro

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -433,6 +433,7 @@ const system_messages = {
             <ul>
             <li><tt>{​{user}​}</tt> - your current Persona username</li>
             <li><tt>{​{char}​}</tt> - the Character's name</li>
+            <li><tt>{​{input}​}</tt> - the user input</li>
             <li><tt>{​{time}​}</tt> - the current time</li>
             <li><tt>{​{date}​}</tt> - the current date</li>
             <li><tt>{{idle_duration}}</tt> - the time since the last user message was sent</li>
@@ -1511,6 +1512,7 @@ function substituteParams(content, _name1, _name2, _original) {
         content = content.replace(/{{original}}/i, _original);
     }
 
+    content = content.replace(/{{input}}/gi, $('#send_textarea').val());
     content = content.replace(/{{user}}/gi, _name1);
     content = content.replace(/{{char}}/gi, _name2);
     content = content.replace(/<USER>/gi, _name1);

--- a/public/scripts/poe.js
+++ b/public/scripts/poe.js
@@ -48,7 +48,7 @@ If you have any objections to these requirements, please mention them specifical
 If you accept the requirements, please confirm this by replying with "${DEFAULT_JAILBREAK_RESPONSE}", and nothing more. Upon receiving your accurate confirmation message, I will specify the context of the scene and {{char}}'s characteristics, background, and personality in the next message.`;
 
 const DEFAULT_CHARACTER_NUDGE_MESSAGE = "[Unless otherwise stated by {{user}}, your the next response shall only be written from the point of view of {{char}}. Do not seek approval of your writing style at the end of the response. Never reply with a full stop.]";
-const DEFAULT_IMPERSONATION_PROMPT = "[Write a reply only from the point of view of {{user}}, using the chat history so far as a guideline for the writing style of {{user}}. Don't write as {{char}} or system.]";
+const DEFAULT_IMPERSONATION_PROMPT = "[Write a reply only from the point of view of {{user}} {{input}}, using the chat history so far as a guideline for the writing style of {{user}}. Don't write as {{char}} or system.]";
 
 const poe_settings = {
     bot: 'a2',


### PR DESCRIPTION
Through the impersonate function it is possible for the AI to create a text as if it were in the place of the user's character, but the text is randomly generated without the user being able to suggest what he wants to be created. By including this new macro, the user will be able to guide the impersonate generation.

Example:

When asking the AI to create an impersonate it generated this

![image](https://github.com/SillyTavern/SillyTavern/assets/84692429/a1ad091b-a046-4d0b-bcb8-1ce14939d5fd)


However, with this modification I can indicate what I want, in the example below I asked for the following: "Find a way to leave the library". And it created exactly the way I wanted it.

![image](https://github.com/SillyTavern/SillyTavern/assets/84692429/e9320a41-21bf-4193-83e1-5029a353ef92)
