### PR TITLE
Fix greeting message continue

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2690,7 +2690,8 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
             pinExmString = examplesString = mesExamplesArray.join('');
         }
 
-        if (isContinue) {
+        // Only add the chat in context if past the greeting message
+        if (isContinue && chat2.length > 1) {
             cyclePrompt = chat2.shift();
         }
 


### PR DESCRIPTION
See commit message. Author's note and extension prompts weren't being added properly due to mesSend being empty at the first message.