### PR TITLE
NAI instruct prompt handling

### DIFF
--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -578,7 +578,7 @@ function calculateLogitBias() {
 }
 
 /**
- * Transforms instruction into compatible format for Novel AI.
+ * Transforms instruction into compatible format for Novel AI if Novel AI instruct format not already detected.
  * 1. Instruction must begin and end with curly braces followed and preceded by a space.
  * 2. Instruction must not contain square brackets as it serves different purpose in NAI.
  * @param {string} prompt Original instruction prompt
@@ -586,7 +586,10 @@ function calculateLogitBias() {
  */
 export function adjustNovelInstructionPrompt(prompt) {
     const stripedPrompt = prompt.replace(/[\[\]]/g, '').trim();
-    return `{ ${stripedPrompt} }`;
+    if (!stripedPrompt.includes('{ ')) {
+        return `{ ${stripedPrompt} }`;
+    }
+    return stripedPrompt;
 }
 
 export async function generateNovelWithStreaming(generate_data, signal) {


### PR DESCRIPTION
Does not add curly braces if Novel AI instruct format is already present in the supplied prompt. 

I prefer to format my instruct prompts manually, this should handle that use case cleanly without the need for additional settings.