### PR TITLE
removes width: 100% from img.expression

### DIFF
--- a/public/scripts/extensions/expressions/style.css
+++ b/public/scripts/extensions/expressions/style.css
@@ -56,7 +56,6 @@ img.expression {
     min-height: 100px;
     max-height: 90vh;
     max-width: 90vh;
-    width: 100%;
     top: 0;
     bottom: 0;
     padding: 0;


### PR DESCRIPTION
this will fix the image resolution on mobile

![image](https://github.com/SillyTavern/SillyTavern/assets/61471128/f18891bb-a1ba-4ebe-946e-a9bb69a114aa)


![image](https://github.com/SillyTavern/SillyTavern/assets/61471128/fd70721d-0d95-4537-b0d6-398934a7d6fb)
