### PR TITLE
Add Lightning 1.1 Context and Instruct templates

### DIFF
--- a/public/context/Lightning 1.1.json
+++ b/public/context/Lightning 1.1.json
@@ -1,0 +1,6 @@
+{
+    "story_string": "{{system}}\n{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{char}}’s description:{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality:{{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{user}}’s persona: {{persona}}\n{{/if}}",
+    "chat_start": "This is the history of the roleplay:",
+    "example_separator": "Example of an interaction:",
+    "name": "Lightning 1.1"
+}

--- a/public/context/Lightning 1.1.json
+++ b/public/context/Lightning 1.1.json
@@ -1,5 +1,5 @@
 {
-    "story_string": "{{system}}\n{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{char}}’s description:{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality:{{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{user}}’s persona: {{persona}}\n{{/if}}",
+    "story_string": "{{system}}\n{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{char}}'s description:{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality:{{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{user}}'s persona: {{persona}}\n{{/if}}",
     "chat_start": "This is the history of the roleplay:",
     "example_separator": "Example of an interaction:",
     "name": "Lightning 1.1"

--- a/public/instruct/Lightning 1.1.json
+++ b/public/instruct/Lightning 1.1.json
@@ -1,0 +1,18 @@
+{
+    "wrap": true,
+    "names": false,
+    "system_prompt": "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:\nTake the role of {{char}} in a play that leaves a lasting impression on {{user}}.  Write {{char}}'s next reply.\nNever skip or gloss over {{char}}’s actions. Progress the scene at a naturally slow pace.\n\n",
+    "system_sequence": "",
+    "stop_sequence": "",
+    "input_sequence": "### Instruction:",
+    "output_sequence": "### Response: (length = unlimited)",
+    "separator_sequence": "",
+    "macro": true,
+    "names_force_groups": true,
+    "last_output_sequence": "",
+    "system_sequence_prefix": "",
+    "system_sequence_suffix": "",
+    "first_output_sequence": "",
+    "activation_regex": "",
+    "name": "Lightning 1.1"
+}

--- a/public/instruct/Lightning 1.1.json
+++ b/public/instruct/Lightning 1.1.json
@@ -1,7 +1,7 @@
 {
     "wrap": true,
     "names": false,
-    "system_prompt": "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:\nTake the role of {{char}} in a play that leaves a lasting impression on {{user}}.  Write {{char}}'s next reply.\nNever skip or gloss over {{char}}’s actions. Progress the scene at a naturally slow pace.\n\n",
+    "system_prompt": "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:\nTake the role of {{char}} in a play that leaves a lasting impression on {{user}}. Write {{char}}'s next reply.\nNever skip or gloss over {{char}}’s actions. Progress the scene at a naturally slow pace.\n\n",
     "system_sequence": "",
     "stop_sequence": "",
     "input_sequence": "### Instruction:",


### PR DESCRIPTION
These are the context and instruct templates for "Lightning" -- an Alpaca-like, highly RP-focused configuration that the community has been honing over the past several months around MythoMax 13B, ReMM-type models, Synthia-based "20B" hybrid models, and 7B Mystral models.

When combined with an AN block injected further down the prompt, RP and ERP performance with these types of models has been dramatically more pleasant for most users.  This is particularly the case with Mirostat at high Tau and Eta values ("Gold" or even "Platinum" with higher quants above 4-bit).

Documentation, such as it is, of the feature as well as the current and prior ANs intended for injection is at: [Improving your LLM RP results with Lightning](https://gist.github.com/majick/5d0f61be41f66587846c9174c5cd7848)