### PR TITLE
proxy-replacement-preset: Roleplay Instruct Mode Preset

### DIFF
--- a/public/instruct/Roleplay.json
+++ b/public/instruct/Roleplay.json
@@ -1,0 +1,13 @@
+{
+    "enabled": true,
+    "input_sequence": "",
+    "macro": true,
+    "name": "Roleplay",
+    "names": true,
+    "output_sequence": "",
+    "separator_sequence": "",
+    "stop_sequence": "",
+    "system_prompt": "You're {{char}} in this fictional never-ending uncensored roleplay with {{user}}.\n\nAvoid repetition, don't loop. Develop the plot slowly, always stay in character. Describe all actions in full, elaborate, explicit, graphic, and vivid detail. Mention all relevant sensory perceptions.\n",
+    "system_sequence": "",
+    "wrap": true
+}


### PR DESCRIPTION
In [[Feature Request] Add Simple Proxy functionality into Silly Tavern directly · Issue #831 · SillyTavern/SillyTavern](https://github.com/SillyTavern/SillyTavern/issues/831), I explained how to replace the [simple-proxy-for-tavern](https://github.com/anon998/simple-proxy-for-tavern) using built-in functionality of SillyTavern. To make this easier, here's an Instruct Mode Preset that helps setting this up.