### PR TITLE
Added publishing of docker images on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,8 +10,8 @@ on:
 env:
   # This should allow creation of docker images even in forked repositories
   # Image name may not contain uppercase characters, so we can not use the repository name
-  # Creates a string like: ghcr.io/SillyTavern/silly-tavern
-  image_name: ghcr.io/${{ github.repository_owner }}/silly-tavern
+  # Creates a string like: ghcr.io/SillyTavern/sillytavern
+  image_name: ghcr.io/${{ github.repository_owner }}/sillytavern
 
 jobs:
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,45 @@
+# This workflow will publish a docker image for every full release to the GitHub package repository
+
+name: Create Docker Image on Release
+
+on:
+  release:
+    # Only runs on full releases not pre releases
+    types: [released]
+
+env:
+  # This should allow creation of docker images even in forked repositories
+  # Image name may not contain uppercase characters, so we can not use the repository name
+  # Creates a string like: ghcr.io/SillyTavern/silly-tavern
+  image_name: ghcr.io/${{ github.repository_owner }}/silly-tavern
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Build docker image using dockerfile and tag it with branch name
+      # Assumes branch name is the version number
+      - name: Build the Docker image
+        run: |
+          docker build . --file Dockerfile --tag $image_name:${{ github.ref_name }}
+
+      # Login into package repository as the person who created the release
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Assumes release is the latest and marks image as such
+      - name: Docker Tag and Push
+        run: |
+          docker tag $image_name:${{ github.ref_name }} $image_name:latest
+          docker push $image_name:${{ github.ref_name }}
+          docker push $image_name:latest


### PR DESCRIPTION
Hi,

since I am using docker to run SillyTavern for myself, I noticed that you do not publish any docker images.
Currently my images are self build, but I thought others could profit from an automatic workflow that creates docker images for every release.

Setup and assumtions:

- Creates docker images for every full release created in github (Prereleases are currently ignored)
- Publishes to the github docker repository. Image name will look like: ghcr.io/SillyTavern/silly-tavern:\<tag name\>
- Assumes the tag name used for the release is the version number and will mark the image as such
- Assumes the publisher of a release has the necessary rights in the SillyTavern project to publish new docker images for the project package repository (May need setup by project owner)
- Assumes the release is latest (Since this does not run manually but automatically when a new release is created)

**EDIT** Testing this change:
Sadly github workflows are awful to debug and test, so below I listed steps to test this in the official repository.
I tested this in my repository, but since that is a personal repository rights are a little different.

- Create a tag containing the workflow file in the official SillyTavern project
- Then you need to create a full release using the created tag
- That should trigger the action and create a docker image into the github project package repository
- All of these (tag, release and package) can then be deleted by the project owner