### PR TITLE
kobold-presets-without-max_length+genamt

### DIFF
--- a/public/KoboldAI Settings/Ace of Spades.settings
+++ b/public/KoboldAI Settings/Ace of Spades.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 1.15,
     "top_k": 0,
     "top_p": 0.95,

--- a/public/KoboldAI Settings/Adventurer-NeoX-20B-Erebus.settings
+++ b/public/KoboldAI Settings/Adventurer-NeoX-20B-Erebus.settings
@@ -1,6 +1,4 @@
 {
-   "max_length": 2048,
-   "genamt": 90,
    "temp": 0.8,
    "top_k": 28,
    "top_p": 0.94,

--- a/public/KoboldAI Settings/Basic Coherence.settings
+++ b/public/KoboldAI Settings/Basic Coherence.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 0.59,
     "top_k": 0,
     "top_p": 1,

--- a/public/KoboldAI Settings/Best Guess.settings
+++ b/public/KoboldAI Settings/Best Guess.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 0.8,
     "top_k": 100,
     "top_p": 0.9,

--- a/public/KoboldAI Settings/Calibrated-Pygmalion-6b.settings
+++ b/public/KoboldAI Settings/Calibrated-Pygmalion-6b.settings
@@ -1,6 +1,4 @@
 {
-	"max_length": 2048,
-	"genamt": 180,
 	"temp": 1.0,
 	"top_p": 0.9,
 	"top_k": 40,

--- a/public/KoboldAI Settings/Classic-Pygmalion-2.7b.settings
+++ b/public/KoboldAI Settings/Classic-Pygmalion-2.7b.settings
@@ -1,6 +1,4 @@
 {
-	"max_length": 2048,
-	"genamt": 180,
 	"temp": 0.43,
 	"top_p": 0.96,
 	"top_k": 0,

--- a/public/KoboldAI Settings/Classic-Pygmalion-6b.settings
+++ b/public/KoboldAI Settings/Classic-Pygmalion-6b.settings
@@ -1,6 +1,4 @@
 {
-	"max_length": 2048,
-	"genamt": 180,
 	"temp": 0.65,
 	"top_p": 0.9,
 	"top_k": 0,

--- a/public/KoboldAI Settings/Coherent Creativity.settings
+++ b/public/KoboldAI Settings/Coherent Creativity.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 0.51,
     "top_p": 1,
     "top_k": 0,

--- a/public/KoboldAI Settings/Default-TavernAI.settings
+++ b/public/KoboldAI Settings/Default-TavernAI.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 1600,
-    "genamt": 180,
     "temp": 0.79,
     "top_k": 0,
     "top_p": 0.9,

--- a/public/KoboldAI Settings/Deterministic.settings
+++ b/public/KoboldAI Settings/Deterministic.settings
@@ -1,6 +1,4 @@
 {
-    "genamt": 300,
-    "max_length": 2048,
     "temp": 0,
     "rep_pen": 1.1,
     "rep_pen_range": 2048,

--- a/public/KoboldAI Settings/DragonSlayer-Pygmalion-6b.settings
+++ b/public/KoboldAI Settings/DragonSlayer-Pygmalion-6b.settings
@@ -1,6 +1,4 @@
 {
-	"max_length": 2048,
-	"genamt": 180,
 	"temp": 0.79,
 	"top_p": 0.9,
 	"top_k": 0,

--- a/public/KoboldAI Settings/GPU-Pygmalion-6b.settings
+++ b/public/KoboldAI Settings/GPU-Pygmalion-6b.settings
@@ -1,6 +1,4 @@
 {
-	"max_length": 1400,
-	"genamt": 180,
 	"temp": 0.65,
 	"top_p": 0.9,
 	"top_k": 0,

--- a/public/KoboldAI Settings/Genesis.settings
+++ b/public/KoboldAI Settings/Genesis.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 0.63,
     "top_k": 0,
     "top_p": 0.98,

--- a/public/KoboldAI Settings/Godlike.settings
+++ b/public/KoboldAI Settings/Godlike.settings
@@ -1,6 +1,4 @@
 {
-	"max_length": 2048,
-    "genamt": 100,
     "temp": 0.7,
     "top_k": 0,
     "top_p": 0.5,

--- a/public/KoboldAI Settings/Good Winds.settings
+++ b/public/KoboldAI Settings/Good Winds.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 0.7,
     "top_k": 0,
     "top_p": 1,

--- a/public/KoboldAI Settings/Lancer-OPT-2.7B-Erebus.settings
+++ b/public/KoboldAI Settings/Lancer-OPT-2.7B-Erebus.settings
@@ -1,6 +1,4 @@
 {
-   "max_length": 2048,
-   "genamt": 90,
    "temp": 0.8,
    "top_p": 0.94,
    "top_k": 15,

--- a/public/KoboldAI Settings/Liminal Drift.settings
+++ b/public/KoboldAI Settings/Liminal Drift.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 0.66,
     "top_k": 0,
     "top_p": 1,

--- a/public/KoboldAI Settings/Low Rider.settings
+++ b/public/KoboldAI Settings/Low Rider.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 0.94,
     "top_k": 12,
     "top_p": 1,

--- a/public/KoboldAI Settings/Luna Moth.settings
+++ b/public/KoboldAI Settings/Luna Moth.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 1.5,
     "top_k": 85,
     "top_p": 0.24,

--- a/public/KoboldAI Settings/Mayday.settings
+++ b/public/KoboldAI Settings/Mayday.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 1.05,
     "top_k": 0,
     "top_p": 0.95,

--- a/public/KoboldAI Settings/Ouroboros.settings
+++ b/public/KoboldAI Settings/Ouroboros.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 1.07,
     "top_k": 100,
     "top_p": 1,

--- a/public/KoboldAI Settings/Pleasing Results.settings
+++ b/public/KoboldAI Settings/Pleasing Results.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 0.44,
     "top_k": 0,
     "top_p": 1,

--- a/public/KoboldAI Settings/Pro Writer.settings
+++ b/public/KoboldAI Settings/Pro Writer.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 1.35,
     "top_k": 0,
     "top_p": 1,

--- a/public/KoboldAI Settings/RA - Pygmalion-1.3b.settings
+++ b/public/KoboldAI Settings/RA - Pygmalion-1.3b.settings
@@ -1,6 +1,4 @@
 {
-	"max_length": 1400,
-	"genamt": 80,
 	"temp": 1,
 	"top_p": 1,
 	"top_k": 0,

--- a/public/KoboldAI Settings/RecoveredRuins.settings
+++ b/public/KoboldAI Settings/RecoveredRuins.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 200,
     "temp": 1,
     "top_k": 0,
     "top_p": 0.95,

--- a/public/KoboldAI Settings/Storywriter-Llama2.settings
+++ b/public/KoboldAI Settings/Storywriter-Llama2.settings
@@ -1,6 +1,4 @@
 {
-    "genamt": 300,
-    "max_length": 4096,
     "temp": 0.72,
     "rep_pen": 1.1,
     "rep_pen_range": 4096,

--- a/public/KoboldAI Settings/Storywriter.settings
+++ b/public/KoboldAI Settings/Storywriter.settings
@@ -1,6 +1,4 @@
 {
-    "max_length": 2048,
-    "genamt": 100,
     "temp": 0.72,
     "tfs": 1,
     "top_a": 0,

--- a/public/KoboldAI Settings/simple-proxy-for-tavern.settings
+++ b/public/KoboldAI Settings/simple-proxy-for-tavern.settings
@@ -1,6 +1,4 @@
 {
-    "genamt": 250,
-    "max_length": 2048,
     "temp": 0.65,
     "rep_pen": 1.18,
     "rep_pen_range": 2048,


### PR DESCRIPTION
Removed "max_length" and "genamt" from KoboldAI Settings presets, making them consistent with TextGen Settings presets which don't have those, either - and solving the problem of varying max context sizes with different models (presets are now model-independent, user has to set preferred max length and generation amount only once, independently of presets).

I didn't change the preset updating/saving logic, so users can still link max length and generation amount to their presets if they want. Not sure how ooba presets handle this, but if it's differently done there, we probably should make it work consistently.