### PR TITLE
Hotfix: Fix author's note not injecting on first message

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7236,7 +7236,6 @@ $(document).ready(function () {
                 chat_metadata = {};
                 characters[this_chid].chat = name2 + " - " + humanizedDateTime();
                 $("#selected_chat_pole").val(characters[this_chid].chat);
-                saveCharacterDebounced();
                 getChat();
             }
         }


### PR DESCRIPTION
This is associated with a bigger problem of the save character function being called when a new chat is spawned. There should be no need to save a character again when a chat is created since you're not editing or altering the character in any way.