### PR TITLE
fix old popup closing next popup

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7920,12 +7920,14 @@ jQuery(async function () {
     });
 
     $('#dialogue_popup_cancel').click(function (e) {
+        dialogueCloseStop = false;
         $('#shadow_popup').transition({
             opacity: 0,
             duration: 200,
             easing: animation_easing,
         });
         setTimeout(function () {
+            if (dialogueCloseStop) return;
             $('#shadow_popup').css('display', 'none');
             $('#dialogue_popup').removeClass('large_dialogue_popup');
         }, 200);

--- a/public/script.js
+++ b/public/script.js
@@ -381,6 +381,7 @@ let rawPromptPopper = Popper.createPopper(document.getElementById('dialogue_popu
 });
 
 let dialogueResolve = null;
+let dialogueCloseStop = false;
 let chat_metadata = {};
 let streamingProcessor = null;
 let crop_data = undefined;
@@ -6261,6 +6262,7 @@ function onScenarioOverrideRemoveClick() {
 }
 
 function callPopup(text, type, inputValue = '', { okButton, rows, wide, large } = {}) {
+    dialogueCloseStop = true;
     if (type) {
         popup_type = type;
     }
@@ -7823,12 +7825,14 @@ jQuery(async function () {
     });
 
     $('#dialogue_popup_ok').click(async function (e) {
+        dialogueCloseStop = false;
         $('#shadow_popup').transition({
             opacity: 0,
             duration: 200,
             easing: animation_easing,
         });
         setTimeout(function () {
+            if (dialogueCloseStop) return;
             $('#shadow_popup').css('display', 'none');
             $('#dialogue_popup').removeClass('large_dialogue_popup');
             $('#dialogue_popup').removeClass('wide_dialogue_popup');


### PR DESCRIPTION
Calling multiple popups right after one another did not work. The second popup would immediately be closed due to the 200ms timeout in the closing function.

```javascript
await callPopup(...)
callPopup(...)
```

The PR fixes that by using a stop close flag `dialogueCloseStop` that is set to `true` at the beginning of `callPopup` and set to `false` at the beginning of the closing handler. The timeout function in the closing handler aborts if the flag is set to true again.