### PR TITLE
Fix top_a for Simple-1 Text generation web UI preset

### DIFF
--- a/public/TextGen Settings/Simple-1.settings
+++ b/public/TextGen Settings/Simple-1.settings
@@ -3,7 +3,7 @@
     "top_p": 0.9,
     "top_k": 20,
     "typical_p": 1,
-    "top_a": 0.75,
+    "top_a": 0,
     "tfs": 1,
     "epsilon_cutoff": 0,
     "eta_cutoff": 0,


### PR DESCRIPTION
The Simple-1 preset for Ooba's Text generation web UI has `top_a` mistakenly set to 0.75 instead of its actual default value, `0` (disabled).

Reference:
https://github.com/oobabooga/text-generation-webui/blob/main/presets/simple-1.yaml
https://github.com/oobabooga/text-generation-webui/blob/6c521ce96787552a9604c344b9949945ef359a59/modules/presets.py#L16

(I hope I'm doing this right...)