### PR TITLE
update live2d assets detection to allow for subfolder organisation.

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -93,7 +93,7 @@ function registerEndpoints(app, jsonParser) {
                         const files = getFiles(live2d_folder)
                         //console.debug("FILE FOUND:",files)
                         for (let file of files) {
-                            file = path.normalize(file.replace('public\\', ''));
+                            file = path.normalize(file.replace(path.normalize('public\\'), ''));
                             if (file.endsWith("model3.json")) {
                                 //console.debug("Asset live2d model found:",file)
                                 output[folder].push(path.normalize(path.join(file)));

--- a/src/assets.js
+++ b/src/assets.js
@@ -274,7 +274,7 @@ function registerEndpoints(app, jsonParser) {
                             for (let file of fs.readdirSync(live2dModelPath)) {
                                 //console.debug("Character live2d model found:", file)
                                 if (file.includes("model"))
-                                    output.push([`${modelFolder}`, path.join("characters", name, category, modelFolder, file)]);
+                                    output.push(path.join("characters", name, category, modelFolder, file));
                             }
                         }
                     }

--- a/src/assets.js
+++ b/src/assets.js
@@ -37,6 +37,25 @@ function checkAssetFileName(inputFilename) {
     return path.normalize(inputFilename).replace(/^(\.\.(\/|\\|$))+/, '');;
 }
 
+// Recursive function to get files
+function getFiles(dir, files = []) {
+    // Get an array of all files and directories in the passed directory using fs.readdirSync
+    const fileList = fs.readdirSync(dir)
+    // Create the full path of the file/directory by concatenating the passed directory and file/directory name
+    for (const file of fileList) {
+        const name = `${dir}/${file}`
+        // Check if the current file/directory is a directory using fs.statSync
+        if (fs.statSync(name).isDirectory()) {
+        // If it is a directory, recursively call the getFiles function with the directory path and the files array
+        getFiles(name, files)
+        } else {
+        // If it is a file, push the full path to the files array
+        files.push(name)
+        }
+    }
+    return files
+}
+
 /**
  * Registers the endpoints for the asset management.
  * @param {import('express').Express} app Express app
@@ -70,16 +89,14 @@ function registerEndpoints(app, jsonParser) {
                     // Live2d assets
                     if (folder == "live2d") {
                         output[folder] = [];
-                        const live2d_folders = fs.readdirSync(path.join(folderPath, folder));
-                        for (let model_folder of live2d_folders) {
-                            const live2d_model_path = path.join(folderPath, folder, model_folder);
-                            if (fs.statSync(live2d_model_path).isDirectory()) {
-                                for (let file of fs.readdirSync(live2d_model_path)) {
-                                    if (file.includes("model")) {
-                                        //console.debug("Asset live2d model found:",file)
-                                        output[folder].push([`${model_folder}`, path.join("assets", folder, model_folder, file)]);
-                                    }
-                                }
+                        const live2d_folder = path.normalize(path.join(folderPath, folder));
+                        const files = getFiles(live2d_folder)
+                        //console.debug("FILE FOUND:",files)
+                        for (let file of files) {
+                            file = path.normalize(file.replace('public\\', ''));
+                            if (file.endsWith("model3.json")) {
+                                //console.debug("Asset live2d model found:",file)
+                                output[folder].push(path.normalize(path.join(file)));
                             }
                         }
                         continue;

--- a/src/assets.js
+++ b/src/assets.js
@@ -93,7 +93,7 @@ function registerEndpoints(app, jsonParser) {
                         const files = getFiles(live2d_folder)
                         //console.debug("FILE FOUND:",files)
                         for (let file of files) {
-                            file = path.normalize(file.replace(path.normalize('public\\'), ''));
+                            file = path.normalize(file.replace('public'+path.sep, ''));
                             if (file.endsWith("model3.json")) {
                                 //console.debug("Asset live2d model found:",file)
                                 output[folder].push(path.normalize(path.join(file)));


### PR DESCRIPTION
Allow user to have live2d assets organise the way they want as long as files are into assets/lived2/ (before no subfolder organisation was managed).

![image](https://github.com/SillyTavern/SillyTavern/assets/48798118/68c0fbdd-5b4e-483f-a420-3f57a3947b29)
