### PR TITLE
chore: fix href for aphrodite

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1928,7 +1928,7 @@
                             </div>
                             <div data-tg-type="aphrodite">
                                 <div class="flex-container flexFlowColumn">
-                                    <a href="https://github.com/oobabooga/text-generation-webui" target="_blank">
+                                    <a href="https://github.com/PygmalionAI/aphrodite-engine" target="_blank">
                                         PygmalionAI/aphrodite-engine
                                     </a>
                                 </div>


### PR DESCRIPTION
The current href leads to text-generation-webui, this PR changes that to the correct URL.