### PR TITLE
Add token counting slash command.

### DIFF
--- a/public/scripts/extensions/token-counter/index.js
+++ b/public/scripts/extensions/token-counter/index.js
@@ -1,6 +1,7 @@
 import { callPopup, main_api } from "../../../script.js";
 import { getContext } from "../../extensions.js";
-import { getTokenizerModel } from "../../tokenizers.js";
+import { registerSlashCommand } from "../../slash-commands.js";
+import { getTokenCount, getTokenizerModel } from "../../tokenizers.js";
 
 async function doTokenCounter() {
     const selectedTokenizer = main_api == 'openai'
@@ -29,6 +30,20 @@ async function doTokenCounter() {
     callPopup(dialog, 'text');
 }
 
+function doCount() {
+    // get all of the messages in the chat
+    const context = getContext();
+    const messages = context.chat.filter(x => x.mes && !x.is_system).map(x => x.mes);
+
+    //concat all the messages into a single string
+    const allMessages = messages.join(' ');
+
+    console.debug('All messages:', allMessages);
+
+    //toastr success with the token count of the chat
+    toastr.success(`Token count: ${getTokenCount(allMessages)}`);
+}
+
 jQuery(() => {
     const buttonHtml = `
         <div id="token_counter" class="list-group-item flex-container flexGap5">
@@ -37,4 +52,5 @@ jQuery(() => {
         </div>`;
     $('#extensionsMenu').prepend(buttonHtml);
     $('#token_counter').on('click', doTokenCounter);
+    registerSlashCommand('count', doCount, [], '– counts the number of tokens in the current chat', true, false);
 });

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -28,7 +28,7 @@ import {
 } from "./instruct-mode.js";
 
 import { registerSlashCommand } from "./slash-commands.js";
-import { tokenizers, getTokenCount } from "./tokenizers.js";
+import { tokenizers } from "./tokenizers.js";
 
 import { countOccurrences, debounce, delay, isOdd, resetScrollHeight, sortMoments, timestampToMoment } from "./utils.js";
 
@@ -1554,21 +1554,6 @@ function doResetPanels() {
     $("#movingUIreset").trigger('click');
 }
 
-function doCount() {
-    // get all of the messages in the chat
-    const messages = $('#chat .mes');
-
-    //concat all the messages into a single string
-    const allMessages = messages.toArray().map(x => $(x).find('.mes_text').text()).join(' ');
-
-    console.log(allMessages);
-
-    //toastr success with the token count of the chat
-    toastr.success(`Token count: ${getTokenCount(allMessages)}`);
-}
-
-
-
 function setAvgBG() {
     const bgimg = new Image();
     bgimg.src = $('#bg1')
@@ -2411,5 +2396,4 @@ $(document).ready(() => {
     registerSlashCommand('cut', doMesCut, [], '<span class="monospace">(number)</span> – cuts the specified message from the chat', true, true);
     registerSlashCommand('resetpanels', doResetPanels, ['resetui'], '– resets UI panels to original state.', true, true);
     registerSlashCommand('bgcol', setAvgBG, [], '– WIP test of auto-bg avg coloring', true, true);
-    registerSlashCommand('count', doCount, [], '– counts the number of tokens in the current chat', true, false);
 });

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -28,7 +28,7 @@ import {
 } from "./instruct-mode.js";
 
 import { registerSlashCommand } from "./slash-commands.js";
-import { tokenizers } from "./tokenizers.js";
+import { tokenizers, getTokenCount } from "./tokenizers.js";
 
 import { countOccurrences, debounce, delay, isOdd, resetScrollHeight, sortMoments, timestampToMoment } from "./utils.js";
 
@@ -1554,6 +1554,21 @@ function doResetPanels() {
     $("#movingUIreset").trigger('click');
 }
 
+function doCount() {
+    // get all of the messages in the chat
+    const messages = $('#chat .mes');
+
+    //concat all the messages into a single string
+    const allMessages = messages.toArray().map(x => $(x).find('.mes_text').text()).join(' ');
+
+    console.log(allMessages);
+
+    //toastr success with the token count of the chat
+    toastr.success(`Token count: ${getTokenCount(allMessages)}`);
+}
+
+
+
 function setAvgBG() {
     const bgimg = new Image();
     bgimg.src = $('#bg1')
@@ -2396,4 +2411,5 @@ $(document).ready(() => {
     registerSlashCommand('cut', doMesCut, [], '<span class="monospace">(number)</span> – cuts the specified message from the chat', true, true);
     registerSlashCommand('resetpanels', doResetPanels, ['resetui'], '– resets UI panels to original state.', true, true);
     registerSlashCommand('bgcol', setAvgBG, [], '– WIP test of auto-bg avg coloring', true, true);
+    registerSlashCommand('count', doCount, [], '– counts the number of tokens in the current chat', true, false);
 });


### PR DESCRIPTION
This is an idea for a quick command to give the current token count of the chat without having to prompt and getting the itemized report. It could probably be expanded to give more detailed counts and I will likely make a few more changes. @Cohee1207 is that roughly how you could get the token count?