### PR TITLE
get rid of node-rest-client and fix types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
                 "mime-types": "^2.1.35",
                 "multer": "^1.4.5-lts.1",
                 "node-fetch": "^2.6.11",
-                "node-rest-client": "^3.1.1",
                 "open": "^8.4.2",
                 "piexifjs": "^1.0.6",
                 "png-chunk-text": "^1.0.0",
@@ -2271,40 +2270,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/node-rest-client": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/node-rest-client/-/node-rest-client-3.1.1.tgz",
-            "integrity": "sha512-O8RUGGhGLLbzlL7SFOBza1AgUWP3uITv4mas4f5Q7A87HAy6qtYpa8Sj5x4UG9cDf4374v7lWyvgWladI04zzQ==",
-            "dependencies": {
-                "debug": "~4.3.3",
-                "follow-redirects": ">=1.14.7",
-                "xml2js": ">=0.4.23"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/node-rest-client/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/node-rest-client/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/object-assign": {
             "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "mime-types": "^2.1.35",
         "multer": "^1.4.5-lts.1",
         "node-fetch": "^2.6.11",
-        "node-rest-client": "^3.1.1",
         "open": "^8.4.2",
         "piexifjs": "^1.0.6",
         "png-chunk-text": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -3984,7 +3984,7 @@ app.post("/tokenize_via_api", jsonParser, async function (request, response) {
 // ** REST CLIENT ASYNC WRAPPERS **
 
 /**
- * Convenience function for fetch requests returning as JSON.
+ * Convenience function for fetch requests (default GET) returning as JSON.
  * @param {string} url 
  * @param {import('node-fetch').RequestInit} args 
  */
@@ -3999,7 +3999,12 @@ async function fetchJSON(url, args = {}) {
 
     throw response;
 }
-const postAsync = (url, args) => fetchJSON(url, { method: 'POST', timeout: 0, ...args });
+/**
+ * Convenience function for fetch requests (default POST with no timeout) returning as JSON.
+ * @param {string} url 
+ * @param {import('node-fetch').RequestInit} args 
+ */
+async function postAsync (url, args) {return fetchJSON(url, { method: 'POST', timeout: 0, ...args })}
 
 // ** END **
 

--- a/server.js
+++ b/server.js
@@ -3837,10 +3837,9 @@ app.post("/delete_preset", jsonParser, function (request, response) {
 });
 
 app.post("/savepreset_openai", jsonParser, function (request, response) {
+    if (!request.body || typeof request.query.name !== 'string') return response.sendStatus(400);
     const name = sanitize(request.query.name);
-    if (!request.body || !name) {
-        return response.sendStatus(400);
-    }
+    if (!name) return response.sendStatus(400);
 
     const filename = `${name}.settings`;
     const fullpath = path.join(directories.openAI_Settings, filename);

--- a/server.js
+++ b/server.js
@@ -4279,10 +4279,10 @@ app.post('/generate_horde', jsonParser, async (request, response) => {
         "body": JSON.stringify(request.body),
         "headers": {
             "Content-Type": "application/json",
-            "Client-Agent": request.header('Client-Agent'),
             "apikey": api_key_horde,
         }
     };
+    if (request.header('Client-Agent') !== undefined) args.headers['Client-Agent'] = request.header('Client-Agent');
 
     console.log(args.body);
     try {

--- a/server.js
+++ b/server.js
@@ -3984,8 +3984,8 @@ app.post("/tokenize_via_api", jsonParser, async function (request, response) {
 
 /**
  * Convenience function for fetch requests (default GET) returning as JSON.
- * @param {string} url 
- * @param {import('node-fetch').RequestInit} args 
+ * @param {string} url
+ * @param {import('node-fetch').RequestInit} args
  */
 async function fetchJSON(url, args = {}) {
     if (args.method === undefined) args.method = 'GET';
@@ -4000,10 +4000,10 @@ async function fetchJSON(url, args = {}) {
 }
 /**
  * Convenience function for fetch requests (default POST with no timeout) returning as JSON.
- * @param {string} url 
- * @param {import('node-fetch').RequestInit} args 
+ * @param {string} url
+ * @param {import('node-fetch').RequestInit} args
  */
-async function postAsync (url, args) {return fetchJSON(url, { method: 'POST', timeout: 0, ...args })}
+async function postAsync(url, args) { return fetchJSON(url, { method: 'POST', timeout: 0, ...args }) }
 
 // ** END **
 

--- a/server.js
+++ b/server.js
@@ -3083,6 +3083,8 @@ async function generateThumbnail(type, file) {
 }
 
 app.get('/thumbnail', jsonParser, async function (request, response) {
+    if (typeof request.query.file !== 'string' || typeof request.query.type !== 'string') return response.sendStatus(400);
+
     const type = request.query.type;
     const file = sanitize(request.query.file);
 
@@ -3100,7 +3102,9 @@ app.get('/thumbnail', jsonParser, async function (request, response) {
     }
 
     if (config.disableThumbnails == true) {
-        const pathToOriginalFile = path.join(getOriginalFolder(type), file);
+        let folder = getOriginalFolder(file)
+        if (folder === undefined) return response.sendStatus(400);
+        const pathToOriginalFile = path.join(folder, file);
         return response.sendFile(pathToOriginalFile, { root: process.cwd() });
     }
 


### PR DESCRIPTION
this not only fixes type issues caused by `node-rest-client` bad types, but it completely removes that library as a dependency.

needs testing @ `/getstatus`, especially when `main_api == "kobold"`. pretty sure that is the only possible impact.

as a library has been removed, maybe an install from scratch might be a good test too, although the `package.json` and `package-lock.json` edits seem fairly straightforward