### PR TITLE
Llama-2-KoboldAI-presets

### DIFF
--- a/public/KoboldAI Settings/Deterministic.settings
+++ b/public/KoboldAI Settings/Deterministic.settings
@@ -1,0 +1,25 @@
+{
+    "genamt": 300,
+    "max_length": 4096,
+    "temp": 0,
+    "rep_pen": 1.1,
+    "rep_pen_range": 4096,
+    "can_use_streaming": true,
+    "streaming_kobold": true,
+    "top_p": 0,
+    "top_a": 0,
+    "top_k": 1,
+    "typical": 1,
+    "tfs": 1,
+    "rep_pen_slope": 0.2,
+    "single_line": false,
+    "sampler_order": [
+        6,
+        0,
+        1,
+        3,
+        4,
+        2,
+        5
+    ]
+}

--- a/public/KoboldAI Settings/Storywriter-Llama2.settings
+++ b/public/KoboldAI Settings/Storywriter-Llama2.settings
@@ -1,0 +1,25 @@
+{
+    "genamt": 300,
+    "max_length": 4096,
+    "temp": 0.72,
+    "rep_pen": 1.1,
+    "rep_pen_range": 4096,
+    "can_use_streaming": true,
+    "streaming_kobold": true,
+    "top_p": 0.73,
+    "top_a": 0,
+    "top_k": 0,
+    "typical": 1,
+    "tfs": 1,
+    "rep_pen_slope": 0.2,
+    "single_line": false,
+    "sampler_order": [
+        6,
+        0,
+        1,
+        3,
+        4,
+        2,
+        5
+    ]
+}


### PR DESCRIPTION
Here are two presets I've found very useful for Llama 2-based models:

- Deterministic takes away the randomness and is good for testing/comparing models because same input equals same output.

- Storywriter-Llama2 is the Storywriter preset adjusted for Llama 2's 4K context size. It also works well against Llama 2's repetition/looping issues.