### PR TITLE
Clean up file name sanitization

### DIFF
--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -2,7 +2,7 @@ const path = require('path');
 const writeFileSyncAtomic = require('write-file-atomic').sync;
 const express = require('express');
 const router = express.Router();
-const { checkAssetFileName } = require('./assets');
+const { sanitizeAssetFileName } = require('./assets');
 const { jsonParser } = require('../express-common');
 const { DIRECTORIES } = require('../constants');
 
@@ -16,7 +16,7 @@ router.post('/upload', jsonParser, async (request, response) => {
             return response.status(400).send('No upload data specified');
         }
 
-        const safeInput = checkAssetFileName(request.body.name);
+        const safeInput = sanitizeAssetFileName(request.body.name);
 
         if (!safeInput) {
             return response.status(400).send('Invalid upload name');


### PR DESCRIPTION
I'm working on some larger cleanups of the file upload code, but thought I'd submit this separately to make sure I didn't miss anything.

I've renamed checkAssetFileName to sanitizeAssetFileName, and removed some redundant code:
- Checking for null bytes is unnecessary because the check for illegal characters directly below it will catch them.
- We can use the path.extname method to get the file extension more cleanly. It returns the *last* extension (e.g.
path.extname('file.foo.js') === '.js'), so behavior is preserved.
- Normalizing the path is unnecessary. We don't allow any path separators in the file name, so it does nothing.
- Stripping '..', path separators, and '$' is unnecessary because of the earlier illegal character check, and having a ".." in the *middle* of the file name is perfectly fine without path separators.