### PR TITLE
Make jsdoc/type-checker happy Pt 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ content.log
 cloudflared.exe
 public/assets/
 access.log
+debugLogs/

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ content.log
 cloudflared.exe
 public/assets/
 access.log
-debugLogs/

--- a/server.js
+++ b/server.js
@@ -4349,6 +4349,7 @@ app.post('/horde_generateimage', jsonParser, async (request, response) => {
                 {
                     sampler_name: request.body.sampler,
                     hires_fix: request.body.enable_hr,
+                    // @ts-ignore - use_gfpgan param is not in the type definition, need to update to new ai_horde @ https://github.com/ZeldaFan0225/ai_horde/blob/main/index.ts
                     use_gfpgan: request.body.restore_faces,
                     cfg_scale: request.body.scale,
                     steps: request.body.steps,

--- a/server.js
+++ b/server.js
@@ -4704,7 +4704,7 @@ app.post('/import_custom', jsonParser, async (request, response) => {
             return response.sendStatus(404);
         }
 
-        response.set('Content-Type', result.fileType);
+        if (result.fileType) response.set('Content-Type', result.fileType)
         response.set('Content-Disposition', `attachment; filename="${result.fileName}"`);
         response.set('X-Custom-Content-Type', chubParsed?.type);
         return response.send(result.buffer);

--- a/server.js
+++ b/server.js
@@ -596,7 +596,7 @@ app.post("/generate", jsonParser, async function (request, response_generate = r
 });
 
 //************** Text generation web UI
-app.post("/generate_textgenerationwebui", jsonParser, async function (request, response_generate = response) {
+app.post("/generate_textgenerationwebui", jsonParser, async function (request, response_generate) {
     if (!request.body) return response_generate.sendStatus(400);
 
     console.log(request.body);

--- a/server.js
+++ b/server.js
@@ -4287,7 +4287,7 @@ app.post('/viewsecrets', jsonParser, async (_, response) => {
 
     try {
         const fileContents = fs.readFileSync(SECRETS_FILE);
-        const secrets = JSON.parse(fileContents);
+        const secrets = JSON.parse(fileContents.toString());
         return response.send(secrets);
     } catch (error) {
         console.error(error);

--- a/server.js
+++ b/server.js
@@ -422,7 +422,7 @@ app.use(function (req, res, next) {
 });
 
 
-app.use(express.static(process.cwd() + "/public", { refresh: true }));
+app.use(express.static(process.cwd() + "/public", {}));
 
 app.use('/backgrounds', (req, res) => {
     const filePath = decodeURIComponent(path.join(process.cwd(), 'public/backgrounds', req.url.replace(/%20/g, ' ')));

--- a/server.js
+++ b/server.js
@@ -4978,6 +4978,7 @@ async function getManifest(extensionPath) {
 }
 
 async function checkIfRepoIsUpToDate(extensionPath) {
+    // @ts-ignore - simple-git types are incorrect, this is apparently callable but no call signature
     const git = simpleGit();
     await git.cwd(extensionPath).fetch('origin');
     const currentBranch = await git.cwd(extensionPath).branch();
@@ -5008,6 +5009,7 @@ async function checkIfRepoIsUpToDate(extensionPath) {
  * @returns {void}
  */
 app.post('/get_extension', jsonParser, async (request, response) => {
+    // @ts-ignore - simple-git types are incorrect, this is apparently callable but no call signature
     const git = simpleGit();
     if (!request.body.url) {
         return response.status(400).send('Bad Request: URL is required in the request body.');
@@ -5053,6 +5055,7 @@ app.post('/get_extension', jsonParser, async (request, response) => {
  * @returns {void}
  */
 app.post('/update_extension', jsonParser, async (request, response) => {
+    // @ts-ignore - simple-git types are incorrect, this is apparently callable but no call signature
     const git = simpleGit();
     if (!request.body.extensionName) {
         return response.status(400).send('Bad Request: extensionName is required in the request body.');
@@ -5098,6 +5101,7 @@ app.post('/update_extension', jsonParser, async (request, response) => {
  * @returns {void}
  */
 app.post('/get_extension_version', jsonParser, async (request, response) => {
+    // @ts-ignore - simple-git types are incorrect, this is apparently callable but no call signature
     const git = simpleGit();
     if (!request.body.extensionName) {
         return response.status(400).send('Bad Request: extensionName is required in the request body.');

--- a/server.js
+++ b/server.js
@@ -5365,7 +5365,8 @@ app.post('/asset_delete', jsonParser, async (request, response) => {
  * @returns {void}
  */
 app.post('/get_character_assets_list', jsonParser, async (request, response) => {
-    const name = sanitize(request.query.name);
+    if (request.query.name === undefined) return response.sendStatus(400);
+    const name = sanitize(request.query.name.toString());
     const inputCategory = request.query.category;
     const validCategories = ["bgm", "ambient"]
 

--- a/server.js
+++ b/server.js
@@ -5328,7 +5328,7 @@ app.post('/asset_delete', jsonParser, async (request, response) => {
     // Sanitize filename
     const safe_input = checkAssetFileName(inputFilename);
     if (safe_input == '')
-        return response.sendFile(400);
+        return response.sendFile('400');
 
     const file_path = path.join(directories.assets, category, safe_input)
     console.debug("Request received to delete", category, file_path);

--- a/server.js
+++ b/server.js
@@ -5274,7 +5274,7 @@ app.post('/asset_download', jsonParser, async (request, response) => {
     try {
         // Download to temp
         const res = await fetch(url);
-        if (!res.ok) {
+        if (!res.ok || res.body === null) {
             throw new Error(`Unexpected response ${res.statusText}`);
         }
         const destination = path.resolve(temp_path);

--- a/server.js
+++ b/server.js
@@ -5265,7 +5265,7 @@ app.post('/asset_download', jsonParser, async (request, response) => {
     // Sanitize filename
     const safe_input = checkAssetFileName(inputFilename);
     if (safe_input == '')
-        return response.sendFile(400);
+        return response.sendFile('400');
 
     const temp_path = path.join(directories.assets, "temp", safe_input)
     const file_path = path.join(directories.assets, category, safe_input)

--- a/server.js
+++ b/server.js
@@ -4963,7 +4963,7 @@ async function getImageBuffers(zipFilePath) {
 /**
  * This function extracts the extension information from the manifest file.
  * @param {string} extensionPath - The path of the extension folder
- * @returns {Object} - Returns the manifest data as an object
+ * @returns {Promise<Object>} - Returns the manifest data as an object
  */
 async function getManifest(extensionPath) {
     const manifestPath = path.join(extensionPath, 'manifest.json');

--- a/server.js
+++ b/server.js
@@ -5254,7 +5254,7 @@ app.post('/asset_download', jsonParser, async (request, response) => {
 
     // Check category
     let category = null;
-    for (i of validCategories)
+    for (let i of validCategories)
         if (i == inputCategory)
             category = i;
 
@@ -5316,7 +5316,7 @@ app.post('/asset_delete', jsonParser, async (request, response) => {
 
     // Check category
     let category = null;
-    for (i of validCategories)
+    for (let i of validCategories)
         if (i == inputCategory)
             category = i;
 
@@ -5371,7 +5371,7 @@ app.post('/get_character_assets_list', jsonParser, async (request, response) => 
 
     // Check category
     let category = null
-    for (i of validCategories)
+    for (let i of validCategories)
         if (i == inputCategory)
             category = i
 
@@ -5390,7 +5390,7 @@ app.post('/get_character_assets_list', jsonParser, async (request, response) => 
                     return filename != ".placeholder";
                 });
 
-            for (i of files)
+            for (let i of files)
                 output.push(`/characters/${name}/${category}/${i}`);
 
         }

--- a/server.js
+++ b/server.js
@@ -4286,8 +4286,8 @@ app.post('/viewsecrets', jsonParser, async (_, response) => {
     }
 
     try {
-        const fileContents = fs.readFileSync(SECRETS_FILE);
-        const secrets = JSON.parse(fileContents.toString());
+        const fileContents = fs.readFileSync(SECRETS_FILE, 'utf8');
+        const secrets = JSON.parse(fileContents);
         return response.send(secrets);
     } catch (error) {
         console.error(error);

--- a/server.js
+++ b/server.js
@@ -53,8 +53,8 @@ const cliArguments = yargs(hideBin(process.argv))
 
 // change all relative paths
 const path = require('path');
-const directory = process.pkg ? path.dirname(process.execPath) : __dirname;
-console.log(process.pkg ? 'Running from binary' : 'Running from source');
+const directory = process['pkg'] ? path.dirname(process.execPath) : __dirname;
+console.log(process['pkg'] ? 'Running from binary' : 'Running from source');
 process.chdir(directory);
 
 const express = require('express');
@@ -837,7 +837,7 @@ function getVersion() {
     try {
         const pkgJson = require('./package.json');
         pkgVersion = pkgJson.version;
-        if (!process.pkg && commandExistsSync('git')) {
+        if (!process['pkg'] && commandExistsSync('git')) {
             gitRevision = require('child_process')
                 .execSync('git rev-parse --short HEAD', { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'ignore'] })
                 .toString().trim();

--- a/server.js
+++ b/server.js
@@ -4227,7 +4227,7 @@ app.post('/readsecretstate', jsonParser, (_, response) => {
     }
 
     try {
-        const fileContents = fs.readFileSync(SECRETS_FILE);
+        const fileContents = fs.readFileSync(SECRETS_FILE, 'utf8');
         const secrets = JSON.parse(fileContents);
         const state = {};
 
@@ -4286,7 +4286,7 @@ app.post('/viewsecrets', jsonParser, async (_, response) => {
     }
 
     try {
-        const fileContents = fs.readFileSync(SECRETS_FILE, 'utf8');
+        const fileContents = fs.readFileSync(SECRETS_FILE, 'utf-8');
         const secrets = JSON.parse(fileContents);
         return response.send(secrets);
     } catch (error) {
@@ -4872,8 +4872,8 @@ function writeSecret(key, value) {
         writeFileAtomicSync(SECRETS_FILE, emptyFile, "utf-8");
     }
 
-    const fileContents = fs.readFileSync(SECRETS_FILE);
-    const secrets = JSON.parse(fileContents.toString());
+    const fileContents = fs.readFileSync(SECRETS_FILE, 'utf-8');
+    const secrets = JSON.parse(fileContents);
     secrets[key] = value;
     writeFileAtomicSync(SECRETS_FILE, JSON.stringify(secrets), "utf-8");
 }
@@ -4883,8 +4883,8 @@ function readSecret(key) {
         return undefined;
     }
 
-    const fileContents = fs.readFileSync(SECRETS_FILE);
-    const secrets = JSON.parse(fileContents.toString());
+    const fileContents = fs.readFileSync(SECRETS_FILE, 'utf-8');
+    const secrets = JSON.parse(fileContents);
     return secrets[key];
 }
 

--- a/server.js
+++ b/server.js
@@ -385,7 +385,7 @@ function getIpFromRequest(req) {
     let clientIp = req.connection.remoteAddress;
     let ip = ipaddr.parse(clientIp);
     // Check if the IP address is IPv4-mapped IPv6 address
-    if (ip.kind() === 'ipv6' && ip.isIPv4MappedAddress()) {
+    if (ip.kind() === 'ipv6' && ip instanceof ipaddr.IPv6 && ip.isIPv4MappedAddress()) {
         const ipv4 = ip.toIPv4Address().toString();
         clientIp = ipv4;
     } else {

--- a/server.js
+++ b/server.js
@@ -4871,7 +4871,7 @@ function writeSecret(key, value) {
     }
 
     const fileContents = fs.readFileSync(SECRETS_FILE);
-    const secrets = JSON.parse(fileContents);
+    const secrets = JSON.parse(fileContents.toString());
     secrets[key] = value;
     writeFileAtomicSync(SECRETS_FILE, JSON.stringify(secrets), "utf-8");
 }
@@ -4882,7 +4882,7 @@ function readSecret(key) {
     }
 
     const fileContents = fs.readFileSync(SECRETS_FILE);
-    const secrets = JSON.parse(fileContents);
+    const secrets = JSON.parse(fileContents.toString());
     return secrets[key];
 }
 

--- a/server.js
+++ b/server.js
@@ -711,7 +711,7 @@ app.post("/generate_textgenerationwebui", jsonParser, async function (request, r
             console.log("Endpoint response:", data);
             return response_generate.send(data);
         } catch (error) {
-            retval = { error: true, status: error.status, response: error.statusText };
+            let retval = { error: true, status: error.status, response: error.statusText };
             console.log("Endpoint error:", error);
             try {
                 retval.response = await error.json();

--- a/server.js
+++ b/server.js
@@ -4375,6 +4375,7 @@ app.post('/horde_generateimage', jsonParser, async (request, response) => {
 
             if (check.done) {
                 const result = await ai_horde.getImageGenerationStatus(generation.id);
+                if (result.generations === undefined) return response.sendStatus(500);
                 return response.send(result.generations[0].img);
             }
 

--- a/server.js
+++ b/server.js
@@ -4761,6 +4761,11 @@ async function downloadChubCharacter(id) {
     return { buffer, fileName, fileType };
 }
 
+/**
+ * 
+ * @param {String} str 
+ * @returns { { id: string, type: "character" | "lorebook" } | null }
+ */
 function parseChubUrl(str) {
     const splitStr = str.split('/');
     const length = splitStr.length;

--- a/server.js
+++ b/server.js
@@ -5250,6 +5250,7 @@ app.post('/asset_download', jsonParser, async (request, response) => {
     const inputCategory = request.body.category;
     const inputFilename = sanitize(request.body.filename);
     const validCategories = ["bgm", "ambient"];
+    const fetch = require('node-fetch').default;
 
     // Check category
     let category = null;
@@ -5285,7 +5286,7 @@ app.post('/asset_download', jsonParser, async (request, response) => {
             });
         }
         const fileStream = fs.createWriteStream(destination, { flags: 'wx' });
-        await finished(Readable.fromWeb(res.body).pipe(fileStream));
+        await finished(res.body.pipe(fileStream));
 
         // Move into asset place
         console.debug("Download finished, moving file from", temp_path, "to", file_path);

--- a/server.js
+++ b/server.js
@@ -5273,23 +5273,19 @@ app.post('/asset_download', jsonParser, async (request, response) => {
 
     try {
         // Download to temp
-        const downloadFile = (async (url, temp_path) => {
-            const res = await fetch(url);
-            if (!res.ok) {
-                throw new Error(`Unexpected response ${res.statusText}`);
-            }
-            const destination = path.resolve(temp_path);
-            // Delete if previous download failed
-            if (fs.existsSync(temp_path)) {
-                fs.unlink(temp_path, (err) => {
-                    if (err) throw err;
-                });
-            }
-            const fileStream = fs.createWriteStream(destination, { flags: 'wx' });
-            await finished(Readable.fromWeb(res.body).pipe(fileStream));
-        });
-
-        await downloadFile(url, temp_path);
+        const res = await fetch(url);
+        if (!res.ok) {
+            throw new Error(`Unexpected response ${res.statusText}`);
+        }
+        const destination = path.resolve(temp_path);
+        // Delete if previous download failed
+        if (fs.existsSync(temp_path)) {
+            fs.unlink(temp_path, (err) => {
+                if (err) throw err;
+            });
+        }
+        const fileStream = fs.createWriteStream(destination, { flags: 'wx' });
+        await finished(Readable.fromWeb(res.body).pipe(fileStream));
 
         // Move into asset place
         console.debug("Download finished, moving file from", temp_path, "to", file_path);


### PR DESCRIPTION
this removes a lot of red from vscode that upsets the new type checking. specifically, vscode reported "127 problems" in server.js, now it reports "89 problems".
- most changes are straightforward or benign
- some changes are fixes to polluting the global namespace, which is quite alarming
- some changes are where functions were expecting strings, and we gave them possible `Buffer`. rectified with `.toString()`
- some changes are just type-guarding against undefined or null where it wasn't accounted for previously

only unknown i can think of is the modification to references of `process.pkg` making type-checking go nuts. switching to `process['pkg']` fixes it. i do not know the exact context that this code is used though ("Running from binary" vs "Running from source").

if you would like this broken down in smaller PRs over the 21 commits that make up this PR, let me know.
as of the time of submitting the PR, the parent branch is updated to current `staging` branch for ease of merging.