### PR TITLE
Remove boolean equality checks from cliArguments

### DIFF
--- a/server.js
+++ b/server.js
@@ -74,7 +74,7 @@ dns.setDefaultResultOrder('ipv4first');
 const cliArguments = yargs(hideBin(process.argv))
     .option('autorun', {
         type: 'boolean',
-        default: true,
+        default: false,
         describe: 'Automatically launch SillyTavern in the browser.',
     }).option('corsProxy', {
         type: 'boolean',
@@ -124,7 +124,7 @@ if (fs.existsSync(whitelistPath)) {
 }
 
 const whitelistMode = getConfigValue('whitelistMode', true);
-const autorun = getConfigValue('autorun', false) && cliArguments.autorun && !cliArguments.ssl;
+const autorun = (getConfigValue('autorun', false) || cliArguments.autorun) && !cliArguments.ssl;
 const enableExtensions = getConfigValue('enableExtensions', true);
 const listen = getConfigValue('listen', false);
 

--- a/server.js
+++ b/server.js
@@ -306,7 +306,7 @@ app.use(function (req, res, next) {
     next();
 });
 
-if (getConfigValue('enableCorsProxy', false) === true || cliArguments.corsProxy) {
+if (getConfigValue('enableCorsProxy', false) || cliArguments.corsProxy) {
     const bodyParser = require('body-parser');
     app.use(bodyParser.json());
     console.log('Enabling CORS proxy');

--- a/server.js
+++ b/server.js
@@ -74,7 +74,7 @@ dns.setDefaultResultOrder('ipv4first');
 const cliArguments = yargs(hideBin(process.argv))
     .option('autorun', {
         type: 'boolean',
-        default: null,
+        default: true,
         describe: 'Automatically launch SillyTavern in the browser.',
     }).option('corsProxy', {
         type: 'boolean',
@@ -124,7 +124,7 @@ if (fs.existsSync(whitelistPath)) {
 }
 
 const whitelistMode = getConfigValue('whitelistMode', true);
-const autorun = getConfigValue('autorun', false) && cliArguments.autorun !== false && !cliArguments.ssl;
+const autorun = getConfigValue('autorun', false) && cliArguments.autorun && !cliArguments.ssl;
 const enableExtensions = getConfigValue('enableExtensions', true);
 const listen = getConfigValue('listen', false);
 
@@ -220,7 +220,7 @@ const { DIRECTORIES, UPLOADS_PATH, PALM_SAFETY, TEXTGEN_TYPES, CHAT_COMPLETION_S
 const { TavernCardValidator } = require('./src/validator/TavernCardValidator');
 
 // CSRF Protection //
-if (cliArguments.disableCsrf === false) {
+if (!cliArguments.disableCsrf) {
     const CSRF_SECRET = crypto.randomBytes(8).toString('hex');
     const COOKIES_SECRET = crypto.randomBytes(8).toString('hex');
 
@@ -306,7 +306,7 @@ app.use(function (req, res, next) {
     next();
 });
 
-if (getConfigValue('enableCorsProxy', false) === true || cliArguments.corsProxy === true) {
+if (getConfigValue('enableCorsProxy', false) === true || cliArguments.corsProxy) {
     const bodyParser = require('body-parser');
     app.use(bodyParser.json());
     console.log('Enabling CORS proxy');
@@ -3687,7 +3687,7 @@ if (listen && !getConfigValue('whitelistMode', true) && !getConfigValue('basicAu
     }
 }
 
-if (true === cliArguments.ssl) {
+if (cliArguments.ssl) {
     https.createServer(
         {
             cert: fs.readFileSync(cliArguments.certPath),


### PR DESCRIPTION
yargs ensures that the Boolean options will always be booleans, so the strict equality checks are unnecessary.

I've not removed the strict equality checks from the `getConfigValue` calls, since there could be some edge cases (e.g. the config values are of the wrong type) where this could matter. I'll try to clean up the config system later.