### PR TITLE
Secrets: Add find endpoint to retrieve a secret value (with conditions)

### DIFF
--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -116,6 +116,23 @@ export async function readSecretState() {
     }
 }
 
+export async function findSecret(key) {
+    try {
+        const response = await fetch('/api/secrets/find', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({ key }),
+        });
+
+        if (response.ok) {
+            const data = await response.json();
+            return data.value
+        }
+    } catch {
+        console.error('Could not find secret value: ', key);
+    }
+}
+
 function authorizeOpenRouter() {
     const openRouterUrl = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(location.origin)}`;
     location.href = openRouterUrl;

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -190,6 +190,30 @@ function registerEndpoints(app, jsonParser) {
             return response.sendStatus(500);
         }
     });
+
+    app.post('/api/secrets/find', jsonParser, (request, response) => {
+        const allowKeysExposure = getConfigValue('allowKeysExposure', false);
+
+        if (!allowKeysExposure) {
+            console.error('Cannot fetch secrets unless allowKeysExposure in config.conf is set to true');
+            return response.sendStatus(403);
+        }
+
+        const key = request.body.key
+
+        try {
+            const secret = readSecret(key)
+
+            if (!secret) {
+                response.sendStatus(404);
+            }
+
+            return response.send({ value: secret });
+        } catch (error) {
+            console.error(error);
+            return response.sendStatus(500);
+        }
+    });
 }
 
 module.exports = {


### PR DESCRIPTION
This works the same way as `/viewsecrets` and requires that allowKeysExposure is set to true before fetching ANY secret value.