### PR TITLE
FIX: Claude system message order

### DIFF
--- a/src/chat-completion.js
+++ b/src/chat-completion.js
@@ -18,13 +18,19 @@ function convertClaudePrompt(messages, addHumanPrefix, addAssistantPostfix, with
 
     let systemPrompt = '';
     if (withSystemPrompt) {
-        for (const message of messages) {
+        let lastSystemIdx = -1;
+
+        for (let i = 0; i < messages.length - 1; i++) {
+            const message = messages[i];
             if (message.role === "system" && !message.name) {
                 systemPrompt += message.content + '\n\n';
-                messages.splice(messages.indexOf(message), 1);
             } else {
+                lastSystemIdx = i - 1;
                 break;
             }
+        }
+        if (lastSystemIdx >= 0) {
+            messages.splice(0, lastSystemIdx + 1);
         }
     }
 


### PR DESCRIPTION
The previous implementation of Claude system messages messed up the order because it spliced inside a `for of` loop.
This one splices at the end once based on the index.