### PR TITLE
Make v2 spec read logspam at least slightly actionable.  Slightly.

### DIFF
--- a/server.js
+++ b/server.js
@@ -858,7 +858,7 @@ function unsetFavFlag(char) {
 
 function readFromV2(char) {
     if (_.isUndefined(char.data)) {
-        console.warn('Spec v2 data missing');
+        console.warn('Char ${char['name']} has Spec v2 data missing');
         return char;
     }
 
@@ -893,12 +893,12 @@ function readFromV2(char) {
                 //console.debug(`Spec v2 extension data missing for field: ${charField}, using default value: ${defaultValue}`);
                 char[charField] = defaultValue;
             } else {
-                console.debug(`Spec v2 data missing for unknown field: ${charField}`);
+                console.debug(`Char ${char['name']} has Spec v2 data missing for unknown field: ${charField}`);
                 return;
             }
         }
         if (!_.isUndefined(char[charField]) && !_.isUndefined(v2Value) && String(char[charField]) !== String(v2Value)) {
-            console.debug(`Spec v2 data mismatch with Spec v1 for field: ${charField}`, char[charField], v2Value);
+            console.debug(`Char ${char['name']} has Spec v2 data mismatch with Spec v1 for field: ${charField}`, char[charField], v2Value);
         }
         char[charField] = v2Value;
     });

--- a/server.js
+++ b/server.js
@@ -858,7 +858,7 @@ function unsetFavFlag(char) {
 
 function readFromV2(char) {
     if (_.isUndefined(char.data)) {
-        console.warn('Char ${char['name']} has Spec v2 data missing');
+        console.warn(`Char ${char['name']} has Spec v2 data missing`);
         return char;
     }
 


### PR DESCRIPTION
The existing logspam doesn't even tell the user what char is failing, which means it's just going to emit every startup, forever, grinding at the poor user's soul, never letting them know *which* of their 352 cards is causing the spam... day after day after day.  Until one day, the poor beleaguered user will emit the world's ugliest PR to at least find the broken card in an attempt kill it.

Ask me how I know.