### PR TITLE
Presets and readme

### DIFF
--- a/.github/readme-zh_cn.md
+++ b/.github/readme-zh_cn.md
@@ -291,6 +291,7 @@ SillyTavern 会将 API 密钥保存在目录中的 `secrets.json` 文件内。
 * RossAscends' additions: AGPL v3
 * Portions of CncAnon's TavernAITurbo mod: Unknown license
 * kingbri's various commits and suggestions (https://github.com/bdashore3)
+* StefanDanielSchwarz's various commits and bug reports (https://github.com/StefanDanielSchwarz)
 * Waifu mode inspired by the work of PepperTaco (https://github.com/peppertaco/Tavern/)
 * Thanks Pygmalion University for being awesome testers and suggesting cool features!
 * Thanks oobabooga for compiling presets for TextGen

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -293,6 +293,7 @@ GNU Affero General Public License for more details.**
 * RossAscends' additions: AGPL v3
 * Portions of CncAnon's TavernAITurbo mod: Unknown license
 * kingbri's various commits and suggestions (<https://github.com/bdashore3>)
+* StefanDanielSchwarz's various commits and bug reports (<https://github.com/StefanDanielSchwarz>)
 * Waifu mode inspired by the work of PepperTaco (<https://github.com/peppertaco/Tavern/>)
 * Thanks Pygmalion University for being awesome testers and suggesting cool features!
 * Thanks oobabooga for compiling presets for TextGen

--- a/public/KoboldAI Settings/Deterministic.settings
+++ b/public/KoboldAI Settings/Deterministic.settings
@@ -1,9 +1,9 @@
 {
     "genamt": 300,
-    "max_length": 4096,
+    "max_length": 2048,
     "temp": 0,
     "rep_pen": 1.1,
-    "rep_pen_range": 4096,
+    "rep_pen_range": 2048,
     "streaming_kobold": true,
     "top_p": 0,
     "top_a": 0,

--- a/public/KoboldAI Settings/simple-proxy-for-tavern.settings
+++ b/public/KoboldAI Settings/simple-proxy-for-tavern.settings
@@ -1,9 +1,9 @@
 {
     "genamt": 250,
-    "max_length": 4096,
+    "max_length": 2048,
     "temp": 0.65,
     "rep_pen": 1.18,
-    "rep_pen_range": 4096,
+    "rep_pen_range": 2048,
     "streaming_kobold": true,
     "top_p": 0.47,
     "top_a": 0,


### PR DESCRIPTION
[As discussed here](https://github.com/SillyTavern/SillyTavern/pull/848#issuecomment-1662510842), I've put the new presets in line with the old ones, at max length 2048 instead of 4096, to be more compatible and less model-dependent. Llama 2 users will just have to adjust these values, just like they have to use special parameters with koboldcpp. (We could revisit the default max length again when/if koboldcpp changes their own default context size settings.)

I'd still like to keep the extra Storywriter-Llama2 preset as is, as a one-click solution for Llama 2 users that provides our community favorite. So I didn't change that.

Finally, I added myself to the Readme doc, feel free to adjust the position or text as you like. And I hope it's OK to have done multiple things in this single PR, let me know if you prefer more granular PRs and I'll split things up in the future.