### PR TITLE
Fixes for bulk editing overlay

### DIFF
--- a/public/css/character-group-overlay.css
+++ b/public/css/character-group-overlay.css
@@ -31,7 +31,7 @@
 #character_context_menu {
     position: absolute;
     padding: 3px;
-    z-index: 10000;
+    z-index: 9998;
     background-color: var(--black90a);
     border: 1px solid var(--black90a);
     border-radius: 10px;

--- a/public/css/character-group-overlay.css
+++ b/public/css/character-group-overlay.css
@@ -1,12 +1,17 @@
-#rm_print_characters_block .character_select,
-#rm_print_characters_block .group_select{
-    cursor: pointer;
-}
 
 #rm_print_characters_block.group_overlay_mode_select .character_select {
     transition: background-color 0.4s ease;
     margin-bottom: 1px;
     background-color: rgba(170, 170, 170, 0.15);
+}
+
+#rm_print_characters_block.group_overlay_mode_select .group_select {
+    cursor: auto;
+    filter: saturate(0.3);
+}
+
+#rm_print_characters_block.group_overlay_mode_select .group_select:hover {
+    background: none;
 }
 
 #rm_print_characters_block.group_overlay_mode_select .character_select input.bulk_select_checkbox {

--- a/public/index.html
+++ b/public/index.html
@@ -102,11 +102,11 @@
 
     <div id="character_context_menu" class="hidden">
         <ul>
-            <li><button id="character_context_menu_favorite">Favorite</button></li>
-            <li><button id="character_context_menu_tag">Tag</button></li>
-            <li><button id="character_context_menu_duplicate">Duplicate</button></li>
-            <li><button id="character_context_menu_persona">Persona</button></li>
-            <li><button id="character_context_menu_delete">Delete</button></li>
+            <li><button id="character_context_menu_favorite" data-i18n="Favorite">Favorite</button></li>
+            <li><button id="character_context_menu_tag" data-i18n="Tag">Tag</button></li>
+            <li><button id="character_context_menu_duplicate" data-i18n="Duplicate">Duplicate</button></li>
+            <li><button id="character_context_menu_persona" data-i18n="Persona">Persona</button></li>
+            <li><button id="character_context_menu_delete" data-i18n="Delete">Delete</button></li>
         </ul>
     </div>
 

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -290,7 +290,7 @@ class BulkEditOverlay {
     #selectedCharacters = [];
 
     /**
-     * If ture, prevents items from being deselected by clicking anywhere
+     * Locks other pointer actions when the context menu is open
      *
      * @type {boolean}
      */
@@ -523,7 +523,7 @@ class BulkEditOverlay {
 
         const legacyBulkEditCheckbox = character.querySelector('.' + BulkEditOverlay.legacySelectedClass);
 
-        // Only toggle when context menu is closed and has not just been closed
+        // Only toggle when context menu is closed and wasn't just closed.
         if (!this.#contextMenuOpen && !this.#cancelNextToggle)
             if (alreadySelected) {
                 character.classList.remove(BulkEditOverlay.selectedClass);

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -436,6 +436,11 @@ class BulkEditOverlay {
      */
     handleHold = (event) => {
         if (0 !== event.button && event.type !== 'touchstart') return;
+        if (this.#selectModeLock) {
+            this.#selectModeLock = false;
+            CharacterContextMenu.hide();
+            return;
+        }
 
         let cancel = false;
 
@@ -446,19 +451,19 @@ class BulkEditOverlay {
         this.isLongPress = true;
 
         setTimeout(() => {
-            if (this.isLongPress && !cancel) {
-                if (this.state === BulkEditOverlayState.browse) {
-                    this.selectState();
+                if (this.isLongPress && !cancel) {
+                    if (this.state === BulkEditOverlayState.browse) {
+                        this.selectState();
+                    } else if (this.state === BulkEditOverlayState.select) {
+                        this.#selectModeLock = true;
+                        CharacterContextMenu.show(...this.#getContextMenuPosition(event));
+                    }
                 }
-                else if (this.state === BulkEditOverlayState.select) {
-                    this.#selectModeLock = true;
-                    CharacterContextMenu.show(...this.#getContextMenuPosition(event));
-                }
-            }
 
-            this.container.removeEventListener('mouseup', cancelHold);
-            this.container.removeEventListener('touchend', cancelHold);
-        }, BulkEditOverlay.longPressDelay);
+                this.container.removeEventListener('mouseup', cancelHold);
+                this.container.removeEventListener('touchend', cancelHold);
+            },
+            BulkEditOverlay.longPressDelay);
     }
 
     handleLongPressEnd = () => {
@@ -498,7 +503,7 @@ class BulkEditOverlay {
 
     #getEnabledElements = () => [...this.container.getElementsByClassName(BulkEditOverlay.characterClass)];
 
-    #getDisabledElements = () =>[...this.container.querySelectorAll('.' + BulkEditOverlay.groupClass)];
+    #getDisabledElements = () =>[...this.container.getElementsByClassName(BulkEditOverlay.groupClass)];
 
     toggleCharacterSelected = event => {
         event.stopPropagation();
@@ -524,13 +529,11 @@ class BulkEditOverlay {
 
     handleContextMenuShow = (event) => {
         event.preventDefault();
-        this.container.style.pointerEvents = 'none';
         CharacterContextMenu.show(...this.#getContextMenuPosition(event));
         this.#selectModeLock = true;
     }
 
     handleContextMenuHide = (event) => {
-        this.container.style.pointerEvents = '';
         let contextMenu = document.getElementById(BulkEditOverlay.contextMenuId);
         if (false === contextMenu.contains(event.target)) {
             CharacterContextMenu.hide();

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -332,7 +332,6 @@ class BulkEditOverlay {
             return bulkEditOverlayInstance
 
         this.container = document.getElementById(BulkEditOverlay.containerId);
-        this.container.addEventListener('click', this.handleCancelClick);
 
         eventSource.on(event_types.CHARACTER_GROUP_OVERLAY_STATE_CHANGE_AFTER, this.handleStateChange);
         bulkEditOverlayInstance = Object.freeze(this);
@@ -364,8 +363,7 @@ class BulkEditOverlay {
         elements.forEach(element => element.addEventListener('dragend', this.handleLongPressEnd));
         elements.forEach(element => element.addEventListener('touchmove', this.handleLongPressEnd));
 
-        const grid = document.getElementById(BulkEditOverlay.containerId);
-        grid.addEventListener('click', this.handleCancelClick);
+        this.container.addEventListener('click', this.handleCancelClick);
     }
 
     /**
@@ -399,7 +397,7 @@ class BulkEditOverlay {
      * set a click event to hide the custom context menu.
      */
     enableContextMenu = () => {
-        document.getElementById(BulkEditOverlay.containerId).addEventListener('contextmenu', this.handleContextMenuShow);
+        this.container.addEventListener('contextmenu', this.handleContextMenuShow);
         document.addEventListener('click', this.handleContextMenuHide);
     }
 
@@ -408,7 +406,7 @@ class BulkEditOverlay {
      * menu to be opened.
      */
     disableContextMenu = () => {
-        document.getElementById(BulkEditOverlay.containerId).removeEventListener('contextmenu', this.handleContextMenuShow);
+        this.container.removeEventListener('contextmenu', this.handleContextMenuShow);
         document.removeEventListener('click', this.handleContextMenuHide);
     }
 
@@ -430,10 +428,9 @@ class BulkEditOverlay {
 
         let cancel = false;
 
-        const container = document.getElementById(BulkEditOverlay.containerId);
         const cancelHold = (event) => cancel = true;
-        container.addEventListener('mouseup', cancelHold);
-        container.addEventListener('touchend', cancelHold);
+        this.container.addEventListener('mouseup', cancelHold);
+        this.container.addEventListener('touchend', cancelHold);
 
         this.isLongPress = true;
 
@@ -445,8 +442,8 @@ class BulkEditOverlay {
                     CharacterContextMenu.show(...this.#getContextMenuPosition(event));
             }
 
-            container.removeEventListener('mouseup', cancelHold);
-            container.removeEventListener('touchend', cancelHold);
+            this.container.removeEventListener('mouseup', cancelHold);
+            this.container.removeEventListener('touchend', cancelHold);
         }, BulkEditOverlay.longPressDelay);
     }
 
@@ -502,12 +499,12 @@ class BulkEditOverlay {
 
     handleContextMenuShow = (event) => {
         event.preventDefault();
-        document.getElementById(BulkEditOverlay.containerId).style.pointerEvents = 'none';
+        this.container.style.pointerEvents = 'none';
         CharacterContextMenu.show(...this.#getContextMenuPosition(event));
     }
 
     handleContextMenuHide = (event) => {
-        document.getElementById(BulkEditOverlay.containerId).style.pointerEvents = '';
+        this.container.style.pointerEvents = '';
         let contextMenu = document.getElementById(BulkEditOverlay.contextMenuId);
         if (false === contextMenu.contains(event.target)) {
             CharacterContextMenu.hide();

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -159,6 +159,15 @@ class CharacterContextMenu {
         contextMenu.style.top = `${positionY}px`;
 
         document.getElementById(BulkEditOverlay.contextMenuId).classList.remove('hidden');
+
+        // Adjust position if context menu is outside of viewport
+        const boundingRect = contextMenu.getBoundingClientRect();
+        if (boundingRect.right > window.innerWidth) {
+            contextMenu.style.left = `${positionX - (boundingRect.right - window.innerWidth)}px`;
+        }
+        if (boundingRect.bottom > window.innerHeight) {
+            contextMenu.style.top = `${positionY - (boundingRect.bottom - window.innerHeight)}px`;
+        }
     }
 
     /**
@@ -378,7 +387,9 @@ class BulkEditOverlay {
         elements.forEach(element => element.addEventListener('dragend', this.handleLongPressEnd));
         elements.forEach(element => element.addEventListener('touchmove', this.handleLongPressEnd));
 
-        this.container.addEventListener('click', this.handleCancelClick);
+        // Cohee: It only triggers when clicking on a margin between the elements?
+        // Feel free to fix or remove this, I'm not sure how to.
+        //this.container.addEventListener('click', this.handleCancelClick);
     }
 
     /**

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -399,7 +399,7 @@ class BulkEditOverlay {
      * set a click event to hide the custom context menu.
      */
     enableContextMenu = () => {
-        document.getElementById('rm_print_characters_block').addEventListener('contextmenu', this.handleContextMenuShow);
+        document.getElementById(BulkEditOverlay.containerId).addEventListener('contextmenu', this.handleContextMenuShow);
         document.addEventListener('click', this.handleContextMenuHide);
     }
 
@@ -408,7 +408,7 @@ class BulkEditOverlay {
      * menu to be opened.
      */
     disableContextMenu = () => {
-        document.getElementById('rm_print_characters_block').removeEventListener('contextmenu', this.handleContextMenuShow);
+        document.getElementById(BulkEditOverlay.containerId).removeEventListener('contextmenu', this.handleContextMenuShow);
         document.removeEventListener('click', this.handleContextMenuHide);
     }
 
@@ -420,17 +420,33 @@ class BulkEditOverlay {
         }
     }
 
+    /**
+     * Opens menu on long-press.
+     *
+     * @param event - Pointer event
+     */
     handleHold = (event) => {
         if (0 !== event.button && event.type !== 'touchstart') return;
 
+        let cancel = false;
+
+        const container = document.getElementById(BulkEditOverlay.containerId);
+        const cancelHold = (event) => cancel = true;
+        container.addEventListener('mouseup', cancelHold);
+        container.addEventListener('touchend', cancelHold);
+
         this.isLongPress = true;
+
         setTimeout(() => {
-            if (this.isLongPress) {
+            if (this.isLongPress && !cancel) {
                 if (this.state === BulkEditOverlayState.browse)
                     this.selectState();
                 else if (this.state === BulkEditOverlayState.select)
                     CharacterContextMenu.show(...this.#getContextMenuPosition(event));
             }
+
+            container.removeEventListener('mouseup', cancelHold);
+            container.removeEventListener('touchend', cancelHold);
         }, BulkEditOverlay.longPressDelay);
     }
 

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -277,6 +277,7 @@ class BulkEditOverlay {
     static containerId = 'rm_print_characters_block';
     static contextMenuId = 'character_context_menu';
     static characterClass = 'character_select';
+    static groupClass = 'group_select';
     static selectModeClass = 'group_overlay_mode_select';
     static selectedClass = 'character_selected';
     static legacySelectedClass = 'bulk_select_checkbox';
@@ -376,6 +377,7 @@ class BulkEditOverlay {
             case BulkEditOverlayState.browse:
                 this.container.classList.remove(BulkEditOverlay.selectModeClass);
                 this.#enableClickEventsForCharacters();
+                this.#enableClickEventsForGroups();
                 this.clearSelectedCharacters();
                 this.disableContextMenu();
                 this.#disableBulkEditButtonHighlight();
@@ -384,6 +386,7 @@ class BulkEditOverlay {
             case BulkEditOverlayState.select:
                 this.container.classList.add(BulkEditOverlay.selectModeClass);
                 this.#disableClickEventsForCharacters();
+                this.#disableClickEventsForGroups();
                 this.enableContextMenu();
                 this.#enableBulkEditButtonHighlight();
                 break;
@@ -466,6 +469,12 @@ class BulkEditOverlay {
         event.clientY || event.touches[0].clientY,
     ];
 
+    #stopEventPropagation = (event) => event.stopPropagation();
+
+    #enableClickEventsForGroups = () => this.#getDisabledElements().forEach((element) => element.removeEventListener('click', this.#stopEventPropagation));
+
+    #disableClickEventsForGroups = () => this.#getDisabledElements().forEach((element) => element.addEventListener('click', this.#stopEventPropagation));
+
     #enableClickEventsForCharacters = () => this.#getEnabledElements().forEach(element => element.removeEventListener('click', this.toggleCharacterSelected));
 
     #disableClickEventsForCharacters = () => this.#getEnabledElements().forEach(element => element.addEventListener('click', this.toggleCharacterSelected));
@@ -475,6 +484,8 @@ class BulkEditOverlay {
     #disableBulkEditButtonHighlight = () => document.getElementById('bulkEditButton').classList.remove('bulk_edit_overlay_active');
 
     #getEnabledElements = () => [...this.container.getElementsByClassName(BulkEditOverlay.characterClass)];
+
+    #getDisabledElements = () =>[...this.container.querySelectorAll('.' + BulkEditOverlay.groupClass)];
 
     toggleCharacterSelected = event => {
         event.stopPropagation();

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -485,7 +485,7 @@ class BulkEditOverlay {
             BulkEditOverlay.longPressDelay);
     }
 
-    handleLongPressEnd = () => {
+    handleLongPressEnd = (event) => {
         this.isLongPress = false;
         if (this.#contextMenuOpen) event.stopPropagation();
     }
@@ -506,7 +506,12 @@ class BulkEditOverlay {
         event.clientY || event.touches[0].clientY,
     ];
 
-    #stopEventPropagation = (event) => event.stopPropagation();
+    #stopEventPropagation = (event) => {
+        if (this.#contextMenuOpen) {
+            this.handleContextMenuHide(event);
+        }
+        event.stopPropagation();
+    }
 
     #enableClickEventsForGroups = () => this.#getDisabledElements().forEach((element) => element.removeEventListener('click', this.#stopEventPropagation));
 

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -10,7 +10,7 @@ import {
 import { FILTER_TYPES, FilterHelper } from "./filters.js";
 
 import { groupCandidatesFilter, selected_group } from "./group-chats.js";
-import { uuidv4 } from "./utils.js";
+import { onlyUnique, uuidv4 } from "./utils.js";
 
 export {
     tags,
@@ -153,6 +153,7 @@ function addTagToMap(tagId, characterId = null) {
     }
     else {
         tag_map[key].push(tagId);
+        tag_map[key] = tag_map[key].filter(onlyUnique);
     }
 }
 


### PR DESCRIPTION
- [x]  Prevent menu from opening multiple times in different positions when a user selects and ends with a long-press.
- [x]  Prevent groups from being selected and provide visual feedback for it.
- [x]  Closing the context menu does not deselect all characters.
- [x]  Context menu does not overlap popups anymore. 
- [x] Adds missingi18n attributes.