### PR TITLE
Add regex for the sysgen command

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -177,6 +177,8 @@ async function generateSystemMessage(_, prompt) {
         return;
     }
 
+    prompt = getRegexedString(prompt, regex_placement.SYSTEM);
+
     toastr.info('Please wait', 'Generating...');
     const message = await generateQuietPrompt(prompt);
     sendNarratorMessage(_, message);


### PR DESCRIPTION
Since sysgen responds as system, bundle it under the system regex placement.