### PR TITLE
ensure checkboxes have contrast

### DIFF
--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -917,6 +917,11 @@ function applyChatWidth(type) {
 async function applyThemeColor(type) {
     if (type === 'main') {
         document.documentElement.style.setProperty('--SmartThemeBodyColor', power_user.main_text_color);
+        const color = power_user.main_text_color.split('(')[1].split(')')[0].split(',');
+        document.documentElement.style.setProperty('--SmartThemeCheckboxBgColorR', color[0]);
+        document.documentElement.style.setProperty('--SmartThemeCheckboxBgColorG', color[1]);
+        document.documentElement.style.setProperty('--SmartThemeCheckboxBgColorB', color[2]);
+        document.documentElement.style.setProperty('--SmartThemeCheckboxBgColorA', color[3]);
     }
     if (type === 'italics') {
         document.documentElement.style.setProperty('--SmartThemeEmColor', power_user.italics_text_color);

--- a/public/style.css
+++ b/public/style.css
@@ -58,6 +58,25 @@
     --SmartThemeBlurStrength: calc(var(--blurStrength) * 1px);
     --SmartThemeShadowColor: rgba(0, 0, 0, 0.5);
     --SmartThemeBorderColor: rgba(0, 0, 0, 0.5);
+    --SmartThemeCheckboxBgColorR: 220;
+    --SmartThemeCheckboxBgColorG: 220;
+    --SmartThemeCheckboxBgColorB: 210;
+    --SmartThemeCheckboxTickColorValue: calc(
+        (
+            (
+                (
+                    (var(--SmartThemeCheckboxBgColorR) * 299) + 
+                    (var(--SmartThemeCheckboxBgColorG) * 587) + 
+                    (var(--SmartThemeCheckboxBgColorB) * 114)
+                ) / 1000
+            ) - 128
+        ) * -1000
+    );
+    --SmartThemeCheckboxTickColor: rgb(
+        var(--SmartThemeCheckboxTickColorValue),
+        var(--SmartThemeCheckboxTickColorValue),
+        var(--SmartThemeCheckboxTickColorValue)
+    );
 
 
     --sheldWidth: 50vw;
@@ -2242,7 +2261,7 @@ input[type="checkbox"]:not(#nav-toggle):not(#rm_button_panel_pin):not(#lm_button
     height: 0.65em;
     transform: scale(0);
     transition: 120ms transform ease-in-out;
-    box-shadow: inset 1em 1em var(--SmartThemeBlurTintColor);
+    box-shadow: inset 1em 1em var(--SmartThemeCheckboxTickColor);
     transform-origin: bottom left;
     clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
 }


### PR DESCRIPTION
Ensures that ticks on checkboxes always contrast with the checkbox body. Ticks will either be black or white and drop the alpha value completely.

Based on https://css-tricks.com/css-variables-calc-rgb-enforcing-high-contrast-colors/