### PR TITLE
Add ComfyUI to the Stable Diffusion extension

### DIFF
--- a/public/scripts/extensions/stable-diffusion/comfyWorkflowEditor.html
+++ b/public/scripts/extensions/stable-diffusion/comfyWorkflowEditor.html
@@ -1,0 +1,30 @@
+<div id="sd_comfy_workflow_editor_template">
+	<div class="sd_comfy_workflow_editor">
+		<h3><strong>ComfyUI Workflow Editor</strong></h3>
+		<div class="sd_comfy_workflow_editor_content">
+			<div class="flex-container flexFlowColumn sd_comfy_workflow_editor_workflow_container">
+				<label for="sd_comfy_workflow_editor_workflow">Workflow (JSON)</label>
+				<textarea id="sd_comfy_workflow_editor_workflow" class="text_pole wide100p textarea_compact flex1" placeholder="Put the ComfyUI's workflow (JSON) here and replace the variable settings with placeholders."></textarea>
+			</div>
+			<div class="sd_comfy_workflow_editor_placeholder_container">
+				<div>Placeholders</div>
+				<ul class="sd_comfy_workflow_editor_placeholder_list">
+					<li data-placeholder="prompt" class="sd_comfy_workflow_editor_not_found">"%prompt%"</li>
+					<li data-placeholder="negative_prompt" class="sd_comfy_workflow_editor_not_found">"%negative_prompt%"</li>
+					<li data-placeholder="model" class="sd_comfy_workflow_editor_not_found">"%model%"</li>
+					<li data-placeholder="sampler" class="sd_comfy_workflow_editor_not_found">"%sampler%"</li>
+					<li data-placeholder="scheduler" class="sd_comfy_workflow_editor_not_found">"%scheduler%"</li>
+					<li data-placeholder="steps" class="sd_comfy_workflow_editor_not_found">"%steps%"</li>
+					<li data-placeholder="scale" class="sd_comfy_workflow_editor_not_found">"%scale%"</li>
+					<li data-placeholder="width" class="sd_comfy_workflow_editor_not_found">"%width%"</li>
+					<li data-placeholder="height" class="sd_comfy_workflow_editor_not_found">"%height%"</li>
+					<li><hr></li>
+					<li data-placeholder="seed" class="sd_comfy_workflow_editor_not_found">
+						"%seed%"
+						<a href="javascript:;" class="notes-link"><span class="note-link-span" title="Will generate a new random seed in SillyTavern that is then used in the ComfyUI workflow.">?</span></a>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</div>

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -128,7 +128,7 @@
                     <i class="fa-solid fa-pen-to-square"></i>
                     <span>Open Workflow Editor</span>
                 </div>
-                <p><i><b>Important:</b> run ComfyUI with the <code>--enable-cors-header http://127.0.0.1:8000</code> argument (adjust URL according to your SillyTavern setup)! The server must be accessible from the SillyTavern host machine.</i></p>
+                <p><i><b>Important:</b> The server must be accessible from the SillyTavern host machine.</i></p>
             </div>
             <label for="sd_scale">CFG Scale (<span id="sd_scale_value"></span>)</label>
             <input id="sd_scale" type="range" min="{{scale_min}}" max="{{scale_max}}" step="{{scale_step}}" value="{{scale}}" />

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -30,6 +30,7 @@
                 <option value="vlad">SD.Next (vladmandic)</option>
                 <option value="novel">NovelAI Diffusion</option>
                 <option value="openai">OpenAI (DALL-E)</option>
+                <option value="comfy">ComfyUI</option>
             </select>
             <div data-sd-source="auto">
                 <label for="sd_auto_url">SD Web UI URL</label>
@@ -112,6 +113,23 @@
                     </select>
                 </div>
             </div>
+            <div data-sd-source="comfy">
+                <label for="sd_comfy_url">ComfyUI URL</label>
+                <div class="flex-container flexnowrap">
+                    <input id="sd_comfy_url" type="text" class="text_pole" placeholder="Example: {{comfy_url}}" value="{{comfy_url}}" />
+                    <div id="sd_comfy_validate" class="menu_button menu_button_icon">
+                        <i class="fa-solid fa-check"></i>
+                        <span data-i18n="Connect">
+                            Connect
+                        </span>
+                    </div>
+                </div>
+                <div id="sd_comfy_open_workflow_editor" class="menu_button">
+                    <i class="fa-solid fa-pen-to-square"></i>
+                    <span>Open Workflow Editor</span>
+                </div>
+                <p><i><b>Important:</b> run ComfyUI with the <code>--enable-cors-header http://127.0.0.1:8000</code> argument (adjust URL according to your SillyTavern setup)! The server must be accessible from the SillyTavern host machine.</i></p>
+            </div>
             <label for="sd_scale">CFG Scale (<span id="sd_scale_value"></span>)</label>
             <input id="sd_scale" type="range" min="{{scale_min}}" max="{{scale_max}}" step="{{scale_step}}" value="{{scale}}" />
             <label for="sd_steps">Sampling steps (<span id="sd_steps_value"></span>)</label>
@@ -124,6 +142,10 @@
             <select id="sd_model"></select>
             <label for="sd_sampler">Sampling method</label>
             <select id="sd_sampler"></select>
+            <div data-sd-source="comfy">
+                <label for="sd_scheduler">Scheduler</label>
+                <select id="sd_scheduler"></select>
+            </div>
             <div class="flex-container marginTop10 margin-bot-10px">
                 <label class="flex1 checkbox_label">
                     <input id="sd_restore_faces" type="checkbox" />

--- a/public/scripts/extensions/stable-diffusion/style.css
+++ b/public/scripts/extensions/stable-diffusion/style.css
@@ -27,3 +27,48 @@
     z-index: 30000;
     backdrop-filter: blur(--SmartThemeBlurStrength);
 }
+
+#sd_comfy_open_workflow_editor {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    width: fit-content;
+}
+#sd_comfy_workflow_editor_template {
+    height: 100%;
+}
+.sd_comfy_workflow_editor {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+.sd_comfy_workflow_editor_content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: row;
+}
+.sd_comfy_workflow_editor_workflow_container {
+    flex: 1 1 auto;
+}
+#sd_comfy_workflow_editor_workflow {
+    font-family: monospace;
+}
+.sd_comfy_workflow_editor_placeholder_container {
+    flex: 0 0 auto;
+}
+.sd_comfy_workflow_editor_placeholder_list {
+    font-size: x-small;
+    list-style: none;
+    margin: 5px 0;
+    padding: 3px 5px;
+    text-align: left;
+}
+.sd_comfy_workflow_editor_placeholder_list > li[data-placeholder]:before {
+    content: "✅ ";
+}
+.sd_comfy_workflow_editor_placeholder_list > li.sd_comfy_workflow_editor_not_found:before {
+    content: "❌ ";
+}
+.sd_comfy_workflow_editor_placeholder_list > li > .notes-link {
+    cursor: help;
+}

--- a/src/stable-diffusion.js
+++ b/src/stable-diffusion.js
@@ -347,6 +347,122 @@ function registerEndpoints(app, jsonParser) {
             return response.send({ prompt: originalPrompt });
         }
     });
+
+
+    app.post('/api/sd/comfy/ping', jsonParser, async(request, response)=>{
+		try {
+			const url = new URL(request.body.url);
+			url.pathname = '/system_stats'
+
+			const result = await fetch(url);
+			if (!result.ok) {
+				throw new Error('ComfyUI returned an error.');
+			}
+			
+			return response.sendStatus(200);
+		} catch (error) {
+			console.log(error);
+			return response.sendStatus(500);
+		}
+	});
+
+    app.post('/api/sd/comfy/samplers', jsonParser, async(request, response)=>{
+		try {
+			const url = new URL(request.body.url);
+			url.pathname = '/object_info'
+
+			const result = await fetch(url);
+			if (!result.ok) {
+				throw new Error('ComfyUI returned an error.');
+			}
+
+			const data = await result.json();
+			return response.send(data.KSampler.input.required.sampler_name[0]);
+		} catch (error) {
+			console.log(error);
+			return response.sendStatus(500);
+		}
+	});
+
+    app.post('/api/sd/comfy/models', jsonParser, async(request, response)=>{
+		try {
+			const url = new URL(request.body.url);
+			url.pathname = '/object_info'
+
+			const result = await fetch(url);
+			if (!result.ok) {
+				throw new Error('ComfyUI returned an error.');
+			}
+            const data = await result.json();
+			return response.send(data.CheckpointLoaderSimple.input.required.ckpt_name[0].map(it=>({value:it,text:it})));
+		} catch (error) {
+			console.log(error);
+			return response.sendStatus(500);
+		}
+	});
+
+    app.post('/api/sd/comfy/schedulers', jsonParser, async(request, response)=>{
+		try {
+			const url = new URL(request.body.url);
+			url.pathname = '/object_info'
+
+			const result = await fetch(url);
+			if (!result.ok) {
+				throw new Error('ComfyUI returned an error.');
+			}
+
+			const data = await result.json();
+			return response.send(data.KSampler.input.required.scheduler[0]);
+		} catch (error) {
+			console.log(error);
+			return response.sendStatus(500);
+		}
+	});
+
+    app.post('/api/sd/comfy/generate', jsonParser, async(request, response)=>{
+		try {
+			const url = new URL(request.body.url);
+			url.pathname = '/prompt'
+
+			const promptResult = await fetch(url, {
+                method: 'POST',
+                body: request.body.prompt,
+            });
+			if (!promptResult.ok) {
+				throw new Error('ComfyUI returned an error.');
+			}
+
+			const data = await promptResult.json();
+            const id = data.prompt_id;
+            let item;
+            const historyUrl = new URL(request.body.url);
+            historyUrl.pathname = '/history';
+            while (true) {
+                const result = await fetch(historyUrl);
+                if (!result.ok) {
+                    throw new Error('ComfyUI returned an error.');
+                }
+                const history = await result.json();
+                item = history[id];
+                if (item) {
+                    break;
+                }
+                await delay(100);
+            }
+            const imgInfo = Object.keys(item.outputs).map(it=>item.outputs[it].images).flat()[0];
+            const imgUrl = new URL(request.body.url);
+            imgUrl.pathname = '/view';
+            imgUrl.search = `?filename=${imgInfo.filename}&subfolder=${imgInfo.subfolder}&type=${imgInfo.type}`;
+            const imgResponse = await fetch(imgUrl);
+            if (!imgResponse.ok) {
+                throw new Error('ComfyUI returned an error.');
+            }
+            const imgBuffer = await imgResponse.buffer();
+            return response.send(imgBuffer.toString('base64'));
+		} catch (error) {
+			return response.sendStatus(500);
+		}
+	});
 }
 
 module.exports = {


### PR DESCRIPTION
Ok, so I had a more serious go at adding comfy support to ST.

Added support for more of the available settings and put the textarea for the workflow JSON into its own modal with a list of the supported placeholders that highlight those that are found in the provided workflow.  
I also added `%seed%` as a placeholder to provide a random seed to comfy (using JS `Math.random()`) since comfy only changes random seeds *after* generation, not before.