### PR TITLE
Fix Docker by copying post-install.js into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENTRYPOINT [ "tini", "--" ]
 WORKDIR ${APP_HOME}
 
 # Install app dependencies
-COPY package*.json ./
+COPY package*.json post-install.js ./
 RUN \
   echo "*** Install npm packages ***" && \
   npm install && npm cache clean --force


### PR DESCRIPTION
Building the Docker image currently doesn't work, because the `post-install.js` script is missing when `npm install` is run in the `Dockerfile`.