### PR TITLE
Improved cleanup for Instruct Mode

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3855,6 +3855,13 @@ function cleanUpMessage(getMessage, isImpersonate, isContinue, displayIncomplete
             getMessage = getMessage.substring(0, getMessage.indexOf(power_user.instruct.stop_sequence));
         }
     }
+    // Hana: Only use the first sequence (should be <|model|>)
+    // of the prompt before <|user|> (as KoboldAI Lite does it).
+    if (isInstruct && power_user.instruct.input_sequence) {
+        if (getMessage.indexOf(power_user.instruct.input_sequence) != -1) {
+            getMessage = getMessage.substring(0, getMessage.indexOf(power_user.instruct.input_sequence));
+        }
+    }
     if (isInstruct && power_user.instruct.input_sequence && isImpersonate) {
         //getMessage = getMessage.replaceAll(power_user.instruct.input_sequence, '');
         power_user.instruct.input_sequence.split('\n')


### PR DESCRIPTION
This PR does the following changes to the staging branch. (One for release coming as well).

## Additions
- Added a `if-statement` in which if Instruct Mode is active and there exists a Input Sequence, to filter out anything after the Input Sequence (including itself)
> It is just modified stop sequence code but for input in regards.

With KoboldAI Lite, it uses the start sequence as a stop sequence by default and I think this change would add this feature into ST, making more improvements for many models that work well in KAI Lite in ST itself.