### PR TITLE
del_char_checkbox unchecked by default

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7520,7 +7520,7 @@ $(document).ready(function () {
                 <h3>Delete the character?</h3>
                 <b>THIS IS PERMANENT!<br><br>
                 <label for="del_char_checkbox" class="checkbox_label justifyCenter">
-                    <input type="checkbox" id="del_char_checkbox" checked />
+                    <input type="checkbox" id="del_char_checkbox" />
                     <span>Also delete the chat files</span>
                 </label><br></b>`
         );


### PR DESCRIPTION
QoL change to make life easier when updating characters and not having to sweat forgetting unchecking this dangerous little checkbox...

When you delete a character, you can always re-import them - but if you deleted the chat files, they're gone forever unless you backed them up manually. That's why I think this checkbox should be off by default, making chat file deletion a conscious effort.

With it off, worst case someone forgets to check the box and has some unnecessary files on their disk that they can then delete manually. That's much less of a problem than someone forgetting to uncheck the box (e. g. when importing a new version of the character) and then suffering data loss.