### PR TITLE
Several NovelAI fixes

### DIFF
--- a/default/settings.json
+++ b/default/settings.json
@@ -71,7 +71,7 @@
         "disable_start_formatting": false,
         "trim_sentences": false,
         "include_newline": false,
-        "always_force_name2": false,
+        "always_force_name2": true,
         "user_prompt_bias": "",
         "show_user_prompt_bias": true,
         "multigen": false,

--- a/public/index.html
+++ b/public/index.html
@@ -195,6 +195,24 @@
                             <hr>
                         </div>
 
+                        <div id="ai_module_block_novel" class="width100p">
+                            <div class="range-block">
+                                <div class="range-block-title justifyLeft">
+                                    AI Module
+                                </div>
+                                <div class="toggle-description justifyLeft"
+                                    data-i18n="Changes the style of the generated text.">
+                                    Changes the style of the generated text.
+                                </div>
+                                <select id="nai_prefix">
+                                    <option value="vanilla" data-i18n="No Module">No Module</option>
+                                    <option value="special_instruct" data-i18n="Instruct">Instruct</option>
+                                    <option value="special_proseaugmenter" data-i18n="Prose Augmenter">Prose Augmenter</option>
+                                    <option value="theme_textadventure" data-i18n="Text Adventure">Text Adventure</option>
+                                </select>
+                            </div>
+                        </div>
+
                         <div id="common-gen-settings-block" class="width100p">
                             <div id="pro-settings-block">
                                 <div id="amount_gen_block" class="range-block">
@@ -432,12 +450,12 @@
                                         Phrase Repetition Penalty
                                     </div>
                                     <select id="phrase_rep_pen_novel">
-                                        <option value="0" data-i18n="Disabled">Disabled</option>
-                                        <option value="1" data-i18n="Very Light">Very Light</option>
-                                        <option value="2" data-i18n="Light">Light</option>
-                                        <option value="3" data-i18n="Medium">Medium</option>
-                                        <option value="4" data-i18n="Aggressive">Aggressive</option>
-                                        <option value="5" data-i18n="Very Aggressive">Very Aggressive</option>
+                                        <option value="off" data-i18n="Off">Disabled</option>
+                                        <option value="very_light" data-i18n="Very Light">Very Light</option>
+                                        <option value="light" data-i18n="Light">Light</option>
+                                        <option value="medium" data-i18n="Medium">Medium</option>
+                                        <option value="aggressive" data-i18n="Aggressive">Aggressive</option>
+                                        <option value="very_aggressive" data-i18n="Very Aggressive">Very Aggressive</option>
                                     </select>
                                 </div>
                             </div>
@@ -851,21 +869,6 @@
                             </div>
                             <div id="novel_api-settings">
                                 <div class="range-block">
-                                    <div class="range-block-title justifyLeft">
-                                        AI Module
-                                    </div>
-                                    <div class="toggle-description justifyLeft" data-i18n="Change the style of the generated text. Set to Vanilla to use the default style.">
-                                        Change the style of the generated text. Set to Vanilla to use the default style.
-                                    </div>
-                                    <select id="nai_prefix">
-                                        <option value="" data-i18n="Auto-select">Auto-select</option>
-                                        <option value="vanilla" data-i18n="Vanilla">Vanilla</option>
-                                        <option value="special_instruct" data-i18n="Instruct">Instruct</option>
-                                        <option value="special_proseaugmenter" data-i18n="Prose Augmenter">Prose Augmenter</option>
-                                        <option value="theme_textadventure" data-i18n="Text Adventure">Text Adventure</option>
-                                    </select>
-                                </div>
-                                <div class="range-block">
                                     <div class="range-block-title openai_restorable">
                                         <span data-i18n="Preamble">Preamble</span>
                                         <div id="nai_preamble_restore" title="Restore default prompt" data-i18n="[title]Restore default prompt" class="right_menu_button">
@@ -1018,7 +1021,7 @@
                                     </div>
                                     <div class="range-block-range-and-counter">
                                         <div class="range-block-range">
-                                            <input type="range" id="min_length_novel" name="volume" min="0" max="1024" step="1">
+                                            <input type="range" id="min_length_novel" name="volume" min="1" max="150" step="1">
                                         </div>
                                         <div class="range-block-counter">
                                             <div contenteditable="true" data-for="min_length_novel" id="min_length_counter_novel">

--- a/public/index.html
+++ b/public/index.html
@@ -450,12 +450,12 @@
                                         Phrase Repetition Penalty
                                     </div>
                                     <select id="phrase_rep_pen_novel">
-                                        <option value="off" data-i18n="Off">Disabled</option>
-                                        <option value="very_light" data-i18n="Very Light">Very Light</option>
+                                        <option value="off" data-i18n="Off">Off</option>
+                                        <option value="very_light" data-i18n="Very light">Very light</option>
                                         <option value="light" data-i18n="Light">Light</option>
                                         <option value="medium" data-i18n="Medium">Medium</option>
                                         <option value="aggressive" data-i18n="Aggressive">Aggressive</option>
-                                        <option value="very_aggressive" data-i18n="Very Aggressive">Very Aggressive</option>
+                                        <option value="very_aggressive" data-i18n="Very aggressive">Very aggressive</option>
                                     </select>
                                 </div>
                             </div>

--- a/public/script.js
+++ b/public/script.js
@@ -3334,8 +3334,9 @@ function parseTokenCounts(counts, thisPromptBits) {
 }
 
 function addChatsPreamble(mesSendString) {
-    const preamble = main_api === 'novel' ? nai_settings.preamble : "";
-    return preamble + '\n' + mesSendString;
+    return main_api === 'novel'
+        ? nai_settings.preamble + '\n' + mesSendString
+        : mesSendString;   
 }
 
 function addChatsSeparator(mesSendString) {
@@ -3349,7 +3350,7 @@ function addChatsSeparator(mesSendString) {
     }
 
     else if (main_api === 'novel') {
-        mesSendString = '\n***\n' + mesSendString;
+        mesSendString = '***\n' + mesSendString;
     }
 
     // add non-pygma dingus
@@ -4607,6 +4608,12 @@ function changeMainAPI() {
         console.log("enabling amount_gen for ooba/novel");
         activeItem.amountGenElem.find('input').prop("disabled", false);
         activeItem.amountGenElem.css("opacity", 1.0);
+    }
+
+    if (selectedVal === "novel") {
+        $("#ai_module_block_novel").css("display", "block");
+    } else {
+        $("#ai_module_block_novel").css("display", "none");
     }
 
     // Hide common settings for OpenAI

--- a/server.js
+++ b/server.js
@@ -1935,6 +1935,7 @@ app.post("/generate_novelai", jsonParser, async function (request, response_gene
             }
 
             const data = await response.json();
+            console.log(data);
             return response_generate_novel.send(data);
         }
     } catch (error) {


### PR DESCRIPTION
* Remove AI Module "Autoselect" and make the auto-instruct work for all modules. This is how NAI is supposed to work.
* Log the response from the API.
* Move the AI Module setting up to the top of the settings window since it isn't saved with the preset, and so that it's more like the NAI client.
* Refactor phrase_rep_pen to use the actual API strings.
* Clamp the maximum token length to 150 before we call the API.
* Clamp the minimum token length in the UX from 1 to 150.
* Fix bug where the preamble was not initialized on cold start.
* Get rid of extra newline before dinkus. Extra newlines are extra bad.
* Make always_force_name2 default true on cold start.