### PR TITLE
importing process unneeded, native to node runtime

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,6 @@ function createDefaultFiles() {
     }
 }
 
-const process = require('process')
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 const net = require("net");


### PR DESCRIPTION
`process` is native (global) to node runtime, no need to import. i believe this has been true for all versions of node.