### PR TITLE
Fix TTS autogen chkbox set by elevenlabs multilingual setting

### DIFF
--- a/public/scripts/extensions/tts/elevenlabs.js
+++ b/public/scripts/extensions/tts/elevenlabs.js
@@ -69,7 +69,7 @@ class ElevenLabsTtsProvider {
         $('#elevenlabs_tts_stability').val(this.settings.stability)
         $('#elevenlabs_tts_similarity_boost').val(this.settings.similarity_boost)
         $('#elevenlabs_tts_api_key').val(this.settings.apiKey)
-        $('#tts_auto_generation').prop('checked', this.settings.multilingual)
+        $('#elevenlabs_tts_multilingual').prop('checked', this.settings.multilingual)
         $('#eleven_labs_connect').on('click', () => {this.onConnectClick()})
         $('#elevenlabs_tts_settings').on('input',this.onSettingsChange)
 


### PR DESCRIPTION
# Background

I noticed some odd behavior with the elevenlabs TTS multilingual setting seeming to effect the general TTS autogen setting, and after a bit of experimenting and poking around the source code, I found a line of code which seems to be a mistake where the TTS auto gen checkbox is being set based on the multilingual setting. I assume that it should be setting the multilingual checkbox instead, which seems to make a lot more sense.

# Changes

 - In `public/scripts/extensions/tts/elevenlabs.js`, modify code that sets the state of the UI  based on loaded settings such that the elevenlabs multilingual setting sets the correct associated checkbox rather than the checkbox for the TTS auto generation setting.

# Results

 - UI state now properly loaded from saved settings.