### PR TITLE
fix tts re-trigger for complete/autocomplete/delete

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -145,7 +145,7 @@ async function moduleWorker() {
     }
 
     // clone message object, as things go haywire if message object is altered below (it's passed by reference)
-    const message = JSON.parse(JSON.stringify(chat[chat.length - 1]))
+    const message = structuredClone(chat[chat.length - 1])
 
     // if last message within current message, message got extended. only send diff to TTS.
     if (ttsLastMessage !== null && message.mes.indexOf(ttsLastMessage) !== -1) {
@@ -646,6 +646,7 @@ export function saveTtsProviderSettings() {
 async function onChatChanged() {
     await resetTtsPlayback()
     await initVoiceMap()
+    ttsLastMessage = null
 }
 
 async function onChatDeleted() {

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -76,6 +76,8 @@ let ttsProviders = {
 let ttsProvider
 let ttsProviderName
 
+let ttsLastMessage = null;
+
 async function onNarrateOneMessage() {
     audioElement.src = '/sounds/silence.mp3';
     const context = getContext();
@@ -132,11 +134,27 @@ async function moduleWorker() {
     let diff = lastMessageNumber - currentMessageNumber
     let hashNew = getStringHash((chat.length && chat[chat.length - 1].mes) ?? '')
 
+    // if messages got deleted, diff will be < 0
+    if (diff < 0) {
+        // necessary actions will be taken by the onChatDeleted() handler
+        return
+    }
+
     if (diff == 0 && hashNew === lastMessageHash) {
         return
     }
 
-    const message = chat[chat.length - 1]
+    // clone message object, as things go haywire if message object is altered below (it's passed by reference)
+    const message = JSON.parse(JSON.stringify(chat[chat.length - 1]))
+
+    // if last message within current message, message got extended. only send diff to TTS.
+    if (ttsLastMessage !== null && message.mes.indexOf(ttsLastMessage) !== -1) {
+        let tmp = message.mes
+        message.mes = message.mes.replace(ttsLastMessage, '')
+        ttsLastMessage = tmp
+    } else {
+        ttsLastMessage = message.mes
+    }
 
     // We're currently swiping or streaming. Don't generate voice
     if (
@@ -630,6 +648,25 @@ async function onChatChanged() {
     await initVoiceMap()
 }
 
+async function onChatDeleted() {
+    const context = getContext()
+
+    // update internal references to new last message
+    lastChatId = context.chatId
+    currentMessageNumber = context.chat.length ? context.chat.length : 0
+
+    // compare against lastMessageHash. If it's the same, we did not delete the last chat item, so no need to reset tts queue
+    let messageHash = getStringHash((context.chat.length && context.chat[context.chat.length - 1].mes) ?? '')
+    if (messageHash === lastMessageHash) {
+        return
+    }
+    lastMessageHash = messageHash
+    ttsLastMessage = (context.chat.length && context.chat[context.chat.length - 1].mes) ?? '';
+
+    // stop any tts playback since message might not exist anymore
+    await resetTtsPlayback()
+}
+
 function getCharacters(){
     const context = getContext()
     let characters = []
@@ -771,7 +808,7 @@ export async function initVoiceMap(){
     // Clear existing voiceMap state
     $('#tts_voicemap_block').empty()
     voiceMapEntries = []
-    
+
     // Get characters in current chat
     const characters = getCharacters()
 
@@ -898,4 +935,5 @@ $(document).ready(function () {
     eventSource.on(event_types.MESSAGE_SWIPED, resetTtsPlayback);
     eventSource.on(event_types.CHAT_CHANGED, onChatChanged)
     eventSource.on(event_types.GROUP_UPDATED, onChatChanged)
+    eventSource.on(event_types.MESSAGE_DELETED, onChatDeleted);
 })


### PR DESCRIPTION
There is currently an issue regarding TTS and the auto-continue and the manual continue feature:

As soon as the first block of text is generated by the model, it is sent do the TTS for output.
Then, as soon as the model has generated more text, either by the auto-continue or the manual continue feature, it will resend the whole text again to the TTS for output.

What this change does is to create a diff and only send the added lines to the TTS.

There is a drawback in terms of that currently it will not try to send only complete sentences to the TTS, which results in a not so smooth transition between the TTS calls. I'm unsure if this really can be fixed, but nonetheless with this patch it is now much better, as the char is not repeating itself all the time now. :)


Then there was an issue with deleting messages, which was not handled by the TTS, resulting in repetition as well. I've added a `onDelete` listener to accommodate for that.


There is one issue left that I have noticed, but I have yet to come up with a solution:
The talkinghead is always talking, even if it's a sys or user message, which makes no sense. But in the code that triggers the talking, there is no way right now to tell who's talking. I'll look into that later.

I'm open for suggestions. :)