### PR TITLE
Fixes to Markdown fixes - tildes, newlines, symbol counts

### DIFF
--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -256,7 +256,7 @@ function fixMarkdown(text) {
     // i.e. "^example * text* * harder problem *\n" -> "^example *text* *harder problem*\n"
 
     // Find pairs of formatting characters and capture the text in between them
-    const format = /(\*|_|~){1,2}([\s\S]*?)\1{1,2}/gm;
+    const format = /([\*_]{1,2})([\s\S]*?)\1/gm;
     let matches = [];
     let match;
     while ((match = format.exec(text)) !== null) {
@@ -267,7 +267,7 @@ function fixMarkdown(text) {
     let newText = text;
     for (let i = matches.length - 1; i >= 0; i--) {
         let matchText = matches[i][0];
-        let replacementText = matchText.replace(/(\*|_|~)(\s+)|(\s+)(\*|_|~)/g, '$1$4');
+        let replacementText = matchText.replace(/(\*|_)(\s+)|(\s+)(\*|_)/g, '$1$4');
         newText = newText.slice(0, matches[i].index) + replacementText + newText.slice(matches[i].index + matchText.length);
     }
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -267,7 +267,7 @@ function fixMarkdown(text) {
     let newText = text;
     for (let i = matches.length - 1; i >= 0; i--) {
         let matchText = matches[i][0];
-        let replacementText = matchText.replace(/(\*|_)(\s+)|(\s+)(\*|_)/g, '$1$4');
+        let replacementText = matchText.replace(/(\*|_)([\t \u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]+)|([\t \u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]+)(\*|_)/g, '$1$4');
         newText = newText.slice(0, matches[i].index) + replacementText + newText.slice(matches[i].index + matchText.length);
     }
 


### PR DESCRIPTION
1. Tilde does nothing in our markdown, stop futzing with the spacing around them.
2. Don't consume newline/vertical-whitespace chars when fixing markdown.
3. (Bonus!) Match begin/end formatting symbol counts.

Tilde example:
When I write this:
![firefox_67fkUR9MHQ](https://github.com/SillyTavern/SillyTavern/assets/136940546/8c7102e3-327a-42f0-8eef-d80b2d006e05)
I get this:
![firefox_ogrdIkfccc](https://github.com/SillyTavern/SillyTavern/assets/136940546/81591f78-6241-4228-bbef-f1b908615b5e)
I should get this:
![firefox_2IiLq5jSjo](https://github.com/SillyTavern/SillyTavern/assets/136940546/9365609c-8255-4142-a901-bd000da96058)

Vertical whitespace example:
When I write this:
![firefox_oB6OK7Deha](https://github.com/SillyTavern/SillyTavern/assets/136940546/3cf5a4f2-917d-410f-8eba-bb71e81bb3e2)
I get this:
![firefox_2qrhvga78a](https://github.com/SillyTavern/SillyTavern/assets/136940546/ae74cf3c-943b-40f6-a137-745979f65283)
I should (IMO) get this:
![firefox_bj4J0SnwcX](https://github.com/SillyTavern/SillyTavern/assets/136940546/3bfc5007-d8f7-45ac-9d74-16fa84f56079)