### PR TITLE
context template preset manager

### DIFF
--- a/default/settings.json
+++ b/default/settings.json
@@ -151,6 +151,7 @@
             "names_force_groups": true,
             "activation_regex": ""
         },
+        "default_context": "Default",
         "context": {
             "preset": "Default",
             "story_string": "{{#if system}}{{system}}\n{{/if}}{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{persona}}\n{{/if}}",

--- a/public/index.html
+++ b/public/index.html
@@ -2137,7 +2137,6 @@
                                     <span data-i18n="Enabled">Enabled</span>
                                 </label>
                             </div>
-                            </div>
                             <label for="instruct_presets">
                                 <span data-i18n="Presets">Presets</span>
                             </label>
@@ -2176,6 +2175,7 @@
                                     <input id="instruct_names_force_groups" type="checkbox" />
                                     <span data-i18n="Force for Groups and Personas">Force for Groups and Personas</span>
                                 </label>
+                            </div>
                             <label>
                                 <small data-i18n="System Prompt">System Prompt</small>
                             </label>

--- a/public/index.html
+++ b/public/index.html
@@ -2093,12 +2093,12 @@
                             <div class="preset_buttons">
                                 <select id="context_presets" data-preset-manager-for="context" class="flex1"></select>
                                 <input type="file" hidden data-preset-manager-file="context" accept=".json, .settings">
-                                <i id="context_set_default" class="menu_button fa-solid fa-heart" title="Auto-select this preset on API connection."></i>
+                                <i id="context_set_default" class="menu_button fa-solid fa-heart" title="Auto-select this preset for Instruct Mode."></i>
                                 <i data-preset-manager-update="context" class="menu_button fa-solid fa-save" title="Update current preset" data-i18n="[title]Update current preset"></i>
                                 <i data-preset-manager-new="context" class="menu_button fa-solid fa-plus" title="Create new preset" data-i18n="[title]Create new preset"></i>
                                 <i data-preset-manager-import="context" class="menu_button fa-solid fa-file-import" title="Import preset" data-i18n="[title]Import preset"></i>
                                 <i data-preset-manager-export="context" class="menu_button fa-solid fa-file-export" title="Export preset" data-i18n="[title]Export preset"></i>
-                                <i data-preset-manager-delete="context" class="menu_button fa-solid fa-trash-can" title="Delete the preset" data-i18n="[title]Delete the preset"></i>
+                                <i id="context_delete_preset" data-preset-manager-delete="context" class="menu_button fa-solid fa-trash-can" title="Delete the preset" data-i18n="[title]Delete the preset"></i>
                             </div>
                             <div>
                                 <label for="context_story_string">

--- a/public/index.html
+++ b/public/index.html
@@ -2090,9 +2090,15 @@
                             <h4 data-i18n="Context Template">
                                 Context Template
                             </h4>
-                            <div class="flex-container flexGap5">
-                                <select id="context_presets" class="flex1 margin0">
-                                </select>
+                            <div class="preset_buttons">
+                                <select id="context_presets" data-preset-manager-for="context" class="flex1"></select>
+                                <input type="file" hidden data-preset-manager-file="context" accept=".json, .settings">
+                                <i id="context_set_default" class="menu_button fa-solid fa-heart" title="Auto-select this preset on API connection."></i>
+                                <i data-preset-manager-update="context" class="menu_button fa-solid fa-save" title="Update current preset" data-i18n="[title]Update current preset"></i>
+                                <i data-preset-manager-new="context" class="menu_button fa-solid fa-plus" title="Create new preset" data-i18n="[title]Create new preset"></i>
+                                <i data-preset-manager-import="context" class="menu_button fa-solid fa-file-import" title="Import preset" data-i18n="[title]Import preset"></i>
+                                <i data-preset-manager-export="context" class="menu_button fa-solid fa-file-export" title="Export preset" data-i18n="[title]Export preset"></i>
+                                <i data-preset-manager-delete="context" class="menu_button fa-solid fa-trash-can" title="Delete the preset" data-i18n="[title]Delete the preset"></i>
                             </div>
                             <div>
                                 <label for="context_story_string">

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -90,7 +90,7 @@ function selectContextPreset(preset) {
     }
 
     // If instruct mode is disabled, enable it, except for default context template
-    if (!power_user.instruct.enabled && preset !== 'Default') {
+    if (!power_user.instruct.enabled && preset !== power_user.default_context) {
         power_user.instruct.enabled = true;
         $('#instruct_enabled').prop('checked', true).trigger('change');
         toastr.info(`Instruct Mode enabled`);
@@ -359,7 +359,7 @@ jQuery(() => {
             $('#instruct_presets').trigger('change');
         // When instruct mode gets disabled, select default context preset
         } else {
-            selectContextPreset('Default');
+            selectContextPreset(power_user.default_context);
         }
     });
 
@@ -397,7 +397,7 @@ jQuery(() => {
         }
         if (!foundMatch) {
             // If no match was found, select default context preset
-            selectContextPreset('Default');
+            selectContextPreset(power_user.default_context);
         }
 
         highlightDefaultPreset();

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -176,6 +176,7 @@ let power_user = {
         activation_regex: "",
     },
 
+    default_context: 'Default',
     context: {
         preset: 'Default',
         story_string: defaultStoryString,
@@ -951,7 +952,29 @@ function loadContextSettings() {
                 break;
             }
         }
+
+        highlightDefaultContext();
+
+        saveSettingsDebounced();
     });
+
+    $('#context_set_default').on('click', function () {
+        if (power_user.context.preset !== power_user.default_context) {
+            power_user.default_context = power_user.context.preset;
+            $(this).addClass('default');
+            toastr.info(`Default context template set to ${power_user.default_context}`);
+
+            highlightDefaultContext();
+
+            saveSettingsDebounced();
+        }
+    });
+
+    highlightDefaultContext();
+}
+
+function highlightDefaultContext() {
+    $('#context_set_default').toggleClass('default', power_user.default_context === power_user.context.preset);
 }
 
 export function fuzzySearchCharacters(searchValue) {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -975,6 +975,8 @@ function loadContextSettings() {
 
 function highlightDefaultContext() {
     $('#context_set_default').toggleClass('default', power_user.default_context === power_user.context.preset);
+    $('#context_set_default').toggleClass('disabled', power_user.default_context === power_user.context.preset);
+    $('#context_delete_preset').toggleClass('disabled', power_user.default_context === power_user.context.preset);
 }
 
 export function fuzzySearchCharacters(searchValue) {

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -18,7 +18,7 @@ import {
 import { groups, selected_group } from "./group-chats.js";
 import { instruct_presets } from "./instruct-mode.js";
 import { kai_settings } from "./kai-settings.js";
-import { power_user } from "./power-user.js";
+import { context_presets, power_user } from "./power-user.js";
 import {
     textgenerationwebui_preset_names,
     textgenerationwebui_presets,
@@ -167,6 +167,10 @@ class PresetManager {
                 presets = textgenerationwebui_presets;
                 preset_names = textgenerationwebui_preset_names;
                 break;
+            case "context":
+                presets = context_presets;
+                preset_names = context_presets.map(x => x.name);
+                break;
             case "instruct":
                 presets = instruct_presets;
                 preset_names = instruct_presets.map(x => x.name);
@@ -179,11 +183,11 @@ class PresetManager {
     }
 
     isKeyedApi() {
-        return this.apiId == "textgenerationwebui" || this.apiId == "instruct";
+        return this.apiId == "textgenerationwebui" || this.apiId == "context" || this.apiId == "instruct";
     }
 
     isNonGenericApi() {
-        return this.apiId == "instruct";
+        return this.apiId == "context" || this.apiId == "instruct";
     }
 
     updateList(name, preset) {
@@ -231,10 +235,14 @@ class PresetManager {
                     return nai_settings;
                 case "textgenerationwebui":
                     return textgenerationwebui_settings;
+                case "context":
+                    const context_preset = deepClone(power_user.context);
+                    context_preset['name'] = name || power_user.context.preset;
+                    return context_preset;
                 case "instruct":
-                    const preset = deepClone(power_user.instruct);
-                    preset['name'] = name || power_user.instruct.preset;
-                    return preset;
+                    const instruct_preset = deepClone(power_user.instruct);
+                    instruct_preset['name'] = name || power_user.instruct.preset;
+                    return instruct_preset;
                 default:
                     console.warn(`Unknown API ID ${apiId}`);
                     return {};

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -399,6 +399,11 @@ jQuery(async () => {
             return;
         }
 
+        // default context preset cannot be deleted
+        if (apiId == "context" && power_user.default_context === power_user.context.preset) {
+            return;
+        }
+
         const confirm = await callPopup('Delete the preset? This action is irreversible and your current settings will be overwritten.', 'confirm');
 
         if (!confirm) {

--- a/public/style.css
+++ b/public/style.css
@@ -1291,6 +1291,10 @@ select option:not(:checked) {
     color: var(--active) !important;
 }
 
+#context_set_default.default {
+    color: var(--preferred) !important;
+}
+
 #instruct_set_default.default {
     color: var(--preferred) !important;
 }

--- a/server.js
+++ b/server.js
@@ -3819,6 +3819,8 @@ function getPresetSettingsByAPI(apiId) {
             return { folder: directories.textGen_Settings, extension: '.settings' };
         case 'instruct':
             return { folder: directories.instruct, extension: '.json' };
+        case 'context':
+            return { folder: directories.context, extension: '.json' };
         default:
             return { folder: null, extension: null };
     }


### PR DESCRIPTION
**Context Template Preset Manager**

- Added context template preset manager.
- Favorite context template will be auto-selected when switching instruct mode preset to one without associated context template.
- Deleting the favorited context template is disabled to ensure there will always be a default context template remaining.
- Unfavoriting is disabled to ensure there will always be a default context template remaining. (So to unselect, just favorite another preset.)