### PR TITLE
Replace Macro in Custom Stopping Strings

### DIFF
--- a/default/settings.json
+++ b/default/settings.json
@@ -147,6 +147,7 @@
         "persona_description": "",
         "persona_description_position": 0,
         "custom_stopping_strings": "",
+        "custom_stopping_strings_macro": true,
         "fuzzy_search": false
     },
     "extension_settings": {

--- a/public/index.html
+++ b/public/index.html
@@ -2038,6 +2038,12 @@
                             <div>
                                 <textarea id="custom_stopping_strings" rows="2" class="text_pole textarea_compact" placeholder="[&quot;Ford&quot;, &quot;BMW&quot;, &quot;Fiat&quot;]"></textarea>
                             </div>
+                            <label class="checkbox_label" for="custom_stopping_strings_macro">
+                                <input id="custom_stopping_strings_macro" type="checkbox" checked>
+                                <span data-i18n="Replace Macro in Custom Stopping Strings">
+                                    Replace Macro in Custom Stopping Strings
+                                </span>
+                            </label>
                             <h4>
                                 <span data-i18n="Pygmalion Formatting">
                                     Pygmalion Formatting

--- a/public/script.js
+++ b/public/script.js
@@ -1750,7 +1750,7 @@ function getStoppingStrings(isImpersonate, addSpace) {
 
     if (power_user.custom_stopping_strings) {
         const customStoppingStrings = getCustomStoppingStrings();
-        result.push(...customStoppingStrings);
+        result.push(...customStoppingStrings.map(x => substituteParams(x, name1, name2)));
     }
 
     return addSpace ? result.map(x => `${x} `) : result;

--- a/public/script.js
+++ b/public/script.js
@@ -1750,7 +1750,11 @@ function getStoppingStrings(isImpersonate, addSpace) {
 
     if (power_user.custom_stopping_strings) {
         const customStoppingStrings = getCustomStoppingStrings();
-        result.push(...customStoppingStrings.map(x => substituteParams(x, name1, name2)));
+        if (power_user.custom_stopping_strings_macro) {
+            result.push(...customStoppingStrings.map(x => substituteParams(x, name1, name2)));
+        } else {
+            result.push(...customStoppingStrings);
+        }
     }
 
     return addSpace ? result.map(x => `${x} `) : result;

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -188,6 +188,7 @@ let power_user = {
     persona_show_notifications: true,
 
     custom_stopping_strings: '',
+    custom_stopping_strings_macro: true,
     fuzzy_search: false,
 };
 
@@ -679,6 +680,7 @@ function loadPowerUserSettings(settings, data) {
     $('#auto_swipe_blacklist').val(power_user.auto_swipe_blacklist.join(", "));
     $('#auto_swipe_blacklist_threshold').val(power_user.auto_swipe_blacklist_threshold);
     $('#custom_stopping_strings').val(power_user.custom_stopping_strings);
+    $("#custom_stopping_strings_macro").prop("checked", power_user.custom_stopping_strings_macro);
     $('#fuzzy_search_checkbox').prop("checked", power_user.fuzzy_search);
     $('#persona_show_notifications').prop("checked", power_user.persona_show_notifications);
 
@@ -1993,6 +1995,11 @@ $(document).ready(() => {
 
     $('#custom_stopping_strings').on('input', function () {
         power_user.custom_stopping_strings = $(this).val();
+        saveSettingsDebounced();
+    });
+
+    $("#custom_stopping_strings_macro").change(function () {
+        power_user.custom_stopping_strings_macro = $(this).prop("checked");
         saveSettingsDebounced();
     });
 


### PR DESCRIPTION
Replaces user and char names in custom stopping strings, making them much more versatile and useful.

Example Use Case: Now you can use a custom stopping string like "\n*{{user}} " to stop generation when the AI tries to act as the user.