### PR TITLE
Fix parameters not substituted when editing first message

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5165,7 +5165,10 @@ function messageEditAuto(div) {
 }
 
 async function messageEditDone(div) {
-    const { mesBlock, text, mes, bias } = updateMessage(div);
+    let { mesBlock, text, mes, bias } = updateMessage(div);
+    if (this_edit_mes_id == 0) {
+        text = substituteParams(text);
+    }
 
     mesBlock.find(".mes_text").empty();
     mesBlock.find(".mes_edit_buttons").css("display", "none");


### PR DESCRIPTION
It's expected that pasting the contents of the first message into the first message should be the same as starting a new chat.
Currently this is not the case and parameters are dropped.

I'm not sure why parameters aren't *always* substituted but I don't intend to change that behavior.