### PR TITLE
Check for errors on the `stream_end` event

### DIFF
--- a/server.js
+++ b/server.js
@@ -627,6 +627,9 @@ app.post("/generate_textgenerationwebui", jsonParser, async function (request, r
                         yield message.text;
                         break;
                     case 'stream_end':
+                        if (message.error) {
+                            yield `\n[API Error] ${message.error}\n`
+                        }
                         websocket.close();
                         return;
                 }


### PR DESCRIPTION
Less horrifying than Mancer's current "I'm going to stream the error as if it's text output".

Still not ideal from an ST UX perspective, but better solutions would require a complete overhaul of how streamed text is communicated from `server.js` to `script.js`.