### PR TITLE
Add support for importing character from JanitorAI

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9366,6 +9366,7 @@ jQuery(async function () {
         <ul class="justifyLeft">
             <li>Chub characters (direct link or id)<br>Example: <tt>Anonymous/example-character</tt></li>
             <li>Chub lorebooks (direct link or id)<br>Example: <tt>lorebooks/bartleby/example-lorebook</tt></li>
+            <li>JanitorAI character (direct link or id)<br>Example: <tt>https://janitorai.com/characters/ddd1498a-a370-4136-b138-a8cd9461fdfe_character-aqua-the-useless-goddess</tt></li>
             <li>More coming soon...</li>
         <ul>`
         const input = await callPopup(html, 'input');

--- a/public/scripts/templates/welcome.html
+++ b/public/scripts/templates/welcome.html
@@ -29,6 +29,11 @@
             Chub (NSFW)
         </a>
     </li>
+    <li>
+        <a target="_blank" href="https://janitorai.me/">
+            JanitorAI-S (NSFW)
+        </a>
+    </li>
 </ul>
 <hr>
 <h3>Confused or lost?</h3>

--- a/public/scripts/templates/welcome.html
+++ b/public/scripts/templates/welcome.html
@@ -29,11 +29,6 @@
             Chub (NSFW)
         </a>
     </li>
-    <li>
-        <a target="_blank" href="https://janitorai.me/">
-            JanitorAI-S (NSFW)
-        </a>
-    </li>
 </ul>
 <hr>
 <h3>Confused or lost?</h3>

--- a/src/content-manager.js
+++ b/src/content-manager.js
@@ -178,6 +178,9 @@ function parseChubUrl(str) {
 
 // Warning: Some characters might not exist in JannyAI.me
 async function downloadJannyCharacter(uuid) {
+    // This endpoint is being guarded behind Bot Fight Mode of Cloudflare
+    // So hosted ST on Azure/AWS/GCP/Collab might get blocked by IP
+    // Should work normally on self-host PC/Android
     const result = await fetch('https://api.janitorai.me/api/v1/download', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json'},
@@ -238,7 +241,7 @@ function registerEndpoints(app, jsonParser) {
                 if (!uuid) {
                     return response.sendStatus(404);
                 }
-                
+
                 type = 'character';
                 result = await downloadJannyCharacter(uuid);
             } else {

--- a/src/content-manager.js
+++ b/src/content-manager.js
@@ -176,6 +176,46 @@ function parseChubUrl(str) {
     return null;
 }
 
+// Warning: Some characters might not exist in JannyAI.me
+async function downloadJannyCharacter(uuid) {
+    const result = await fetch('https://api.janitorai.me/api/v1/download', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json'},
+        body: JSON.stringify({
+            "characterId": uuid,
+        })
+    });
+
+    if (result.ok) {
+        const downloadResult = await result.json();
+        if (downloadResult.status === 'ok') {
+            const imageResult = await fetch(downloadResult.downloadUrl)
+            const buffer = await imageResult.buffer();
+            const fileName = `${sanitize(uuid)}.png`;
+            const fileType = result.headers.get('content-type');
+    
+            return { buffer, fileName, fileType };
+        }  
+    }
+
+    console.log('Janny returned error', result.statusText, await result.text());
+    throw new Error('Failed to download character');
+}
+
+/**
+* @param {String} url
+* @returns {String | null } UUID of the character
+*/
+function parseJannyUrl(url) {
+   // Extract UUID from URL
+    const uuidRegex = /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/;
+    const matches = url.match(uuidRegex);
+
+    // Check if UUID is found
+    const uuid = matches ? matches[0] : null;
+    return uuid
+}
+
 /**
  * Registers endpoints for custom content management
  * @param {import('express').Express} app Express app
@@ -190,24 +230,37 @@ function registerEndpoints(app, jsonParser) {
         try {
             const url = request.body.url;
             let result;
+            let type;
 
-            const chubParsed = parseChubUrl(url);
+            const isJannnyContent = url.includes('janitorai')
+            if (isJannnyContent) {
+                const uuid = parseJannyUrl(url);
+                if (!uuid) {
+                    return response.sendStatus(404);
+                }
+                
+                type = 'character';
+                result = await downloadJannyCharacter(uuid);
+            } else {
+                const chubParsed = parseChubUrl(url);
+                type = chubParsed?.type;
 
-            if (chubParsed?.type === 'character') {
-                console.log('Downloading chub character:', chubParsed.id);
-                result = await downloadChubCharacter(chubParsed.id);
+                if (chubParsed?.type === 'character') {
+                    console.log('Downloading chub character:', chubParsed.id);
+                    result = await downloadChubCharacter(chubParsed.id);
+                }
+                else if (chubParsed?.type === 'lorebook') {
+                    console.log('Downloading chub lorebook:', chubParsed.id);
+                    result = await downloadChubLorebook(chubParsed.id);
+                }
+                else {
+                    return response.sendStatus(404);
+                }
             }
-            else if (chubParsed?.type === 'lorebook') {
-                console.log('Downloading chub lorebook:', chubParsed.id);
-                result = await downloadChubLorebook(chubParsed.id);
-            }
-            else {
-                return response.sendStatus(404);
-            }
-
+            
             if (result.fileType) response.set('Content-Type', result.fileType)
             response.set('Content-Disposition', `attachment; filename="${result.fileName}"`);
-            response.set('X-Custom-Content-Type', chubParsed?.type);
+            response.set('X-Custom-Content-Type', type);
             return response.send(result.buffer);
         } catch (error) {
             console.log('Importing custom content failed', error);


### PR DESCRIPTION
- Added support for importing character from JanitorAI, using the JanitorAI URL
- How it works
    - Extract the UUID from JanitorAI url
    - Call `https://api.janitorai.me/api/v1/download` to download the PNG with character definition and import to ST
    - JanitorAI.me crawls and store bot definition/images so it can still works if JanitorAI.com goes down or run out of business

- Potential risks
   - JanitorAI.me might go down/API broken (I should keep this alive as long as I can, hosting fee is cheap, so no potential financial issue)
   - This endpoint is being guarded behind Bot Fight Mode of Cloudflare, so ST hosted on popular VPS might be blocked (Shouldn't be an issue on local ST). Or I can also remove bot fight mode if needed.

Demo video on how it works

https://github.com/SillyTavern/SillyTavern/assets/135049225/87d2bfb6-8755-4461-85eb-4b8e1449ffef

