### PR TITLE
Relax URL requirements when Mancer is enabled.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7774,9 +7774,9 @@ $(document).ready(function () {
     $("#api_button_textgenerationwebui").click(async function (e) {
         e.stopPropagation();
         if ($("#textgenerationwebui_api_url_text").val() != "") {
-            let value = formatTextGenURL($("#textgenerationwebui_api_url_text").val().trim())
+            let value = formatTextGenURL($("#textgenerationwebui_api_url_text").val().trim(), api_use_mancer_webui);
             if (!value) {
-                callPopup('Please enter a valid URL.<br/>WebUI URLs should end with <tt>/api</tt>', 'text');
+                callPopup("Please enter a valid URL.<br/>WebUI URLs should end with <tt>/api</tt><br/>Enable 'Relaxed API URLs' to allow other paths.", 'text');
                 return;
             }
 

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -99,11 +99,17 @@ function selectPreset(name) {
     saveSettingsDebounced();
 }
 
-function formatTextGenURL(value) {
+function formatTextGenURL(value, use_mancer) {
     try {
         const url = new URL(value);
         if (!power_user.relaxed_api_urls) {
-            url.pathname = '/api';
+            if (use_mancer) { // If Mancer is in use, only require the URL to *end* with `/api`.
+                if (!url.pathname.endsWith('/api')) {
+                    return null;
+                }
+            } else {
+                url.pathname = '/api';
+            }
         }
         return url.toString();
     } catch { } // Just using URL as a validation check


### PR DESCRIPTION
But only a little.

With Mancer enabled, only require `/api` at the end.
`Relaxed API URLs` will remove even that requirement.