### PR TITLE
Fix duplicate TTS voicemap UI when autoload last chat is enabled

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -749,10 +749,6 @@ class VoiceMapEntry {
  *
  */
 export async function initVoiceMap(){
-    // Clear existing voiceMap state
-    $('#tts_voicemap_block').empty()
-    voiceMapEntries = []
-
     // Gate initialization if not enabled or TTS Provider not ready. Prevents error popups.
     const enabled = $('#tts_enabled').is(':checked')
     if (!enabled){
@@ -770,6 +766,10 @@ export async function initVoiceMap(){
 
     setTtsStatus("TTS Provider Loaded", true)
 
+    // Clear existing voiceMap state
+    $('#tts_voicemap_block').empty()
+    voiceMapEntries = []
+    
     // Get characters in current chat
     const characters = getCharacters()
 


### PR DESCRIPTION
# Background

I noticed an issue where the dropdown elements for the voicemap settings are sometimes being duplicated in the TTS settings UI for me. After a bit of investigation, I found that this is happening due to a race condition that can occur when both the "Autoload last chat" feature and the TTS extension are both enabled at the same time. This causes the `initVoiceMap` function to be immediately called twice back-to-back on initial load, first in response to the TTS provider loading, and again in response to the last chat loading. Because the logic in `initVoiceMap` meant to clear the UI elements on initialization is being executed *prior* to the subsequent async call to `await ttsProvider.checkReady()`, this means that both calls to `initVoiceMap` first clear the UI elements from the voicemap block, and then after they both return from the async `await ttsProvider.checkReady()` call, they then cause the UI elements to be duplicated.

# Reproduction

### Steps:

1. Load SillyTavern

2. Start a chat with some character.

3. Navigate to `User Settings` > `Chat/Message Handling` and use the checkbox to enable the `"Auto-load Last Chat"` setting.

![enable_autoload_last_chat](https://github.com/SillyTavern/SillyTavern/assets/1627957/977d4951-57ac-435f-b5c5-1e845460ba0d)

4. Navigate to `Extensions` > `TTS` and use the checkbox to enable the TTS feature. 
(I'm using the Elevenlabs TTS provider, but I don't believe this issue is specific to a particular TTS provider.)

6. Reload SillyTavern using your browser's refresh function.

7. Navigate back to `Extensions` > `TTS` and observe the list of dropdowns UI elements for the character voicemap settings.

### Expected Result:

The dropdown UI elements for the character voicemap settings should not contains duplicates.

### Actual Result:

The dropdown UI elements for the character voicemap usually contains duplicates.

# Changes

Move the call to `$('#tts_voicemap_block').empty()` for clearing the UI elements associated with the voicemap entries so that it is executed *after* the async call `await ttsProvider.checkReady()` to avoid race conditions. 

# Results

### Before fix, UI elements duplicated:

![before_fix](https://github.com/SillyTavern/SillyTavern/assets/1627957/316de2c1-ead5-46de-8a16-4c9b415f7e64)

### After fix, UI elements not duplicated:

![after_fix](https://github.com/SillyTavern/SillyTavern/assets/1627957/f4b75b7a-7a04-40d1-b6e3-2057f054c00f)


