### PR TITLE
Hotfix prompt manager

### DIFF
--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -263,7 +263,7 @@
     padding: 1em;
     border: 1px solid #333333;
     flex-direction: column;
-    z-index: 3010;
+    z-index: 3010 !important;
     border-radius: 0 0 20px 20px;
     background-color:  var(--SmartThemeBlurTintColor);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1357,7 +1357,7 @@
                                                 </div>
                                             </div>
                                             <div class="range-block m-t-1">
-                                                <div class="justifyLeft" data-i18n="NSFW">Main</div>
+                                                <div class="justifyLeft" data-i18n="NSFW">NSFW</div>
                                                 <div class="wide100p">
                                                     <textarea id="nsfw_prompt_quick_edit_textarea" class="text_pole textarea_compact" name="nsfw_prompt" rows="6" placeholder=""></textarea>
                                                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -166,8 +166,7 @@
                                 <div>
                                     <h4><span data-i18n="openaipresets">Chat Completion Presets</span></h4>
                                     <div class="openai_preset_buttons">
-                                        <select i
-                                                d="settings_perset_openai">
+                                        <select id="settings_perset_openai">
                                             <option value="gui" data-i18n="default">Default</option>
                                         </select>
                                         <i id="update_oai_preset" class="menu_button fa-solid fa-save" title="Update current preset" data-i18n="[title]Update current preset"></i>

--- a/public/index.html
+++ b/public/index.html
@@ -166,7 +166,8 @@
                                 <div>
                                     <h4><span data-i18n="openaipresets">Chat Completion Presets</span></h4>
                                     <div class="openai_preset_buttons">
-                                        <select id="settings_perset_openai">
+                                        <select i
+                                                d="settings_perset_openai">
                                             <option value="gui" data-i18n="default">Default</option>
                                         </select>
                                         <i id="update_oai_preset" class="menu_button fa-solid fa-save" title="Update current preset" data-i18n="[title]Update current preset"></i>
@@ -1352,13 +1353,19 @@
                                             <div class="range-block m-t-1">
                                                 <div class="justifyLeft" data-i18n="Main">Main</div>
                                                 <div class="wide100p">
-                                                    <textarea id="main_prompt_quick_edit_textarea" class="text_pole textarea_compact" name="impersonation_prompt" rows="6" placeholder=""></textarea>
+                                                    <textarea id="main_prompt_quick_edit_textarea" class="text_pole textarea_compact" name="main_prompt" rows="6" placeholder=""></textarea>
+                                                </div>
+                                            </div>
+                                            <div class="range-block m-t-1">
+                                                <div class="justifyLeft" data-i18n="NSFW">Main</div>
+                                                <div class="wide100p">
+                                                    <textarea id="nsfw_prompt_quick_edit_textarea" class="text_pole textarea_compact" name="nsfw_prompt" rows="6" placeholder=""></textarea>
                                                 </div>
                                             </div>
                                             <div class="range-block m-t-1">
                                                 <div class="justifyLeft" data-i18n="Jailbreak">Jailbreak</div>
                                                 <div class="wide100p">
-                                                    <textarea id="jailbreak_prompt_quick_edit_textarea" class="text_pole textarea_compact" rows="6" placeholder=""></textarea>
+                                                    <textarea id="jailbreak_prompt_quick_edit_textarea" class="text_pole textarea_compact" name="jailbreak_prompt" rows="6" placeholder=""></textarea>
                                                 </div>
                                             </div>
                                             <div class="range-block" data-source="claude">

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -1,4 +1,4 @@
-import {callPopup, event_types, eventSource, main_api, substituteParams} from "../script.js";
+import {callPopup, event_types, eventSource, main_api, saveSettingsDebounced, substituteParams} from "../script.js";
 import {TokenHandler} from "./openai.js";
 import {power_user} from "./power-user.js";
 import { debounce } from "./utils.js";
@@ -308,7 +308,6 @@ PromptManagerModule.prototype.init = function (moduleConfiguration, serviceSetti
     };
 
     // Factory function for creating quick edit elements
-    const saveSettings = this.saveServiceSettings;
     const createQuickEdit = function() {
         return {
             element: null,
@@ -319,7 +318,7 @@ PromptManagerModule.prototype.init = function (moduleConfiguration, serviceSetti
                 element.value = prompt.content ?? '';
                 element.addEventListener('input', () => {
                     prompt.content = element.value;
-                    saveSettings();
+                    saveSettingsDebounced()
                 });
 
                 return this;

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -159,6 +159,11 @@ function PromptManagerModule() {
             jailbreak: '',
             enhanceDefinitions: ''
         },
+        quickEdit: {
+            main: '',
+            nsfw: '',
+            jailbreak: ''
+        }
     };
 
     // Chatcompletion configuration object
@@ -327,15 +332,15 @@ PromptManagerModule.prototype.init = function (moduleConfiguration, serviceSetti
     }
 
     const mainPrompt = this.getPromptById('main');
-    const mainPromptTextarea = document.getElementById('main_prompt_quick_edit_textarea');
+    const mainPromptTextarea = document.getElementById(this.configuration.quickEdit.main);
     const mainQuickEdit = createQuickEdit().from(mainPromptTextarea, mainPrompt);
 
     const nsfwPrompt = this.getPromptById('nsfw');
-    const nsfwPromptTextarea = document.getElementById('nsfw_prompt_quick_edit_textarea');
+    const nsfwPromptTextarea = document.getElementById(this.configuration.quickEdit.nsfw);
     const nsfwQuickEdit = createQuickEdit().from(nsfwPromptTextarea, nsfwPrompt);
 
     const jailbreakPrompt = this.getPromptById('jailbreak');
-    const jailbreakPromptTextarea = document.getElementById('jailbreak_prompt_quick_edit_textarea');
+    const jailbreakPromptTextarea = document.getElementById(this.configuration.quickEdit.jailbreak);
     const jailbreakQuickEdit = createQuickEdit().from(jailbreakPromptTextarea, jailbreakPrompt);
 
     // Save prompt edit form to settings and close form.

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -330,6 +330,10 @@ PromptManagerModule.prototype.init = function (moduleConfiguration, serviceSetti
     const mainPromptTextarea = document.getElementById('main_prompt_quick_edit_textarea');
     const mainQuickEdit = createQuickEdit().from(mainPromptTextarea, mainPrompt);
 
+    const nsfwPrompt = this.getPromptById('nsfw');
+    const nsfwPromptTextarea = document.getElementById('nsfw_prompt_quick_edit_textarea');
+    const nsfwQuickEdit = createQuickEdit().from(nsfwPromptTextarea, nsfwPrompt);
+
     const jailbreakPrompt = this.getPromptById('jailbreak');
     const jailbreakPromptTextarea = document.getElementById('jailbreak_prompt_quick_edit_textarea');
     const jailbreakQuickEdit = createQuickEdit().from(jailbreakPromptTextarea, jailbreakPrompt);
@@ -347,8 +351,9 @@ PromptManagerModule.prototype.init = function (moduleConfiguration, serviceSetti
             this.updatePromptWithPromptEditForm(prompt);
         }
 
-        if ('main' === promptId) mainQuickEdit.update(prompt.content)
-        if ('jailbreak' === promptId) jailbreakQuickEdit.update(prompt.content)
+        if ('main' === promptId) mainQuickEdit.update(prompt.content);
+        if ('nsfw' === promptId) nsfwQuickEdit.update(prompt.content);
+        if ('jailbreak' === promptId) jailbreakQuickEdit.update(prompt.content);
 
         this.log('Saved prompt: ' + promptId);
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -348,6 +348,11 @@ function setupChatCompletionPromptManager(openAiSettings) {
             jailbreak: default_jailbreak_prompt,
             enhanceDefinitions: default_enhance_definitions_prompt
         },
+        quickEdit: {
+            main: 'main_prompt_quick_edit_textarea',
+            nsfw: 'nsfw_prompt_quick_edit_textarea',
+            jailbreak: 'jailbreak_prompt_quick_edit_textarea'
+        }
     };
 
     promptManager.saveServiceSettings = () => {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -726,32 +726,22 @@ function preparePromptsForChatCompletion(Scenario, charPersonality, name2, world
     // Apply character-specific main prompt
     const systemPromptOverride = promptManager.activeCharacter.data?.system_prompt ?? null;
     const systemPrompt = prompts.get('main') ?? null;
-    if (systemPromptOverride) {
+    if (systemPromptOverride && systemPrompt) {
+        const mainOriginalContent = systemPrompt.content;
         systemPrompt.content = systemPromptOverride;
-        prompts.set(systemPrompt, prompts.index('main'));
+        const mainReplacement = promptManager.preparePrompt(systemPrompt, mainOriginalContent);
+        prompts.set(mainReplacement, prompts.index('main'));
     }
 
     // Apply character-specific jailbreak
     const jailbreakPromptOverride = promptManager.activeCharacter.data?.post_history_instructions ?? null;
     const jailbreakPrompt = prompts.get('jailbreak') ?? null;
     if (jailbreakPromptOverride && jailbreakPrompt) {
+        const jbOriginalContent = jailbreakPrompt.content;
         jailbreakPrompt.content = jailbreakPromptOverride;
-        prompts.set(jailbreakPrompt, prompts.index('jailbreak'));
+        const jbReplacement = promptManager.preparePrompt(jailbreakPrompt, jbOriginalContent);
+        prompts.set(jbReplacement, prompts.index('jailbreak'));
     }
-
-    // Replace {{original}} placeholder for supported prompts
-    const originalReplacements = {
-        main: default_main_prompt,
-        nsfw: default_nsfw_prompt,
-        jailbreak: default_jailbreak_prompt
-    }
-
-    prompts.collection.forEach(prompt => {
-        if (originalReplacements.hasOwnProperty(prompt.identifier)) {
-            const original = originalReplacements[prompt.identifier];
-            prompt.content = promptManager.preparePrompt(prompt, original)?.content;
-        }
-    });
 
     // Allow subscribers to manipulate the prompts object
     eventSource.emit(event_types.OAI_BEFORE_CHATCOMPLETION, prompts);


### PR DESCRIPTION
Put edit popup on top on mobile. 
Add NSFW prompt to quick edit.
Fixes {{original}} placeholder being replaced by default instead of the respective user prompt
