### PR TITLE
update docker registry in compose file to github from dockerhub

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: ..
     container_name: sillytavern
     hostname: sillytavern
-    image: sillytavern/sillytavern:latest
+    image: ghcr.io/sillytavern/sillytavern:latest
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
Updated the repo to pull from github as the dockerhub project for sillytavern appears to be deprecated (was deleted sometime in last few weeks).   Location in this PR is where github action publishes to.