### PR TITLE
Update docker-compose.yml to keep images

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,4 +9,5 @@ services:
       - "8000:8000"
     volumes:
       - "./config:/home/node/app/config"
+      - "./user:/home/node/app/public/user"
     restart: unless-stopped


### PR DESCRIPTION
Images provided by stable diffusion are lost on reset, this mounts them to a volume instead.