### PR TITLE
Better input inject Quick Reply

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2749,8 +2749,8 @@
                                     Alert On Overflow
                                 </small>
                             </label>
-                            <div id="WIInputWidthReference" style="display:none; height:1px;">10000</div>
                         </div>
+                        <div id="WIInputWidthReference" style="display:none; height:1px;">10000</div>
 
                     </div>
 

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -132,19 +132,14 @@ async function sendQuickReply(index) {
 
     let newText;
 
-    if (existingText) {
-        // If existing text, add space after prompt
-        if (extension_settings.quickReply.AutoInputInject){
-            if (extension_settings.quickReply.placeBeforePromptEnabled) {
-                newText = `${prompt} ${existingText} `;
-            } else {
-                newText = `${existingText} ${prompt} `;
-            }
-        }else{
-            newText = `${prompt} `;
+    if (existingText && extension_settings.quickReply.AutoInputInject){
+        if (extension_settings.quickReply.placeBeforePromptEnabled) {
+            newText = `${prompt} ${existingText} `;
+        } else {
+            newText = `${existingText} ${prompt} `;
         }
     } else {
-        // If no existing text, add prompt only (with a trailing space)
+        // If no existing text and placeBeforePromptEnabled false, add prompt only (with a trailing space)
         newText = `${prompt} `;
     }
 

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -15,7 +15,7 @@ const defaultSettings = {
     quickReplyEnabled: false,
     numberOfSlots: 5,
     quickReplySlots: [],
-    placeBeforePromptEnabled: false,
+    placeBeforeInputEnabled: false,
     quickActionEnabled: false,
     AutoInputInject: true
 }
@@ -78,7 +78,7 @@ async function loadSettings(type) {
 
     $('#quickReplyEnabled').prop('checked', extension_settings.quickReply.quickReplyEnabled);
     $('#quickReplyNumberOfSlots').val(extension_settings.quickReply.numberOfSlots);
-    $('#placeBeforePromptEnabled').prop('checked', extension_settings.quickReply.placeBeforePromptEnabled);
+    $('#placeBeforeInputEnabled').prop('checked', extension_settings.quickReply.placeBeforeInputEnabled);
     $('#quickActionEnabled').prop('checked', extension_settings.quickReply.quickActionEnabled);
     $('#AutoInputInject').prop('checked', extension_settings.quickReply.AutoInputInject);
 }
@@ -111,8 +111,8 @@ async function onQuickActionEnabledInput() {
     saveSettingsDebounced();
 }
 
-async function onPlaceBeforePromptEnabledInput() {
-    extension_settings.quickReply.placeBeforePromptEnabled = !!$(this).prop('checked');
+async function onPlaceBeforeInputEnabledInput() {
+    extension_settings.quickReply.placeBeforeInputEnabled = !!$(this).prop('checked');
     saveSettingsDebounced();
 }
 
@@ -133,13 +133,13 @@ async function sendQuickReply(index) {
     let newText;
 
     if (existingText && extension_settings.quickReply.AutoInputInject){
-        if (extension_settings.quickReply.placeBeforePromptEnabled) {
+        if (extension_settings.quickReply.placeBeforeInputEnabled) {
             newText = `${prompt} ${existingText} `;
         } else {
             newText = `${existingText} ${prompt} `;
         }
     } else {
-        // If no existing text and placeBeforePromptEnabled false, add prompt only (with a trailing space)
+        // If no existing text and placeBeforeInputEnabled false, add prompt only (with a trailing space)
         newText = `${prompt} `;
     }
 
@@ -361,8 +361,8 @@ jQuery(async () => {
                         Disable Send / Insert In User Input
                 </label>
                 <label class="checkbox_label marginBot10">
-                    <input id="placeBeforePromptEnabled" type="checkbox" />
-                        Place Quick-reply before the Prompt
+                    <input id="placeBeforeInputEnabled" type="checkbox" />
+                        Place Quick-reply before the Input
                 </label>
                 <label class="checkbox_label marginBot10">
                     <input id="AutoInputInject" type="checkbox" />
@@ -392,7 +392,7 @@ jQuery(async () => {
     
     // Add event handler for quickActionEnabled
     $('#quickActionEnabled').on('input', onQuickActionEnabledInput);
-    $('#placeBeforePromptEnabled').on('input', onPlaceBeforePromptEnabledInput);
+    $('#placeBeforeInputEnabled').on('input', onPlaceBeforeInputEnabledInput);
     $('#AutoInputInject').on('input', onAutoInputInject);
     $('#quickReplyEnabled').on('input', onQuickReplyEnabledInput);
     $('#quickReplyNumberOfSlotsApply').on('click', onQuickReplyNumberOfSlotsInput);

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -17,6 +17,7 @@ const defaultSettings = {
     quickReplySlots: [],
     placeBeforePromptEnabled: false,
     quickActionEnabled: false,
+    AutoInputInject: true
 }
 
 //method from worldinfo
@@ -79,6 +80,7 @@ async function loadSettings(type) {
     $('#quickReplyNumberOfSlots').val(extension_settings.quickReply.numberOfSlots);
     $('#placeBeforePromptEnabled').prop('checked', extension_settings.quickReply.placeBeforePromptEnabled);
     $('#quickActionEnabled').prop('checked', extension_settings.quickReply.quickActionEnabled);
+    $('#AutoInputInject').prop('checked', extension_settings.quickReply.AutoInputInject);
 }
 
 function onQuickReplyInput(id) {
@@ -114,6 +116,11 @@ async function onPlaceBeforePromptEnabledInput() {
     saveSettingsDebounced();
 }
 
+async function onAutoInputInject() {
+    extension_settings.quickReply.AutoInputInject = !!$(this).prop('checked');
+    saveSettingsDebounced();
+}
+
 async function sendQuickReply(index) {
     const existingText = $("#send_textarea").val();
     const prompt = extension_settings.quickReply.quickReplySlots[index]?.mes || '';
@@ -127,14 +134,18 @@ async function sendQuickReply(index) {
 
     if (existingText) {
         // If existing text, add space after prompt
-        if (extension_settings.quickReply.placeBeforePromptEnabled) {
-            newText = `${prompt} ${existingText} `;
-        } else {
-            newText = `${existingText} ${prompt} `;
+        if (extension_settings.quickReply.AutoInputInject){
+            if (extension_settings.quickReply.placeBeforePromptEnabled) {
+                newText = `${prompt} ${existingText} `;
+            } else {
+                newText = `${existingText} ${prompt} `;
+            }
+        }else{
+            newText = `${prompt} `;
         }
     } else {
         // If no existing text, add prompt only (with a trailing space)
-        newText = prompt + ' ';
+        newText = `${prompt} `;
     }
 
     newText = substituteParams(newText);
@@ -358,6 +369,10 @@ jQuery(async () => {
                     <input id="placeBeforePromptEnabled" type="checkbox" />
                         Place Quick-reply before the Prompt
                 </label>
+                <label class="checkbox_label marginBot10">
+                    <input id="AutoInputInject" type="checkbox" />
+                        Inject user input automatically (If disabled, use {{input}} macro for manual injection)
+                </label>
                 <div class="flex-container flexnowrap wide100p">
                     <select id="quickReplyPresets" name="quickreply-preset">
                     </select>
@@ -383,6 +398,7 @@ jQuery(async () => {
     // Add event handler for quickActionEnabled
     $('#quickActionEnabled').on('input', onQuickActionEnabledInput);
     $('#placeBeforePromptEnabled').on('input', onPlaceBeforePromptEnabledInput);
+    $('#AutoInputInject').on('input', onAutoInputInject);
     $('#quickReplyEnabled').on('input', onQuickReplyEnabledInput);
     $('#quickReplyNumberOfSlotsApply').on('click', onQuickReplyNumberOfSlotsInput);
     $("#quickReplyPresetSaveButton").on('click', saveQuickReplyPreset);

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1094,7 +1094,7 @@ function createWorldInfoEntry(name, data) {
         selectiveLogic: 0,
         addMemo: false,
         order: 100,
-        position: 0,
+        position: 1,
         disable: false,
         excludeRecursion: false,
         probability: 100,
@@ -2086,13 +2086,13 @@ jQuery(() => {
         if (chid) {
             const worldName = characters[chid]?.data?.extensions?.world;
             const hasEmbed = checkEmbeddedWorld(chid);
-            if (worldName && world_names.includes(worldName)) {
+            if (worldName && world_names.includes(worldName) && !event.shiftKey) {
                 if (!$('#WorldInfo').is(':visible')) {
                     $('#WIDrawerIcon').trigger('click');
                 }
                 const index = world_names.indexOf(worldName);
                 $("#world_editor_select").val(index).trigger('change');
-            } else if (hasEmbed) {
+            } else if (hasEmbed && !event.shiftKey) {
                 await importEmbeddedWorldInfo();
                 saveCharacterDebounced();
             }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1094,7 +1094,7 @@ function createWorldInfoEntry(name, data) {
         selectiveLogic: 0,
         addMemo: false,
         order: 100,
-        position: 1,
+        position: 0,
         disable: false,
         excludeRecursion: false,
         probability: 100,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2065,7 +2065,7 @@ jQuery(() => {
     });
 
     $('#world_info_character_strategy').on('change', function () {
-        world_info_character_strategy = $(this).val();
+        world_info_character_strategy = Number($(this).val());
         saveSettings();
     });
 
@@ -2080,7 +2080,7 @@ jQuery(() => {
         saveSettings();
     });
 
-    $('#world_button').on('click', async function () {
+    $('#world_button').on('click', async function (event) {
         const chid = $('#set_character_world').data('chid');
 
         if (chid) {

--- a/public/style.css
+++ b/public/style.css
@@ -3569,6 +3569,7 @@ a {
     padding: 5px;
     font-size: calc(var(--mainFontSize) * .8);
     font-weight: bold;
+    width: max-content;
 }
 
 .onboarding {


### PR DESCRIPTION
You can now do {{input}} to inject the user input into everywhere in the message, this could be really useful for something like this:
![grafik](https://github.com/SillyTavern/SillyTavern/assets/90197782/0a244e52-32d2-4f02-8d99-79eb43de72a1)