### PR TITLE
Regex script: prompt only checkbox

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2441,14 +2441,6 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
         reject = () => { };
     }
 
-    let chat_regexed = chat.map(x => ({
-        ...x,
-        mes: getRegexedString(x.mes, x.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT, {
-            isPrompt: true,
-        }),
-    }))
-
-
     if (selected_group && !is_group_generating && !dryRun) {
         generateGroupWrapper(false, type, { resolve, reject, quiet_prompt, force_chid, signal: abortController.signal });
         return;
@@ -2493,34 +2485,34 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
             $("#send_textarea").val('').trigger('input');
         } else {
             textareaText = "";
-            if (chat_regexed.length && chat_regexed[chat_regexed.length - 1]['is_user']) {
+            if (chat.length && chat[chat.length - 1]['is_user']) {
                 //do nothing? why does this check exist?
             }
-            else if (type !== 'quiet' && type !== "swipe" && !isImpersonate && !dryRun && chat_regexed.length) {
-                chat_regexed.length = chat_regexed.length - 1;
+            else if (type !== 'quiet' && type !== "swipe" && !isImpersonate && !dryRun && chat.length) {
+                chat.length = chat.length - 1;
                 count_view_mes -= 1;
                 $('#chat').children().last().hide(250, function () {
                     $(this).remove();
                 });
-                await eventSource.emit(event_types.MESSAGE_DELETED, chat_regexed.length);
+                await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
             }
         }
 
-        if (!type && !textareaText && power_user.continue_on_send && !selected_group && chat_regexed.length && !chat_regexed[chat_regexed.length - 1]['is_user'] && !chat_regexed[chat_regexed.length - 1]['is_system']) {
+        if (!type && !textareaText && power_user.continue_on_send && !selected_group && chat.length && !chat[chat.length - 1]['is_user'] && !chat[chat.length - 1]['is_system']) {
             type = 'continue';
         }
 
         const isContinue = type == 'continue';
 
         // Rewrite the generation timer to account for the time passed for all the continuations.
-        if (isContinue && chat_regexed.length) {
-            const prevFinished = chat_regexed[chat_regexed.length - 1]['gen_finished'];
-            const prevStarted = chat_regexed[chat_regexed.length - 1]['gen_started'];
+        if (isContinue && chat.length) {
+            const prevFinished = chat[chat.length - 1]['gen_finished'];
+            const prevStarted = chat[chat.length - 1]['gen_started'];
 
             if (prevFinished && prevStarted) {
                 const timePassed = prevFinished - prevStarted;
                 generation_started = new Date(Date.now() - timePassed);
-                chat_regexed[chat_regexed.length - 1]['gen_started'] = generation_started;
+                chat[chat.length - 1]['gen_started'] = generation_started;
             }
         }
 
@@ -2608,15 +2600,22 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
             mesExamplesArray = []
 
         // First message in fresh 1-on-1 chat reacts to user/character settings changes
-        if (chat_regexed.length) {
-            chat_regexed[0].mes = substituteParams(chat_regexed[0].mes);
+        if (chat.length) {
+            chat[0].mes = substituteParams(chat[0].mes);
         }
 
         // Collect messages with usable content
-        let coreChat = chat_regexed.filter(x => !x.is_system);
+        let coreChat = chat.filter(x => !x.is_system);
         if (type === 'swipe') {
             coreChat.pop();
         }
+
+        coreChat = coreChat.map(x => ({
+            ...x,
+            mes: getRegexedString(x.mes, x.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT, {
+                isPrompt: true,
+            }),
+        }))
 
         // Determine token limit
         let this_max_context = getMaxContextSize();
@@ -2634,7 +2633,7 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
             console.debug('Skipping extension interceptors for dry run');
         }
 
-        console.log(`Core/all messages: ${coreChat.length}/${chat_regexed.length}`);
+        console.log(`Core/all messages: ${coreChat.length}/${chat.length}`);
 
         // kingbri MARK: - Make sure the prompt bias isn't the same as the user bias
         if ((promptBias && !isUserPromptBias) || power_user.always_force_name2 || main_api == 'novel') {

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -86,7 +86,7 @@
                     <input type="checkbox" name="only_format_display" />
                     <span data-i18n="Only Format Display">Only Format Display</span>
                 </label>
-                <label class="checkbox flex-container" title="Chat history won't change, only as the prompt as the request is sent (on generation)">
+                <label class="checkbox flex-container" title="Chat history won't change, only the prompt as the request is sent (on generation)">
                     <input type="checkbox" name="only_format_prompt"/>
                     <span data-i18n="Only Format Prompt (?)">Only Format Prompt (?)</span>
                 </label>

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -33,7 +33,7 @@
                     <small data-i18n="Replace With">Replace With</small>
                 </label>
                 <div>
-                    <textarea 
+                    <textarea
                         class="regex_replace_string text_pole wide100p textarea_compact"
                         placeholder="Use {{match}} to include the matched text from the Find Regex"
                         rows="2"
@@ -45,7 +45,7 @@
                     <small data-i18n="Trim Out">Trim Out</small>
                 </label>
                 <div>
-                    <textarea 
+                    <textarea
                         class="regex_trim_strings text_pole wide100p textarea_compact"
                         placeholder="Globally trims any unwanted parts from a regex match before replacement. Separate each element by an enter."
                         rows="3"
@@ -85,6 +85,10 @@
                 <label class="checkbox flex-container">
                     <input type="checkbox" name="only_format_display" />
                     <span data-i18n="Only Format Display">Only Format Display</span>
+                </label>
+                <label class="checkbox flex-container" title="Chat history won't change, only as the prompt as the request is sent (on generation)">
+                    <input type="checkbox" name="only_format_prompt"/>
+                    <span data-i18n="Only Format Prompt (?)">Only Format Prompt (?)</span>
                 </label>
                 <label class="checkbox flex-container">
                     <input type="checkbox" name="run_on_edit" />

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -114,6 +114,9 @@ async function onRegexEditorOpenClick(existingId) {
                 .find(`input[name="only_format_display"]`)
                 .prop("checked", existingScript.markdownOnly ?? false);
             editorHtml
+                .find(`input[name="only_format_prompt"]`)
+                .prop("checked", existingScript.promptOnly ?? false);
+            editorHtml
                 .find(`input[name="run_on_edit"]`)
                 .prop("checked", existingScript.runOnEdit ?? false);
             editorHtml
@@ -165,6 +168,10 @@ async function onRegexEditorOpenClick(existingId) {
                 editorHtml
                     .find(`input[name="only_format_display"]`)
                     .prop("checked"),
+            promptOnly:
+                editorHtml
+                    .find(`input[name="only_format_prompt"]`)
+                    .prop("checked"),
             runOnEdit:
                 editorHtml
                     .find(`input[name="run_on_edit"]`)
@@ -197,6 +204,7 @@ function migrateSettings() {
                 script.placement = script.placement.filter((e) => e !== regex_placement.MD_DISPLAY);
 
             script.markdownOnly = true
+            script.promptOnly = true
 
             performSave = true;
         }


### PR DESCRIPTION
Adds "Only Format Prompt" checkbox option on scripts, default disabled
- (subtitle on hover: "Chat history won't change, only the prompt as the request is sent (on generation)")

![image](https://github.com/SillyTavern/SillyTavern/assets/21046091/510a9569-5b51-4d99-9be7-aa04d42a50a5)

- What it does: It applies the regex formatting only on `Generate`, keeping chat history the same
- Why: I want to filter regex patterns before sending the generation request, but I don't want to remove things from chat history, so I can check the output if needed
- Why?: This is useful for the rare cards that use CoT techniques with invisible text. 
    - I'm doing an CoT planning technique with invisible text , but it generates lots of invisible text tokens I don't want to take up token space on the history. But I also need to debug it or check if I want. 
- Extra detail: If both "Only Format Display" and "Only Format Prompt" are checked, it will do both and keep chat history unchanged (if none are, it will do all, as usual)