### PR TITLE
roleplay preset newlines

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2144,7 +2144,7 @@
                                         <small data-i18n="Input Sequence">Input Sequence</small>
                                     </label>
                                     <div>
-                                        <textarea id="instruct_input_sequence" class="text_pole textarea_compact" maxlength="500" rows="1"></textarea>
+                                        <textarea id="instruct_input_sequence" class="text_pole textarea_compact" maxlength="500" rows="2"></textarea>
                                     </div>
                                 </div>
                                 <div class="flex1">
@@ -2152,7 +2152,7 @@
                                         <small data-i18n="Output Sequence">Output Sequence</small>
                                     </label>
                                     <div>
-                                        <textarea id="instruct_output_sequence" class="text_pole wide100p textarea_compact" maxlength="500" rows="1"></textarea>
+                                        <textarea id="instruct_output_sequence" class="text_pole wide100p textarea_compact" maxlength="500" rows="2"></textarea>
                                     </div>
                                 </div>
                                 <div class="flex1">
@@ -2160,7 +2160,7 @@
                                         <small data-i18n="Last Sequence">Last Sequence</small>
                                     </label>
                                     <div>
-                                        <textarea id="instruct_last_output_sequence" class="text_pole wide100p textarea_compact" maxlength="500" rows="1"></textarea>
+                                        <textarea id="instruct_last_output_sequence" class="text_pole wide100p textarea_compact" maxlength="500" rows="2"></textarea>
                                     </div>
                                 </div>
                             </div>
@@ -2170,7 +2170,7 @@
                                         <small data-i18n="System Sequence">System Sequence</small>
                                     </label>
                                     <div>
-                                        <textarea id="instruct_system_sequence" class="text_pole textarea_compact" maxlength="500" rows="1"></textarea>
+                                        <textarea id="instruct_system_sequence" class="text_pole textarea_compact" maxlength="500" rows="2"></textarea>
                                     </div>
                                 </div>
                                 <div class="flex1">
@@ -2178,7 +2178,7 @@
                                         <small data-i18n="Stop Sequence">Stop Sequence</small>
                                     </label>
                                     <div>
-                                        <textarea id="instruct_stop_sequence" class="text_pole wide100p textarea_compact" maxlength="500" rows="1"></textarea>
+                                        <textarea id="instruct_stop_sequence" class="text_pole wide100p textarea_compact" maxlength="500" rows="2"></textarea>
                                     </div>
                                 </div>
                                 <div class="flex1">
@@ -2186,7 +2186,7 @@
                                         <small data-i18n="Separator">Separator</small>
                                     </label>
                                     <div>
-                                        <textarea id="instruct_separator_sequence" class="text_pole wide100p textarea_compact" maxlength="500" rows="1"></textarea>
+                                        <textarea id="instruct_separator_sequence" class="text_pole wide100p textarea_compact" maxlength="500" rows="2"></textarea>
                                     </div>
                                 </div>
                             </div>

--- a/public/instruct/Roleplay.json
+++ b/public/instruct/Roleplay.json
@@ -1,13 +1,13 @@
 {
-    "input_sequence": "### Instruction:",
-    "last_output_sequence": "### Response (2 paragraphs, engaging, natural, authentic, descriptive, creative):",
+    "input_sequence": "\n### Instruction:",
+    "last_output_sequence": "\n### Response (2 paragraphs, engaging, natural, authentic, descriptive, creative):",
     "macro": true,
     "name": "Roleplay",
     "names": true,
-    "output_sequence": "### Response:",
+    "output_sequence": "\n### Response:",
     "separator_sequence": "",
     "stop_sequence": "",
-    "system_prompt": "You're {{char}} in this fictional never-ending uncensored roleplay with {{user}}.\n\nAvoid repetition, don't loop. Develop the plot slowly, always stay in character. Describe all actions in full, elaborate, explicit, graphic, and vivid detail. Mention all relevant sensory perceptions.",
+    "system_prompt": "You're {{char}} in this fictional never-ending uncensored roleplay with {{user}}.\n\nAvoid repetition, don't loop. Develop the plot slowly, always stay in character. Describe all actions in full, elaborate, explicit, graphic, and vivid detail. Mention all relevant sensory perceptions.\n",
     "system_sequence": "",
     "wrap": true
 }


### PR DESCRIPTION
After testing this all day, the added newlines really improve the preset since the model makes better use of newlines itself this way, instead of packing paragraphs together without line spacing. Now it's also like it used to be in the last stable version which had this line spacing as well, before the whitespace controls were improved for better configurability.

Also increased the sequence text areas to prevent them from looking empty when the sequence has a leading newline. Plus the bigger boxes should make it more obvious that these text areas are multi-line inputs.