### PR TITLE
Make AN not uber-z.  Make options uber-z.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -548,7 +548,7 @@ hr {
 #options,
 #extensionsMenu {
     display: flex;
-    z-index: 100;
+    z-index: 29999;
     background-color: var(--SmartThemeBlurTintColor);
     -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
     backdrop-filter: blur(var(--SmartThemeBlurStrength));
@@ -4152,7 +4152,7 @@ input.extension_missing[type="checkbox"] {
     margin: 0 auto;
     backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
     -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
-    z-index: 9999 !important;
+    z-index: 1000 !important;
 }
 
 /*to prevent draggables from being made too small to see*/


### PR DESCRIPTION
AN should not have higher Z than the panel that's supposed to own the left.  This may or may not conflict with the use case of AN as "floating prompt," but I'm not sure if users see AN as a thing that ought to float over the universe.

Hover interaction like the hamburger should probably have really high Z, so tweaked that as well to not get lost in movables.

I have a demo video of this I can link offline if you want to see it in action.