### PR TITLE
Fix inconsistent newline trimming

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2489,7 +2489,7 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                     }
 
                     if (i === arrMes.length - 1 && !item.trim().startsWith(name1 + ":")) {
-                        if (textareaText == "") {
+                        //if (textareaText == "") {
                             // Cohee: I think this was added to allow the model to continue
                             // where it left off by removing the trailing newline at the end
                             // that was added by chat2 generator. This causes problems with
@@ -2497,7 +2497,7 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                             // removing a newline ONLY at the end of the string if it exists.
                             item = item.replace(/\n?$/, '');
                             //item = item.substr(0, item.length - 1);
-                        }
+                        //}
                     }
                     if (is_pygmalion && !isInstruct) {
                         if (item.trim().startsWith(name1)) {


### PR DESCRIPTION
Newlines weren't trimmed at first generation in a new chat, only on subsequent generations. By commenting out this check, it works consistently for all generations.

(I noticed because even with my deterministic preset, a regen/swipe would give a different output than the very first generation, so I went looking and found this if-clause as the source of the inconsistent behavior.)