### PR TITLE
Only refresh character list after all deletions have been processed.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5927,7 +5927,7 @@ export async function getChatsFromFiles(data, isGroupChat) {
  * in descending order by file name. Returns `undefined` if the fetch request is unsuccessful.
  */
 export async function getPastCharacterChats(characterId = null) {
-    characterId = characterId || this_chid;
+    characterId = characterId ?? this_chid;
     if (!characters[characterId]) return [];
 
     const response = await fetch('/api/characters/chats', {

--- a/public/script.js
+++ b/public/script.js
@@ -5921,20 +5921,23 @@ export async function getChatsFromFiles(data, isGroupChat) {
  * The function sends a POST request to the server to retrieve all chats for the character. It then
  * processes the received data, sorts it by the file name, and returns the sorted data.
  *
+ * @param {null|number} [characterId=null] - When set, the function will use this character id instead of this_chid.
+ *
  * @returns {Promise<Array>} - An array containing metadata of all past chats of the character, sorted
  * in descending order by file name. Returns `undefined` if the fetch request is unsuccessful.
  */
-async function getPastCharacterChats() {
-    if (!characters[this_chid]) return;
+export async function getPastCharacterChats(characterId = null) {
+    characterId = characterId || this_chid;
+    if (!characters[characterId]) return [];
 
     const response = await fetch('/api/characters/chats', {
         method: 'POST',
-        body: JSON.stringify({ avatar_url: characters[this_chid].avatar }),
+        body: JSON.stringify({ avatar_url: characters[characterId].avatar }),
         headers: getRequestHeaders(),
     });
 
     if (!response.ok) {
-        return;
+        return [];
     }
 
     let data = await response.json();

--- a/public/script.js
+++ b/public/script.js
@@ -7652,8 +7652,9 @@ export async function handleDeleteCharacter(popup_type, this_chid, delete_chats)
  *
  * @param {string} name - The name of the character to be deleted.
  * @param {string} avatar - The avatar URL of the character to be deleted.
+ * @param {boolean} reloadCharacters - Whether the character list should be refreshed after deletion.
  */
-export async function deleteCharacter(name, avatar) {
+export async function deleteCharacter(name, avatar, reloadCharacters = true) {
     await clearChat();
     $('#character_cross').click();
     this_chid = 'invalid-safety-id';
@@ -7664,7 +7665,7 @@ export async function deleteCharacter(name, avatar) {
     $(document.getElementById('rm_button_selected_ch')).children('h2').text('');
     this_chid = undefined;
     delete tag_map[avatar];
-    await getCharacters();
+    if (reloadCharacters) await getCharacters();
     select_rm_info('char_delete', name);
     await printMessages();
     saveSettingsDebounced();

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -123,9 +123,9 @@ class CharacterContextMenu {
             cache: 'no-cache',
         }).then(response => {
             if (response.ok) {
-                deleteCharacter(character.name, character.avatar).then(() => {
+                return deleteCharacter(character.name, character.avatar, false).then(() => {
                     if (deleteChats) {
-                        fetch('/api/characters/chats', {
+                        return fetch('/api/characters/chats', {
                             method: 'POST',
                             body: JSON.stringify({ avatar_url: character.avatar }),
                             headers: getRequestHeaders(),

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -6,10 +6,10 @@ import {
     deleteCharacter,
     event_types,
     eventSource,
-    getCharacters, getPastCharacterChats,
+    getCharacters,
+    getPastCharacterChats,
     getRequestHeaders,
     printCharacters,
-    this_chid,
 } from '../script.js';
 
 import { favsToHotswap } from './RossAscends-mods.js';
@@ -119,12 +119,12 @@ class CharacterContextMenu {
         return fetch('/api/characters/delete', {
             method: 'POST',
             headers: getRequestHeaders(),
-            body: JSON.stringify({avatar_url: character.avatar, delete_chats: deleteChats}),
+            body: JSON.stringify({ avatar_url: character.avatar, delete_chats: deleteChats }),
             cache: 'no-cache',
         }).then(response => {
             if (response.ok) {
                 return deleteCharacter(character.name, character.avatar, false).then(() => {
-                    eventSource.emit('characterDeleted', {id: characterId, character: characters[characterId]});
+                    eventSource.emit('characterDeleted', { id: characterId, character: characters[characterId] });
                     if (deleteChats) getPastCharacterChats(characterId).then(pastChats => {
                         for (const chat of pastChats) {
                             const name = chat.file_name.replace('.jsonl', '');
@@ -462,18 +462,18 @@ class BulkEditOverlay {
         this.isLongPress = true;
 
         setTimeout(() => {
-                if (this.isLongPress && !cancel) {
-                    if (this.state === BulkEditOverlayState.browse) {
-                        this.selectState();
-                    } else if (this.state === BulkEditOverlayState.select) {
-                        this.#contextMenuOpen = true;
-                        CharacterContextMenu.show(...this.#getContextMenuPosition(event));
-                    }
+            if (this.isLongPress && !cancel) {
+                if (this.state === BulkEditOverlayState.browse) {
+                    this.selectState();
+                } else if (this.state === BulkEditOverlayState.select) {
+                    this.#contextMenuOpen = true;
+                    CharacterContextMenu.show(...this.#getContextMenuPosition(event));
                 }
+            }
 
-                this.container.removeEventListener('mouseup', cancelHold);
-                this.container.removeEventListener('touchend', cancelHold);
-            },
+            this.container.removeEventListener('mouseup', cancelHold);
+            this.container.removeEventListener('touchend', cancelHold);
+        },
             BulkEditOverlay.longPressDelay);
     };
 


### PR DESCRIPTION
First commit fixes exhaustive refreshing of the character list when bulk-deleting characters.
Second and third commit fix a non-critical error on the server side when character and chat were deleted in the wrong order.