### PR TITLE
Force open char WI selector with Shift-click

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1094,7 +1094,7 @@ function createWorldInfoEntry(name, data) {
         selectiveLogic: 0,
         addMemo: false,
         order: 100,
-        position: 0,
+        position: 1,
         disable: false,
         excludeRecursion: false,
         probability: 100,
@@ -2086,13 +2086,13 @@ jQuery(() => {
         if (chid) {
             const worldName = characters[chid]?.data?.extensions?.world;
             const hasEmbed = checkEmbeddedWorld(chid);
-            if (worldName && world_names.includes(worldName)) {
+            if (worldName && world_names.includes(worldName) && !event.shiftKey) {
                 if (!$('#WorldInfo').is(':visible')) {
                     $('#WIDrawerIcon').trigger('click');
                 }
                 const index = world_names.indexOf(worldName);
                 $("#world_editor_select").val(index).trigger('change');
-            } else if (hasEmbed) {
+            } else if (hasEmbed && !event.shiftKey) {
                 await importEmbeddedWorldInfo();
                 saveCharacterDebounced();
             }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1094,7 +1094,7 @@ function createWorldInfoEntry(name, data) {
         selectiveLogic: 0,
         addMemo: false,
         order: 100,
-        position: 1,
+        position: 0,
         disable: false,
         excludeRecursion: false,
         probability: 100,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2065,7 +2065,7 @@ jQuery(() => {
     });
 
     $('#world_info_character_strategy').on('change', function () {
-        world_info_character_strategy = $(this).val();
+        world_info_character_strategy = Number($(this).val());
         saveSettings();
     });
 
@@ -2080,7 +2080,7 @@ jQuery(() => {
         saveSettings();
     });
 
-    $('#world_button').on('click', async function () {
+    $('#world_button').on('click', async function (event) {
         const chid = $('#set_character_world').data('chid');
 
         if (chid) {


### PR DESCRIPTION
Small QoL - I don't like to use pull-down menu to access control elements that I use frequently. And setting character's WI is one of them.
This is allow to open selector of LoreBooks for a character with Shift-Click on the icon.
(Revert is: I prefer to have new WI with the After Character Definition position and forget about this change before doing file upload. Edited here.)