### PR TITLE
Highlighting for mismatched quotations

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1172,7 +1172,7 @@ function messageFormatting(mes, ch_name, isSystem, isUser) {
             .replace(/\*\*(.+?)\*\*/g, "<b>$1</b>")
             .replace(/\n/g, "<br/>");
     } else if (!isSystem) {
-        mes = mes.replace(/[\"“](.+?)[\"”]/gm, '<q>"$1"</q>') // Wrap quotes in <q></q>. Even if they don't *quite* match.
+        mes = mes.replace(/[\"“]([^\"“”]*)[\"”]/g, '<q>"$1"</q>') // Wrap quotes in <q></q>. Even if they don't *quite* match.
 
         mes = mes.replaceAll('\\begin{align*}', '$$');
         mes = mes.replaceAll('\\end{align*}', '$$');

--- a/public/script.js
+++ b/public/script.js
@@ -1172,15 +1172,7 @@ function messageFormatting(mes, ch_name, isSystem, isUser) {
             .replace(/\*\*(.+?)\*\*/g, "<b>$1</b>")
             .replace(/\n/g, "<br/>");
     } else if (!isSystem) {
-        mes = mes.replace(/```[\s\S]*?```|``[\s\S]*?``|`[\s\S]*?`|(\".+?\")|(\u201C.+?\u201D)/gm, function (match, p1, p2) {
-            if (p1) {
-                return '<q>"' + p1.replace(/\"/g, "") + '"</q>';
-            } else if (p2) {
-                return '<q>“' + p2.replace(/\u201C|\u201D/g, "") + '”</q>';
-            } else {
-                return match;
-            }
-        });
+        mes = mes.replace(/[\"“](.+?)[\"”]/gm, '<q>"$1"</q>') // Wrap quotes in <q></q>. Even if they don't *quite* match.
 
         mes = mes.replaceAll('\\begin{align*}', '$$');
         mes = mes.replaceAll('\\end{align*}', '$$');


### PR DESCRIPTION
Also greatly simplify `<q>` block creation.

The old regex block also matched all the codeblock stuff, but... didn't do anything with them.

This replaces directional and normal quotes with `"` when displayed.
Is there a case to display the directional quotes, if they do match?