### PR TITLE
Add model info to model icon as title

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1324,6 +1324,7 @@ function insertSVGIcon(mes, extra) {
     // Add classes for styling and identification
     image.classList.add('icon-svg', 'timestamp-icon');
     image.src = `/img/${modelName}.svg`;
+    image.title = `${extra?.api ? extra.api + ' - ' : ''}${extra?.model ?? ''}`;
 
     image.onload = async function () {
         // Check if an SVG already exists adjacent to the timestamp


### PR DESCRIPTION
Simple one-line PR:

- **Add model info to model icon as title**, to show the model info not only on the timestamp (which isn't very logical IMHO), but also on the model icon (which was lacking a title).

When I saw the model icon for the first time, I didn't know what it meant, and it didn't even have a mouse-over hover/title. Later I found out that the model info is added to the timestamp, where I'd not expect it. So now it's also where it should have been in the first place, on the model icon itself. Hope this can get in the next release before people get confused by the title-less image like I did.

@Cohee1207 Should we remove the model info from the timestamp or keep it there as well? I don't mind either way, but if you want it moved to instead of duplicated on the icon, I can do that in this PR as well. Just let me know, otherwise you can just merge it as is and we'll keep it on both.