### PR TITLE
comment message formatting

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -136,7 +136,7 @@ import {
 } from "./scripts/utils.js";
 
 import { extension_settings, getContext, loadExtensionSettings, processExtensionHelpers, registerExtensionHelper, runGenerationInterceptors, saveMetadataDebounced } from "./scripts/extensions.js";
-import { executeSlashCommands, getSlashCommandsHelp, registerSlashCommand } from "./scripts/slash-commands.js";
+import { COMMENT_NAME_DEFAULT, executeSlashCommands, getSlashCommandsHelp, registerSlashCommand } from "./scripts/slash-commands.js";
 import {
     tag_map,
     tags,
@@ -1197,6 +1197,11 @@ function messageFormatting(mes, ch_name, isSystem, isUser) {
 
     if (!mes) {
         mes = '';
+    }
+
+    // Force isSystem = false on comment messages so they get formatted properly
+    if (ch_name === COMMENT_NAME_DEFAULT && isSystem && !isUser) {
+        isSystem = false;
     }
 
     // Prompt bias replacement should be applied on the raw message

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -385,7 +385,7 @@ async function sendCommentMessage(_, text) {
         name: COMMENT_NAME_DEFAULT,
         is_user: false,
         is_name: true,
-        is_system: true,
+        is_system: false,
         send_date: getMessageTimeStamp(),
         mes: substituteParams(text.trim()),
         force_avatar: comment_avatar,

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -131,7 +131,7 @@ parser.addCommand('send', sendUserMessageCallback, ['add'], '<span class="monosp
 
 const NARRATOR_NAME_KEY = 'narrator_name';
 const NARRATOR_NAME_DEFAULT = 'System';
-const COMMENT_NAME_DEFAULT = 'Note';
+export const COMMENT_NAME_DEFAULT = 'Note';
 
 async function sendUserMessageCallback(_, text) {
     if (!text) {
@@ -385,7 +385,7 @@ async function sendCommentMessage(_, text) {
         name: COMMENT_NAME_DEFAULT,
         is_user: false,
         is_name: true,
-        is_system: false,
+        is_system: true,
         send_date: getMessageTimeStamp(),
         mes: substituteParams(text.trim()),
         force_avatar: comment_avatar,


### PR DESCRIPTION
**Comment Message Formatting**

I've missed comments being formatted properly, as I'd like to add multiple newline-separated paragraphs with formatting.

Looking for why comments didn't get formatted, I found out it's because they're treated as system messages, which don't get formatted.

The easiest fix was to change them to non-system messages. I didn't see a drawback in my tests, they're still client-only and don't get sent to the backend.

So unless there's a specific reason they need to be declared as system messages, I propose this as a simple implementation of comment message formatting.