### PR TITLE
Update RossAscends-mods.js

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -882,15 +882,18 @@ export function initRossMods() {
             }
         }
     });
-    document.addEventListener('swiped-right', function (e) {
-        var SwipeButL = $('.swipe_left:last');
-        var SwipeTargetMesClassParent = $(e.target).closest('.last_mes');
-        if (SwipeTargetMesClassParent !== null) {
-            if (SwipeButL.css('display') === 'flex') {
-                SwipeButL.click();
+    
+    // Disable swipe gesture on mobile
+    if (!/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+        document.addEventListener('swiped-left', function (e) {
+            var SwipeButR = $('.swipe_right:last');
+            var SwipeTargetMesClassParent = $(e.target).closest('.last_mes');
+            if (SwipeTargetMesClassParent !== null) {
+                if (SwipeButR.css('display') === 'flex') {
+                    SwipeButR.click();
+                }
             }
-        }
-    });
+        });
 
 
     function isInputElementInFocus() {


### PR DESCRIPTION
Disable the gesture swipe right - swipe left  that click the button all the time and make a lots of user errors.  (on mobile). 

