### PR TITLE
Clean up assets and files API

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -167,7 +167,7 @@ export async function uploadFileAttachment(fileName, base64Data) {
         }
 
         const responseData = await result.json();
-        return responseData.path.replace(/\\/g, '/');
+        return responseData.path;
     } catch (error) {
         toastr.error(String(error), 'Could not upload file');
         console.error('Could not upload file', error);

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -950,7 +950,7 @@ export async function saveBase64AsFile(base64Data, characterName, filename = '',
     // If the response is successful, get the saved image path from the server's response
     if (response.ok) {
         const responseData = await response.json();
-        return responseData.path.replace(/\\/g, '/'); // Replace backslashes with forward slashes
+        return responseData.path;
     } else {
         const errorData = await response.json();
         throw new Error(errorData.error || 'Failed to upload the image to the server');

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ const { jsonParser, urlencodedParser } = require('./src/express-common.js');
 const contentManager = require('./src/endpoints/content-manager');
 const statsHelpers = require('./statsHelpers.js');
 const { readSecret, migrateSecrets, SECRET_KEYS } = require('./src/endpoints/secrets');
-const { delay, getVersion, getConfigValue, color, uuidv4, humanizedISO8601DateTime, tryParse } = require('./src/util');
+const { delay, getVersion, getConfigValue, color, uuidv4, humanizedISO8601DateTime, tryParse, clientRelativePath } = require('./src/util');
 const { invalidateThumbnail, ensureThumbnailCache } = require('./src/endpoints/thumbnails');
 const { getTokenizerModel, getTiktokenTokenizer, loadTokenizers, TEXT_COMPLETION_MODELS, getSentencepiceTokenizer, sentencepieceTokenizers } = require('./src/endpoints/tokenizers');
 const { convertClaudePrompt } = require('./src/chat-completion');
@@ -1587,10 +1587,7 @@ app.post('/uploadimage', jsonParser, async (request, response) => {
         ensureDirectoryExistence(pathToNewFile);
         const imageBuffer = Buffer.from(base64Data, 'base64');
         await fs.promises.writeFile(pathToNewFile, imageBuffer);
-        // send the path to the image, relative to the client folder, which means removing the first folder from the path which is 'public'
-        // Use forward slashes, even on Windows
-        pathToNewFile = pathToNewFile.split(path.sep).slice(1).join('/');
-        response.send({ path: pathToNewFile });
+        response.send({ path: clientRelativePath(pathToNewFile) });
     } catch (error) {
         console.log(error);
         response.status(500).send({ error: 'Failed to save the image' });

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ const { jsonParser, urlencodedParser } = require('./src/express-common.js');
 const contentManager = require('./src/endpoints/content-manager');
 const statsHelpers = require('./statsHelpers.js');
 const { readSecret, migrateSecrets, SECRET_KEYS } = require('./src/endpoints/secrets');
-const { delay, getVersion, getConfigValue, color, uuidv4, humanizedISO8601DateTime, tryParse, clientRelativePath } = require('./src/util');
+const { delay, getVersion, getConfigValue, color, uuidv4, humanizedISO8601DateTime, tryParse, clientRelativePath, removeFileExtension } = require('./src/util');
 const { invalidateThumbnail, ensureThumbnailCache } = require('./src/endpoints/thumbnails');
 const { getTokenizerModel, getTiktokenTokenizer, loadTokenizers, TEXT_COMPLETION_MODELS, getSentencepiceTokenizer, sentencepieceTokenizers } = require('./src/endpoints/tokenizers');
 const { convertClaudePrompt } = require('./src/chat-completion');
@@ -1573,9 +1573,11 @@ app.post('/uploadimage', jsonParser, async (request, response) => {
         }
 
         // Constructing filename and path
-        let filename = `${Date.now()}.${format}`;
+        let filename;
         if (request.body.filename) {
-            filename = `${request.body.filename}.${format}`;
+            filename = `${removeFileExtension(request.body.filename)}.${format}`;
+        } else {
+            filename = `${Date.now()}.${format}`;
         }
 
         // if character is defined, save to a sub folder for that character

--- a/server.js
+++ b/server.js
@@ -1588,7 +1588,8 @@ app.post('/uploadimage', jsonParser, async (request, response) => {
         const imageBuffer = Buffer.from(base64Data, 'base64');
         await fs.promises.writeFile(pathToNewFile, imageBuffer);
         // send the path to the image, relative to the client folder, which means removing the first folder from the path which is 'public'
-        pathToNewFile = pathToNewFile.split(path.sep).slice(1).join(path.sep);
+        // Use forward slashes, even on Windows
+        pathToNewFile = pathToNewFile.split(path.sep).slice(1).join('/');
         response.send({ path: pathToNewFile });
     } catch (error) {
         console.log(error);

--- a/src/endpoints/assets.js
+++ b/src/endpoints/assets.js
@@ -102,7 +102,7 @@ router.post('/get', jsonParser, async (_, response) => {
                         file = path.normalize(file.replace('public' + path.sep, ''));
                         if (file.includes('model') && file.endsWith('.json')) {
                             //console.debug("Asset live2d model found:",file)
-                            output[folder].push(path.normalize(path.join(file)));
+                            output[folder].push(path.normalize(file).replace(/\\/g, '/'));
                         }
                     }
                     continue;
@@ -115,7 +115,7 @@ router.post('/get', jsonParser, async (_, response) => {
                     });
                 output[folder] = [];
                 for (const file of files) {
-                    output[folder].push(path.join('assets', folder, file));
+                    output[folder].push(path.join('assets', folder, file).replace(/\\/g, '/'));
                 }
             }
         }

--- a/src/endpoints/assets.js
+++ b/src/endpoints/assets.js
@@ -6,6 +6,7 @@ const fetch = require('node-fetch').default;
 const { finished } = require('stream/promises');
 const { DIRECTORIES, UNSAFE_EXTENSIONS } = require('../constants');
 const { jsonParser } = require('../express-common');
+const { clientRelativePath } = require('../util');
 
 const VALID_CATEGORIES = ['bgm', 'ambient', 'blip', 'live2d'];
 
@@ -99,10 +100,9 @@ router.post('/get', jsonParser, async (_, response) => {
                     const files = getFiles(live2d_folder);
                     //console.debug("FILE FOUND:",files)
                     for (let file of files) {
-                        file = path.normalize(file.replace('public' + path.sep, ''));
                         if (file.includes('model') && file.endsWith('.json')) {
                             //console.debug("Asset live2d model found:",file)
-                            output[folder].push(path.normalize(file).replace(/\\/g, '/'));
+                            output[folder].push(clientRelativePath(file));
                         }
                     }
                     continue;
@@ -115,7 +115,7 @@ router.post('/get', jsonParser, async (_, response) => {
                     });
                 output[folder] = [];
                 for (const file of files) {
-                    output[folder].push(path.join('assets', folder, file).replace(/\\/g, '/'));
+                    output[folder].push(`assets/${folder}/${file}`);
                 }
             }
         }

--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -2,7 +2,7 @@ const path = require('path');
 const writeFileSyncAtomic = require('write-file-atomic').sync;
 const express = require('express');
 const router = express.Router();
-const { sanitizeAssetFileName } = require('./assets');
+const { validateAssetFileName } = require('./assets');
 const { jsonParser } = require('../express-common');
 const { DIRECTORIES } = require('../constants');
 
@@ -16,7 +16,7 @@ router.post('/upload', jsonParser, async (request, response) => {
             return response.status(400).send('No upload data specified');
         }
 
-        const safeInput = sanitizeAssetFileName(request.body.name);
+        const safeInput = validateAssetFileName(request.body.name);
 
         if (!safeInput) {
             return response.status(400).send('Invalid upload name');

--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -23,7 +23,7 @@ router.post('/upload', jsonParser, async (request, response) => {
 
         const pathToUpload = path.join(DIRECTORIES.files, request.body.name);
         writeFileSyncAtomic(pathToUpload, request.body.data, 'base64');
-        const url = path.normalize(pathToUpload.replace('public' + path.sep, ''));
+        const url = path.normalize(pathToUpload.replace('public' + path.sep, '').replace(/\\/g, '/'));
         return response.send({ path: url });
     } catch (error) {
         console.log(error);

--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -5,6 +5,7 @@ const router = express.Router();
 const { validateAssetFileName } = require('./assets');
 const { jsonParser } = require('../express-common');
 const { DIRECTORIES } = require('../constants');
+const { clientRelativePath } = require('../util');
 
 router.post('/upload', jsonParser, async (request, response) => {
     try {
@@ -23,7 +24,7 @@ router.post('/upload', jsonParser, async (request, response) => {
 
         const pathToUpload = path.join(DIRECTORIES.files, request.body.name);
         writeFileSyncAtomic(pathToUpload, request.body.data, 'base64');
-        const url = path.normalize(pathToUpload.replace('public' + path.sep, '').replace(/\\/g, '/'));
+        const url = clientRelativePath(pathToUpload);
         return response.send({ path: url });
     } catch (error) {
         console.log(error);

--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -16,13 +16,12 @@ router.post('/upload', jsonParser, async (request, response) => {
             return response.status(400).send('No upload data specified');
         }
 
-        const safeInput = validateAssetFileName(request.body.name);
+        // Validate filename
+        const validation = validateAssetFileName(request.body.name);
+        if (validation.error)
+            return response.status(400).send(validation.message);
 
-        if (!safeInput) {
-            return response.status(400).send('Invalid upload name');
-        }
-
-        const pathToUpload = path.join(DIRECTORIES.files, safeInput);
+        const pathToUpload = path.join(DIRECTORIES.files, request.body.name);
         writeFileSyncAtomic(pathToUpload, request.body.data, 'base64');
         const url = path.normalize(pathToUpload.replace('public' + path.sep, ''));
         return response.send({ path: url });

--- a/src/util.js
+++ b/src/util.js
@@ -298,6 +298,15 @@ function clientRelativePath(inputPath) {
     return path.normalize(inputPath).split(path.sep).slice(1).join('/');
 }
 
+/**
+ * Strip the last file extension from a given file name. If there are multiple extensions, only the last is removed.
+ * @param {string} filename The file name to remove the extension from.
+ * @returns The file name, sans extension
+ */
+function removeFileExtension(filename) {
+    return filename.replace(/\.[^.]+$/, '');
+}
+
 module.exports = {
     getConfig,
     getConfigValue,
@@ -313,4 +322,5 @@ module.exports = {
     humanizedISO8601DateTime,
     tryParse,
     clientRelativePath,
+    removeFileExtension,
 };

--- a/src/util.js
+++ b/src/util.js
@@ -288,6 +288,16 @@ function tryParse(str) {
     }
 }
 
+/**
+ * Takes a path to a client-accessible file in the `public` folder and converts it to a relative URL segment that the
+ * client can fetch it from. This involves stripping the `public/` prefix and always using `/` as the separator.
+ * @param {string} inputPath The path to be converted.
+ * @returns The relative URL path from which the client can access the file.
+ */
+function clientRelativePath(inputPath) {
+    return path.normalize(inputPath).split(path.sep).slice(1).join('/');
+}
+
 module.exports = {
     getConfig,
     getConfigValue,
@@ -302,4 +312,5 @@ module.exports = {
     uuidv4,
     humanizedISO8601DateTime,
     tryParse,
+    clientRelativePath,
 };


### PR DESCRIPTION
- Move the `sanitize` call inside the function which validates the asset filenames (which I've renamed again to `validateAssetFileName`). There's a slight behavior change in that trailing periods and control characters will now be rejected instead of silently removed, but I don't think that's too big of an issue.
- Change `validateAssetFileName` to return error messages.
- Replace `\` with `/` in paths on the server side instead of the client side, since it's the server's responsibility to provide a consistent API.
- Extract the functionality for creating a client-relative URL path into its own helper function.
- Replace the `getFiles` with Node's `readdir` using the `{recursive: true}` option, added in Node v18.
- Use the `withFileTypes` option when listing folders in the assets directory, so we don't have to `stat` each one to determine if it's a directory.
  - It might be better to just iterate over `VALID_CATEGORIES` instead? Not sure, so I didn't do that.