### PR TITLE
Toggle Regex Script Checkboxes

### DIFF
--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -76,6 +76,14 @@ async function loadRegexScripts() {
         const scriptHtml = scriptTemplate.clone();
         scriptHtml.attr('id', uuidv4());
         scriptHtml.find('.regex_script_name').text(script.scriptName);
+        scriptHtml.find('.disable_regex').prop("checked", script.disabled ?? false)
+            .each(function() {
+                $(this).closest('.checkbox').find('span').toggle(this.checked);
+            })
+            .on('click', function() {
+                script.disabled = !script.disabled;
+                $(this).closest('.checkbox').find('span').toggle(this.checked);
+            });
         scriptHtml.find('.edit_existing_regex').on('click', async function() {
             await onRegexEditorOpenClick(scriptHtml.attr("id"));
         });

--- a/public/scripts/extensions/regex/scriptTemplate.html
+++ b/public/scripts/extensions/regex/scriptTemplate.html
@@ -2,6 +2,10 @@
     <span class="drag-handle menu-handle">&#9776;</span>
     <div class="regex_script_name flexGrow overflow-hidden"></div>
     <div class="flex-container flexnowrap">
+        <label class="checkbox flex-container">
+          <span data-i18n="Disabled">Disabled</span>
+          <input id="disabled" type="checkbox" name="disabled" class="disable_regex" />
+        </label>
         <div class="edit_existing_regex menu_button">
             <i class="fa-solid fa-pencil"></i>
         </div>

--- a/public/scripts/extensions/regex/style.css
+++ b/public/scripts/extensions/regex/style.css
@@ -5,6 +5,10 @@
     flex-direction: row;
 }
 
+.regex_settings .checkbox {
+    align-items: center;
+}
+
 .regex-script-container {
     margin-top: 10px;
     margin-bottom: 10px;


### PR DESCRIPTION
Added a checkbox to each Regex Script listed under Saved Scripts to easily enable/disable. It can be cumbersome having to load Regex Editor for each script when disabling/enabling multiple Regex Scripts.

![image](https://github.com/SillyTavern/SillyTavern/assets/149027551/6ff70f29-b95e-4a54-80fb-3422614339ca)
