### PR TITLE
TTS: Set character default voice from `disabled` to `default` (#1077)

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -462,7 +462,7 @@ async function processTtsQueue() {
             return;
         }
 
-        const voiceMapEntry = voiceMap[char] || voiceMap[DEFAULT_VOICE_MARKER]
+        const voiceMapEntry = voiceMap[char] === DEFAULT_VOICE_MARKER ? voiceMap[DEFAULT_VOICE_MARKER] : voiceMap[char]
 
         if (!voiceMapEntry) {
             throw `${char} not in voicemap. Configure character in extension settings voice map`
@@ -708,7 +708,7 @@ class VoiceMapEntry {
     name
     voiceId
     selectElement
-    constructor (name, voiceId='disabled') {
+    constructor (name, voiceId=DEFAULT_VOICE_MARKER) {
         this.name = name
         this.voiceId = voiceId
         this.selectElement = null
@@ -720,6 +720,7 @@ class VoiceMapEntry {
             <div class='tts_voicemap_block_char flex-container flexGap5'>
                 <span id='tts_voicemap_char_${sanitizedName}'>${this.name}</span>
                 <select id='tts_voicemap_char_${sanitizedName}_voice'>
+                    <option>${DEFAULT_VOICE_MARKER}</option>
                     <option>disabled</option>
                 </select>
             </div>
@@ -804,8 +805,10 @@ export async function initVoiceMap(){
         let voiceId
         if (character in voiceMapFromSettings){
             voiceId = voiceMapFromSettings[character]
-        } else {
+        } else if (character === DEFAULT_VOICE_MARKER) {
             voiceId = 'disabled'
+        } else {
+            voiceId = '[Default Voice]'
         }
         const voiceMapEntry = new VoiceMapEntry(character, voiceId)
         voiceMapEntry.addUI(voiceIdsFromProvider)

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -716,12 +716,14 @@ class VoiceMapEntry {
 
     addUI(voiceIds){
         let sanitizedName = sanitizeId(this.name)
+        let defaultOption = this.name === DEFAULT_VOICE_MARKER ?
+            '<option>disabled</option>' :
+            `<option>${DEFAULT_VOICE_MARKER}</option><option>disabled</option>`
         let template = `
             <div class='tts_voicemap_block_char flex-container flexGap5'>
                 <span id='tts_voicemap_char_${sanitizedName}'>${this.name}</span>
                 <select id='tts_voicemap_char_${sanitizedName}_voice'>
-                    <option>${DEFAULT_VOICE_MARKER}</option>
-                    <option>disabled</option>
+                    ${defaultOption}
                 </select>
             </div>
         `
@@ -808,7 +810,7 @@ export async function initVoiceMap(){
         } else if (character === DEFAULT_VOICE_MARKER) {
             voiceId = 'disabled'
         } else {
-            voiceId = '[Default Voice]'
+            voiceId = DEFAULT_VOICE_MARKER
         }
         const voiceMapEntry = new VoiceMapEntry(character, voiceId)
         voiceMapEntry.addUI(voiceIdsFromProvider)


### PR DESCRIPTION
## Features and improvements
- TTS Extension
  - Set character default voice from `disabled` to `DEFAULT_VOICE_MARKER`
  - Add `DEFAULT_VOICE_MARKER` option for all characters
  - Set default `DEFAULT_VOICE_MARKER` voice as `disabled`

## Related issues
- #1077
