### PR TITLE
Increase the precision of the Min P slider and counter.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -835,10 +835,10 @@
                                         </div>
                                         <div class="range-block-range-and-counter">
                                             <div class="range-block-range">
-                                                <input type="range" id="min_p" name="volume" min="0" max="1" step="0.01">
+                                                <input type="range" id="min_p" name="volume" min="0" max="1" step="0.001">
                                             </div>
                                             <div class="range-block-counter">
-                                                <input type="number" min="0" max="1" step="0.01" data-for="min_p" id="min_p_counter">
+                                                <input type="number" min="0" max="1" step="0.001" data-for="min_p" id="min_p_counter">
 
                                             </div>
                                         </div>


### PR DESCRIPTION
The most useful values of Min P are very low, between 0.01 and 0.05. With a precision of 0.01, users have very few interesting values to choose from, while the back end can accept an arbitrary float.