### PR TITLE
Phrase Rep Pen typo fix

### DIFF
--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -102,7 +102,7 @@ const phraseRepPenStrings = [
 ]
 
 function getPhraseRepPenString(phraseRepPenCounter) {
-    if (phraseRepPenCounter < 1 || phraseRepPenCounter > F5) {
+    if (phraseRepPenCounter < 1 || phraseRepPenCounter > 5) {
         return null;
     } else {
         return phraseRepPenStrings[phraseRepPenCounter];


### PR DESCRIPTION
Minor typo that was breaking the slider for Phrase Repetition Penality for NovelAI.