### PR TITLE
Multi LLMAPI proof of concept

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -763,50 +763,96 @@ async function getStatus() {
             return;
         }
 
-        jQuery.ajax({
-            type: "POST", //
-            url: "/getstatus", //
-            data: JSON.stringify({
-                api_server: main_api == "kobold" ? api_server : api_server_textgenerationwebui,
-                main_api: main_api,
-                use_mancer: main_api == "textgenerationwebui" ? api_use_mancer_webui : false,
-            }),
-            beforeSend: function () { },
-            cache: false,
-            dataType: "json",
-            crossDomain: true,
-            contentType: "application/json",
-            //processData: false,
-            success: function (data) {
-                online_status = data.result;
-                if (online_status == undefined) {
+        if(api_server_textgenerationwebui.includes(','))
+            const arr_api_server_textgenerationwebui = api_server_textgenerationwebui.split(',');
+            jQuery.ajax({
+                type: "POST", //
+                url: "/getstatus", //
+                data: JSON.stringify({
+                    api_server: main_api == "kobold" ? api_server : arr_api_server_textgenerationwebui[0],
+                    main_api: main_api,
+                    use_mancer: main_api == "textgenerationwebui" ? api_use_mancer_webui : false,
+                }),
+                beforeSend: function () { },
+                cache: false,
+                dataType: "json",
+                crossDomain: true,
+                contentType: "application/json",
+                //processData: false,
+                success: function (data) {
+                    online_status = data.result;
+                    if (online_status == undefined) {
+                        online_status = "no_connection";
+                    }
+    
+                    // Determine instruct mode preset
+                    autoSelectInstructPreset(online_status);
+    
+                    // determine if we can use stop sequence and streaming
+                    if (main_api === "kobold" || main_api === "koboldhorde") {
+                        setKoboldFlags(data.version, data.koboldVersion);
+                    }
+    
+                    // We didn't get a 200 status code, but the endpoint has an explanation. Which means it DID connect, but I digress.
+                    if (online_status == "no_connection" && data.response) {
+                        toastr.error(data.response, "API Error", { timeOut: 5000, preventDuplicates: true })
+                    }
+    
+                    //console.log(online_status);
+                    resultCheckStatus();
+                    jQuery.ajax({
+                        type: "POST", //
+                        url: "/getstatus", //
+                        data: JSON.stringify({
+                            api_server: main_api == "kobold" ? api_server : arr_api_server_textgenerationwebui[1],
+                            main_api: main_api,
+                            use_mancer: main_api == "textgenerationwebui" ? api_use_mancer_webui : false,
+                        }),
+                        beforeSend: function () { },
+                        cache: false,
+                        dataType: "json",
+                        crossDomain: true,
+                        contentType: "application/json",
+                        //processData: false,
+                        success: function (data) {
+                            online_status = online_status+', '+data.result;
+                            if (online_status == undefined) {
+                                online_status = "no_connection";
+                            }
+            
+                            // Determine instruct mode preset
+                            autoSelectInstructPreset(online_status);
+            
+                            // determine if we can use stop sequence and streaming
+                            if (main_api === "kobold" || main_api === "koboldhorde") {
+                                setKoboldFlags(data.version, data.koboldVersion);
+                            }
+            
+                            // We didn't get a 200 status code, but the endpoint has an explanation. Which means it DID connect, but I digress.
+                            if (online_status == "no_connection" && data.response) {
+                                toastr.error(data.response, "API Error", { timeOut: 5000, preventDuplicates: true })
+                            }
+            
+                            //console.log(online_status);
+                            resultCheckStatus();
+                        },
+                        error: function (jqXHR, exception) {
+                            console.log(exception);
+                            console.log(jqXHR);
+                            online_status = "no_connection";
+            
+                            resultCheckStatus();
+                        },
+                    });
+                },
+                error: function (jqXHR, exception) {
+                    console.log(exception);
+                    console.log(jqXHR);
                     online_status = "no_connection";
-                }
-
-                // Determine instruct mode preset
-                autoSelectInstructPreset(online_status);
-
-                // determine if we can use stop sequence and streaming
-                if (main_api === "kobold" || main_api === "koboldhorde") {
-                    setKoboldFlags(data.version, data.koboldVersion);
-                }
-
-                // We didn't get a 200 status code, but the endpoint has an explanation. Which means it DID connect, but I digress.
-                if (online_status == "no_connection" && data.response) {
-                    toastr.error(data.response, "API Error", { timeOut: 5000, preventDuplicates: true })
-                }
-
-                //console.log(online_status);
-                resultCheckStatus();
-            },
-            error: function (jqXHR, exception) {
-                console.log(exception);
-                console.log(jqXHR);
-                online_status = "no_connection";
-
-                resultCheckStatus();
-            },
-        });
+    
+                    resultCheckStatus();
+                },
+            });
     } else {
         if (is_get_status_novel != true && is_get_status_openai != true) {
             online_status = "no_connection";

--- a/public/script.js
+++ b/public/script.js
@@ -3192,45 +3192,42 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                 streamingProcessor.generator = await generateKoboldWithStreaming(generate_data, streamingProcessor.abortController.signal);
             }
             else {
-                if(api_server.includes(','))) {
-                    const arr_api_server = arr_api_server.split(',');
+                if(api_server_textgenerationwebui.includes(',')) {
+                    const arr_api_server_textgenerationwebui = api_server_textgenerationwebui.split(',');
                     try {
-                        generate_data.api_server = arr_api_server[0];
-                        const response = await fetch(generate_url, {
+                        generate_data.api_server = arr_api_server_textgenerationwebui[0];
+                        console.log(generate_data.api_server)
+                        fetch(generate_url, {
                             method: 'POST',
                             headers: getRequestHeaders(),
                             cache: 'no-cache',
                             body: JSON.stringify(generate_data),
                             signal: abortController.signal,
+                        }).then(response => {
+                            if (!response.ok) {
+                                const error = response.json();
+                                throw error;
+                            }
+        
+                            response.json().then(data => onSuccess(data));
                         });
     
-                        if (!response.ok) {
-                            const error = await response.json();
-                            throw error;
-                        }
-    
-                        const data = await response.json();
-                        onSuccess(data);
-                    } catch (error) {
-                        onError(error);
-                    }
-                    try {
-                        generate_data.api_server = arr_api_server[1];
-                        const response = await fetch(generate_url, {
+                        generate_data.api_server = arr_api_server_textgenerationwebui[1];
+                        console.log(generate_data.api_server)
+                        fetch(generate_url, {
                             method: 'POST',
                             headers: getRequestHeaders(),
                             cache: 'no-cache',
                             body: JSON.stringify(generate_data),
                             signal: abortController.signal,
+                        }).then(response => {
+                            if (!response.ok) {
+                                const error = response.json();
+                                throw error;
+                            }
+        
+                            response.json().then(data => onSuccess(data));
                         });
-    
-                        if (!response.ok) {
-                            const error = await response.json();
-                            throw error;
-                        }
-    
-                        const data = await response.json();
-                        onSuccess(data);
                     } catch (error) {
                         onError(error);
                     }
@@ -7740,11 +7737,12 @@ jQuery(async function () {
     $("#api_button_textgenerationwebui").click(async function (e) {
         const url_source = api_use_mancer_webui ? "#mancer_api_url_text" : "#textgenerationwebui_api_url_text";
         if ($(url_source).val() != "") {
-            let value = formatTextGenURL(String($(url_source).val()).trim(), api_use_mancer_webui);
-            if (!value) {
-                callPopup("Please enter a valid URL.<br/>WebUI URLs should end with <tt>/api</tt><br/>Enable 'Relaxed API URLs' to allow other paths.", 'text');
-                return;
-            }
+            let value = String($(url_source).val()).trim();
+            //let value = formatTextGenURL(String($(url_source).val()).trim(), api_use_mancer_webui);
+            //if (!value) {
+            //    callPopup("Please enter a valid URL.<br/>WebUI URLs should end with <tt>/api</tt><br/>Enable 'Relaxed API URLs' to allow other paths.", 'text');
+            //    return;
+            //}
 
             const mancer_key = String($("#api_key_mancer").val()).trim();
             if (mancer_key.length) {

--- a/public/script.js
+++ b/public/script.js
@@ -3192,24 +3192,68 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                 streamingProcessor.generator = await generateKoboldWithStreaming(generate_data, streamingProcessor.abortController.signal);
             }
             else {
-                try {
-                    const response = await fetch(generate_url, {
-                        method: 'POST',
-                        headers: getRequestHeaders(),
-                        cache: 'no-cache',
-                        body: JSON.stringify(generate_data),
-                        signal: abortController.signal,
-                    });
-
-                    if (!response.ok) {
-                        const error = await response.json();
-                        throw error;
+                if(api_server.includes(','))) {
+                    const arr_api_server = arr_api_server.split(',');
+                    try {
+                        generate_data.api_server = arr_api_server[0];
+                        const response = await fetch(generate_url, {
+                            method: 'POST',
+                            headers: getRequestHeaders(),
+                            cache: 'no-cache',
+                            body: JSON.stringify(generate_data),
+                            signal: abortController.signal,
+                        });
+    
+                        if (!response.ok) {
+                            const error = await response.json();
+                            throw error;
+                        }
+    
+                        const data = await response.json();
+                        onSuccess(data);
+                    } catch (error) {
+                        onError(error);
                     }
-
-                    const data = await response.json();
-                    onSuccess(data);
-                } catch (error) {
-                    onError(error);
+                    try {
+                        generate_data.api_server = arr_api_server[1];
+                        const response = await fetch(generate_url, {
+                            method: 'POST',
+                            headers: getRequestHeaders(),
+                            cache: 'no-cache',
+                            body: JSON.stringify(generate_data),
+                            signal: abortController.signal,
+                        });
+    
+                        if (!response.ok) {
+                            const error = await response.json();
+                            throw error;
+                        }
+    
+                        const data = await response.json();
+                        onSuccess(data);
+                    } catch (error) {
+                        onError(error);
+                    }
+                } else {
+                    try {
+                        const response = await fetch(generate_url, {
+                            method: 'POST',
+                            headers: getRequestHeaders(),
+                            cache: 'no-cache',
+                            body: JSON.stringify(generate_data),
+                            signal: abortController.signal,
+                        });
+    
+                        if (!response.ok) {
+                            const error = await response.json();
+                            throw error;
+                        }
+    
+                        const data = await response.json();
+                        onSuccess(data);
+                    } catch (error) {
+                        onError(error);
+                    }
                 }
             }
 

--- a/server.js
+++ b/server.js
@@ -454,7 +454,7 @@ app.post("/generate", jsonParser, async function (request, response_generate) {
 //************** Text generation web UI
 app.post("/generate_textgenerationwebui", jsonParser, async function (request, response_generate) {
     if (!request.body) return response_generate.sendStatus(400);
-    api_server = request.body.api_server;
+    if (request.body.api_server) api_server = request.body.api_server;
     console.log(request.body);
 
     const controller = new AbortController();

--- a/server.js
+++ b/server.js
@@ -454,7 +454,7 @@ app.post("/generate", jsonParser, async function (request, response_generate) {
 //************** Text generation web UI
 app.post("/generate_textgenerationwebui", jsonParser, async function (request, response_generate) {
     if (!request.body) return response_generate.sendStatus(400);
-
+    api_server = request.body.api_server;
     console.log(request.body);
 
     const controller = new AbortController();


### PR DESCRIPTION
THIS IS A DRAFT

Setup like this:
![image](https://github.com/SillyTavern/SillyTavern/assets/6138806/a08c564e-30a5-4f75-ba6a-57aee70216db)

Then click `sent_but`, it will trigger both API, and the {{char}} will response twice:
![image](https://github.com/SillyTavern/SillyTavern/assets/6138806/9e3a8d70-69b4-42e1-9adc-bd5a4990f830)
![image](https://github.com/SillyTavern/SillyTavern/assets/6138806/a534ba34-e681-4471-8f4d-329bdd035675)

In 2 local API the performance won't improve much (Because two backend sharing 50% of CUDA), should use 2 online API / 1 local API + 1 online API to have x2 time performance (for swipe or group chat).
