### PR TITLE
Smart Context - bug fixes

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2198,10 +2198,9 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
         // Determine token limit
         let this_max_context = getMaxContextSize();
 
-        if (extension_settings.chromadb.n_results !== 0) {
-            await runGenerationInterceptors(coreChat, this_max_context);
-            console.log(`Core/all messages: ${coreChat.length}/${chat.length}`);
-        }
+        // Always run the extension interceptors.
+        await runGenerationInterceptors(coreChat, this_max_context);
+        console.log(`Core/all messages: ${coreChat.length}/${chat.length}`);
 
         let storyString = "";
 

--- a/public/scripts/extensions/infinity-context/index.js
+++ b/public/scripts/extensions/infinity-context/index.js
@@ -622,11 +622,11 @@ window.chromadb_interceptGeneration = async (chat, maxContext) => {
             queryBlob = lastMessage.mes;
         }
         else {
-            for (let msg of chat) {
+            for (let msg of chat.slice(-extension_settings.chromadb.keep_context)) {
                 queryBlob += `${msg.mes}\n`
             }
         }
-        console.log("ChromDB Query text:", queryBlob);
+        console.log("CHROMADB: Query text:", queryBlob);
 
         if (recallStrategy === 'multichat') {
             console.log("Utilizing multichat")
@@ -642,7 +642,7 @@ window.chromadb_interceptGeneration = async (chat, maxContext) => {
         else {
             queriedMessages.sort((a, b) => b.distance - a.distance);
         }
-        console.log(queriedMessages);
+        console.debug("CHROMADB: Query results: %o", queriedMessages);
 
 
         let newChat = [];
@@ -702,6 +702,7 @@ window.chromadb_interceptGeneration = async (chat, maxContext) => {
             }
 
             const promptBlob = wrapperMsg.replace('{{memories}}', allMemoryBlob);
+            console.debug("CHROMADB: prompt blob: %o", promptBlob);
             context.setExtensionPrompt(MODULE_NAME, promptBlob, extension_prompt_types.AFTER_SCENARIO);
         }
         if (selectedStrategy === 'custom') {


### PR DESCRIPTION
1. Always run extension intercept code, don't gate it behind one specific SmartContext parameter.
2. Let's not run queries using _every single chat message since the dawn of time_.