### PR TITLE
Allow /run for quick replies from any preset

### DIFF
--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -241,7 +241,15 @@ async function executeQuickReplyByName(name) {
         throw new Error('Quick Reply is disabled');
     }
 
-    const qr = extension_settings.quickReply.quickReplySlots.find(x => x.label == name);
+    let qr = extension_settings.quickReply.quickReplySlots.find(x => x.label == name);
+
+    if (!qr && name.includes('.')) {
+        const [presetName, qrName] = name.split('.');
+        const preset = presets.find(x => x.name == presetName);
+        if (preset) {
+            qr = preset.quickReplySlots.find(x => x.label == qrName);
+        }
+    }
 
     if (!qr) {
         throw new Error(`Quick Reply "${name}" not found`);


### PR DESCRIPTION
```
/run otherPresetName.quickReplyLabel
```

This only happens when not QR with the exact name is found.
```
/run a.b
```
The above will try to find a QR in the current preset with the label "a.b", if no QR is found, it will try to find preset "a" and look in there for QR "b".