### PR TITLE
Fix CORS proxy with URLs

### DIFF
--- a/server.js
+++ b/server.js
@@ -308,7 +308,7 @@ app.use(function (req, res, next) {
 if (getConfigValue('enableCorsProxy', false) === true || cliArguments.corsProxy === true) {
     console.log('Enabling CORS proxy');
 
-    app.use('/proxy/:url', async (req, res) => {
+    app.use('/proxy/:url(*)', async (req, res) => {
         const url = req.params.url; // get the url from the request path
 
         // Disallow circular requests


### PR DESCRIPTION
An extra part in the express route is required for URLs to get parsed correctly.

Also headers like `Authorization` don't work when basic auth is on in config.conf. I don't think that's something we can fix, so just leaving that as a note.