### PR TITLE
Refactor server-sent events parsing

### DIFF
--- a/default/settings.json
+++ b/default/settings.json
@@ -596,7 +596,6 @@
         "openrouter_model": "OR_Website",
         "jailbreak_system": true,
         "reverse_proxy": "",
-        "legacy_streaming": false,
         "chat_completion_source": "openai",
         "max_context_unlocked": false,
         "api_url_scale": "",

--- a/public/index.html
+++ b/public/index.html
@@ -759,19 +759,6 @@
                                         <input type="number" id="seed_openai" name="seed_openai" class="text_pole" min="-1" max="2147483647" value="-1">
                                     </div>
                                 </div>
-                                <div data-newbie-hidden class="range-block" data-source="openai,claude">
-                                    <div class="range-block-title justifyLeft">
-                                        <label for="legacy_streaming" class="checkbox_label">
-                                            <input id="legacy_streaming" type="checkbox" />
-                                            <span data-i18n="Legacy Streaming Processing">
-                                                Legacy Streaming Processing
-                                            </span>
-                                        </label>
-                                    </div>
-                                    <div class="toggle-description justifyLeft" data-i18n="Enable this if the streaming doesn't work with your proxy">
-                                        Enable this if the streaming doesn't work with your proxy.
-                                    </div>
-                                </div>
                             </div>
                         </div>
                         <div id="advanced-ai-config-block" class="width100p">

--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -163,7 +163,7 @@ function tryParseStreamingError(response, decoded) {
         }
 
         if (data.error) {
-            toastr.error(data.error.message || response.statusText, 'API returned an error');
+            toastr.error(data.error.message || response.statusText, 'KoboldAI API');
             throw new Error(data);
         }
     }
@@ -180,7 +180,7 @@ export async function generateKoboldWithStreaming(generate_data, signal) {
         signal: signal,
     });
     if (!response.ok) {
-        tryParseStreamingError(response, await response.body.text());
+        tryParseStreamingError(response, await response.text());
         throw new Error(`Got response status ${response.status}`);
     }
     const eventStream = new EventSourceStream();

--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -672,8 +672,8 @@ function tryParseStreamingError(response, decoded) {
             return;
         }
 
-        if (data.error) {
-            toastr.error(data.error.message || response.statusText, 'API returned an error');
+        if (data.message || data.error) {
+            toastr.error(data.message || data.error?.message || response.statusText, 'NovelAI API');
             throw new Error(data);
         }
     }
@@ -692,7 +692,7 @@ export async function generateNovelWithStreaming(generate_data, signal) {
         signal: signal,
     });
     if (!response.ok) {
-        tryParseStreamingError(response, await response.body.text());
+        tryParseStreamingError(response, await response.text());
         throw new Error(`Got response status ${response.status}`);
     }
     const eventStream = new EventSourceStream();

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1565,6 +1565,11 @@ async function sendOpenAIRequest(type, messages, signal) {
         signal: signal,
     });
 
+    if (!response.ok) {
+        tryParseStreamingError(response, await response.body.text());
+        throw new Error(`Got response status ${response.status}`);
+    }
+
     if (stream) {
         const eventStream = new EventSourceStream();
         response.body.pipeThrough(eventStream);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -216,7 +216,6 @@ const default_settings = {
     openrouter_sort_models: 'alphabetically',
     jailbreak_system: false,
     reverse_proxy: '',
-    legacy_streaming: false,
     chat_completion_source: chat_completion_sources.OPENAI,
     max_context_unlocked: false,
     api_url_scale: '',
@@ -270,7 +269,6 @@ const oai_settings = {
     openrouter_sort_models: 'alphabetically',
     jailbreak_system: false,
     reverse_proxy: '',
-    legacy_streaming: false,
     chat_completion_source: chat_completion_sources.OPENAI,
     max_context_unlocked: false,
     api_url_scale: '',
@@ -2277,7 +2275,6 @@ function loadOpenAISettings(data, settings) {
     oai_settings.openai_max_tokens = settings.openai_max_tokens ?? default_settings.openai_max_tokens;
     oai_settings.bias_preset_selected = settings.bias_preset_selected ?? default_settings.bias_preset_selected;
     oai_settings.bias_presets = settings.bias_presets ?? default_settings.bias_presets;
-    oai_settings.legacy_streaming = settings.legacy_streaming ?? default_settings.legacy_streaming;
     oai_settings.max_context_unlocked = settings.max_context_unlocked ?? default_settings.max_context_unlocked;
     oai_settings.send_if_empty = settings.send_if_empty ?? default_settings.send_if_empty;
     oai_settings.wi_format = settings.wi_format ?? default_settings.wi_format;
@@ -2340,7 +2337,6 @@ function loadOpenAISettings(data, settings) {
     $('#wrap_in_quotes').prop('checked', oai_settings.wrap_in_quotes);
     $('#names_in_completion').prop('checked', oai_settings.names_in_completion);
     $('#jailbreak_system').prop('checked', oai_settings.jailbreak_system);
-    $('#legacy_streaming').prop('checked', oai_settings.legacy_streaming);
     $('#openai_show_external_models').prop('checked', oai_settings.show_external_models);
     $('#openai_external_category').toggle(oai_settings.show_external_models);
     $('#use_ai21_tokenizer').prop('checked', oai_settings.use_ai21_tokenizer);
@@ -2545,7 +2541,6 @@ async function saveOpenAIPreset(name, settings, triggerUi = true) {
         bias_preset_selected: settings.bias_preset_selected,
         reverse_proxy: settings.reverse_proxy,
         proxy_password: settings.proxy_password,
-        legacy_streaming: settings.legacy_streaming,
         max_context_unlocked: settings.max_context_unlocked,
         wi_format: settings.wi_format,
         scenario_format: settings.scenario_format,
@@ -2906,7 +2901,6 @@ function onSettingsPresetChange() {
         continue_nudge_prompt: ['#continue_nudge_prompt_textarea', 'continue_nudge_prompt', false],
         bias_preset_selected: ['#openai_logit_bias_preset', 'bias_preset_selected', false],
         reverse_proxy: ['#openai_reverse_proxy', 'reverse_proxy', false],
-        legacy_streaming: ['#legacy_streaming', 'legacy_streaming', true],
         wi_format: ['#wi_format_textarea', 'wi_format', false],
         scenario_format: ['#scenario_format_textarea', 'scenario_format', false],
         personality_format: ['#personality_format_textarea', 'personality_format', false],
@@ -3659,11 +3653,6 @@ $(document).ready(async function () {
     $('#group_nudge_prompt_restore').on('click', function () {
         oai_settings.group_nudge_prompt = default_group_nudge_prompt;
         $('#group_nudge_prompt_textarea').val(oai_settings.group_nudge_prompt);
-        saveSettingsDebounced();
-    });
-
-    $('#legacy_streaming').on('input', function () {
-        oai_settings.legacy_streaming = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1123,7 +1123,7 @@ function tryParseStreamingError(response, decoded) {
         checkQuotaError(data);
 
         if (data.error) {
-            toastr.error(data.error.message || response.statusText, 'API returned an error');
+            toastr.error(data.error.message || response.statusText, 'Chat Completion API');
             throw new Error(data);
         }
     }
@@ -1564,7 +1564,7 @@ async function sendOpenAIRequest(type, messages, signal) {
     });
 
     if (!response.ok) {
-        tryParseStreamingError(response, await response.body.text());
+        tryParseStreamingError(response, await response.text());
         throw new Error(`Got response status ${response.status}`);
     }
 

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -18,7 +18,7 @@ class EventSourceStream {
             streamBuffer = events.pop();
 
             for (const eventChunk of events) {
-                let eventType = 'message';
+                let eventType = '';
                 // Split up by single newlines.
                 const lines = eventChunk.split(/\n|\r|\r\n/g);
                 let eventData = '';
@@ -55,7 +55,7 @@ class EventSourceStream {
                 }
 
                 // Trim the *last* trailing newline only.
-                const event = new MessageEvent(eventType, { data: eventData, lastEventId });
+                const event = new MessageEvent(eventType || 'message', { data: eventData, lastEventId });
                 controller.enqueue(event);
             }
         }

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -3,7 +3,7 @@
  */
 class EventSourceStream {
     constructor() {
-        const decoder = new TextDecoderStream('utf-8', { ignoreBOM: true });
+        const decoder = new TextDecoderStream('utf-8');
 
         let streamBuffer = '';
 

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -1,0 +1,105 @@
+/**
+ * A stream which handles Server-Sent Events from a binary ReadableStream like you get from the fetch API.
+ */
+class EventSourceStream {
+    constructor() {
+        const decoder = new TextDecoderStream('utf-8', { ignoreBOM: true });
+
+        let streamBuffer = '';
+
+        let dataBuffer = '';
+        let eventType = 'message';
+        let lastEventId = '';
+
+        // https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream Parses a line from the
+        // event stream. This is hard to read, so here's how it works: The first group matches either a field (field
+        // name, optional (colon, value)) or a comment (colon, text). That group is optional, and is followed by a group
+        // which matches a newline. This means that: The only *capturing* groups are the field, field value, comment,
+        // and newline. This lets us determine what the line is by which capture groups are filled in. The field and
+        // value groups being present means it's a field, the comment group being present means it's a comment, and
+        // neither means it's a blank line. This is best viewed in RegExr if you value your sanity.
+        const parserRegex = /(?:(?:([^\r\n:]+)(?:: ?([^\r\n]*)?)?)|(:[^\r\n]*))?(\r\n|\r|\n)/y;
+
+        function processChunk(controller, isLastChunk) {
+            while (parserRegex.lastIndex < streamBuffer.length) {
+                const lastLastIndex = parserRegex.lastIndex;
+                const matchResult = parserRegex.exec(streamBuffer);
+                // We need to wait for more data to come in
+                if (!matchResult) {
+                    if (lastLastIndex !== 0) {
+                        // Slice off what we've successfully parsed so far. lastIndex is set to 0 if there's no match,
+                        // so it'll be set to start off here.
+                        streamBuffer = streamBuffer.slice(lastLastIndex);
+                    }
+                    return;
+                }
+
+                const field = matchResult[1];
+                const value = matchResult[2];
+                const comment = matchResult[3];
+                const newline = matchResult[4];
+                // Corner case: if the last character in the buffer is '\r', we need to wait for more data. These chunks
+                // could be split up any which way, and it's entirely possible that the next chunk we receive will start
+                // with '\n', and this trailing '\r' is actually part of a '\r\n' sequence.
+                if (newline === '\r' && parserRegex.lastIndex === streamBuffer.length && !isLastChunk) {
+                    // Trim off what we've parsed so far, and wait for more data
+                    streamBuffer = streamBuffer.slice(lastLastIndex);
+                    parserRegex.lastIndex = 0;
+                    return;
+                }
+
+                // https://html.spec.whatwg.org/multipage/server-sent-events.html#processField
+                if (typeof field === 'string') {
+                    switch (field) {
+                        case 'event':
+                            eventType = value;
+                            break;
+                        case 'data':
+                            // If the data field is empty, there won't be a match for the value. Just add a newline.
+                            if (typeof value === 'string') dataBuffer += value;
+                            dataBuffer += '\n';
+                            break;
+                        case 'id':
+                            if (!value.includes('\0')) lastEventId = value;
+                            break;
+                        // We do nothing for the `delay` type, and other types are explicitly ignored
+                    }
+                } else if (typeof comment === 'string') {
+                    continue;
+                } else {
+                    // https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage
+                    // Must be a newline. Dispatch the event.
+                    // Skip the event if the data buffer is the empty string.
+                    if (dataBuffer === '') continue;
+                    // Trim the *last* trailing newline
+                    if (dataBuffer[dataBuffer.length - 1] === '\n') {
+                        dataBuffer = dataBuffer.slice(0, -1);
+                    }
+                    const event = new MessageEvent(eventType, { data: dataBuffer, lastEventId });
+                    controller.enqueue(event);
+                    dataBuffer = '';
+                    eventType = 'message';
+                }
+            }
+        }
+
+        const sseStream = new TransformStream({
+            transform(chunk, controller) {
+                streamBuffer += chunk;
+                processChunk(controller, false);
+            },
+
+            flush(controller) {
+                // If it's the last chunk, trailing carriage returns are allowed
+                processChunk(controller, true);
+            },
+        });
+
+        decoder.readable.pipeThrough(sseStream);
+
+        this.readable = sseStream.readable;
+        this.writable = decoder.writable;
+    }
+}
+
+export default EventSourceStream;

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -6,92 +6,64 @@ class EventSourceStream {
         const decoder = new TextDecoderStream('utf-8');
 
         let streamBuffer = '';
-
-        let dataBuffer = '';
-        let eventType = 'message';
         let lastEventId = '';
 
-        // https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream Parses a line from the
-        // event stream. This is hard to read, so here's how it works: The first group matches either a field (field
-        // name, optional (colon, value)) or a comment (colon, text). That group is optional, and is followed by a group
-        // which matches a newline. This means that: The only *capturing* groups are the field, field value, comment,
-        // and newline. This lets us determine what the line is by which capture groups are filled in. The field and
-        // value groups being present means it's a field, the comment group being present means it's a comment, and
-        // neither means it's a blank line. This is best viewed in RegExr if you value your sanity.
-        const parserRegex = /(?:(?:([^\r\n:]+)(?:: ?([^\r\n]*)?)?)|(:[^\r\n]*))?(\r\n|\r|\n)/y;
+        function processChunk(controller) {
+            // Events are separated by two newlines
+            const events = streamBuffer.split(/\r\n\r\n|\r\r|\n\n/g);
+            if (events.length === 0) return;
 
-        function processChunk(controller, isLastChunk) {
-            while (parserRegex.lastIndex < streamBuffer.length) {
-                const lastLastIndex = parserRegex.lastIndex;
-                const matchResult = parserRegex.exec(streamBuffer);
-                // We need to wait for more data to come in
-                if (!matchResult) {
-                    if (lastLastIndex !== 0) {
-                        // Slice off what we've successfully parsed so far. lastIndex is set to 0 if there's no match,
-                        // so it'll be set to start off here.
-                        streamBuffer = streamBuffer.slice(lastLastIndex);
+            // The leftover text to remain in the buffer is whatever doesn't have two newlines after it. If the buffer ended
+            // with two newlines, this will be an empty string.
+            streamBuffer = events.pop();
+
+            for (const eventChunk of events) {
+                let eventType = 'message';
+                // Split up by single newlines.
+                const lines = eventChunk.split(/\n|\r|\r\n/g);
+                let eventData = '';
+                for (const line of lines) {
+                    const lineMatch = /([^:]+)(?:: ?(.*))?/.exec(line);
+                    if (lineMatch) {
+                        const field = lineMatch[1];
+                        const value = lineMatch[2] || '';
+
+                        switch (field) {
+                            case 'event':
+                                eventType = value;
+                                break;
+                            case 'data':
+                                eventData += value;
+                                eventData += '\n';
+                                break;
+                            case 'id':
+                                // The ID field cannot contain null, per the spec
+                                if (!value.includes('\0')) lastEventId = value;
+                                break;
+                            // We do nothing for the `delay` type, and other types are explicitly ignored
+                        }
                     }
-                    return;
                 }
 
-                const field = matchResult[1];
-                const value = matchResult[2];
-                const comment = matchResult[3];
-                const newline = matchResult[4];
-                // Corner case: if the last character in the buffer is '\r', we need to wait for more data. These chunks
-                // could be split up any which way, and it's entirely possible that the next chunk we receive will start
-                // with '\n', and this trailing '\r' is actually part of a '\r\n' sequence.
-                if (newline === '\r' && parserRegex.lastIndex === streamBuffer.length && !isLastChunk) {
-                    // Trim off what we've parsed so far, and wait for more data
-                    streamBuffer = streamBuffer.slice(lastLastIndex);
-                    parserRegex.lastIndex = 0;
-                    return;
+
+                // https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage
+                // Skip the event if the data buffer is the empty string.
+                if (eventData === '') continue;
+
+                if (eventData[eventData.length - 1] === '\n') {
+                    eventData = eventData.slice(0, -1);
                 }
 
-                // https://html.spec.whatwg.org/multipage/server-sent-events.html#processField
-                if (typeof field === 'string') {
-                    switch (field) {
-                        case 'event':
-                            eventType = value;
-                            break;
-                        case 'data':
-                            // If the data field is empty, there won't be a match for the value. Just add a newline.
-                            if (typeof value === 'string') dataBuffer += value;
-                            dataBuffer += '\n';
-                            break;
-                        case 'id':
-                            if (!value.includes('\0')) lastEventId = value;
-                            break;
-                        // We do nothing for the `delay` type, and other types are explicitly ignored
-                    }
-                } else if (typeof comment === 'string') {
-                    continue;
-                } else {
-                    // https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage
-                    // Must be a newline. Dispatch the event.
-                    // Skip the event if the data buffer is the empty string.
-                    if (dataBuffer === '') continue;
-                    // Trim the *last* trailing newline
-                    if (dataBuffer[dataBuffer.length - 1] === '\n') {
-                        dataBuffer = dataBuffer.slice(0, -1);
-                    }
-                    const event = new MessageEvent(eventType, { data: dataBuffer, lastEventId });
-                    controller.enqueue(event);
-                    dataBuffer = '';
-                    eventType = 'message';
-                }
+                // Trim the *last* trailing newline only.
+                const event = new MessageEvent(eventType, { data: eventData, lastEventId });
+                controller.enqueue(event);
             }
         }
 
         const sseStream = new TransformStream({
             transform(chunk, controller) {
                 streamBuffer += chunk;
-                processChunk(controller, false);
-            },
-
-            flush(controller) {
-                // If it's the last chunk, trailing carriage returns are allowed
-                processChunk(controller, true);
+                processChunk(controller);
             },
         });
 

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -478,7 +478,7 @@ async function generateTextGenWithStreaming(generate_data, signal) {
     });
 
     if (!response.ok) {
-        tryParseStreamingError(response, await response.body.text());
+        tryParseStreamingError(response, await response.text());
         throw new Error(`Got response status ${response.status}`);
     }
 
@@ -512,14 +512,15 @@ async function generateTextGenWithStreaming(generate_data, signal) {
 
 /**
  * Parses errors in streaming responses and displays them in toastr.
- * @param {string} response - Response from the server.
+ * @param {Response} response - Response from the server.
+ * @param {string} decoded - Decoded response body.
  * @returns {void} Nothing.
  */
-function tryParseStreamingError(response) {
+function tryParseStreamingError(response, decoded) {
     let data = {};
 
     try {
-        data = JSON.parse(response);
+        data = JSON.parse(decoded);
     } catch {
         // No JSON. Do nothing.
     }
@@ -527,7 +528,7 @@ function tryParseStreamingError(response) {
     const message = data?.error?.message || data?.message;
 
     if (message) {
-        toastr.error(message, 'API Error');
+        toastr.error(message, 'Text Completion API');
         throw new Error(message);
     }
 }

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -476,6 +476,12 @@ async function generateTextGenWithStreaming(generate_data, signal) {
         method: 'POST',
         signal: signal,
     });
+
+    if (!response.ok) {
+        tryParseStreamingError(response, await response.body.text());
+        throw new Error(`Got response status ${response.status}`);
+    }
+
     const eventStream = new EventSourceStream();
     response.body.pipeThrough(eventStream);
     const reader = eventStream.readable.getReader();

--- a/server.js
+++ b/server.js
@@ -1618,16 +1618,17 @@ app.post('/generate_openai', jsonParser, function (request, response_generate_op
         try {
             const fetchResponse = await fetch(endpointUrl, config);
 
+            if (request.body.stream) {
+                console.log('Streaming request in progress');
+                forwardFetchResponse(fetchResponse, response_generate_openai);
+                return;
+            }
+
             if (fetchResponse.ok) {
-                if (request.body.stream) {
-                    console.log('Streaming request in progress');
-                    forwardFetchResponse(fetchResponse, response_generate_openai);
-                } else {
-                    let json = await fetchResponse.json();
-                    response_generate_openai.send(json);
-                    console.log(json);
-                    console.log(json?.choices[0]?.message);
-                }
+                let json = await fetchResponse.json();
+                response_generate_openai.send(json);
+                console.log(json);
+                console.log(json?.choices[0]?.message);
             } else if (fetchResponse.status === 429 && retries > 0) {
                 console.log(`Out of quota, retrying in ${Math.round(timeout / 1000)}s`);
                 setTimeout(() => {

--- a/server.js
+++ b/server.js
@@ -7,7 +7,6 @@ const http = require('http');
 const https = require('https');
 const path = require('path');
 const util = require('util');
-const { Readable } = require('stream');
 
 // cli/fs related library imports
 const open = require('open');
@@ -45,7 +44,20 @@ const basicAuthMiddleware = require('./src/middleware/basicAuthMiddleware');
 const { jsonParser, urlencodedParser } = require('./src/express-common.js');
 const contentManager = require('./src/endpoints/content-manager');
 const { readSecret, migrateSecrets, SECRET_KEYS } = require('./src/endpoints/secrets');
-const { delay, getVersion, getConfigValue, color, uuidv4, tryParse, clientRelativePath, removeFileExtension, generateTimestamp, removeOldBackups, getImages } = require('./src/util');
+const {
+    delay,
+    getVersion,
+    getConfigValue,
+    color,
+    uuidv4,
+    tryParse,
+    clientRelativePath,
+    removeFileExtension,
+    generateTimestamp,
+    removeOldBackups,
+    getImages,
+    forwardFetchResponse,
+} = require('./src/util');
 const { ensureThumbnailCache } = require('./src/endpoints/thumbnails');
 const { getTokenizerModel, getTiktokenTokenizer, loadTokenizers, TEXT_COMPLETION_MODELS, getSentencepiceTokenizer, sentencepieceTokenizers } = require('./src/endpoints/tokenizers');
 const { convertClaudePrompt } = require('./src/chat-completion');
@@ -307,9 +319,7 @@ if (getConfigValue('enableCorsProxy', false) || cliArguments.corsProxy) {
             });
 
             // Copy over relevant response params to the proxy response
-            res.statusCode = response.status;
-            res.statusMessage = response.statusText;
-            response.body.pipe(res);
+            forwardFetchResponse(response, res);
 
         } catch (error) {
             res.status(500).send('Error occurred while trying to proxy to: ' + url + ' ' + error);
@@ -457,18 +467,9 @@ app.post('/generate', jsonParser, async function (request, response_generate) {
             const response = await fetch(url, { method: 'POST', timeout: 0, ...args });
 
             if (request.body.streaming) {
-                request.socket.on('close', function () {
-                    if (response.body instanceof Readable) response.body.destroy(); // Close the remote stream
-                    response_generate.end(); // End the Express response
-                });
-
-                response.body.on('end', function () {
-                    console.log('Streaming request finished');
-                    response_generate.end();
-                });
-
                 // Pipe remote SSE stream to Express response
-                return response.body.pipe(response_generate);
+                forwardFetchResponse(response, response_generate);
+                return;
             } else {
                 if (!response.ok) {
                     const errorText = await response.text();
@@ -666,17 +667,7 @@ app.post('/api/textgenerationwebui/generate', jsonParser, async function (reques
         if (request.body.stream) {
             const completionsStream = await fetch(url, args);
             // Pipe remote SSE stream to Express response
-            completionsStream.body.pipe(response_generate);
-
-            request.socket.on('close', function () {
-                if (completionsStream.body instanceof Readable) completionsStream.body.destroy(); // Close the remote stream
-                response_generate.end(); // End the Express response
-            });
-
-            completionsStream.body.on('end', function () {
-                console.log('Streaming request finished');
-                response_generate.end();
-            });
+            forwardFetchResponse(completionsStream, response_generate);
         }
         else {
             const completionsReply = await fetch(url, args);
@@ -1427,17 +1418,7 @@ async function sendClaudeRequest(request, response) {
 
         if (request.body.stream) {
             // Pipe remote SSE stream to Express response
-            generateResponse.body.pipe(response);
-
-            request.socket.on('close', function () {
-                if (generateResponse.body instanceof Readable) generateResponse.body.destroy(); // Close the remote stream
-                response.end(); // End the Express response
-            });
-
-            generateResponse.body.on('end', function () {
-                console.log('Streaming request finished');
-                response.end();
-            });
+            forwardFetchResponse(generateResponse, response);
         } else {
             if (!generateResponse.ok) {
                 console.log(`Claude API returned error: ${generateResponse.status} ${generateResponse.statusText} ${await generateResponse.text()}`);
@@ -1640,11 +1621,7 @@ app.post('/generate_openai', jsonParser, function (request, response_generate_op
             if (fetchResponse.ok) {
                 if (request.body.stream) {
                     console.log('Streaming request in progress');
-                    fetchResponse.body.pipe(response_generate_openai);
-                    fetchResponse.body.on('end', () => {
-                        console.log('Streaming request finished');
-                        response_generate_openai.end();
-                    });
+                    forwardFetchResponse(fetchResponse, response_generate_openai);
                 } else {
                     let json = await fetchResponse.json();
                     response_generate_openai.send(json);

--- a/src/endpoints/novelai.js
+++ b/src/endpoints/novelai.js
@@ -1,9 +1,8 @@
 const fetch = require('node-fetch').default;
 const express = require('express');
 const util = require('util');
-const { Readable } = require('stream');
 const { readSecret, SECRET_KEYS } = require('./secrets');
-const { readAllChunks, extractFileFromZipBuffer } = require('../util');
+const { readAllChunks, extractFileFromZipBuffer, forwardFetchResponse } = require('../util');
 const { jsonParser } = require('../express-common');
 
 const API_NOVELAI = 'https://api.novelai.net';
@@ -188,17 +187,7 @@ router.post('/generate', jsonParser, async function (req, res) {
 
         if (req.body.streaming) {
             // Pipe remote SSE stream to Express response
-            response.body.pipe(res);
-
-            req.socket.on('close', function () {
-                if (response.body instanceof Readable) response.body.destroy(); // Close the remote stream
-                res.end(); // End the Express response
-            });
-
-            response.body.on('end', function () {
-                console.log('Streaming request finished');
-                res.end();
-            });
+            forwardFetchResponse(response, res);
         } else {
             if (!response.ok) {
                 const text = await response.text();


### PR DESCRIPTION
Previously, there were 4 slightly different server-sent event parsers for the 4 different streaming API implementations. I've replaced them all with one server-sent event transform stream, which takes in a `Uint8Array` stream and turns it into a `MessageEvent` stream. It implements the entire [server-sent event stream spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream), so the AI frontends don't need to implement their own bespoke parsers.

I've actually released this code [as an npm package](https://www.npmjs.com/package/@server-sent-stream/web), but I've vendored it in case it needs to be changed. I did create a [test suite](https://github.com/valadaptive/server-sent-stream/blob/6e5f2b66a74bd1a66ee01bef2e86ba807f7b0512/test/sse-stream.test.ts) for it, though, so hopefully the implementation's solid.