### PR TITLE
Fixed tags order in Llama2 instruct preset

### DIFF
--- a/public/instruct/Llama2.json
+++ b/public/instruct/Llama2.json
@@ -1,6 +1,6 @@
 {
     "name": "Llama 2",
-    "system_prompt": "Write {{user}}'s next reply in this fictional roleplay with {{char}}.\n<</SYS>>\n",
+    "system_prompt": "Write {{char}}'s next reply in this fictional roleplay with {{user}}.\n<</SYS>>\n",
     "system_sequence": "[INST] <<SYS>>\n",
     "stop_sequence": "",
     "input_sequence": "[INST]",


### PR DESCRIPTION
I didn't notice that the prompt wording in #759 implies impersonation, which is incorrect for common usage. Changed the order of tags used to generate the character's response to the user, rather than the vice versa.