### PR TITLE
Corrections to /help macros, /help format

### DIFF
--- a/public/scripts/templates/formatting.html
+++ b/public/scripts/templates/formatting.html
@@ -8,7 +8,7 @@ Text formatting commands:
 <pre><code> like this</code></pre>
 <ul>
     <li><tt>`text`</tt> - displays as <code>inline code</code></li>
-    <li><tt> text</tt> - displays as a blockquote (note the space after >)</li>
+    <li><tt>&gt; text</tt> - displays as a blockquote (note the space after &gt;)</li>
     <blockquote>like this</blockquote>
     <li><tt># text</tt> - displays as a large header (note the space)</li>
     <h1>like this</h1>

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -17,8 +17,8 @@ System-wide Replacement Macros (in order of evaluation):
     <li><tt>&lcub;&lcub;time&rcub;&rcub;</tt> – the current time</li>
     <li><tt>&lcub;&lcub;date&rcub;&rcub;</tt> – the current date</li>
     <li><tt>&lcub;&lcub;weekday&rcub;&rcub;</tt> – the current weekday</li>
-    <li><tt>&lcub;&lcub;isotime&rcub;&rcub;</tt> – the current ISO date (YYYY-MM-DD)</li>
-    <li><tt>&lcub;&lcub;isodate&rcub;&rcub;</tt> – the current ISO time (24-hour clock)</li>
+    <li><tt>&lcub;&lcub;isotime&rcub;&rcub;</tt> – the current ISO time (24-hour clock)</li>
+    <li><tt>&lcub;&lcub;isodate&rcub;&rcub;</tt> – the current ISO date (YYYY-MM-DD)</li>
     <li><tt>&lcub;&lcub;datetimeformat &hellip;&rcub;&rcub;</tt> – the current date/time in the specified format, e. g. for German date/time: <tt>&lcub;&lcub;datetimeformat DD.MM.YYYY HH:mm&rcub;&rcub;</tt></li>
     <li><tt>&lcub;&lcub;time_UTC±#&rcub;&rcub;</tt> – the current time in the specified UTC time zone offset, e.g. UTC-4 or UTC+2</li>
     <li><tt>&lcub;&lcub;idle_duration&rcub;&rcub;</tt> – the time since the last user message was sent</li>


### PR DESCRIPTION
A missing bracket and a pair of switched descriptions.