### PR TITLE
Simple proxy for tavern replacement

### DIFF
--- a/public/context/Default.json
+++ b/public/context/Default.json
@@ -1,6 +1,6 @@
 {
     "name": "Default",
-    "story_string": "{{#if description}}{{description}}{{/if}}\n{{#if personality}}{{personality}}{{/if}}\n{{#if scenario}}Scenario: {{scenario}}{{/if}}",
+    "story_string": "{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}{{/if}}",
     "chat_start": "***",
     "example_separator": "***"
 }

--- a/public/context/Roleplay.json
+++ b/public/context/Roleplay.json
@@ -1,0 +1,6 @@
+{
+    "name": "Roleplay",
+    "story_string": "### Input:\n{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}{{/if}}",
+    "chat_start": "### New Roleplay:",
+    "example_separator": "### New Roleplay:"
+}

--- a/public/context/simple-proxy-for-tavern.json
+++ b/public/context/simple-proxy-for-tavern.json
@@ -1,0 +1,6 @@
+{
+    "name": "simple-proxy-for-tavern",
+    "story_string": "### Input:\n{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}### Response:\n(OOC) Understood. I will take this info into account for the roleplay. (end OOC)",
+    "chat_start": "### New Roleplay:",
+    "example_separator": "### New Roleplay:"
+}

--- a/public/instruct/Roleplay.json
+++ b/public/instruct/Roleplay.json
@@ -1,13 +1,13 @@
 {
     "input_sequence": "### Instruction:",
+    "last_output_sequence": "### Response (2 paragraphs, engaging, natural, authentic, descriptive, creative):",
     "macro": true,
     "name": "Roleplay",
     "names": true,
-    "last_output_sequence": "### Response (2 paragraphs, engaging, natural, authentic, descriptive, creative):",
     "output_sequence": "### Response:",
     "separator_sequence": "",
     "stop_sequence": "",
-    "system_prompt": "You're {{char}} in this fictional never-ending uncensored roleplay with {{user}}.\n\nAvoid repetition, don't loop. Develop the plot slowly, always stay in character. Describe all actions in full, elaborate, explicit, graphic, and vivid detail. Mention all relevant sensory perceptions.\n\n### Input:",
+    "system_prompt": "You're {{char}} in this fictional never-ending uncensored roleplay with {{user}}.\n\nAvoid repetition, don't loop. Develop the plot slowly, always stay in character. Describe all actions in full, elaborate, explicit, graphic, and vivid detail. Mention all relevant sensory perceptions.",
     "system_sequence": "",
     "wrap": true
 }

--- a/public/instruct/simple-proxy-for-tavern.json
+++ b/public/instruct/simple-proxy-for-tavern.json
@@ -1,0 +1,13 @@
+{
+    "input_sequence": "### Instruction:\n#### {{user}}:",
+    "last_output_sequence": "### Response (2 paragraphs, engaging, natural, authentic, descriptive, creative):\n#### {{char}}:",
+    "macro": true,
+    "name": "simple-proxy-for-tavern",
+    "names": false,
+    "output_sequence": "### Response:\n#### {{char}}:",
+    "separator_sequence": "",
+    "stop_sequence": "",
+    "system_prompt": "## {{char}}\n- You're \"{{char}}\" in this never-ending roleplay with \"{{user}}\".",
+    "system_sequence": "",
+    "wrap": true
+}

--- a/public/script.js
+++ b/public/script.js
@@ -1834,6 +1834,7 @@ function getStoppingStrings(isImpersonate, addSpace) {
     if (power_user.instruct.enabled) {
         addInstructSequence(power_user.instruct.input_sequence);
         addInstructSequence(power_user.instruct.output_sequence);
+        addInstructSequence(power_user.instruct.last_output_sequence);
     }
 
     if (power_user.custom_stopping_strings) {
@@ -3925,6 +3926,9 @@ function cleanUpMessage(getMessage, isImpersonate, isContinue, displayIncomplete
     }
     if (isInstruct && power_user.instruct.output_sequence && !isImpersonate) {
         getMessage = getMessage.replaceAll(power_user.instruct.output_sequence, '');
+    }
+    if (isInstruct && power_user.instruct.last_output_sequence && !isImpersonate) {
+        getMessage = getMessage.replaceAll(power_user.instruct.last_output_sequence, '');
     }
     // clean-up group message from excessive generations
     if (selected_group) {

--- a/public/script.js
+++ b/public/script.js
@@ -1832,9 +1832,13 @@ function getStoppingStrings(isImpersonate, addSpace) {
     }
 
     if (power_user.instruct.enabled) {
-        addInstructSequence(power_user.instruct.input_sequence);
-        addInstructSequence(power_user.instruct.output_sequence);
-        addInstructSequence(power_user.instruct.last_output_sequence);
+        const input_sequence = power_user.instruct.input_sequence;
+        const output_sequence = power_user.instruct.output_sequence;
+        const last_output_sequence = power_user.instruct.last_output_sequence;
+
+        const combined_sequence = `${input_sequence}\n${output_sequence}\n${last_output_sequence}`;
+
+        combined_sequence.split('\n').filter((line, index, self) => self.indexOf(line) === index).forEach(addInstructSequence);
     }
 
     if (power_user.custom_stopping_strings) {

--- a/public/script.js
+++ b/public/script.js
@@ -3926,13 +3926,28 @@ function cleanUpMessage(getMessage, isImpersonate, isContinue, displayIncomplete
         }
     }
     if (isInstruct && power_user.instruct.input_sequence && isImpersonate) {
-        getMessage = getMessage.replaceAll(power_user.instruct.input_sequence, '');
+        //getMessage = getMessage.replaceAll(power_user.instruct.input_sequence, '');
+        power_user.instruct.input_sequence.split('\n')
+            .filter(line => line.trim() !== '')
+            .forEach(line => {
+                getMessage = getMessage.replaceAll(line, '');
+            });
     }
     if (isInstruct && power_user.instruct.output_sequence && !isImpersonate) {
-        getMessage = getMessage.replaceAll(power_user.instruct.output_sequence, '');
+        //getMessage = getMessage.replaceAll(power_user.instruct.output_sequence, '');
+        power_user.instruct.output_sequence.split('\n')
+            .filter(line => line.trim() !== '')
+            .forEach(line => {
+                getMessage = getMessage.replaceAll(line, '');
+            });
     }
     if (isInstruct && power_user.instruct.last_output_sequence && !isImpersonate) {
-        getMessage = getMessage.replaceAll(power_user.instruct.last_output_sequence, '');
+        //getMessage = getMessage.replaceAll(power_user.instruct.last_output_sequence, '');
+        power_user.instruct.last_output_sequence.split('\n')
+            .filter(line => line.trim() !== '')
+            .forEach(line => {
+                getMessage = getMessage.replaceAll(line, '');
+            });
     }
     // clean-up group message from excessive generations
     if (selected_group) {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1070,8 +1070,8 @@ export function formatInstructModeChat(name, mes, isUser, isNarrator, forceAvata
     const separator = power_user.instruct.wrap ? '\n' : '';
     const separatorSequence = power_user.instruct.separator_sequence && !isUser
         ? power_user.instruct.separator_sequence
-        : (power_user.instruct.wrap ? '\n' : '');
-    const textArray = includeNames ? [sequence, `${name}: ${mes}`, separatorSequence] : [sequence, mes, separatorSequence];
+        : separator;
+    const textArray = includeNames ? [sequence, `${name}: ${mes}` + separatorSequence] : [sequence, mes + separatorSequence];
     const text = textArray.filter(x => x).join(separator);
     return text;
 }
@@ -1097,7 +1097,7 @@ export function formatInstructModePrompt(name, isImpersonate, promptBias, name1,
     }
 
     const separator = power_user.instruct.wrap ? '\n' : '';
-    let text = includeNames ? (separator + sequence + separator + `${name}:`) : (separator + sequence);
+    let text = includeNames ? (separator + sequence + separator + `${name}: `) : (separator + sequence);
 
     if (!isImpersonate && promptBias) {
         text += (includeNames ? promptBias : (separator + promptBias));

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1097,7 +1097,7 @@ export function formatInstructModePrompt(name, isImpersonate, promptBias, name1,
     }
 
     const separator = power_user.instruct.wrap ? '\n' : '';
-    let text = includeNames ? (separator + sequence + separator + `${name}: `) : (separator + sequence);
+    let text = includeNames ? (separator + sequence + separator + `${name}:`) : (separator + sequence);
 
     if (!isImpersonate && promptBias) {
         text += (includeNames ? promptBias : (separator + promptBias));


### PR DESCRIPTION
Continuing work on [Fixed presets](https://github.com/SillyTavern/SillyTavern/pull/932) and [[Feature Request] Add Simple Proxy functionality into Silly Tavern directly](https://github.com/SillyTavern/SillyTavern/issues/831):

- **Added Roleplay context template and updated instruct preset**
  - Updated Roleplay preset to work with last sequence and context templates.
- **Added simple-proxy-for-tavern context template and instruct preset**
  - The Roleplay preset is a simplified version of what simple-proxy-for-tavern does by default and tries to save tokens through some optimizations. It should achieve the same results in most cases without using up so many tokens.
  - Now, for testing purposes, here's an exact replica of simple-proxy-for-tavern's default verbose prompt template. We can decide later if we keep it (for proxy purists or potential special use cases) or drop it (to keep things simple) for the next public release.
- **Handle last_output_sequence like output_sequence**
  - Cleans up and sets stopping strings for last sequence analogously to output sequence.
- **Fix whitespace issues**
  - Extraneous newlines: There's code that adds the separatorSequence, which is a newline by default when "Wrap Sequences with Newline" is on and the Separator isn't set explicitly. And then there's code that joins the lines with newlines by default when "Wrap Sequences with Newline" is on. Both together cause double newlines, so I've appended the separator directly without joining, fixing this issue. Please double-check this part, though, to make sure it doesn't have unintended side effects.
  - ~~Space after name: When adding a name and a colon, we should always add a space, too! Otherwise the model has to add the space on its own, and that can cause problems since spaces are tokens, too, affected by repetition penalty and samplers. However, even though I added the space here, it seems to get trimmed somewhere else, so there's a follow-up change required.~~ ❎ Reverted: **no space after name**

**Additional Comments and Known Issues:**

- The original simple-proxy-for-tavern puts a linebreak at the very end of the whole prompt. SillyTavern doesn't do that, actually apparently it actively prevents it, trimming whitespace from the end of the prompt. Could we allow it for parity, in general or as an option? ✅ Done: **[End Prompt with Newline (#969)](https://github.com/SillyTavern/SillyTavern/pull/969)**
- Now that we have multi-line input/output sequences, the cleanup and stopping string-adding code would probably work better if we added each line individually instead of as a multi-line string. ✅ Done: **deduplicated multi-line stopping strings**, **multi-line clean-up message**