### PR TITLE
New optional setting: World info: minimum activations

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2729,7 +2729,7 @@
                                         </div>
                                     </div>
                                     <div class="budget_cap_note">
-                                        <small data-i18n="(0 = disabled) scan chronologically until min entries">(0 = disabled) scan chronologically until min entries</small>
+                                        <small data-i18n="scan chronologically until min entries or token budget">scan chronologically until min entries or token budget</small>
                                     </div>
                                 </div>
                                 <div data-newbie-hidden class="flex1 gap5px range-block">

--- a/public/index.html
+++ b/public/index.html
@@ -2729,7 +2729,7 @@
                                         </div>
                                     </div>
                                     <div class="budget_cap_note">
-                                        <small data-i18n="(0 = disabled) scan chronologically until min entries or token budget filled">(0 = disabled) scan chronologically until min entries or token budget filled</small>
+                                        <small data-i18n="(0 = disabled) scan chronologically until min entries">(0 = disabled) scan chronologically until min entries</small>
                                     </div>
                                 </div>
                                 <div data-newbie-hidden class="flex1 gap5px range-block">
@@ -2746,7 +2746,7 @@
                                         </div>
                                     </div>
                                     <div class="budget_cap_note">
-                                        <small data-i18n="(0 = chronological scan depth unlimited, token budget recommended if min is high)">(0 = chronological scan depth unlimited, token budget recommended if min is high)</small>
+                                        <small data-i18n="(0 = chronological scan depth unlimited, use token budget)">(0 = chronological scan depth unlimited, use token budget)</small>
                                     </div>
                                 </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -2713,6 +2713,44 @@
                                         <small data-i18n="(0 = disabled)">(0 = disabled)</small>
                                     </div>
                                 </div>
+
+                                
+                                <div data-newbie-hidden class="flex1 gap5px range-block">
+                                    <div class="wide10pMinFit">
+                                        <small data-i18n="Min Activations">Min Activations</small>
+                                    </div>
+                                    <div class="range-block-range-and-counter">
+                                        <div class="range-block-range paddingLeftRight5">
+                                            <input type="range" id="world_info_min_activations" name="volume" min="0" max="100" step="1">
+                                        </div>
+                                        <div class="range-block-counter margin0">
+                                            <input type="number" data-for="world_info_min_activations" id="world_info_min_activations_counter">
+
+                                        </div>
+                                    </div>
+                                    <div class="budget_cap_note">
+                                        <small data-i18n="(0 = disabled) scan chronologically until min entries or token budget filled">(0 = disabled) scan chronologically until min entries or token budget filled</small>
+                                    </div>
+                                </div>
+                                <div data-newbie-hidden class="flex1 gap5px range-block">
+                                    <div class="wide10pMinFit">
+                                        <small data-i18n="Min Activations: Max Depth">Min Activations: Max Depth</small>
+                                    </div>
+                                    <div class="range-block-range-and-counter">
+                                        <div class="range-block-range paddingLeftRight5">
+                                            <input type="range" id="world_info_min_activations_depth_max" name="volume" min="0" max="100" step="1">
+                                        </div>
+                                        <div class="range-block-counter margin0">
+                                            <input type="number" data-for="world_info_min_activations_depth_max" id="world_info_min_activations_depth_max_counter">
+
+                                        </div>
+                                    </div>
+                                    <div class="budget_cap_note">
+                                        <small data-i18n="(0 = chronological scan depth unlimited, token budget recommended if min is high)">(0 = chronological scan depth unlimited, token budget recommended if min is high)</small>
+                                    </div>
+                                </div>
+
+                                
                             </div>
                         </div>
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -35,6 +35,9 @@ let world_info = {};
 let selected_world_info = [];
 let world_names;
 let world_info_depth = 2;
+let world_info_min_activations = 0; // if > 0, will continue seeking chat until minimum world infos are activated
+let world_info_min_activations_depth_max = 20; // used when (world_info_min_activations > 0)
+
 let world_info_budget = 25;
 let world_info_recursive = false;
 let world_info_overflow_alert = false;
@@ -1379,6 +1382,7 @@ async function checkWorldInfo(chat, maxContext) {
 
     // Combine the chat
     let textToScan = chat.slice(0, messagesToLookBack).join("");
+    let minActivationMsgIndex = messagesToLookBack; // tracks chat index to satisfy `world_info_min_activations`
 
     // Add the depth or AN if enabled
     // Put this code here since otherwise, the chat reference is modified
@@ -1552,6 +1556,17 @@ async function checkWorldInfo(chat, maxContext) {
             const currentlyActivatedText = transformString(text);
             textToScan = (currentlyActivatedText + '\n' + textToScan);
             allActivatedText = (currentlyActivatedText + '\n' + allActivatedText);
+        }
+
+        // world_info_min_activations
+        if (!needsToScan) {
+            if (world_info_min_activations > 0 && (allActivatedEntries.size < world_info_min_activations)) {
+                if (minActivationMsgIndex <= world_info_min_activations_depth_max) {
+                    needsToScan = true
+                    textToScan = transformString(chat.slice(minActivationMsgIndex, minActivationMsgIndex + 1).join(""));
+                    minActivationMsgIndex += 1
+                }
+            }
         }
     }
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -38,7 +38,7 @@ let selected_world_info = [];
 let world_names;
 let world_info_depth = 2;
 let world_info_min_activations = 0; // if > 0, will continue seeking chat until minimum world infos are activated
-let world_info_min_activations_depth_max = 20; // used when (world_info_min_activations > 0)
+let world_info_min_activations_depth_max = 0; // used when (world_info_min_activations > 0)
 
 let world_info_budget = 25;
 let world_info_recursive = false;


### PR DESCRIPTION
I saw a need for this as activation keywords for world info entries can get buried as the topic/setting advances, without mentioning the keywords.

A tangible example would be: entering a location, defined on world info, called a specific name, but the name not being mentioned after being in such a location for a while, which is natural. I found this necessary as I was testing an adventure card.

This setting, if enabled (> 0) keeps seeking further into the text/chat until a minimum amount of world info is activated (or until maximum seek is reached)
One might ask why not set a token budget and high world_info_depth? Well because it isn't chronological as far as I could tell.

On this branch:
- default is disabled `let world_info_min_activations = 0; // if > 0, will continue seeking chat until minimum world infos are activated`
- not added to the UI yet (or persistence)

So its not ready, I want input if there's no misunderstanding and is of interest or not.