### PR TITLE
Coqui TTS extension added support for custom local model

### DIFF
--- a/public/scripts/extensions/rvc/index.js
+++ b/public/scripts/extensions/rvc/index.js
@@ -208,6 +208,7 @@ $(document).ready(function () {
                             <option value="harvest">harvest</option>
                             <option value="torchcrepe">torchcrepe</option>
                             <option value="rmvpe">rmvpe</option>
+                            <option value="">None (Shitty ASMR)</option>
                         </select>
                         <label for="rvc_index_rate">
                             Index rate for feature retrieval (<span id="rvc_index_rate_value"></span>)

--- a/public/scripts/extensions/rvc/index.js
+++ b/public/scripts/extensions/rvc/index.js
@@ -208,7 +208,7 @@ $(document).ready(function () {
                             <option value="harvest">harvest</option>
                             <option value="torchcrepe">torchcrepe</option>
                             <option value="rmvpe">rmvpe</option>
-                            <option value="">None (Shitty ASMR)</option>
+                            <option value="">None</option>
                         </select>
                         <label for="rvc_index_rate">
                             Index rate for feature retrieval (<span id="rvc_index_rate_value"></span>)

--- a/public/scripts/extensions/tts/manifest.json
+++ b/public/scripts/extensions/tts/manifest.json
@@ -4,7 +4,8 @@
     "requires": [],
     "optional": [
         "silero-tts",
-        "edge-tts"
+        "edge-tts",
+        "coqui-tts"
     ],
     "js": "index.js",
     "css": "style.css",


### PR DESCRIPTION
Added an option in Coqui TTS UI, can now choose "My Models". The list is provided by extras server, correspond to the folder in "data/models/coqui" of extras folder.

![image](https://github.com/SillyTavern/SillyTavern/assets/48798118/70499794-3b01-4d97-9019-8e8413f9e673)

Notes:
- Only handle models with no language/speakers options because I'm lazy :)

Bonus:
- Added the "none" option to RVC pitch extraction method because it can do funny sound with some model (kinda lowtech ASMR).