### PR TITLE
Proxy preset+some fixes

### DIFF
--- a/public/KoboldAI Settings/Deterministic.settings
+++ b/public/KoboldAI Settings/Deterministic.settings
@@ -4,7 +4,6 @@
     "temp": 0,
     "rep_pen": 1.1,
     "rep_pen_range": 4096,
-    "can_use_streaming": true,
     "streaming_kobold": true,
     "top_p": 0,
     "top_a": 0,

--- a/public/KoboldAI Settings/Storywriter-Llama2.settings
+++ b/public/KoboldAI Settings/Storywriter-Llama2.settings
@@ -4,7 +4,6 @@
     "temp": 0.72,
     "rep_pen": 1.1,
     "rep_pen_range": 4096,
-    "can_use_streaming": true,
     "streaming_kobold": true,
     "top_p": 0.73,
     "top_a": 0,

--- a/public/KoboldAI Settings/simple-proxy-for-tavern.settings
+++ b/public/KoboldAI Settings/simple-proxy-for-tavern.settings
@@ -1,0 +1,24 @@
+{
+    "genamt": 250,
+    "max_length": 4096,
+    "temp": 0.65,
+    "rep_pen": 1.18,
+    "rep_pen_range": 4096,
+    "streaming_kobold": true,
+    "top_p": 0.47,
+    "top_a": 0,
+    "top_k": 42,
+    "typical": 1,
+    "tfs": 1,
+    "rep_pen_slope": 0,
+    "single_line": false,
+    "sampler_order": [
+        6,
+        0,
+        1,
+        3,
+        4,
+        2,
+        5
+    ]
+}


### PR DESCRIPTION
Added a new preset that's exactly the same as the default proxy preset - for those giving up on the proxy but wanting the same kind of output.

Also fixed the two presets I recently added, removing "can_use_streaming" since that should - as far as I know - be determined by SillyTavern and not be hardcoded in the preset.