### PR TITLE
Feature/openrouter grouping and sorting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1832,8 +1832,17 @@
                                 </select>
                             </div>
                             <div class="marginTopBot5">
-                                <label for="openrouter_group_options" class="checkbox_label">
-                                    <input id="openrouter_group_options" type="checkbox" onchange="document.getElementById('chat_completion_source').dispatchEvent(new Event('change'))"/>
+                                <label for="openrouter_sort_models" class="checkbox_label">
+                                    <select id="openrouter_sort_models">
+                                        <option data-i18n="Alphabetically" value="alphabetically">Alphabetically</option>
+                                        <option data-i18n="Price" value="pricing.prompt">Price (cheapest)</option>
+                                        <option data-i18n="Context Size" value="context_length">Context Size</option>
+                                    </select>
+                                </label>
+                            </div>
+                            <div class="marginTopBot5">
+                                <label for="openrouter_group_models" class="checkbox_label">
+                                    <input id="openrouter_group_models" type="checkbox" />
                                     <span data-i18n="Group by vendor names">Group by vendor names</span>
                                 </label>
                             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -1832,6 +1832,12 @@
                                 </select>
                             </div>
                             <div class="marginTopBot5">
+                                <label for="openrouter_group_options" class="checkbox_label">
+                                    <input id="openrouter_group_options" type="checkbox" onchange="document.getElementById('chat_completion_source').dispatchEvent(new Event('change'))"/>
+                                    <span data-i18n="Group by vendor names">Group by vendor names</span>
+                                </label>
+                            </div>
+                            <div class="marginTopBot5">
                                 <label for="openrouter_use_fallback" class="checkbox_label">
                                     <input id="openrouter_use_fallback" type="checkbox" />
                                     <span data-i18n="Allow fallback routes">Allow fallback routes</span>

--- a/public/index.html
+++ b/public/index.html
@@ -1832,19 +1832,34 @@
                                 </select>
                             </div>
                             <div class="marginTopBot5">
-                                <label for="openrouter_sort_models" class="checkbox_label">
-                                    <select id="openrouter_sort_models">
-                                        <option data-i18n="Alphabetically" value="alphabetically">Alphabetically</option>
-                                        <option data-i18n="Price" value="pricing.prompt">Price (cheapest)</option>
-                                        <option data-i18n="Context Size" value="context_length">Context Size</option>
-                                    </select>
-                                </label>
-                            </div>
-                            <div class="marginTopBot5">
-                                <label for="openrouter_group_models" class="checkbox_label">
-                                    <input id="openrouter_group_models" type="checkbox" />
-                                    <span data-i18n="Group by vendor names">Group by vendor names</span>
-                                </label>
+                                <div class="inline-drawer wide100p">
+                                    <div class="inline-drawer-toggle inline-drawer-header">
+                                        <b data-i18n="Model Order">Openrouter Model Sorting</b>
+                                        <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                                    </div>
+                                    <div class="inline-drawer-content m-b-1">
+                                        <div class="marginTopBot5">
+                                            <label for="openrouter_sort_models" class="checkbox_label">
+                                                <select id="openrouter_sort_models">
+                                                    <option data-i18n="Alphabetically" value="alphabetically">Alphabetically</option>
+                                                    <option data-i18n="Price" value="pricing.prompt">Price (cheapest)</option>
+                                                    <option data-i18n="Context Size" value="context_length">Context Size</option>
+                                                </select>
+                                            </label>
+                                        </div>
+                                        <div class="marginTopBot5">
+                                            <label for="openrouter_group_models" class="checkbox_label">
+                                                <input id="openrouter_group_models" type="checkbox"/>
+                                                <span data-i18n="Group by vendor names">Group by vendor names</span>
+                                            </label>
+                                            <div class="toggle-description justifyLeft wide100p">
+                                                <span data-i18n="Allow fallback routes Description">
+                                                    Group models by their vendor. I.e. put all OpenAI models in one group, all Anthropic models in one group etc. Can be combined with sorting.
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="marginTopBot5">
                                 <label for="openrouter_use_fallback" class="checkbox_label">

--- a/public/index.html
+++ b/public/index.html
@@ -1853,7 +1853,7 @@
                                                 <span data-i18n="Group by vendor names">Group by vendor names</span>
                                             </label>
                                             <div class="toggle-description justifyLeft wide100p">
-                                                <span data-i18n="Allow fallback routes Description">
+                                                <span data-i18n="Group by vendor names Description">
                                                     Group models by their vendor. I.e. put all OpenAI models in one group, all Anthropic models in one group etc. Can be combined with sorting.
                                                 </span>
                                             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -1834,7 +1834,7 @@
                             <div class="marginTopBot5">
                                 <div class="inline-drawer wide100p">
                                     <div class="inline-drawer-toggle inline-drawer-header">
-                                        <b data-i18n="Model Order">Openrouter Model Sorting</b>
+                                        <b data-i18n="Model Order">OpenRouter Model Sorting</b>
                                         <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                     </div>
                                     <div class="inline-drawer-content m-b-1">
@@ -1850,11 +1850,11 @@
                                         <div class="marginTopBot5">
                                             <label for="openrouter_group_models" class="checkbox_label">
                                                 <input id="openrouter_group_models" type="checkbox"/>
-                                                <span data-i18n="Group by vendor names">Group by vendor names</span>
+                                                <span data-i18n="Group by vendors">Group by vendors</span>
                                             </label>
                                             <div class="toggle-description justifyLeft wide100p">
-                                                <span data-i18n="Group by vendor names Description">
-                                                    Group models by their vendor. I.e. put all OpenAI models in one group, all Anthropic models in one group etc. Can be combined with sorting.
+                                                <span data-i18n="Group by vendors Description">
+                                                    Put OpenAI models in one group, Anthropic models in other group, etc. Can be combined with sorting.
                                                 </span>
                                             </div>
                                         </div>
@@ -1962,7 +1962,7 @@
                             <select id="model_palm_select" class="displayNone"></select>
                         </form>
                         <div class="flex-container flex">
-                            <div id="api_button_openai" class="menu_button menu_button_icon" type="submit" data-i18n="Connect">Connect</div>
+                            <div id="api_button_openai" class="api_button menu_button menu_button_icon" type="submit" data-i18n="Connect">Connect</div>
                             <div class="api_loading menu_button" data-i18n="Cancel">Cancel</div>
                             <div data-source="openrouter" id="openrouter_authorize" class="menu_button menu_button_icon" title="Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai" data-i18n="[title]Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai">Authorize</div>
                             <div id="test_api_button" class="menu_button menu_button_icon" title="Verifies your API connection by sending a short test message. Be aware that you'll be credited for it!" data-i18n="[title]Verifies your API connection by sending a short test message. Be aware that you'll be credited for it!">Test Message</div>

--- a/public/script.js
+++ b/public/script.js
@@ -926,12 +926,12 @@ async function getStatus() {
 
 export function startStatusLoading() {
     $(".api_loading").show();
-    $(".api_button").attr("disabled", "disabled").addClass("disabled");
+    $(".api_button").addClass("disabled");
 }
 
 export function stopStatusLoading() {
     $(".api_loading").hide();
-    $(".api_button").removeAttr("disabled").removeClass("disabled");
+    $(".api_button").removeClass("disabled");
 }
 
 export function resultCheckStatus() {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -209,6 +209,8 @@ const default_settings = {
     openrouter_model: openrouter_website_model,
     openrouter_use_fallback: false,
     openrouter_force_instruct: false,
+    openrouter_group_models: false,
+    openrouter_sort_models: 'alphabetically',
     jailbreak_system: false,
     reverse_proxy: '',
     legacy_streaming: false,
@@ -257,6 +259,8 @@ const oai_settings = {
     openrouter_model: openrouter_website_model,
     openrouter_use_fallback: false,
     openrouter_force_instruct: false,
+    openrouter_group_models: false,
+    openrouter_sort_models: 'alphabetically',
     jailbreak_system: false,
     reverse_proxy: '',
     legacy_streaming: false,
@@ -1241,11 +1245,14 @@ function saveModelList(data) {
     model_list.sort((a, b) => a?.id && b?.id && a.id.localeCompare(b.id));
 
     if (oai_settings.chat_completion_source == chat_completion_sources.OPENROUTER) {
+        const sortingProperty = document.getElementById('openrouter_sort_models').value;
+        model_list = openRouterSortBy(model_list, sortingProperty);
+
         $('#model_openrouter_select').empty();
 
-        const groupModels = document.getElementById('openrouter_group_options')?.checked ?? false;
+        const groupModels = document.getElementById('openrouter_group_models')?.checked ?? false;
         if (groupModels) {
-            appendOpenRouterOptions(groupByVendor(model_list), groupModels);
+            appendOpenRouterOptions(openRouterGroupByVendor(model_list), groupModels);
         } else {
             appendOpenRouterOptions(model_list);
         }
@@ -1301,7 +1308,20 @@ function appendOpenRouterOptions(model_list, groupModels = false, sort = false) 
     }
 }
 
-function groupByVendor(array) {
+const openRouterSortBy = (data, property = 'alphabetically') => {
+    return data.sort((a, b) => {
+        if (property === 'context_length') {
+            return b.context_length - a.context_length;
+        } else if (property === 'pricing.prompt') {
+            return parseFloat(a.pricing.prompt) - parseFloat(b.pricing.prompt);
+        } else {
+            // Alphabetically
+            return a?.id && b?.id && a.id.localeCompare(b.id);
+        }
+    });
+};
+
+function openRouterGroupByVendor(array) {
     const unsorted = array.reduce((acc, curr) => {
         const vendor = curr.id.split('/')[0];
 
@@ -1314,7 +1334,7 @@ function groupByVendor(array) {
         return acc;
     }, new Map());
 
-    return new Map([...unsorted.entries()].sort());
+    return unsorted;
 }
 
 async function sendAltScaleRequest(openai_msgs_tosend, logit_bias, signal, type) {
@@ -2247,6 +2267,7 @@ function loadOpenAISettings(data, settings) {
     oai_settings.windowai_model = settings.windowai_model ?? default_settings.windowai_model;
     oai_settings.openrouter_model = settings.openrouter_model ?? default_settings.openrouter_model;
     oai_settings.openrouter_group_models = settings.openrouter_group_models ?? default_settings.openrouter_group_models;
+    oai_settings.openrouter_sort_models = settings.openrouter_sort_models ?? default_settings.openrouter_sort_models;
     oai_settings.openrouter_use_fallback = settings.openrouter_use_fallback ?? default_settings.openrouter_use_fallback;
     oai_settings.openrouter_force_instruct = settings.openrouter_force_instruct ?? default_settings.openrouter_force_instruct;
     oai_settings.ai21_model = settings.ai21_model ?? default_settings.ai21_model;
@@ -2292,6 +2313,7 @@ function loadOpenAISettings(data, settings) {
     $('#openai_max_context_counter').val(`${oai_settings.openai_max_context}`);
     $('#model_openrouter_select').val(oai_settings.openrouter_model);
     $('#openrouter_group_models').val(oai_settings.openrouter_group_models);
+    $('#openrouter_sort_models').val(oai_settings.openrouter_sort_models);
 
     $('#openai_max_tokens').val(oai_settings.openai_max_tokens);
 
@@ -2833,6 +2855,7 @@ function onSettingsPresetChange() {
         openrouter_use_fallback: ['#openrouter_use_fallback', 'openrouter_use_fallback', true],
         openrouter_force_instruct: ['#openrouter_force_instruct', 'openrouter_force_instruct', true],
         openrouter_group_models: ['#openrouter_group_models', 'openrouter_group_models', false],
+        openrouter_sort_models: ['#openrouter_sort_models', 'openrouter_sort_models', false],
         ai21_model: ['#model_ai21_select', 'ai21_model', false],
         openai_max_context: ['#openai_max_context', 'openai_max_context', false],
         openai_max_tokens: ['#openai_max_tokens', 'openai_max_tokens', false],
@@ -3635,6 +3658,8 @@ $(document).ready(async function () {
     $("#model_scale_select").on("change", onModelChange);
     $("#model_palm_select").on("change", onModelChange);
     $("#model_openrouter_select").on("change", onModelChange);
+    $("#openrouter_group_models").on("change", getStatusOpen);
+    $("#openrouter_sort_models").on("change", getStatusOpen);
     $("#model_ai21_select").on("change", onModelChange);
     $("#settings_preset_openai").on("change", onSettingsPresetChange);
     $("#new_oai_preset").on("click", onNewPresetClick);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1244,14 +1244,12 @@ function saveModelList(data) {
     model_list.sort((a, b) => a?.id && b?.id && a.id.localeCompare(b.id));
 
     if (oai_settings.chat_completion_source == chat_completion_sources.OPENROUTER) {
-        const sortingProperty = document.getElementById('openrouter_sort_models').value;
-        model_list = openRouterSortBy(model_list, sortingProperty);
+        model_list = openRouterSortBy(model_list, oai_settings.openrouter_sort_models);
 
         $('#model_openrouter_select').empty();
 
-        const groupModels = document.getElementById('openrouter_group_models')?.checked ?? false;
-        if (groupModels) {
-            appendOpenRouterOptions(openRouterGroupByVendor(model_list), groupModels);
+        if (true === oai_settings.openrouter_group_models) {
+            appendOpenRouterOptions(openRouterGroupByVendor(model_list), oai_settings.openrouter_group_models);
         } else {
             appendOpenRouterOptions(model_list);
         }

--- a/public/style.css
+++ b/public/style.css
@@ -1383,7 +1383,8 @@ select option:not(:checked) {
 
 .menu_button.disabled {
     filter: brightness(75%) grayscale(1);
-    cursor: not-allowed;
+    opacity: 0.5;
+    pointer-events: none;
 }
 
 .fav_on {


### PR DESCRIPTION
Adds the following toggles:

- Group openrouter models by vendor name
- Sort openrouter models Alphabetically, by price or max. context size.
- Rename 'Infinity/k $' to 'Free'

Defaults are Alphabetically (current behavior) for sorting and false for grouping by vendor name. 

![openrouter](https://github.com/SillyTavern/SillyTavern/assets/12953058/4355f192-6a45-4550-b28e-ece4355a3fce)
