### PR TITLE
Quick-reply enhancements +fix

### DIFF
--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -1,4 +1,4 @@
-import { saveSettingsDebounced, callPopup, getRequestHeaders } from "../../../script.js";
+import { saveSettingsDebounced, callPopup, getRequestHeaders, substituteParams } from "../../../script.js";
 import { getContext, extension_settings } from "../../extensions.js";
 import { initScrollHeight, resetScrollHeight } from "../../utils.js";
 import { executeSlashCommands, getSlashCommandsHelp, registerSlashCommand } from "../../slash-commands.js";
@@ -137,11 +137,7 @@ async function sendQuickReply(index) {
         newText = prompt + ' ';
     }
 
-    const context = getContext();
-    const username = context.name1;
-    const charname = context.name2;
-
-    newText = newText.replace('{{char}}', charname).replace('{{user}}', username);
+    newText = substituteParams(newText);
 
     $("#send_textarea").val(newText);
 

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -105,12 +105,12 @@ async function onQuickReplyEnabledInput() {
 
 // New function to handle input on quickActionEnabled
 async function onQuickActionEnabledInput() {
-    extension_settings.quickReply.quickActionEnabled = $(this).prop('checked');
+    extension_settings.quickReply.quickActionEnabled = !!$(this).prop('checked');
     saveSettingsDebounced();
 }
 
-async function onplaceBeforePromptEnabledInput() {
-    extension_settings.quickReply.placeBeforePromptEnabled = $(this).prop('checked');
+async function onPlaceBeforePromptEnabledInput() {
+    extension_settings.quickReply.placeBeforePromptEnabled = !!$(this).prop('checked');
     saveSettingsDebounced();
 }
 
@@ -127,10 +127,10 @@ async function sendQuickReply(index) {
 
     if (existingText) {
         // If existing text, add space after prompt
-        if($("#placeBeforePromptEnabled").prop('checked')){
-            newText = prompt + ' ' + existingText + ' ';
-        }else{
-            newText = existingText + ' ' + prompt + ' ';
+        if (extension_settings.quickReply.placeBeforePromptEnabled) {
+            newText = `${prompt} ${existingText} `;
+        } else {
+            newText = `${existingText} ${prompt} `;
         }
     } else {
         // If no existing text, add prompt only (with a trailing space)
@@ -146,7 +146,7 @@ async function sendQuickReply(index) {
 
     // Only trigger send button if quickActionEnabled is not checked or 
     // the prompt starts with '/'
-    if (!$("#quickActionEnabled").prop('checked') || prompt.startsWith('/')) {
+    if (!extension_settings.quickReply.quickActionEnabled || prompt.startsWith('/')) {
         $("#send_but").trigger('click');
     }
 }
@@ -382,7 +382,7 @@ jQuery(async () => {
     
     // Add event handler for quickActionEnabled
     $('#quickActionEnabled').on('input', onQuickActionEnabledInput);
-    $('#placeBeforePromptEnabled').on('input', onplaceBeforePromptEnabledInput);
+    $('#placeBeforePromptEnabled').on('input', onPlaceBeforePromptEnabledInput);
     $('#quickReplyEnabled').on('input', onQuickReplyEnabledInput);
     $('#quickReplyNumberOfSlotsApply').on('click', onQuickReplyNumberOfSlotsInput);
     $("#quickReplyPresetSaveButton").on('click', saveQuickReplyPreset);


### PR DESCRIPTION
- fixed quickActionEnabled setting not loading
- added "Place Quick-reply before the prompt" checkbox, which instead of "user's prompt + quick reply prompt" does "quick reply prompt + user's prompt"
- added {{user}} and {{char}} functionality(for things like /sendas {{char}})