### PR TITLE
Custom --grammar support [for koboldcpp]

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -278,24 +278,6 @@
                                     </div>
                                 </div>
 
-                            <hr>
-
-                            <div id="grammar_block">
-                                <div class="range-block">
-                                    <label class="input_label widthFreeExpand">
-                                        <span data-i18n="Grammar">Grammar:</span>
-                                        <input id="grammar" type="text" style="background-color: black; color: white;" />
-                                    </label>
-                                    <div class="toggle-description justifyLeft">
-                                        <span data-i18n="Type in the desired custom grammar (GBNF).">
-                                            Type in the desired custom grammar (<a href="https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md" target="_blank">GBNF</a>).
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <hr>
-
                                 <div class="range-block">
                                     <div class="range-block-title" data-i18n="temperature">
                                         Temperature
@@ -1076,6 +1058,18 @@
                                                 <div contenteditable="true" data-for="mirostat_eta_kobold" id="mirostat_eta_counter_kobold">
                                                     select
                                                 </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <hr>
+                                    <div id="grammar_block">
+                                        <h4 data-i18n="Grammar">Grammar</h4>
+                                        <div class="range-block">
+                                            <textarea id="grammar" rows="2" class="text_pole textarea_compact monospace"></textarea>
+                                            <div class="toggle-description justifyLeft">
+                                                <span data-i18n="Type in the desired custom grammar (GBNF).">
+                                                    Type in the desired custom grammar (<a href="https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md" target="_blank">GBNF</a>).
+                                                </span>
                                             </div>
                                         </div>
                                     </div>
@@ -1954,7 +1948,7 @@
                                     </optgroup>
                                     <optgroup label="GPT-3.5 Turbo Instruct">
                                         <option value="gpt-3.5-turbo-instruct">gpt-3.5-turbo-instruct</option>
-                                        <option value="gpt-3.5-turbo-instruct-0914">gpt-3.5-turbo-instruct-0914</option>                                    
+                                        <option value="gpt-3.5-turbo-instruct-0914">gpt-3.5-turbo-instruct-0914</option>
                                     </optgroup>
                                     <optgroup label="GPT-4">
                                         <option value="gpt-4">gpt-4</option>

--- a/public/index.html
+++ b/public/index.html
@@ -277,6 +277,21 @@
                                         </div>
                                     </div>
                                 </div>
+
+                            <div id="grammar_block">
+                                <div class="range-block">
+                                    <label class="input_label widthFreeExpand">
+                                        <span data-i18n="Grammar">Grammar:</span>
+                                        <input id="grammar" type="text" style="background-color: black; color: white;" />
+                                    </label>
+                                    <div class="toggle-description justifyLeft">
+                                        <span data-i18n="Type in the desired value for the grammar string.">
+                                            Type in the desired value for the grammar string.
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+
                                 <div class="range-block">
                                     <div class="range-block-title" data-i18n="temperature">
                                         Temperature

--- a/public/index.html
+++ b/public/index.html
@@ -278,6 +278,8 @@
                                     </div>
                                 </div>
 
+                            <hr>
+
                             <div id="grammar_block">
                                 <div class="range-block">
                                     <label class="input_label widthFreeExpand">
@@ -285,12 +287,14 @@
                                         <input id="grammar" type="text" style="background-color: black; color: white;" />
                                     </label>
                                     <div class="toggle-description justifyLeft">
-                                        <span data-i18n="Type in the desired value for the grammar string.">
-                                            Type in the desired value for the grammar string.
+                                        <span data-i18n="Type in the desired custom grammar (GBNF).">
+                                            Type in the desired custom grammar (<a href="https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md" target="_blank">GBNF</a>).
                                         </span>
                                     </div>
                                 </div>
                             </div>
+
+                            <hr>
 
                                 <div class="range-block">
                                     <div class="range-block-title" data-i18n="temperature">

--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -26,7 +26,7 @@ export const kai_settings = {
     mirostat_tau: 5.0,
     mirostat_eta: 0.1,
     use_default_badwordsids: true,
-    grammar: "hardcoded",
+    grammar: "",
 };
 
 export const kai_flags = {

--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -26,6 +26,7 @@ export const kai_settings = {
     mirostat_tau: 5.0,
     mirostat_eta: 0.1,
     use_default_badwordsids: true,
+    grammar: "hardcoded",
 };
 
 export const kai_flags = {
@@ -84,10 +85,16 @@ export function loadKoboldSettings(preset) {
         kai_settings.use_default_badwordsids = preset.use_default_badwordsids;
         $('#use_default_badwordsids').prop('checked', kai_settings.use_default_badwordsids);
     }
+    if (preset.hasOwnProperty('grammar')) {
+        kai_settings.grammar = preset.grammar;
+        $('#grammar').val(kai_settings.grammar);
+    }
+
 }
 
 export function getKoboldGenerationData(finalPrompt, this_settings, this_amount_gen, this_max_context, isImpersonate, type) {
     const sampler_order = kai_settings.sampler_order || this_settings.sampler_order;
+
     let generate_data = {
         prompt: finalPrompt,
         gui_settings: false,
@@ -119,6 +126,7 @@ export function getKoboldGenerationData(finalPrompt, this_settings, this_amount_
         mirostat_tau: kai_flags.can_use_mirostat ? kai_settings.mirostat_tau : undefined,
         mirostat_eta: kai_flags.can_use_mirostat ? kai_settings.mirostat_eta : undefined,
         use_default_badwordsids: kai_flags.can_use_default_badwordsids ? kai_settings.use_default_badwordsids : undefined,
+        grammar: kai_settings.grammar,
     };
     return generate_data;
 }
@@ -257,6 +265,7 @@ const sliders = [
         format: (val) => val,
         setValue: (val) => { kai_settings.mirostat_eta = Number(val); },
     },
+    
 ];
 
 export function setKoboldFlags(version, koboldVersion) {
@@ -348,6 +357,12 @@ jQuery(function () {
     $('#streaming_kobold').on("input", function () {
         const value = !!$(this).prop('checked');
         kai_settings.streaming_kobold = value;
+        saveSettingsDebounced();
+    });
+
+    $('#grammar').on("input", function () {
+        const value = $(this).val().toString(); // Even though it's redundant, this ensures the value is a string.
+        kai_settings.grammar = value;
         saveSettingsDebounced();
     });
 

--- a/server.js
+++ b/server.js
@@ -375,6 +375,7 @@ app.post("/generate", jsonParser, async function (request, response_generate) {
             mirostat: request.body.mirostat,
             mirostat_eta: request.body.mirostat_eta,
             mirostat_tau: request.body.mirostat_tau,
+            grammar: request.body.grammar,
         };
         if (!!request.body.stop_sequence) {
             this_settings['stop_sequence'] = request.body.stop_sequence;


### PR DESCRIPTION
![image](https://github.com/SillyTavern/SillyTavern/assets/66376113/457a6d7b-e9c5-4e0e-9e75-35f6efbce226)

Allows for custom [GBNF prompting](https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md) through SillyTavern with koboldcpp. Probably doesn't work with horde? Unsure.
It would be nice to substitute {{char}} and {{user}} properly in that string.