### PR TITLE
Better wi 2

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -170,7 +170,12 @@
 }
 
 .disabledWIEntry {
-    opacity: 0.2;
+    opacity: 0.4;
+    filter: grayscale(1);
+}
+
+.disabledWIEntry:hover {
+    opacity: 1.0;
     filter: grayscale(1);
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -3940,7 +3940,7 @@
                                         (ignored if empty)
                                     </span>
                                 </small>
-                                <div class="flex-container flexFlowRow">
+                                <div class="flex-container flexFlowRow alignitemscenter">
                                     <textarea class="text_pole keysecondarytextpole" name="keysecondary" rows="1" data-i18n="[placeholder]Comma separated (ignored if empty)" placeholder="Comma separated (ignored if empty)" maxlength="1000"></textarea>
                                     <i class="menu_button delete_entry_button fa-solid fa-trash-can" type="submit" data-i18n="" value="" /></i>
                                 </div>
@@ -4082,9 +4082,9 @@
                             </div>
 
                         </div>
-                        
+
                     </div>
- 
+
                 </div>
             </form>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -3912,7 +3912,7 @@
                             <small>
                                 <span>
                                     <span class="world_entry_form_position_value"></span>
-                                    <select name="entryStateSelector" class="widthNatural height32px margin0">
+                                    <select title="State of this entry:&#13;&#13; ! - Constant&#13; O - Normal&#13; X - Disabled" name="entryStateSelector" class="widthNatural height32px margin0">
                                         <option value="constant">!</option>
                                         <option value="normal">O</option>
                                         <option value="disabled">X</option>


### PR DESCRIPTION
Another small QoL improvements in WI editor.

1. Mouse over tooltip for the new three-positional switch.
2. Disabled entry slightly better visibility - with 0.2 it's often not possible to read text (but it's still needed even on disabled entry).
3. On mouse over, on the disabled entry - it's faded effect turned off (only while mouse still over).

As 3 don't apply to mobile and other sensor screens, 2 is still important.