### PR TITLE
add list accessors to /getvar and /getglobalvar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,7 @@ module.exports = {
         'eol-last': ['error', 'always'],
         'no-trailing-spaces': 'error',
         'object-curly-spacing': ['error', 'always'],
+        'space-infix-ops': 'error',
 
         // These rules should eventually be enabled.
         'no-async-promise-executor': 'off',

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -2,7 +2,7 @@ import { chat_metadata, getCurrentChatId, saveSettingsDebounced, sendSystemMessa
 import { extension_settings, saveMetadataDebounced } from './extensions.js';
 import { executeSlashCommands, registerSlashCommand } from './slash-commands.js';
 
-function getLocalVariable(name, args={}) {
+function getLocalVariable(name, args = {}) {
     if (!chat_metadata.variables) {
         chat_metadata.variables = {};
     }
@@ -30,7 +30,7 @@ function setLocalVariable(name, value) {
     return value;
 }
 
-function getGlobalVariable(name, args={}) {
+function getGlobalVariable(name, args = {}) {
     let globalVariable = extension_settings.variables.global[name];
     if (args.index !== undefined) {
         try {

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -549,6 +549,16 @@ function sqrtValuesCallback(value) {
     return performOperation(value, Math.sqrt, true);
 }
 
+function lenValuesCallback(value) {
+    let parsedValue = value;
+    try {
+        parsedValue = JSON.parse(value);
+    } catch {
+        // could not parse
+    }
+    return parsedValue.length;
+}
+
 export function registerVariableCommands() {
     registerSlashCommand('listvar', listVariablesCallback, [], ' – list registered chat variables', true, true);
     registerSlashCommand('setvar', (args, value) => setLocalVariable(args.key || args.name, value), [], '<span class="monospace">key=varname (value)</span> – set a local variable value and pass it down the pipe, e.g. <tt>/setvar key=color green</tt>', true, true);
@@ -579,4 +589,5 @@ export function registerVariableCommands() {
     registerSlashCommand('abs', (_, value) => absValuesCallback(value), [], '<span class="monospace">(a)</span> – performs an absolute value operation of a value and passes the result down the pipe, can use variable names, e.g. <tt>/abs i</tt>', true, true);
     registerSlashCommand('sqrt', (_, value) => sqrtValuesCallback(value), [], '<span class="monospace">(a)</span> – performs a square root operation of a value and passes the result down the pipe, can use variable names, e.g. <tt>/sqrt i</tt>', true, true);
     registerSlashCommand('round', (_, value) => roundValuesCallback(value), [], '<span class="monospace">(a)</span> – rounds a value and passes the result down the pipe, can use variable names, e.g. <tt>/round i</tt>', true, true);
+    registerSlashCommand('len', (_, value) => lenValuesCallback(value), [], '<span class="monospace">(a)</span> – gets the length of a value and passes the result down the pipe, can use variable names, e.g. <tt>/len i</tt>', true, true);
 }


### PR DESCRIPTION
Allows getting list / array elements from variables.

```
/setvar key=myList ["a", "b", "c"]
/getvar index=2 myList
```

If (and only if) the index argument is provided, getvar will try to `JSON.parse` the value and return the entry at the index.
Ideally, all variables would be saved as JSON stringified, but that would be a more extensive overhaul...

Second commit provides a `/len` slash command that returns the length of its argument (and again attempts to JSON parse it first).


Example use case:

Given a global variable costumes:
```/setglobalvar key=costumes ["", "/alternate", "/third", "/rear"]```

The following QR would cycle through the list of costumes (expressions):
```
/len {{getglobalvar::costumes}} |
/mod {{getglobalvar::costumeindex}} {{pipe}} |
/add {{pipe}} 1 |
/setglobalvar key=costumeindex {{pipe}} |
/getglobalvar index={{getglobalvar::costumeindex}} costumes |
/costume {{pipe}}
```