### PR TITLE
Built-in Variables extension

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1801,10 +1801,10 @@ function registerVariable(varname, vartext) {
     extension_settings.variables_extension.tmp_vars[sanitizedName] = vartext;
     if (extension_settings.variables_extension.saved_vars[varname] !== undefined){
         extension_settings.variables_extension.saved_vars[varname] = extension_settings.variables_extension.tmp_vars[varname];
-        console.debug(VAR_LOG_PREFIX("registerVariable"), sanitizedName+" is saved, saved variable was updated in saved_vars");
+        console.debug(VAR_LOG_PREFIX("registerVariable"), `${sanitizedName} is saved, saved variable was updated in saved_vars`);
     }
     saveSettingsDebounced();
-    console.debug(VAR_LOG_PREFIX("registerVariable"), sanitizedName+" variable was registered into tmp_vars");
+    console.debug(VAR_LOG_PREFIX("registerVariable"), `${sanitizedName} variable was registered into tmp_vars`);
 }
 
 function getVariable(_, variable) {
@@ -1812,10 +1812,10 @@ function getVariable(_, variable) {
     const foundVariable = substituteParams(extension_settings.variables_extension.tmp_vars[sanitizedVariable]);
     
     if (foundVariable !== undefined) {
-        console.debug(VAR_LOG_PREFIX("getVariable"), sanitizedVariable+" variable was found");
+        console.debug(VAR_LOG_PREFIX("getVariable"), `${sanitizedVariable} variable was found`);
         return foundVariable;
     } else {
-        console.debug(VAR_LOG_PREFIX("getVariable"), sanitizedVariable+" variable not found");
+        console.debug(VAR_LOG_PREFIX("getVariable"), `${sanitizedVariable} variable not found`);
         return "";
     }
 }

--- a/public/script.js
+++ b/public/script.js
@@ -1818,7 +1818,7 @@ function getVariable(_, variable) {
         return foundVariable;
     } else {
         console.debug(VAR_DEBUG_PREFIX, VAR_FUNC_PREFIX("getVariable"), VAR_SEPARATOR, sanitizedVariable+" variable not found");
-        return "none";
+        return "";
     }
 }
 

--- a/public/script.js
+++ b/public/script.js
@@ -182,7 +182,6 @@ import {
 import { applyLocale } from "./scripts/i18n.js";
 import { getTokenCount, getTokenizerModel, saveTokenCache } from "./scripts/tokenizers.js";
 import { initPersonas, selectCurrentPersona, setPersonaDescription } from "./scripts/personas.js";
-import { getVariable } from "./scripts/extensions/variables/index.js";
 
 //exporting functions and vars for mods
 export {
@@ -1779,6 +1778,18 @@ function substituteParams(content, _name1, _name2, _original, _group) {
         return variable;
     });
     return content;
+}
+
+function getVariable(_, variable) {
+    const sanitizedVariable = variable.replace(/\s/g, '_');
+    const foundVariable = substituteParams(extension_settings.variables_extension.tmp_vars[sanitizedVariable]);
+    
+    if (foundVariable !== undefined) {
+        return foundVariable;
+    } else {
+        toastr.warning(`${sanitizedVariable} not found!`);
+        return "none";
+    }
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -1794,19 +1794,17 @@ function substituteParams(content, _name1, _name2, _original, _group) {
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 
 // For logging purposes:
-const VAR_DEBUG_PREFIX = "<Variables extension> ";
-function VAR_FUNC_PREFIX(f){ return `<script.js / ${f}>`; }
-const VAR_SEPARATOR = ": ";
+function VAR_LOG_PREFIX(f){ return `<Variables extension> <script.js / ${f}>: ` };
 
 function registerVariable(varname, vartext) {
     const sanitizedName = varname.replace(/\s/g, '_');
     extension_settings.variables_extension.tmp_vars[sanitizedName] = vartext;
     if (extension_settings.variables_extension.saved_vars[varname] !== undefined){
         extension_settings.variables_extension.saved_vars[varname] = extension_settings.variables_extension.tmp_vars[varname];
-        console.debug(VAR_DEBUG_PREFIX, VAR_FUNC_PREFIX("registerVariable"), VAR_SEPARATOR, sanitizedName+" is saved, saved variable was updated in saved_vars");
+        console.debug(VAR_LOG_PREFIX("registerVariable"), sanitizedName+" is saved, saved variable was updated in saved_vars");
     }
     saveSettingsDebounced();
-    console.debug(VAR_DEBUG_PREFIX, VAR_FUNC_PREFIX("registerVariable"), VAR_SEPARATOR, sanitizedName+" variable was registered into tmp_vars");
+    console.debug(VAR_LOG_PREFIX("registerVariable"), sanitizedName+" variable was registered into tmp_vars");
 }
 
 function getVariable(_, variable) {
@@ -1814,10 +1812,10 @@ function getVariable(_, variable) {
     const foundVariable = substituteParams(extension_settings.variables_extension.tmp_vars[sanitizedVariable]);
     
     if (foundVariable !== undefined) {
-        console.debug(VAR_DEBUG_PREFIX, VAR_FUNC_PREFIX("getVariable"), VAR_SEPARATOR, sanitizedVariable+" variable was found");
+        console.debug(VAR_LOG_PREFIX("getVariable"), sanitizedVariable+" variable was found");
         return foundVariable;
     } else {
-        console.debug(VAR_DEBUG_PREFIX, VAR_FUNC_PREFIX("getVariable"), VAR_SEPARATOR, sanitizedVariable+" variable not found");
+        console.debug(VAR_LOG_PREFIX("getVariable"), sanitizedVariable+" variable not found");
         return "";
     }
 }

--- a/public/script.js
+++ b/public/script.js
@@ -182,6 +182,7 @@ import {
 import { applyLocale } from "./scripts/i18n.js";
 import { getTokenCount, getTokenizerModel, saveTokenCache } from "./scripts/tokenizers.js";
 import { initPersonas, selectCurrentPersona, setPersonaDescription } from "./scripts/personas.js";
+import { getVariable } from "./scripts/extensions/variables/index.js";
 
 //exporting functions and vars for mods
 export {
@@ -1771,6 +1772,12 @@ function substituteParams(content, _name1, _name2, _original, _group) {
     content = randomReplace(content);
     content = diceRollReplace(content);
     content = bannedWordsReplace(content);
+
+    // Variable substitute needs to always be directly on top of "return content;"
+    content = content.replace(/\[\[var:\s*([^}]+)\]\]/gi, (_, variable) => {
+        variable = getVariable(_, variable);
+        return variable;
+    });
     return content;
 }
 

--- a/public/script.js
+++ b/public/script.js
@@ -1780,6 +1780,10 @@ function substituteParams(content, _name1, _name2, _original, _group) {
     return content;
 }
 
+/*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+             Variable Extension related stuff
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
+
 function getVariable(_, variable) {
     const sanitizedVariable = variable.replace(/\s/g, '_');
     const foundVariable = substituteParams(extension_settings.variables_extension.tmp_vars[sanitizedVariable]);
@@ -1791,6 +1795,8 @@ function getVariable(_, variable) {
         return "none";
     }
 }
+
+//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 /**
  * Replaces banned words in macros with an empty string.

--- a/public/script.js
+++ b/public/script.js
@@ -1739,7 +1739,7 @@ function substituteParams(content, _name1, _name2, _original, _group) {
     //// register Variable extension macros: 
 
     // Variable substitute needs to always be directly on top!
-    content = content.replace(/\[\["([^"]+)"\s*\]\]/gi, (_, variable) => {
+    content = content.replace(/\[\[var:\s*"([^"]+)"\s*\]\]/gi, (_, variable) => {
         variable = getVariable(_, variable);
         return variable;
     });

--- a/public/scripts/extensions/variables/index.js
+++ b/public/scripts/extensions/variables/index.js
@@ -122,7 +122,7 @@ async function listVariables(_) {
     }
 
     const variableList = Object.keys(extension_settings.variables_extension.tmp_vars)
-        .map(key => `<li>${extension_settings.variables_extension.saved_vars[key] !== undefined ? "(Saved) ~ " : ""}<span class="monospace">"${key}"</span>: "${variables[key]}"</li>`)
+        .map(key => `<li>${extension_settings.variables_extension.saved_vars[key] !== undefined ? "(Saved) ~ " : ""}<span class="monospace">"${key}"</span>: "${extension_settings.variables_extension.saved_vars[key]}"</li>`)
         .join('\n');
 
     const infoStr = "<small>Variables get reset on SillyTavern restart!</small>";

--- a/public/scripts/extensions/variables/index.js
+++ b/public/scripts/extensions/variables/index.js
@@ -39,7 +39,7 @@ function loadSettings() {
     }
     saveSettingsDebounced();
     
-    console.debug(VAR_LOG_PREFIX("loadSettings"), "Loaded saved variables: " + JSON.stringify(extension_settings.variables_extension.saved_vars));
+    console.debug(VAR_LOG_PREFIX("loadSettings"), `Loaded saved variables: ${JSON.stringify(extension_settings.variables_extension.saved_vars)}`);
 }
 
 function updateVariables(){
@@ -68,10 +68,10 @@ function registerVariable(name, variable_text) {
     extension_settings.variables_extension.tmp_vars[sanitizedName] = variable_text;
     if (extension_settings.variables_extension.saved_vars[name] !== undefined){
         saveVariable(name);
-        console.debug(VAR_LOG_PREFIX("registerVariable"), sanitizedName+" is saved, saved variable was updated in saved_vars");
+        console.debug(VAR_LOG_PREFIX("registerVariable"), `${sanitizedName} is saved, saved variable was updated in saved_vars`);
     }
     saveSettingsDebounced();
-    console.debug(VAR_LOG_PREFIX("registerVariable"), sanitizedName+" variable was registered into tmp_vars");
+    console.debug(VAR_LOG_PREFIX("registerVariable"), `${sanitizedName} variable was registered into tmp_vars`);
 }
 
 function parseVariableCommand(text) {
@@ -102,7 +102,7 @@ async function setVariable(_, text) {
     updateVariables();
     var [varname, vartext] = parseVariableCommand(text);
     registerVariable(varname, vartext);
-    console.debug(VAR_LOG_PREFIX("setVariable"), varname+" variable was registered into tmp_vars, with text: " + vartext);
+    console.debug(VAR_LOG_PREFIX("setVariable"), `${varname} variable was registered into tmp_vars, with text: ${vartext}`);
 }
 
 registerSlashCommand("savevar", (_, text) => saveVariable(text), ["var.sa"], ` – Saves a variable to file.`, true, true);
@@ -110,7 +110,7 @@ async function saveVariable(name){
     updateVariables();
     extension_settings.variables_extension.saved_vars[name] = extension_settings.variables_extension.tmp_vars[name];
     saveSettingsDebounced();
-    console.debug(VAR_LOG_PREFIX("saveVariable"), name+" variable was registered into saved_vars");
+    console.debug(VAR_LOG_PREFIX("saveVariable"), `${name} variable was registered into saved_vars`);
 }
 
 registerSlashCommand("clonevar", (_, text) => cloneVariable(text), ["var.cl"], ` – Clones/Duplicates a variable.`, true, true);
@@ -118,7 +118,7 @@ async function cloneVariable(nameraw){
     updateVariables();
     if(extension_settings.variables_extension.tmp_vars[nameraw] === undefined){
         toastr.warning(`${nameraw} does not exist`);
-        console.debug(VAR_LOG_PREFIX("cloneVariable"), nameraw+" variable could not be cloned");
+        console.debug(VAR_LOG_PREFIX("cloneVariable"), `${nameraw} variable could not be cloned`);
         return;
     }
     const appendUniqueKey = (obj, nameraw) => {
@@ -131,20 +131,20 @@ async function cloneVariable(nameraw){
     const name = appendUniqueKey(extension_settings.variables_extension.tmp_vars, nameraw);
     extension_settings.variables_extension.tmp_vars[name] = extension_settings.variables_extension.tmp_vars[nameraw];
     saveSettingsDebounced();
-    console.debug(VAR_LOG_PREFIX("cloneVariable"), name+" variable was cloned with name "+nameraw);
+    console.debug(VAR_LOG_PREFIX("cloneVariable"), `${name} variable was cloned with name ${nameraw}`);
 }
 
 registerSlashCommand("deletevar", (_, text) => deleteVariable(text), ["var.d"], ` – Deletes a variable from file and tmp.`, true, true);
 async function deleteVariable(name) {
     if(extension_settings.variables_extension.tmp_vars[name] === undefined || extension_settings.variables_extension.saved_vars[name] === undefined ){
         toastr.warning(`${name} does not exist`);
-        console.debug(VAR_LOG_PREFIX("deleteVariable"), name+" variable could not be deleted");
+        console.debug(VAR_LOG_PREFIX("deleteVariable"), `${name} variable could not be deleted`);
         return;
     }
     delete extension_settings.variables_extension.tmp_vars[name];
     delete extension_settings.variables_extension.saved_vars[name];
     saveSettingsDebounced();
-    console.debug(VAR_LOG_PREFIX("deleteVariable"), name+" variable was deleted from tmp_vars and saved_vars");
+    console.debug(VAR_LOG_PREFIX("deleteVariable"), `${name} variable was deleted from tmp_vars and saved_vars`);
 }
 
 registerSlashCommand("listvars", (_, text) => listVariables(), ["var.l"], ` – lists all currently saved variables.`, true, true);
@@ -191,7 +191,7 @@ function gen_raw_command(text) {
             //toastr.info('Done generating!');
         })
         .catch((error) => {
-            toastr.error('An error occurred: ', error);
+            toastr.error(`An error occurred: ${error}`);
         });
 }
 

--- a/public/scripts/extensions/variables/index.js
+++ b/public/scripts/extensions/variables/index.js
@@ -168,7 +168,7 @@ async function clearTmpVariables(_) {
 /// Commands ///
 //Note: always place updateVariables(); in the first line of your command!
 
-registerSlashCommand("generate_raw", (_, text) => gen_raw_command(text), ["graw"], ` - Lets you generate things based on a prompt you input. Example: <pre><code>/generate_raw variable_name&#10;Once upon a time</code></pre>when done generating, it will be saved inside the variable.`, true, true);
+registerSlashCommand("graw", (_, text) => gen_raw_command(text), ["generate_raw"], ` - Lets you generate things based on a prompt you input. Example: <pre><code>/generate_raw variable_name&#10;Once upon a time</code></pre>when done generating, it will be saved inside the variable.`, true, true);
 function gen_raw_command(text) {
     updateVariables();
     const [varname, prompt] = parseVariableCommand(substituteParams(text));

--- a/public/scripts/extensions/variables/index.js
+++ b/public/scripts/extensions/variables/index.js
@@ -117,6 +117,11 @@ async function saveVariable(name){
 registerSlashCommand("clonevar", (_, text) => cloneVariable(text), ["var.cl"], ` – Clones/Duplicates a variable.`, true, true);
 async function cloneVariable(nameraw){
     updateVariables();
+    if(extension_settings.variables_extension.tmp_vars[nameraw] === undefined){
+        toastr.warning(`${nameraw} does not exist`);
+        console.debug(DEBUG_PREFIX, FUNC_PREFIX("cloneVariable"), SEPARATOR, nameraw+" variable could not be cloned");
+        return;
+    }
     const appendUniqueKey = (obj, nameraw) => {
         let num = 0;
         while (obj.hasOwnProperty(nameraw + (num > 0 ? `_${num}` : ''))) {
@@ -132,6 +137,11 @@ async function cloneVariable(nameraw){
 
 registerSlashCommand("deletevar", (_, text) => deleteVariable(text), ["var.d"], ` – Deletes a variable from file and tmp.`, true, true);
 async function deleteVariable(name) {
+    if(extension_settings.variables_extension.tmp_vars[name] === undefined || extension_settings.variables_extension.saved_vars[name] === undefined ){
+        toastr.warning(`${name} does not exist`);
+        console.debug(DEBUG_PREFIX, FUNC_PREFIX("deleteVariable"), SEPARATOR, name+" variable could not be deleted");
+        return;
+    }
     delete extension_settings.variables_extension.tmp_vars[name];
     delete extension_settings.variables_extension.saved_vars[name];
     saveSettingsDebounced();

--- a/public/scripts/extensions/variables/index.js
+++ b/public/scripts/extensions/variables/index.js
@@ -8,36 +8,49 @@ import {
 import { registerSlashCommand } from "../../slash-commands.js"
 import { extension_settings } from "../../extensions.js";
 
-export { MODULE_NAME, listVariables, setVariable, variables, getVariable, registerVariable, parseVariableCommand }
+//export { MODULE_NAME, listVariables, getVariable, registerVariable, parseVariableCommand }
+export { MODULE_NAME }
 
 const defaultSettings = {
-    saved_vars: {}
+    saved_vars: {},
+    tmp_vars: {}
 }
 
 const MODULE_NAME = "variables_extension";
 const DEBUG_PREFIX = "<Variables extension> ";
 //console.debug(DEBUG_PREFIX, "fdg");
-var variables = {};
 
 function loadSettings() {
-    //if (extension_settings.variables_extension === undefined){
-        //extension_settings.variables_extension = {};
-    //}
-
-    //if (Object.keys(extension_settings.variables_extension).length != Object.keys(defaultSettings).length) {
-    //    Object.assign(extension_settings.variables_extension, defaultSettings);
-    //}
-
-    for (var key of Object.keys(extension_settings.variables_extension.saved_vars)) {
-        variables[key] = extension_settings.variables_extension.saved_vars[key];
+    if (extension_settings.variables_extension === undefined){
+        extension_settings.variables_extension = {};
     }
 
-    console.debug(DEBUG_PREFIX, "Loaded saved variables: " + JSON.stringify(extension_settings.variables_extension));
+    if (Object.keys(extension_settings.variables_extension).length != Object.keys(defaultSettings).length) {
+        Object.assign(extension_settings.variables_extension, defaultSettings);
+    }
+
+    extension_settings.variables_extension.tmp_vars = {};
+    saveSettingsDebounced();
+
+    for (var key of Object.keys(extension_settings.variables_extension.saved_vars)) {
+        extension_settings.variables_extension.tmp_vars[key] = extension_settings.variables_extension.saved_vars[key];
+    }
+    saveSettingsDebounced();
+    
+    console.debug(DEBUG_PREFIX, "Loaded saved variables: " + JSON.stringify(extension_settings.variables_extension.saved_vars));
 }
 
+function updateVariables(){
+    for (var key of Object.keys(extension_settings.variables_extension.saved_vars)) {
+        extension_settings.variables_extension.tmp_vars[key] = extension_settings.variables_extension.saved_vars[key];
+    }
+    saveSettingsDebounced();
+}
+
+/*
 function getVariable(_, variable) {
     const sanitizedVariable = variable.replace(/\s/g, '_');
-    const foundVariable = substituteParams(variables[sanitizedVariable]);
+    const foundVariable = substituteParams(extension_settings.variables_extension.tmp_vars[sanitizedVariable]);
     
     if (foundVariable !== undefined) {
         return foundVariable;
@@ -46,13 +59,15 @@ function getVariable(_, variable) {
         return "none";
     }
 }
+*/
 
 function registerVariable(name, variable_text) {
     const sanitizedName = name.replace(/\s/g, '_');
-    variables[sanitizedName] = variable_text;
+    extension_settings.variables_extension.tmp_vars[sanitizedName] = variable_text;
     if (extension_settings.variables_extension.saved_vars[name] !== undefined){
         saveVariable(name);
     }
+    saveSettingsDebounced();
 }
 
 function parseVariableCommand(text) {
@@ -72,45 +87,41 @@ function parseVariableCommand(text) {
     try {
         return [name, variableText];
     } catch (error) {
-        toastr.error(`Failed to register variable: ${error.message}`);
+        toastr.error(`Failed to parse: ${error.message}`);
     }
 }
 
 /// commands ///
 
-registerSlashCommand("setvar", (_, text) => setVariable(_, text), ["setvariable"], ` – Edits/Creates a new variable.`, true, true);
+registerSlashCommand("setvar", (_, text) => setVariable(_, text), ["setvariable"], ` – Creates/Edits a new variable.`, true, true);
 async function setVariable(_, text) {
+    updateVariables();
     var [varname, vartext] = parseVariableCommand(text);
     registerVariable(varname, vartext);
 }
 
 registerSlashCommand("savevar", (_, text) => saveVariable(text), ["savevariable"], ` – Saves a variable to file.`, true, true);
 async function saveVariable(name){
-    extension_settings.variables_extension.saved_vars[name] = variables[name];
+    extension_settings.variables_extension.saved_vars[name] = extension_settings.variables_extension.tmp_vars[name];
     saveSettingsDebounced();
 }
 
 registerSlashCommand("deletevar", (_, text) => deleteVariable(text), ["deletevariable"], ` – Deletes a variable from file and tmp.`, true, true);
 async function deleteVariable(name) {
-    const index = variables.indexOf(name);
-    if (index > -1) { // only splice array when item is found
-        variables.splice(index, 1); // 2nd parameter means remove one item only
-    }
-    const index2 = variables.indexOf(extension_settings.variables_extension.saved_vars);
-    if (index2 > -1) { // only splice array when item is found
-        variables.splice(index2, 1); // 2nd parameter means remove one item only
-    }
+    delete extension_settings.variables_extension.tmp_vars[name];
+    delete extension_settings.variables_extension.saved_vars[name];
     saveSettingsDebounced();
 }
 
 registerSlashCommand("listvars", (_, text) => listVariables(), ["listvariables"], ` – lists all currently saved variables.`, true, true);
 async function listVariables(_) {
-    if (Object.keys(variables).length === 0) {
+    updateVariables();
+    if (Object.keys(extension_settings.variables_extension.tmp_vars).length === 0) {
         toastr.warning('No variables set yet!');
         return;
     }
 
-    const variableList = Object.keys(variables)
+    const variableList = Object.keys(extension_settings.variables_extension.tmp_vars)
         .map(key => `<li>${extension_settings.variables_extension.saved_vars[key] !== undefined ? "(Saved) ~ " : ""}<span class="monospace">"${key}"</span>: "${variables[key]}"</li>`)
         .join('\n');
 
@@ -120,8 +131,20 @@ async function listVariables(_) {
     sendSystemMessage(system_message_types.GENERIC, outputString);
 }
 
+registerSlashCommand("clearvars", (_, text) => clearTmpVariables(), ["cleartmpvariables"], ` – Deletes all Tmp variables.`, true, true);
+async function clearTmpVariables(_) {
+    updateVariables();
+    extension_settings.variables_extension.tmp_vars = {};
+    saveSettingsDebounced();
+}
+
+
+/// Unrelated commands ///
+//Note: always place updateVariables(); in the first line of your command!
+
 registerSlashCommand("generate_raw", (_, text) => gen_raw_command(text), ["graw"], ` - Lets you generate things based on a prompt you input. Example: <pre><code>/generate_raw variable_name&#10;Once upon a time</code></pre>when done generating, it will be saved inside the variable.`, true, true);
 function gen_raw_command(text) {
+    updateVariables();
     const [varname, vartext] = parseVariableCommand(substituteParams(text));
     toastr.info('Generating... please wait!');
 

--- a/public/scripts/extensions/variables/index.js
+++ b/public/scripts/extensions/variables/index.js
@@ -1,0 +1,140 @@
+import {
+    sendSystemMessage,
+    substituteParams,
+    system_message_types,
+    generateRaw,
+    saveSettingsDebounced
+} from "../../../script.js";
+import { registerSlashCommand } from "../../slash-commands.js"
+import { extension_settings } from "../../extensions.js";
+
+export { MODULE_NAME, listVariables, setVariable, variables, getVariable, registerVariable, parseVariableCommand }
+
+const defaultSettings = {
+    saved_vars: {}
+}
+
+const MODULE_NAME = "variables_extension";
+const DEBUG_PREFIX = "<Variables extension> ";
+//console.debug(DEBUG_PREFIX, "fdg");
+var variables = {};
+
+function loadSettings() {
+    //if (extension_settings.variables_extension === undefined){
+        //extension_settings.variables_extension = {};
+    //}
+
+    //if (Object.keys(extension_settings.variables_extension).length != Object.keys(defaultSettings).length) {
+    //    Object.assign(extension_settings.variables_extension, defaultSettings);
+    //}
+
+    for (var key of Object.keys(extension_settings.variables_extension.saved_vars)) {
+        variables[key] = extension_settings.variables_extension.saved_vars[key];
+    }
+
+    console.debug(DEBUG_PREFIX, "Loaded saved variables: " + JSON.stringify(extension_settings.variables_extension));
+}
+
+function getVariable(_, variable) {
+    const sanitizedVariable = variable.replace(/\s/g, '_');
+    const foundVariable = substituteParams(variables[sanitizedVariable]);
+    
+    if (foundVariable !== undefined) {
+        return foundVariable;
+    } else {
+        toastr.warning(`${sanitizedVariable} not found!`);
+        return "none";
+    }
+}
+
+function registerVariable(name, variable_text) {
+    const sanitizedName = name.replace(/\s/g, '_');
+    variables[sanitizedName] = variable_text;
+    if (extension_settings.variables_extension.saved_vars[name] !== undefined){
+        saveVariable(name);
+    }
+}
+
+function parseVariableCommand(text) {
+    if (!text) {
+        return;
+    }
+
+    const parts = text.split('\n');
+    if (parts.length <= 1) {
+        toastr.warning('Both variable name and text are required. Separate them with a new line.');
+        return;
+    }
+
+    const name = parts.shift().trim();
+    const variableText = parts.join('\n').trim();
+
+    try {
+        return [name, variableText];
+    } catch (error) {
+        toastr.error(`Failed to register variable: ${error.message}`);
+    }
+}
+
+/// commands ///
+
+registerSlashCommand("setvar", (_, text) => setVariable(_, text), ["setvariable"], ` – Edits/Creates a new variable.`, true, true);
+async function setVariable(_, text) {
+    var [varname, vartext] = parseVariableCommand(text);
+    registerVariable(varname, vartext);
+}
+
+registerSlashCommand("savevar", (_, text) => saveVariable(text), ["savevariable"], ` – Saves a variable to file.`, true, true);
+async function saveVariable(name){
+    extension_settings.variables_extension.saved_vars[name] = variables[name];
+    saveSettingsDebounced();
+}
+
+registerSlashCommand("deletevar", (_, text) => deleteVariable(text), ["deletevariable"], ` – Deletes a variable from file and tmp.`, true, true);
+async function deleteVariable(name) {
+    const index = variables.indexOf(name);
+    if (index > -1) { // only splice array when item is found
+        variables.splice(index, 1); // 2nd parameter means remove one item only
+    }
+    const index2 = variables.indexOf(extension_settings.variables_extension.saved_vars);
+    if (index2 > -1) { // only splice array when item is found
+        variables.splice(index2, 1); // 2nd parameter means remove one item only
+    }
+    saveSettingsDebounced();
+}
+
+registerSlashCommand("listvars", (_, text) => listVariables(), ["listvariables"], ` – lists all currently saved variables.`, true, true);
+async function listVariables(_) {
+    if (Object.keys(variables).length === 0) {
+        toastr.warning('No variables set yet!');
+        return;
+    }
+
+    const variableList = Object.keys(variables)
+        .map(key => `<li>${extension_settings.variables_extension.saved_vars[key] !== undefined ? "(Saved) ~ " : ""}<span class="monospace">"${key}"</span>: "${variables[key]}"</li>`)
+        .join('\n');
+
+    const infoStr = "<small>Variables get reset on SillyTavern restart!</small>";
+    const outputString = `Registered variables:\n<ol>${variableList}</ol>\n${infoStr}`;
+
+    sendSystemMessage(system_message_types.GENERIC, outputString);
+}
+
+registerSlashCommand("generate_raw", (_, text) => gen_raw_command(text), ["graw"], ` - Lets you generate things based on a prompt you input. Example: <pre><code>/generate_raw variable_name&#10;Once upon a time</code></pre>when done generating, it will be saved inside the variable.`, true, true);
+function gen_raw_command(text) {
+    const [varname, vartext] = parseVariableCommand(substituteParams(text));
+    toastr.info('Generating... please wait!');
+
+    generateRaw(vartext, undefined)
+        .then((generatedText) => {
+            registerVariable(varname, `${generatedText} ${vartext}`);
+            toastr.info('Done generating!');
+        })
+        .catch((error) => {
+            toastr.error('An error occurred: ', error);
+        });
+}
+
+jQuery(async () => {
+    loadSettings();
+});

--- a/public/scripts/extensions/variables/index.js
+++ b/public/scripts/extensions/variables/index.js
@@ -12,9 +12,8 @@ export { MODULE_NAME }
 
 const MODULE_NAME = "variables_extension";
 
-const DEBUG_PREFIX = "<Variables extension> ";
-function FUNC_PREFIX(f){ return `<${f}>`; }
-const SEPARATOR = ": ";
+function VAR_LOG_PREFIX(f){ return `<Variables extension> <script.js / ${f}>: ` };
+
 
 const defaultSettings = {
     saved_vars: {},
@@ -33,14 +32,14 @@ function loadSettings() {
 
     extension_settings.variables_extension.tmp_vars = {};
     saveSettingsDebounced();
-    console.debug(DEBUG_PREFIX, FUNC_PREFIX("loadSettings"), SEPARATOR, "Cleared tmp_vars");
+    console.debug(VAR_LOG_PREFIX("loadSettings"), "Cleared tmp_vars");
 
     for (var key of Object.keys(extension_settings.variables_extension.saved_vars)) {
         extension_settings.variables_extension.tmp_vars[key] = extension_settings.variables_extension.saved_vars[key];
     }
     saveSettingsDebounced();
     
-    console.debug(DEBUG_PREFIX, FUNC_PREFIX("loadSettings"), SEPARATOR, "Loaded saved variables: " + JSON.stringify(extension_settings.variables_extension.saved_vars));
+    console.debug(VAR_LOG_PREFIX("loadSettings"), "Loaded saved variables: " + JSON.stringify(extension_settings.variables_extension.saved_vars));
 }
 
 function updateVariables(){
@@ -69,10 +68,10 @@ function registerVariable(name, variable_text) {
     extension_settings.variables_extension.tmp_vars[sanitizedName] = variable_text;
     if (extension_settings.variables_extension.saved_vars[name] !== undefined){
         saveVariable(name);
-        console.debug(DEBUG_PREFIX, FUNC_PREFIX("registerVariable"), SEPARATOR, sanitizedName+" is saved, saved variable was updated in saved_vars");
+        console.debug(VAR_LOG_PREFIX("registerVariable"), sanitizedName+" is saved, saved variable was updated in saved_vars");
     }
     saveSettingsDebounced();
-    console.debug(DEBUG_PREFIX, FUNC_PREFIX("registerVariable"), SEPARATOR, sanitizedName+" variable was registered into tmp_vars");
+    console.debug(VAR_LOG_PREFIX("registerVariable"), sanitizedName+" variable was registered into tmp_vars");
 }
 
 function parseVariableCommand(text) {
@@ -103,7 +102,7 @@ async function setVariable(_, text) {
     updateVariables();
     var [varname, vartext] = parseVariableCommand(text);
     registerVariable(varname, vartext);
-    console.debug(DEBUG_PREFIX, FUNC_PREFIX("setVariable"), SEPARATOR, varname+" variable was registered into tmp_vars, with text: " + vartext);
+    console.debug(VAR_LOG_PREFIX("setVariable"), varname+" variable was registered into tmp_vars, with text: " + vartext);
 }
 
 registerSlashCommand("savevar", (_, text) => saveVariable(text), ["var.sa"], ` – Saves a variable to file.`, true, true);
@@ -111,7 +110,7 @@ async function saveVariable(name){
     updateVariables();
     extension_settings.variables_extension.saved_vars[name] = extension_settings.variables_extension.tmp_vars[name];
     saveSettingsDebounced();
-    console.debug(DEBUG_PREFIX, FUNC_PREFIX("saveVariable"), SEPARATOR, name+" variable was registered into saved_vars");
+    console.debug(VAR_LOG_PREFIX("saveVariable"), name+" variable was registered into saved_vars");
 }
 
 registerSlashCommand("clonevar", (_, text) => cloneVariable(text), ["var.cl"], ` – Clones/Duplicates a variable.`, true, true);
@@ -119,7 +118,7 @@ async function cloneVariable(nameraw){
     updateVariables();
     if(extension_settings.variables_extension.tmp_vars[nameraw] === undefined){
         toastr.warning(`${nameraw} does not exist`);
-        console.debug(DEBUG_PREFIX, FUNC_PREFIX("cloneVariable"), SEPARATOR, nameraw+" variable could not be cloned");
+        console.debug(VAR_LOG_PREFIX("cloneVariable"), nameraw+" variable could not be cloned");
         return;
     }
     const appendUniqueKey = (obj, nameraw) => {
@@ -132,20 +131,20 @@ async function cloneVariable(nameraw){
     const name = appendUniqueKey(extension_settings.variables_extension.tmp_vars, nameraw);
     extension_settings.variables_extension.tmp_vars[name] = extension_settings.variables_extension.tmp_vars[nameraw];
     saveSettingsDebounced();
-    console.debug(DEBUG_PREFIX, FUNC_PREFIX("cloneVariable"), SEPARATOR, name+" variable was cloned with name "+nameraw);
+    console.debug(VAR_LOG_PREFIX("cloneVariable"), name+" variable was cloned with name "+nameraw);
 }
 
 registerSlashCommand("deletevar", (_, text) => deleteVariable(text), ["var.d"], ` – Deletes a variable from file and tmp.`, true, true);
 async function deleteVariable(name) {
     if(extension_settings.variables_extension.tmp_vars[name] === undefined || extension_settings.variables_extension.saved_vars[name] === undefined ){
         toastr.warning(`${name} does not exist`);
-        console.debug(DEBUG_PREFIX, FUNC_PREFIX("deleteVariable"), SEPARATOR, name+" variable could not be deleted");
+        console.debug(VAR_LOG_PREFIX("deleteVariable"), name+" variable could not be deleted");
         return;
     }
     delete extension_settings.variables_extension.tmp_vars[name];
     delete extension_settings.variables_extension.saved_vars[name];
     saveSettingsDebounced();
-    console.debug(DEBUG_PREFIX, FUNC_PREFIX("deleteVariable"), SEPARATOR, name+" variable was deleted from tmp_vars and saved_vars");
+    console.debug(VAR_LOG_PREFIX("deleteVariable"), name+" variable was deleted from tmp_vars and saved_vars");
 }
 
 registerSlashCommand("listvars", (_, text) => listVariables(), ["var.l"], ` – lists all currently saved variables.`, true, true);
@@ -171,7 +170,7 @@ async function clearTmpVariables(_) {
     updateVariables();
     extension_settings.variables_extension.tmp_vars = {};
     saveSettingsDebounced();
-    console.debug(DEBUG_PREFIX, FUNC_PREFIX("clearTmpVariables"), SEPARATOR, "All tmp_vars were deleted");
+    console.debug(VAR_LOG_PREFIX("clearTmpVariables"), "All tmp_vars were deleted");
 }
 
 
@@ -182,13 +181,13 @@ registerSlashCommand("graw", (_, text) => gen_raw_command(text), ["generate_raw"
 function gen_raw_command(text) {
     updateVariables();
     const [varname, prompt] = parseVariableCommand(substituteParams(text));
-    console.debug(DEBUG_PREFIX, FUNC_PREFIX("gen_raw_command"), SEPARATOR, "Generating with main api...");
+    console.debug(VAR_LOG_PREFIX("gen_raw_command"), "Generating with main api...");
     //toastr.info('Generating... please wait!');
 
     generateRaw(prompt, undefined)
         .then((generatedText) => {
             registerVariable(varname, `${generatedText} ${prompt}`);
-            console.debug(DEBUG_PREFIX, FUNC_PREFIX("gen_raw_command"), SEPARATOR, `Done generating! Stored in ${varname} variable, with generatedText: ${generatedText}`);
+            console.debug(VAR_LOG_PREFIX("gen_raw_command"), `Done generating! Stored in ${varname} variable, with generatedText: ${generatedText}`);
             //toastr.info('Done generating!');
         })
         .catch((error) => {

--- a/public/scripts/extensions/variables/index.js
+++ b/public/scripts/extensions/variables/index.js
@@ -114,7 +114,7 @@ async function saveVariable(name){
     console.debug(DEBUG_PREFIX, FUNC_PREFIX("saveVariable"), SEPARATOR, name+" variable was registered into saved_vars");
 }
 
-registerSlashCommand("clonevar", (_, text) => cloneVariable(text), ["var.c"], ` – Clones/Duplicates a variable.`, true, true);
+registerSlashCommand("clonevar", (_, text) => cloneVariable(text), ["var.cl"], ` – Clones/Duplicates a variable.`, true, true);
 async function cloneVariable(nameraw){
     updateVariables();
     const appendUniqueKey = (obj, nameraw) => {
@@ -125,7 +125,7 @@ async function cloneVariable(nameraw){
         return nameraw + (num > 0 ? `_${num}` : '');
     };
     const name = appendUniqueKey(extension_settings.variables_extension.tmp_vars, nameraw);
-    extension_settings.variables_extension.tmp_vars[name] = extension_settings.variables_extension.tmp_vars[name];
+    extension_settings.variables_extension.tmp_vars[name] = extension_settings.variables_extension.tmp_vars[nameraw];
     saveSettingsDebounced();
     console.debug(DEBUG_PREFIX, FUNC_PREFIX("cloneVariable"), SEPARATOR, name+" variable was cloned with name "+nameraw);
 }

--- a/public/scripts/extensions/variables/index.js
+++ b/public/scripts/extensions/variables/index.js
@@ -122,7 +122,7 @@ async function listVariables(_) {
     }
 
     const variableList = Object.keys(extension_settings.variables_extension.tmp_vars)
-        .map(key => `<li>${extension_settings.variables_extension.saved_vars[key] !== undefined ? "(Saved) ~ " : ""}<span class="monospace">"${key}"</span>: "${extension_settings.variables_extension.saved_vars[key]}"</li>`)
+        .map(key => `<li>${extension_settings.variables_extension.saved_vars[key] !== undefined ? "(Saved) ~ " : ""}<span class="monospace">"${key}"</span>: "${extension_settings.variables_extension.tmp_vars[key]}"</li>`)
         .join('\n');
 
     const infoStr = "<small>Variables get reset on SillyTavern restart!</small>";

--- a/public/scripts/extensions/variables/manifest.json
+++ b/public/scripts/extensions/variables/manifest.json
@@ -1,11 +1,11 @@
 {
     "display_name": "Variables",
-    "loading_order": 99,
+    "loading_order": 2,
     "requires": [],
     "optional": [],
     "js": "index.js",
     "css": "",
     "author": "IkariDev, Keij",
-    "version": "1.1.1",
+    "version": "1.2.1",
     "homePage": "https://github.com/SillyTavern/SillyTavern"
 }

--- a/public/scripts/extensions/variables/manifest.json
+++ b/public/scripts/extensions/variables/manifest.json
@@ -1,0 +1,11 @@
+{
+    "display_name": "Variables",
+    "loading_order": 99,
+    "requires": [],
+    "optional": [],
+    "js": "index.js",
+    "css": "",
+    "author": "IkariDev",
+    "version": "1.0.0",
+    "homePage": "https://github.com/SillyTavern/SillyTavern"
+}

--- a/public/scripts/extensions/variables/manifest.json
+++ b/public/scripts/extensions/variables/manifest.json
@@ -5,7 +5,7 @@
     "optional": [],
     "js": "index.js",
     "css": "",
-    "author": "IkariDev",
-    "version": "1.0.0",
+    "author": "IkariDev, Keij",
+    "version": "1.1.1",
     "homePage": "https://github.com/SillyTavern/SillyTavern"
 }

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -14,6 +14,6 @@ System-wide Replacement Macros:
     <li><tt>&lcub;&lcub;idle_duration&rcub;&rcub;</tt> - the time since the last user message was sent</li>
     <li><tt>&lcub;&lcub;random:(args)&rcub;&rcub;</tt> - returns a random item from the list. (ex: &lcub;&lcub;random:1,2,3,4&rcub;&rcub; will return 1 of the 4 numbers at random. Works with text lists too.</li>
     <li><tt>&lcub;&lcub;roll:(formula)&rcub;&rcub;</tt> - rolls a dice. (ex: &lcub;&lcub;roll:1d6&rcub;&rcub; will roll a 6-sided dice and return a number between 1 and 6)</li>
-    <li><tt>[[var: "varname"]]</tt> - Places a variable there.</li>
-    <li><tt>[[setvar: "varname"/"content"]]</tt> - It creates a variable.</li>
+    <li><tt>&lbrack;&lbrack;var: "varname"&rbrack;&rbrack;</tt> - Replaces the macro with a variable.</li>
+    <li><tt>&lbrack;&lbrack;setvar: "varname"/"content"&rbrack;&rbrack;</tt> – Creates/Edits a new variable.</li>
 </ul>

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -14,4 +14,6 @@ System-wide Replacement Macros:
     <li><tt>&lcub;&lcub;idle_duration&rcub;&rcub;</tt> - the time since the last user message was sent</li>
     <li><tt>&lcub;&lcub;random:(args)&rcub;&rcub;</tt> - returns a random item from the list. (ex: &lcub;&lcub;random:1,2,3,4&rcub;&rcub; will return 1 of the 4 numbers at random. Works with text lists too.</li>
     <li><tt>&lcub;&lcub;roll:(formula)&rcub;&rcub;</tt> - rolls a dice. (ex: &lcub;&lcub;roll:1d6&rcub;&rcub; will roll a 6-sided dice and return a number between 1 and 6)</li>
+    <li><tt>[[var: "varname"]]</tt> - Places a variable there.</li>
+    <li><tt>[[setvar: "varname"/"content"]]</tt> - It creates a variable.</li>
 </ul>


### PR DESCRIPTION
This is a continuation of my #1256 PR(i broked my fork and everything was broken lol). So anyway here what this thing does:

i know this is already an extension, but the extension is kinda.. limited. I did add some things, and i wanna add a bunch of new things, and thats only possible with directly modifing script.js(as far as i know). Im probably gonna add some commands that are related to this btw(a command that has output = goes directly into a new variable).

TODO
- [X] Convert to extension
- [ ] Change how | command chaining works(one after another, maybe it already works like this.. need to investigate)
- [x] Add something like [[createvar: name/"content"]]
- [ ] Add conditions(like [here](https://github.com/kwaroran/RisuAI/wiki/Curly-Brased-Syntaxes#conditions))
- [ ] Add block syntax(like [here](https://github.com/kwaroran/RisuAI/wiki/Curly-Brased-Syntaxes#block-syntax))
- [ ] idea: [[call-command: /...]] (probably unsecure)

extension is WIP!