### PR TITLE
Llama 2 chat instruct preset fixes

### DIFF
--- a/public/instruct/Llama 2 Chat.json
+++ b/public/instruct/Llama 2 Chat.json
@@ -1,10 +1,10 @@
 {
     "name": "Llama 2 Chat",
-    "system_prompt": "[INST] <<SYS>>\nWrite {{char}}'s next reply in this fictional roleplay with {{user}}.\n<</SYS>>\n",
+    "system_prompt": "Write {{char}}'s next reply in this fictional roleplay with {{user}}.",
     "input_sequence": "[INST] ",
     "output_sequence": " [/INST] ",
     "last_output_sequence": "",
-    "system_sequence": "[INST] <<SYS>>\n",
+    "system_sequence": "[INST] <<SYS>>\n{{sys}}\n<</SYS>>\n",
     "stop_sequence": "",
     "separator_sequence": "\n",
     "wrap": false,

--- a/public/instruct/Llama 2 Chat.json
+++ b/public/instruct/Llama 2 Chat.json
@@ -1,5 +1,5 @@
 {
-    "name": "Llama 2",
+    "name": "Llama 2 Chat",
     "system_prompt": "[INST] <<SYS>>\nWrite {{char}}'s next reply in this fictional roleplay with {{user}}.\n<</SYS>>\n",
     "input_sequence": "[INST] ",
     "output_sequence": " [/INST] ",

--- a/public/instruct/OpenOrca-OpenChat.json
+++ b/public/instruct/OpenOrca-OpenChat.json
@@ -1,5 +1,5 @@
 {
-    "name": "OpenOrca/OpenChat",
+    "name": "OpenOrca-OpenChat",
     "system_prompt": "You are a helpful assistant. Please answer truthfully and write out your thinking step by step to be sure you get the right answer. If you make a mistake or encounter an error in your thinking, say so out loud and attempt to correct it. If you don't know or aren't sure about something, say so clearly. You will act as a professional logician, mathematician, and physicist. You will also act as the most appropriate type of expert to answer any particular question or solve the relevant problem; state which expert type your are, if so. Also think of any particular named expert that would be ideal to answer the relevant question or solve the relevant problem; name and act as them, if appropriate.\n",
     "input_sequence": "User: ",
     "output_sequence": "<|end_of_turn|>\nAssistant: ",

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -258,7 +258,7 @@ export function formatInstructModeSystemPrompt(systemPrompt){
         const separator = power_user.instruct.wrap ? '\n' : '';
 
         if (power_user.instruct.system_sequence.includes("{{sys}}")) {
-            return power_user.instruct.system_sequence.replace(/{{sys}}/gi, systemPrompt) + separator;
+            return power_user.instruct.system_sequence.replace(/{{sys}}/gi, systemPrompt);
         } else {
             return power_user.instruct.system_sequence + separator + systemPrompt;
         }

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -256,7 +256,12 @@ export function formatInstructModeChat(name, mes, isUser, isNarrator, forceAvata
 export function formatInstructModeSystemPrompt(systemPrompt){
     if (power_user.instruct.system_sequence) {
         const separator = power_user.instruct.wrap ? '\n' : '';
-        return power_user.instruct.system_sequence + separator + systemPrompt;
+
+        if (power_user.instruct.system_sequence.includes("{{sys}}")) {
+            return power_user.instruct.system_sequence.replace(/{{sys}}/gi, systemPrompt) + separator;
+        } else {
+            return power_user.instruct.system_sequence + separator + systemPrompt;
+        }
     }
 
     return systemPrompt;


### PR DESCRIPTION
**fix name:**

- Made preset and file name match, and added Chat suffix because the Llama 2 preset is only for the official Llama 2 Chat models. We don't want people to think it's for all Llama 2-based models! (Also fixed mismatch between preset name and file name of OpenOrca-OpenChat while I was at it. Now all instruct presets are correctly named.)

**system prompt in system sequence:**

- Added a placeholder string "{{sys}}" to the system sequence that gets replaced by the system prompt. This is an alternative to simple string concatenation (prefix+prompt) and allows more complex system sequences (prefix+prompt+suffix).

**Open Issues:**

- Output sequence is shown while the response generated. It's cleaned up afterwards, though. This is actually an issue that affects other presets as well, like the proxy preset. I didn't think it's a bug, just a way how the UI works, but if we consider it a bug and fix this, that would be really nice!

- " [/INST] " prefixed to the greeting message, as seen in the console. The leading space looks weird, but I don't see a good way to get rid of it since it's needed in all other cases. We'd probably have to implement some special handling for the greeting message. This shows a special problem we have with our character cards: Some models simply don't expect there to be a message from the AI before the user starts the chat. Llama 2 Chat is one such model. Still, what this PR does so far is the closest we can get to the (pretty terrible) official format, I think.

By the way, even though it's good to have a proper Llama 2 Chat preset, I'd still recommend to anyone contemplating to use the Llama 2 Chat model to use the Roleplay or proxy preset instead because of the silly censorship that the official prompt format often invokes:

![Phina Llama 2](https://github.com/SillyTavern/SillyTavern/assets/52386626/c5c98724-4f59-4e44-9d7d-3986744a1a83)

Roleplay preset:

![Phina Roleplay](https://github.com/SillyTavern/SillyTavern/assets/52386626/cead1236-e81e-422b-be6b-25ddae5b34ca)

At least with the proper Llama 2 Chat system prompt, it *sometimes* gets around the censorship:

![Phina Llama 2 Chat](https://github.com/SillyTavern/SillyTavern/assets/52386626/20b36f6f-8153-440a-ad97-efaca1dfcee9)
