### PR TITLE
Remove "upload" endpoint from assets API

### DIFF
--- a/src/endpoints/assets.js
+++ b/src/endpoints/assets.js
@@ -4,7 +4,6 @@ const express = require('express');
 const sanitize = require('sanitize-filename');
 const fetch = require('node-fetch').default;
 const { finished } = require('stream/promises');
-const writeFileSyncAtomic = require('write-file-atomic').sync;
 const { DIRECTORIES, UNSAFE_EXTENSIONS } = require('../constants');
 const { jsonParser } = require('../express-common');
 
@@ -286,32 +285,6 @@ router.post('/character', jsonParser, async (request, response) => {
     }
     catch (err) {
         console.log(err);
-        return response.sendStatus(500);
-    }
-});
-
-router.post('/upload', jsonParser, async (request, response) => {
-    try {
-        if (!request.body.name) {
-            return response.status(400).send('No upload name specified');
-        }
-
-        if (!request.body.data) {
-            return response.status(400).send('No upload data specified');
-        }
-
-        const safeInput = sanitizeAssetFileName(request.body.name);
-
-        if (!safeInput) {
-            return response.status(400).send('Invalid upload name');
-        }
-
-        const pathToUpload = path.join(DIRECTORIES.files, safeInput);
-        writeFileSyncAtomic(pathToUpload, request.body.data, 'base64');
-        const url = path.normalize(pathToUpload.replace('public' + path.sep, ''));
-        return response.send({ path: url });
-    } catch (error) {
-        console.log(error);
         return response.sendStatus(500);
     }
 });


### PR DESCRIPTION
I accidentally reintroduced this when splitting up the commits, I think. It's a copy of the "files" endpoint.