### PR TITLE
Allow external extensions to add settings

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -41,7 +41,7 @@ class ModuleWorkerWrapper {
     }
 }
 
-const extension_settings = {
+let extension_settings = {
     apiUrl: defaultUrl,
     apiKey: '',
     autoConnect: false,


### PR DESCRIPTION
Super simple change. Allows non-ST extensions to add their own settings key without needing a PR for ST itself.

(alternative is adding an `external: {}` to `extension_settings`, but with this method devs can just look at ST's built-in extensions to understand its usage. IMO.)