### PR TITLE
Old Default context template

### DIFF
--- a/public/context/OldDefault.json
+++ b/public/context/OldDefault.json
@@ -1,0 +1,6 @@
+{
+    "story_string": "{{#if system}}{{system}}\n{{/if}}{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Circumstances and context of the dialogue: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{persona}}\n{{/if}}",
+    "chat_start": "\nThen the roleplay chat between {{user}} and {{char}} begins.\n",
+    "example_separator": "This is how {{char}} should talk",
+    "name": "OldDefault"
+}


### PR DESCRIPTION
Mirrors the old prompting style to a T.
Can only be merged after the PR to add macros to the Example Separator + Chat Start is merged, as it will not handle {{char}} and {{user}} strings correctly.