### PR TITLE
fix all popups being large/wide after first one

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6230,10 +6230,14 @@ function callPopup(text, type, inputValue = '', { okButton, rows, wide, large } 
 
     if (wide) {
         $("#dialogue_popup").addClass("wide_dialogue_popup");
+    } else {
+        $("#dialogue_popup").removeClass("wide_dialogue_popup");
     }
 
     if (large) {
         $("#dialogue_popup").addClass("large_dialogue_popup");
+    } else {
+        $("#dialogue_popup").removeClass("large_dialogue_popup");
     }
 
     $("#dialogue_popup_cancel").css("display", "inline-block");

--- a/public/script.js
+++ b/public/script.js
@@ -6228,17 +6228,9 @@ function callPopup(text, type, inputValue = '', { okButton, rows, wide, large } 
         popup_type = type;
     }
 
-    if (wide) {
-        $("#dialogue_popup").addClass("wide_dialogue_popup");
-    } else {
-        $("#dialogue_popup").removeClass("wide_dialogue_popup");
-    }
+    $('#dialogue_popup').toggleClass('wide_dialogue_popup', !!wide);
 
-    if (large) {
-        $("#dialogue_popup").addClass("large_dialogue_popup");
-    } else {
-        $("#dialogue_popup").removeClass("large_dialogue_popup");
-    }
+    $('#dialogue_popup').toggleClass('large_dialogue_popup', !!large);
 
     $("#dialogue_popup_cancel").css("display", "inline-block");
     switch (popup_type) {


### PR DESCRIPTION
After calling `callPopup` with `wide` or `large` set to `true` the related classes would stay on the elements even if the next popup was called without those options set to true. Result: giant confirm popups.

This would fix that behavior by removing the classes when the options are not set to true.