### PR TITLE
fix context menu for QR popout

### DIFF
--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -354,6 +354,27 @@ async function doQuickReplyBarPopout() {
             let index = $(this).data('index');
             sendQuickReply(index);
         });
+        $('.quickReplyButton > .ctx-expander').on('click', function (evt) {
+            evt.stopPropagation();
+            let index = $(this.closest('.quickReplyButton')).data('index');
+            const qr = extension_settings.quickReply.quickReplySlots[index];
+            if (qr.contextMenu?.length) {
+                evt.preventDefault();
+                const tree = buildContextMenu(qr);
+                const menu = new ContextMenu(tree.children);
+                menu.show(evt);
+            }
+        })
+        $('.quickReplyButton').on('contextmenu', function (evt) {
+            let index = $(this).data('index');
+            const qr = extension_settings.quickReply.quickReplySlots[index];
+            if (qr.contextMenu?.length) {
+                evt.preventDefault();
+                const tree = buildContextMenu(qr);
+                const menu = new ContextMenu(tree.children);
+                menu.show(evt);
+            }
+        });
 
         loadMovingUIState();
         $("#quickReplyBarPopout").fadeIn(250)
@@ -369,6 +390,27 @@ async function doQuickReplyBarPopout() {
             $('.quickReplyButton').on('click', function () {
                 let index = $(this).data('index');
                 sendQuickReply(index);
+            });
+            $('.quickReplyButton > .ctx-expander').on('click', function (evt) {
+                evt.stopPropagation();
+                let index = $(this.closest('.quickReplyButton')).data('index');
+                const qr = extension_settings.quickReply.quickReplySlots[index];
+                if (qr.contextMenu?.length) {
+                    evt.preventDefault();
+                    const tree = buildContextMenu(qr);
+                    const menu = new ContextMenu(tree.children);
+                    menu.show(evt);
+                }
+            })
+            $('.quickReplyButton').on('contextmenu', function (evt) {
+                let index = $(this).data('index');
+                const qr = extension_settings.quickReply.quickReplySlots[index];
+                if (qr.contextMenu?.length) {
+                    evt.preventDefault();
+                    const tree = buildContextMenu(qr);
+                    const menu = new ContextMenu(tree.children);
+                    menu.show(evt);
+                }
             });
             $("#quickReplyPopoutButton").off('click').on('click', doQuickReplyBarPopout)
         })


### PR DESCRIPTION
QR context menus would no longer work after clicking popout or closing popout because the listeners were not added to the new DOM elements.