### PR TITLE
NovelAI preamble cleanup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -815,8 +815,8 @@
                                             <div class="fa-solid fa-clock-rotate-left "></div>
                                         </div>
                                     </div>
-                                    <div class="toggle-description justifyLeft" data-i18n="Use style tags to improve the quality of the output">
-                                        Use style tags to improve the quality of the output
+                                    <div class="toggle-description justifyLeft" data-i18n="Use style tags to modify the writing style of the output">
+                                        Use style tags to modify the writing style of the output
                                     </div>
                                     <div class="wide100p">
                                         <textarea id="nai_preamble_textarea" class="text_pole textarea_compact" name="nai_preamble" rows="2"

--- a/public/script.js
+++ b/public/script.js
@@ -2669,8 +2669,11 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                 setPromtString();
             }
 
+            // add chat preamble
+            mesSendString = addChatsPreamble(mesSendString);
+
             // add a custom dingus (if defined)
-            mesSendString = adjustChatsSeparator(mesSendString);
+            mesSendString = addChatsSeparator(mesSendString);
 
             let finalPromt =
                 storyString +
@@ -3156,22 +3159,23 @@ function parseTokenCounts(counts, thisPromptBits) {
     });
 }
 
-function adjustChatsSeparator(mesSendString) {
-    if (main_api === 'novel') {
-        let preamble = "\n***\n" + nai_settings.nai_preamble;
-        if (!preamble.endsWith('\n')) {
-            preamble += '\n';
-        }
-        mesSendString = preamble + mesSendString;
-    }
+function addChatsPreamble(mesSendString) {
+    const preamble = main_api === 'novel' ? nai_settings.preamble : "";
+    return preamble + '\n' + mesSendString;
+}
 
-    else if (power_user.custom_chat_separator && power_user.custom_chat_separator.length) {
+function addChatsSeparator(mesSendString) {
+    if (power_user.custom_chat_separator && power_user.custom_chat_separator.length) {
         mesSendString = power_user.custom_chat_separator + '\n' + mesSendString;
     }
 
     // if chat start formatting is disabled
     else if (power_user.disable_start_formatting) {
         mesSendString = mesSendString;
+    }
+
+    else if (main_api === 'novel') {
+        mesSendString = '\n***\n' + mesSendString;
     }
 
     // add non-pygma dingus

--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -79,7 +79,7 @@ function loadNovelSettings(settings) {
     $(`#model_novel_select option[value=${nai_settings.model_novel}]`).attr("selected", true);
     $('#model_novel_select').val(nai_settings.model_novel);
 
-    if (settings.nai_preamble !== undefined) nai_settings.nai_preamble = settings.nai_preamble;
+    if (settings.nai_preamble !== undefined) nai_settings.preamble = settings.nai_preamble;
     nai_settings.preset_settings_novel = settings.preset_settings_novel;
     nai_settings.temperature = settings.temperature;
     nai_settings.repetition_penalty = settings.repetition_penalty;
@@ -347,13 +347,13 @@ export async function generateNovelWithStreaming(generate_data, signal) {
 }
 
 $("#nai_preamble_textarea").on('input', function () {
-    nai_settings.nai_preamble = $('#nai_preamble_textarea').val();
+    nai_settings.preamble = $('#nai_preamble_textarea').val();
     saveSettingsDebounced();
 });
 
 $("#nai_preamble_restore").on('click', function () {
-    nai_settings.nai_preamble = default_preamble;
-    $('#nai_preamble_textarea').val(nai_settings.nai_preamble);
+    nai_settings.preamble = default_preamble;
+    $('#nai_preamble_textarea').val(nai_settings.preamble);
     saveSettingsDebounced();
 });
 


### PR DESCRIPTION
* Fixed the NAI preamble to that it still respects the power of the power user options for custom chat separator and disable chat formatting.
* Move preamble append into its own function. Maybe some other models can use it someday.
* Renamed some names that were poorly named.