### PR TITLE
Fix continue formatting

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2263,9 +2263,9 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
 
             chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct);
 
-            // Do not format the message for continuation
+            // Do not suffix the message for continuation
             if (i === 0 && type == 'continue') {
-                chat2[i] = coreChat[j].mes;
+                chat2[i] = chat2[i].slice(0, chat2[i].lastIndexOf(coreChat[j].mes) + coreChat[j].mes.length);
             }
         }
 


### PR DESCRIPTION
Responses from the continue feature are often noticeably worse than regular ones because of the lack of formatting, especially in instruct mode:

```
ASSISTANT: What are you doing here?</s>USER: PIRI: Making pull requests.Pull requests? What is it,
```

It can read as if the response to be continued is actually a part of the user message.

Instead of disabling all formatting, only the part after the message should be disabled:

```
ASSISTANT: What are you doing here?</s>USER: PIRI: Making pull requests.ASSISTANT: Pull requests? What is it,
```