### PR TITLE
Coqui TTS UI, corrected hiding model div when origin select is none

### DIFF
--- a/public/scripts/extensions/tts/coqui.js
+++ b/public/scripts/extensions/tts/coqui.js
@@ -326,6 +326,11 @@ class CoquiTtsProvider {
         resetModelSettings();
         const model_origin = $('#coqui_model_origin').val();
         console.debug(model_origin);
+
+        if (model_origin == "none") {
+            $("#coqui_local_model_div").hide();
+            $("#coqui_api_model_div").hide();
+        }
         
         // show coqui model list
         if (model_origin == "coqui-api") {


### PR DESCRIPTION
Just hide the models options again when user select none origin.