### PR TITLE
End Prompt with Newline

### DIFF
--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1099,7 +1099,7 @@ export function formatInstructModePrompt(name, isImpersonate, promptBias, name1,
         text += (includeNames ? promptBias : (separator + promptBias));
     }
 
-    return text.trimEnd();
+    return text.trimEnd() + (includeNames ? '' : separator);
 }
 
 const sortFunc = (a, b) => power_user.sort_order == 'asc' ? compareFunc(a, b) : compareFunc(b, a);


### PR DESCRIPTION
This change adds a trailing newline to the instruct mode prompt when "Wrap Sequences with Newline" is on and "Include Names" is off. (When "Include Names" is on, "Wrap Sequences with Newline" is already applied before.)

This fixes the only remaining issue from [Simple proxy for tavern replacement (#966)](https://github.com/SillyTavern/SillyTavern/pull/966).