### PR TITLE
Increase kobold max temp to 4.0

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -715,8 +715,8 @@
                                             Temperature
                                             <div class="fa-solid fa-circle-info opacity50p" title="Temperature controls the randomness in token selection:&#13;- low temperature (<1.0) leads to more predictable text, favoring higher probability tokens.&#13;- high temperature (>1.0) increases creativity and diversity in the output by giving lower probability tokens a better chance.&#13;Set to 1.0 for the original probabilities."></div>
                                         </small>
-                                        <input class="neo-range-slider" type="range" id="temp" name="volume" min="0.0" max="2.0" step="0.01">
-                                        <input class="neo-range-input" type="number" min="0.0" max="2.0" step="0.01" data-for="temp" id="temp_counter">
+                                        <input class="neo-range-slider" type="range" id="temp" name="volume" min="0.0" max="4.0" step="0.01">
+                                        <input class="neo-range-input" type="number" min="0.0" max="4.0" step="0.01" data-for="temp" id="temp_counter">
                                     </div>
                                     <div data-newbie-hidden class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
                                         <small data-i18n="Top K">


### PR DESCRIPTION
Not only is a higher temp accepted by the back end, but it's just about necessary in order to make use of Minimum P sampling.

In theory, higher temps are accepted and usable, but practically speaking, 4.0 is about as high as the user is likely to go, and 3.5 is just about as far as most models are capable of making use of these days.