### PR TITLE
Tokenizers cleanup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2438,7 +2438,7 @@
                                 <option value="5">NerdStash v2 (NovelAI Kayra)</option>
                                 <option value="7">Mistral</option>
                                 <option value="8">Yi</option>
-                                <option value="98">API (WebUI / koboldcpp)</option>
+                                <option value="6">API (WebUI / koboldcpp)</option>
                             </select>
                         </div>
                         <div class="range-block" data-newbie-hidden>

--- a/public/index.html
+++ b/public/index.html
@@ -2438,7 +2438,7 @@
                                 <option value="5">NerdStash v2 (NovelAI Kayra)</option>
                                 <option value="7">Mistral</option>
                                 <option value="8">Yi</option>
-                                <option value="6">API (WebUI / koboldcpp)</option>
+                                <option value="98">API (WebUI / koboldcpp)</option>
                             </select>
                         </div>
                         <div class="range-block" data-newbie-hidden>

--- a/public/script.js
+++ b/public/script.js
@@ -871,7 +871,7 @@ async function getStatusKobold() {
 
     const url = '/getstatus';
 
-    let endpoint = getAPIServerUrl();
+    let endpoint = api_server;
 
     if (!endpoint) {
         console.warn('No endpoint for status check');
@@ -919,7 +919,9 @@ async function getStatusKobold() {
 async function getStatusTextgen() {
     const url = '/api/textgenerationwebui/status';
 
-    let endpoint = getAPIServerUrl();
+    let endpoint = textgen_settings.type === MANCER ?
+        MANCER_SERVER :
+        api_server_textgenerationwebui;
 
     if (!endpoint) {
         console.warn('No endpoint for status check');
@@ -997,23 +999,6 @@ export function stopStatusLoading() {
 export function resultCheckStatus() {
     displayOnlineStatus();
     stopStatusLoading();
-}
-
-// TODO(valadaptive): remove the usage of this function in the tokenizers code, then remove the function entirely
-export function getAPIServerUrl() {
-    if (main_api == 'textgenerationwebui') {
-        if (textgen_settings.type === MANCER) {
-            return MANCER_SERVER;
-        }
-
-        return api_server_textgenerationwebui;
-    }
-
-    if (main_api == 'kobold') {
-        return api_server;
-    }
-
-    return '';
 }
 
 export async function selectCharacterById(id) {

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -394,30 +394,6 @@ function getTokenCacheObject() {
     return tokenCache[String(chatId)];
 }
 
-function getServerTokenizationParams(str) {
-    return {
-        text: str,
-    };
-}
-
-function getKoboldAPITokenizationParams(str) {
-    return {
-        text: str,
-        url: api_server,
-    };
-}
-
-function getTextgenAPITokenizationParams(str) {
-    return {
-        text: str,
-        api_type: textgen_settings.type,
-        url: api_server_textgenerationwebui,
-        legacy_api:
-            textgen_settings.legacy_api &&
-            textgen_settings.type !== MANCER,
-    };
-}
-
 /**
  * Count tokens using the server API.
  * @param {string} endpoint API endpoint.
@@ -432,7 +408,7 @@ function countTokensFromServer(endpoint, str, padding) {
         async: false,
         type: 'POST',
         url: endpoint,
-        data: JSON.stringify(getServerTokenizationParams(str)),
+        data: JSON.stringify({ text: str }),
         dataType: 'json',
         contentType: 'application/json',
         success: function (data) {
@@ -461,7 +437,10 @@ function countTokensFromKoboldAPI(endpoint, str, padding) {
         async: false,
         type: 'POST',
         url: endpoint,
-        data: JSON.stringify(getKoboldAPITokenizationParams(str)),
+        data: JSON.stringify({
+            text: str,
+            url: api_server,
+        }),
         dataType: 'json',
         contentType: 'application/json',
         success: function (data) {
@@ -474,6 +453,17 @@ function countTokensFromKoboldAPI(endpoint, str, padding) {
     });
 
     return tokenCount + padding;
+}
+
+function getTextgenAPITokenizationParams(str) {
+    return {
+        text: str,
+        api_type: textgen_settings.type,
+        url: api_server_textgenerationwebui,
+        legacy_api:
+            textgen_settings.legacy_api &&
+            textgen_settings.type !== MANCER,
+    };
 }
 
 /**
@@ -538,7 +528,7 @@ function getTextTokensFromServer(endpoint, str, model = '') {
         async: false,
         type: 'POST',
         url: endpoint,
-        data: JSON.stringify(getServerTokenizationParams(str)),
+        data: JSON.stringify({ text: str }),
         dataType: 'json',
         contentType: 'application/json',
         success: function (data) {

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -211,7 +211,6 @@ export function getTokenizerBestMatch(forApi) {
 function currentRemoteTokenizerAPI() {
     switch (main_api) {
         case 'kobold':
-        case 'koboldhorde':
             return tokenizers.API_KOBOLD;
         case 'textgenerationwebui':
             return tokenizers.API_TEXTGENERATIONWEBUI;
@@ -240,7 +239,7 @@ function callTokenizer(type, str) {
             const endpointUrl = TOKENIZER_URLS[type]?.count;
             if (!endpointUrl) {
                 console.warn('Unknown tokenizer type', type);
-                return callTokenizer(tokenizers.NONE, str);
+                return apiFailureTokenCount(str);
             }
             return countTokensFromServer(endpointUrl, str);
         }
@@ -654,11 +653,13 @@ export function getTextTokens(tokenizerType, str) {
         default: {
             const tokenizerEndpoints = TOKENIZER_URLS[tokenizerType];
             if (!tokenizerEndpoints) {
+                apiFailureTokenCount(str);
                 console.warn('Unknown tokenizer type', tokenizerType);
                 return [];
             }
             let endpointUrl = tokenizerEndpoints.encode;
             if (!endpointUrl) {
+                apiFailureTokenCount(str);
                 console.warn('This tokenizer type does not support encoding', tokenizerType);
                 return [];
             }

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -139,7 +139,18 @@ export function getFriendlyTokenizerName(forApi) {
 
     if (forApi !== 'openai' && tokenizerId === tokenizers.BEST_MATCH) {
         tokenizerId = getTokenizerBestMatch(forApi);
-        tokenizerName = $(`#tokenizer option[value="${tokenizerId}"]`).text();
+
+        switch (tokenizerId) {
+            case tokenizers.API_KOBOLD:
+                tokenizerName = 'API (KoboldAI Classic)';
+                break;
+            case tokenizers.API_TEXTGENERATIONWEBUI:
+                tokenizerName = 'API (Text Completion)';
+                break;
+            default:
+                tokenizerName = $(`#tokenizer option[value="${tokenizerId}"]`).text();
+                break;
+        }
     }
 
     tokenizerName = forApi == 'openai'

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -199,24 +199,23 @@ export function getTokenizerBestMatch(forApi) {
  * Calls the underlying tokenizer model to the token count for a string.
  * @param {number} type Tokenizer type.
  * @param {string} str String to tokenize.
- * @param {number} padding Number of padding tokens.
  * @returns {number} Token count.
  */
-function callTokenizer(type, str, padding) {
-    if (type === tokenizers.NONE) return guesstimate(str) + padding;
+function callTokenizer(type, str) {
+    if (type === tokenizers.NONE) return guesstimate(str);
 
     switch (type) {
         case tokenizers.API_KOBOLD:
-            return countTokensFromKoboldAPI(str, padding);
+            return countTokensFromKoboldAPI(str);
         case tokenizers.API_TEXTGENERATIONWEBUI:
-            return countTokensFromTextgenAPI(str, padding);
+            return countTokensFromTextgenAPI(str);
         default: {
             const endpointUrl = TOKENIZER_URLS[type]?.count;
             if (!endpointUrl) {
                 console.warn('Unknown tokenizer type', type);
-                return callTokenizer(tokenizers.NONE, str, padding);
+                return callTokenizer(tokenizers.NONE, str);
             }
-            return countTokensFromServer(endpointUrl, str, padding);
+            return countTokensFromServer(endpointUrl, str);
         }
     }
 }
@@ -260,7 +259,7 @@ export function getTokenCount(str, padding = undefined) {
         return cacheObject[cacheKey];
     }
 
-    const result = callTokenizer(tokenizerType, str, padding);
+    const result = callTokenizer(tokenizerType, str) + padding;
 
     if (isNaN(result)) {
         console.warn('Token count calculation returned NaN');
@@ -436,10 +435,9 @@ function getTokenCacheObject() {
  * Count tokens using the server API.
  * @param {string} endpoint API endpoint.
  * @param {string} str String to tokenize.
- * @param {number} padding Number of padding tokens.
- * @returns {number} Token count with padding.
+ * @returns {number} Token count.
  */
-function countTokensFromServer(endpoint, str, padding) {
+function countTokensFromServer(endpoint, str) {
     let tokenCount = 0;
 
     jQuery.ajax({
@@ -458,16 +456,15 @@ function countTokensFromServer(endpoint, str, padding) {
         },
     });
 
-    return tokenCount + padding;
+    return tokenCount;
 }
 
 /**
  * Count tokens using the AI provider's API.
  * @param {string} str String to tokenize.
- * @param {number} padding Number of padding tokens.
- * @returns {number} Token count with padding.
+ * @returns {number} Token count.
  */
-function countTokensFromKoboldAPI(str, padding) {
+function countTokensFromKoboldAPI(str) {
     let tokenCount = 0;
 
     jQuery.ajax({
@@ -489,7 +486,7 @@ function countTokensFromKoboldAPI(str, padding) {
         },
     });
 
-    return tokenCount + padding;
+    return tokenCount;
 }
 
 function getTextgenAPITokenizationParams(str) {
@@ -506,10 +503,9 @@ function getTextgenAPITokenizationParams(str) {
 /**
  * Count tokens using the AI provider's API.
  * @param {string} str String to tokenize.
- * @param {number} padding Number of padding tokens.
- * @returns {number} Token count with padding.
+ * @returns {number} Token count.
  */
-function countTokensFromTextgenAPI(str, padding) {
+function countTokensFromTextgenAPI(str) {
     let tokenCount = 0;
 
     jQuery.ajax({
@@ -528,7 +524,7 @@ function countTokensFromTextgenAPI(str, padding) {
         },
     });
 
-    return tokenCount + padding;
+    return tokenCount;
 }
 
 function apiFailureTokenCount(str) {

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -161,19 +161,19 @@ function callTokenizer(type, str, padding) {
         case tokenizers.NONE:
             return guesstimate(str) + padding;
         case tokenizers.GPT2:
-            return countTokensRemote('/api/tokenizers/gpt2/encode', str, padding);
+            return countTokensFromServer('/api/tokenizers/gpt2/encode', str, padding);
         case tokenizers.LLAMA:
-            return countTokensRemote('/api/tokenizers/llama/encode', str, padding);
+            return countTokensFromServer('/api/tokenizers/llama/encode', str, padding);
         case tokenizers.NERD:
-            return countTokensRemote('/api/tokenizers/nerdstash/encode', str, padding);
+            return countTokensFromServer('/api/tokenizers/nerdstash/encode', str, padding);
         case tokenizers.NERD2:
-            return countTokensRemote('/api/tokenizers/nerdstash_v2/encode', str, padding);
+            return countTokensFromServer('/api/tokenizers/nerdstash_v2/encode', str, padding);
         case tokenizers.MISTRAL:
-            return countTokensRemote('/api/tokenizers/mistral/encode', str, padding);
+            return countTokensFromServer('/api/tokenizers/mistral/encode', str, padding);
         case tokenizers.YI:
-            return countTokensRemote('/api/tokenizers/yi/encode', str, padding);
+            return countTokensFromServer('/api/tokenizers/yi/encode', str, padding);
         case tokenizers.API:
-            return countTokensRemote('/api/tokenizers/remote/encode', str, padding);
+            return countTokensFromServer('/api/tokenizers/remote/encode', str, padding);
         default:
             console.warn('Unknown tokenizer type', type);
             return callTokenizer(tokenizers.NONE, str, padding);
@@ -391,7 +391,7 @@ function getTokenCacheObject() {
     return tokenCache[String(chatId)];
 }
 
-function getRemoteTokenizationParams(str) {
+function getServerTokenizationParams(str) {
     return {
         text: str,
         main_api,
@@ -404,20 +404,20 @@ function getRemoteTokenizationParams(str) {
 }
 
 /**
- * Counts token using the remote server API.
+ * Counts token using the server API.
  * @param {string} endpoint API endpoint.
  * @param {string} str String to tokenize.
  * @param {number} padding Number of padding tokens.
  * @returns {number} Token count with padding.
  */
-function countTokensRemote(endpoint, str, padding) {
+function countTokensFromServer(endpoint, str, padding) {
     let tokenCount = 0;
 
     jQuery.ajax({
         async: false,
         type: 'POST',
         url: endpoint,
-        data: JSON.stringify(getRemoteTokenizationParams(str)),
+        data: JSON.stringify(getServerTokenizationParams(str)),
         dataType: 'json',
         contentType: 'application/json',
         success: function (data) {
@@ -450,7 +450,7 @@ function countTokensRemote(endpoint, str, padding) {
  * @param {string} model Tokenizer model.
  * @returns {number[]} Array of token ids.
  */
-function getTextTokensRemote(endpoint, str, model = '') {
+function getTextTokensFromServer(endpoint, str, model = '') {
     if (model) {
         endpoint += `?model=${model}`;
     }
@@ -460,7 +460,7 @@ function getTextTokensRemote(endpoint, str, model = '') {
         async: false,
         type: 'POST',
         url: endpoint,
-        data: JSON.stringify(getRemoteTokenizationParams(str)),
+        data: JSON.stringify(getServerTokenizationParams(str)),
         dataType: 'json',
         contentType: 'application/json',
         success: function (data) {
@@ -480,7 +480,7 @@ function getTextTokensRemote(endpoint, str, model = '') {
  * @param {string} endpoint API endpoint.
  * @param {number[]} ids Array of token ids
  */
-function decodeTextTokensRemote(endpoint, ids, model = '') {
+function decodeTextTokensFromServer(endpoint, ids, model = '') {
     if (model) {
         endpoint += `?model=${model}`;
     }
@@ -501,7 +501,7 @@ function decodeTextTokensRemote(endpoint, ids, model = '') {
 }
 
 /**
- * Encodes a string to tokens using the remote server API.
+ * Encodes a string to tokens using the server API.
  * @param {number} tokenizerType Tokenizer type.
  * @param {string} str String to tokenize.
  * @returns {number[]} Array of token ids.
@@ -509,23 +509,23 @@ function decodeTextTokensRemote(endpoint, ids, model = '') {
 export function getTextTokens(tokenizerType, str) {
     switch (tokenizerType) {
         case tokenizers.GPT2:
-            return getTextTokensRemote('/api/tokenizers/gpt2/encode', str);
+            return getTextTokensFromServer('/api/tokenizers/gpt2/encode', str);
         case tokenizers.LLAMA:
-            return getTextTokensRemote('/api/tokenizers/llama/encode', str);
+            return getTextTokensFromServer('/api/tokenizers/llama/encode', str);
         case tokenizers.NERD:
-            return getTextTokensRemote('/api/tokenizers/nerdstash/encode', str);
+            return getTextTokensFromServer('/api/tokenizers/nerdstash/encode', str);
         case tokenizers.NERD2:
-            return getTextTokensRemote('/api/tokenizers/nerdstash_v2/encode', str);
+            return getTextTokensFromServer('/api/tokenizers/nerdstash_v2/encode', str);
         case tokenizers.MISTRAL:
-            return getTextTokensRemote('/api/tokenizers/mistral/encode', str);
+            return getTextTokensFromServer('/api/tokenizers/mistral/encode', str);
         case tokenizers.YI:
-            return getTextTokensRemote('/api/tokenizers/yi/encode', str);
+            return getTextTokensFromServer('/api/tokenizers/yi/encode', str);
         case tokenizers.OPENAI: {
             const model = getTokenizerModel();
-            return getTextTokensRemote('/api/tokenizers/openai/encode', str, model);
+            return getTextTokensFromServer('/api/tokenizers/openai/encode', str, model);
         }
         case tokenizers.API:
-            return getTextTokensRemote('/api/tokenizers/remote/encode', str);
+            return getTextTokensFromServer('/api/tokenizers/remote/encode', str);
         default:
             console.warn('Calling getTextTokens with unsupported tokenizer type', tokenizerType);
             return [];
@@ -533,27 +533,27 @@ export function getTextTokens(tokenizerType, str) {
 }
 
 /**
- * Decodes token ids to text using the remote server API.
+ * Decodes token ids to text using the server API.
  * @param {number} tokenizerType Tokenizer type.
  * @param {number[]} ids Array of token ids
  */
 export function decodeTextTokens(tokenizerType, ids) {
     switch (tokenizerType) {
         case tokenizers.GPT2:
-            return decodeTextTokensRemote('/api/tokenizers/gpt2/decode', ids);
+            return decodeTextTokensFromServer('/api/tokenizers/gpt2/decode', ids);
         case tokenizers.LLAMA:
-            return decodeTextTokensRemote('/api/tokenizers/llama/decode', ids);
+            return decodeTextTokensFromServer('/api/tokenizers/llama/decode', ids);
         case tokenizers.NERD:
-            return decodeTextTokensRemote('/api/tokenizers/nerdstash/decode', ids);
+            return decodeTextTokensFromServer('/api/tokenizers/nerdstash/decode', ids);
         case tokenizers.NERD2:
-            return decodeTextTokensRemote('/api/tokenizers/nerdstash_v2/decode', ids);
+            return decodeTextTokensFromServer('/api/tokenizers/nerdstash_v2/decode', ids);
         case tokenizers.MISTRAL:
-            return decodeTextTokensRemote('/api/tokenizers/mistral/decode', ids);
+            return decodeTextTokensFromServer('/api/tokenizers/mistral/decode', ids);
         case tokenizers.YI:
-            return decodeTextTokensRemote('/api/tokenizers/yi/decode', ids);
+            return decodeTextTokensFromServer('/api/tokenizers/yi/decode', ids);
         case tokenizers.OPENAI: {
             const model = getTokenizerModel();
-            return decodeTextTokensRemote('/api/tokenizers/openai/decode', ids, model);
+            return decodeTextTokensFromServer('/api/tokenizers/openai/decode', ids, model);
         }
         default:
             console.warn('Calling decodeTextTokens with unsupported tokenizer type', tokenizerType);

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -648,7 +648,7 @@ function decodeTextTokensFromServer(endpoint, ids) {
 export function getTextTokens(tokenizerType, str) {
     switch (tokenizerType) {
         case tokenizers.API_CURRENT:
-            return callTokenizer(currentRemoteTokenizerAPI(), str);
+            return getTextTokens(currentRemoteTokenizerAPI(), str);
         case tokenizers.API_TEXTGENERATIONWEBUI:
             return getTextTokensFromTextgenAPI(str);
         default: {
@@ -678,7 +678,7 @@ export function getTextTokens(tokenizerType, str) {
 export function decodeTextTokens(tokenizerType, ids) {
     // Currently, neither remote API can decode, but this may change in the future. Put this guard here to be safe
     if (tokenizerType === tokenizers.API_CURRENT) {
-        return decodeTextTokens(tokenizers.NONE);
+        return decodeTextTokens(tokenizers.NONE, ids);
     }
     const tokenizerEndpoints = TOKENIZER_URLS[tokenizerType];
     if (!tokenizerEndpoints) {

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -173,7 +173,7 @@ function callTokenizer(type, str, padding) {
         case tokenizers.YI:
             return countTokensRemote('/api/tokenizers/yi/encode', str, padding);
         case tokenizers.API:
-            return countTokensRemote('/tokenize_via_api', str, padding);
+            return countTokensRemote('/api/tokenizers/remote/encode', str, padding);
         default:
             console.warn('Unknown tokenizer type', type);
             return callTokenizer(tokenizers.NONE, str, padding);
@@ -525,7 +525,7 @@ export function getTextTokens(tokenizerType, str) {
             return getTextTokensRemote('/api/tokenizers/openai/encode', str, model);
         }
         case tokenizers.API:
-            return getTextTokensRemote('/tokenize_via_api', str);
+            return getTextTokensRemote('/api/tokenizers/remote/encode', str);
         default:
             console.warn('Calling getTextTokens with unsupported tokenizer type', tokenizerType);
             return [];

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -1,4 +1,4 @@
-import { characters, getAPIServerUrl, main_api, nai_settings, online_status, this_chid } from '../script.js';
+import { characters, main_api, api_server, api_server_textgenerationwebui, nai_settings, online_status, this_chid } from '../script.js';
 import { power_user, registerDebugFunction } from './power-user.js';
 import { chat_completion_sources, model_list, oai_settings } from './openai.js';
 import { groups, selected_group } from './group-chats.js';
@@ -174,9 +174,9 @@ function callTokenizer(type, str, padding) {
         case tokenizers.YI:
             return countTokensFromServer('/api/tokenizers/yi/encode', str, padding);
         case tokenizers.API_KOBOLD:
-            return countTokensFromKoboldAPI('/api/tokenizers/remote/encode', str, padding);
+            return countTokensFromKoboldAPI('/api/tokenizers/remote/kobold/count', str, padding);
         case tokenizers.API_TEXTGENERATIONWEBUI:
-            return countTokensFromTextgenAPI('/api/tokenizers/remote/encode', str, padding);
+            return countTokensFromTextgenAPI('/api/tokenizers/remote/textgenerationwebui/encode', str, padding);
         default:
             console.warn('Unknown tokenizer type', type);
             return callTokenizer(tokenizers.NONE, str, padding);
@@ -403,17 +403,15 @@ function getServerTokenizationParams(str) {
 function getKoboldAPITokenizationParams(str) {
     return {
         text: str,
-        main_api: 'kobold',
-        url: getAPIServerUrl(),
+        url: api_server,
     };
 }
 
 function getTextgenAPITokenizationParams(str) {
     return {
         text: str,
-        main_api: 'textgenerationwebui',
         api_type: textgen_settings.type,
-        url: getAPIServerUrl(),
+        url: api_server_textgenerationwebui,
         legacy_api:
             textgen_settings.legacy_api &&
             textgen_settings.type !== MANCER,
@@ -627,7 +625,7 @@ export function getTextTokens(tokenizerType, str) {
             return getTextTokensFromServer('/api/tokenizers/openai/encode', str, model);
         }
         case tokenizers.API_TEXTGENERATIONWEBUI:
-            return getTextTokensFromTextgenAPI('/api/tokenizers/remote/encode', str);
+            return getTextTokensFromTextgenAPI('/api/tokenizers/textgenerationwebui/encode', str);
         default:
             console.warn('Calling getTextTokens with unsupported tokenizer type', tokenizerType);
             return [];

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -18,11 +18,11 @@ export const tokenizers = {
     LLAMA: 3,
     NERD: 4,
     NERD2: 5,
-    API_KOBOLD: 6,
+    API_CURRENT: 6,
     MISTRAL: 7,
     YI: 8,
     API_TEXTGENERATIONWEBUI: 9,
-    API_CURRENT: 98,
+    API_KOBOLD: 10,
     BEST_MATCH: 99,
 };
 

--- a/server.js
+++ b/server.js
@@ -49,6 +49,7 @@ const { delay, getVersion, getConfigValue, color, uuidv4, tryParse, clientRelati
 const { ensureThumbnailCache } = require('./src/endpoints/thumbnails');
 const { getTokenizerModel, getTiktokenTokenizer, loadTokenizers, TEXT_COMPLETION_MODELS, getSentencepiceTokenizer, sentencepieceTokenizers } = require('./src/endpoints/tokenizers');
 const { convertClaudePrompt } = require('./src/chat-completion');
+const { getOverrideHeaders, setAdditionalHeaders } = require('./src/additional-headers');
 
 // Work around a node v20.0.0, v20.1.0, and v20.2.0 bug. The issue was fixed in v20.3.0.
 // https://github.com/nodejs/node/issues/47822#issuecomment-1564708870
@@ -118,70 +119,6 @@ const listen = getConfigValue('listen', false);
 
 const API_OPENAI = 'https://api.openai.com/v1';
 const API_CLAUDE = 'https://api.anthropic.com/v1';
-
-function getMancerHeaders() {
-    const apiKey = readSecret(SECRET_KEYS.MANCER);
-
-    return apiKey ? ({
-        'X-API-KEY': apiKey,
-        'Authorization': `Bearer ${apiKey}`,
-    }) : {};
-}
-
-function getAphroditeHeaders() {
-    const apiKey = readSecret(SECRET_KEYS.APHRODITE);
-
-    return apiKey ? ({
-        'X-API-KEY': apiKey,
-        'Authorization': `Bearer ${apiKey}`,
-    }) : {};
-}
-
-function getTabbyHeaders() {
-    const apiKey = readSecret(SECRET_KEYS.TABBY);
-
-    return apiKey ? ({
-        'x-api-key': apiKey,
-        'Authorization': `Bearer ${apiKey}`,
-    }) : {};
-}
-
-function getOverrideHeaders(urlHost) {
-    const requestOverrides = getConfigValue('requestOverrides', []);
-    const overrideHeaders = requestOverrides?.find((e) => e.hosts?.includes(urlHost))?.headers;
-    if (overrideHeaders && urlHost) {
-        return overrideHeaders;
-    } else {
-        return {};
-    }
-}
-
-/**
- * Sets additional headers for the request.
- * @param {object} request Original request body
- * @param {object} args New request arguments
- * @param {string|null} server API server for new request
- */
-function setAdditionalHeaders(request, args, server) {
-    let headers;
-
-    switch (request.body.api_type) {
-        case TEXTGEN_TYPES.MANCER:
-            headers = getMancerHeaders();
-            break;
-        case TEXTGEN_TYPES.APHRODITE:
-            headers = getAphroditeHeaders();
-            break;
-        case TEXTGEN_TYPES.TABBY:
-            headers = getTabbyHeaders();
-            break;
-        default:
-            headers = server ? getOverrideHeaders((new URL(server))?.host) : {};
-            break;
-    }
-
-    Object.assign(args.headers, headers);
-}
 
 const SETTINGS_FILE = './public/settings.json';
 const { DIRECTORIES, UPLOADS_PATH, PALM_SAFETY, TEXTGEN_TYPES, CHAT_COMPLETION_SOURCES, AVATAR_WIDTH, AVATAR_HEIGHT } = require('./src/constants');
@@ -1773,93 +1710,6 @@ async function sendAI21Request(request, response) {
         });
 
 }
-
-app.post('/api/tokenizers/remote/encode', jsonParser, async function (request, response) {
-    if (!request.body) {
-        return response.sendStatus(400);
-    }
-    const text = String(request.body.text) || '';
-    const api = String(request.body.main_api);
-    const baseUrl = String(request.body.url);
-    const legacyApi = Boolean(request.body.legacy_api);
-
-    try {
-        if (api == 'textgenerationwebui') {
-            const args = {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-            };
-
-            setAdditionalHeaders(request, args, null);
-
-            // Convert to string + remove trailing slash + /v1 suffix
-            let url = String(baseUrl).replace(/\/$/, '').replace(/\/v1$/, '');
-
-            if (legacyApi) {
-                url += '/v1/token-count';
-                args.body = JSON.stringify({ 'prompt': text });
-            } else {
-                switch (request.body.api_type) {
-                    case TEXTGEN_TYPES.TABBY:
-                        url += '/v1/token/encode';
-                        args.body = JSON.stringify({ 'text': text });
-                        break;
-                    case TEXTGEN_TYPES.KOBOLDCPP:
-                        url += '/api/extra/tokencount';
-                        args.body = JSON.stringify({ 'prompt': text });
-                        break;
-                    default:
-                        url += '/v1/internal/encode';
-                        args.body = JSON.stringify({ 'text': text });
-                        break;
-                }
-            }
-
-            const result = await fetch(url, args);
-
-            if (!result.ok) {
-                console.log(`API returned error: ${result.status} ${result.statusText}`);
-                return response.send({ error: true });
-            }
-
-            const data = await result.json();
-            const count = legacyApi ? data?.results[0]?.tokens : (data?.length ?? data?.value);
-            const ids = legacyApi ? [] : (data?.tokens ?? []);
-
-            return response.send({ count, ids });
-        }
-
-        else if (api == 'kobold') {
-            const args = {
-                method: 'POST',
-                body: JSON.stringify({ 'prompt': text }),
-                headers: { 'Content-Type': 'application/json' },
-            };
-
-            let url = String(baseUrl).replace(/\/$/, '');
-            url += '/extra/tokencount';
-
-            const result = await fetch(url, args);
-
-            if (!result.ok) {
-                console.log(`API returned error: ${result.status} ${result.statusText}`);
-                return response.send({ error: true });
-            }
-
-            const data = await result.json();
-            const count = data['value'];
-            return response.send({ count: count, ids: [] });
-        }
-
-        else {
-            console.log('Unknown API', api);
-            return response.send({ error: true });
-        }
-    } catch (error) {
-        console.log(error);
-        return response.send({ error: true });
-    }
-});
 
 /**
  * Redirect a deprecated API endpoint URL to its replacement. Because fetch, form submissions, and $.ajax follow

--- a/server.js
+++ b/server.js
@@ -1774,7 +1774,7 @@ async function sendAI21Request(request, response) {
 
 }
 
-app.post('/tokenize_via_api', jsonParser, async function (request, response) {
+app.post('/api/tokenizers/remote/encode', jsonParser, async function (request, response) {
     if (!request.body) {
         return response.sendStatus(400);
     }

--- a/src/additional-headers.js
+++ b/src/additional-headers.js
@@ -1,0 +1,72 @@
+const { TEXTGEN_TYPES } = require('./constants');
+const { SECRET_KEYS, readSecret } = require('./endpoints/secrets');
+const { getConfigValue } = require('./util');
+
+function getMancerHeaders() {
+    const apiKey = readSecret(SECRET_KEYS.MANCER);
+
+    return apiKey ? ({
+        'X-API-KEY': apiKey,
+        'Authorization': `Bearer ${apiKey}`,
+    }) : {};
+}
+
+function getAphroditeHeaders() {
+    const apiKey = readSecret(SECRET_KEYS.APHRODITE);
+
+    return apiKey ? ({
+        'X-API-KEY': apiKey,
+        'Authorization': `Bearer ${apiKey}`,
+    }) : {};
+}
+
+function getTabbyHeaders() {
+    const apiKey = readSecret(SECRET_KEYS.TABBY);
+
+    return apiKey ? ({
+        'x-api-key': apiKey,
+        'Authorization': `Bearer ${apiKey}`,
+    }) : {};
+}
+
+function getOverrideHeaders(urlHost) {
+    const requestOverrides = getConfigValue('requestOverrides', []);
+    const overrideHeaders = requestOverrides?.find((e) => e.hosts?.includes(urlHost))?.headers;
+    if (overrideHeaders && urlHost) {
+        return overrideHeaders;
+    } else {
+        return {};
+    }
+}
+
+/**
+ * Sets additional headers for the request.
+ * @param {object} request Original request body
+ * @param {object} args New request arguments
+ * @param {string|null} server API server for new request
+ */
+function setAdditionalHeaders(request, args, server) {
+    let headers;
+
+    switch (request.body.api_type) {
+        case TEXTGEN_TYPES.MANCER:
+            headers = getMancerHeaders();
+            break;
+        case TEXTGEN_TYPES.APHRODITE:
+            headers = getAphroditeHeaders();
+            break;
+        case TEXTGEN_TYPES.TABBY:
+            headers = getTabbyHeaders();
+            break;
+        default:
+            headers = server ? getOverrideHeaders((new URL(server))?.host) : {};
+            break;
+    }
+
+    Object.assign(args.headers, headers);
+}
+
+module.exports = {
+    getOverrideHeaders,
+    setAdditionalHeaders,
+};

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -6,7 +6,9 @@ const tiktoken = require('@dqbd/tiktoken');
 const { Tokenizer } = require('@agnai/web-tokenizers');
 const { convertClaudePrompt } = require('../chat-completion');
 const { readSecret, SECRET_KEYS } = require('./secrets');
+const { TEXTGEN_TYPES } = require('../constants');
 const { jsonParser } = require('../express-common');
+const { setAdditionalHeaders } = require('../additional-headers');
 
 /**
  * @type {{[key: string]: import("@dqbd/tiktoken").Tiktoken}} Tokenizers cache
@@ -531,6 +533,93 @@ router.post('/openai/count', jsonParser, async function (req, res) {
         const jsonBody = JSON.stringify(req.body);
         const num_tokens = Math.ceil(jsonBody.length / CHARS_PER_TOKEN);
         res.send({ 'token_count': num_tokens });
+    }
+});
+
+router.post('/remote/encode', jsonParser, async function (request, response) {
+    if (!request.body) {
+        return response.sendStatus(400);
+    }
+    const text = String(request.body.text) || '';
+    const api = String(request.body.main_api);
+    const baseUrl = String(request.body.url);
+    const legacyApi = Boolean(request.body.legacy_api);
+
+    try {
+        if (api == 'textgenerationwebui') {
+            const args = {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+            };
+
+            setAdditionalHeaders(request, args, null);
+
+            // Convert to string + remove trailing slash + /v1 suffix
+            let url = String(baseUrl).replace(/\/$/, '').replace(/\/v1$/, '');
+
+            if (legacyApi) {
+                url += '/v1/token-count';
+                args.body = JSON.stringify({ 'prompt': text });
+            } else {
+                switch (request.body.api_type) {
+                    case TEXTGEN_TYPES.TABBY:
+                        url += '/v1/token/encode';
+                        args.body = JSON.stringify({ 'text': text });
+                        break;
+                    case TEXTGEN_TYPES.KOBOLDCPP:
+                        url += '/api/extra/tokencount';
+                        args.body = JSON.stringify({ 'prompt': text });
+                        break;
+                    default:
+                        url += '/v1/internal/encode';
+                        args.body = JSON.stringify({ 'text': text });
+                        break;
+                }
+            }
+
+            const result = await fetch(url, args);
+
+            if (!result.ok) {
+                console.log(`API returned error: ${result.status} ${result.statusText}`);
+                return response.send({ error: true });
+            }
+
+            const data = await result.json();
+            const count = legacyApi ? data?.results[0]?.tokens : (data?.length ?? data?.value);
+            const ids = legacyApi ? [] : (data?.tokens ?? []);
+
+            return response.send({ count, ids });
+        }
+
+        else if (api == 'kobold') {
+            const args = {
+                method: 'POST',
+                body: JSON.stringify({ 'prompt': text }),
+                headers: { 'Content-Type': 'application/json' },
+            };
+
+            let url = String(baseUrl).replace(/\/$/, '');
+            url += '/extra/tokencount';
+
+            const result = await fetch(url, args);
+
+            if (!result.ok) {
+                console.log(`API returned error: ${result.status} ${result.statusText}`);
+                return response.send({ error: true });
+            }
+
+            const data = await result.json();
+            const count = data['value'];
+            return response.send({ count: count, ids: [] });
+        }
+
+        else {
+            console.log('Unknown API', api);
+            return response.send({ error: true });
+        }
+    } catch (error) {
+        console.log(error);
+        return response.send({ error: true });
     }
 });
 

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -536,87 +536,90 @@ router.post('/openai/count', jsonParser, async function (req, res) {
     }
 });
 
-router.post('/remote/encode', jsonParser, async function (request, response) {
+router.post('/remote/kobold/count', jsonParser, async function (request, response) {
     if (!request.body) {
         return response.sendStatus(400);
     }
     const text = String(request.body.text) || '';
-    const api = String(request.body.main_api);
+    const baseUrl = String(request.body.url);
+
+    try {
+        const args = {
+            method: 'POST',
+            body: JSON.stringify({ 'prompt': text }),
+            headers: { 'Content-Type': 'application/json' },
+        };
+
+        let url = String(baseUrl).replace(/\/$/, '');
+        url += '/extra/tokencount';
+
+        const result = await fetch(url, args);
+
+        if (!result.ok) {
+            console.log(`API returned error: ${result.status} ${result.statusText}`);
+            return response.send({ error: true });
+        }
+
+        const data = await result.json();
+        const count = data['value'];
+        return response.send({ count, ids: [] });
+    } catch (error) {
+        console.log(error);
+        return response.send({ error: true });
+    }
+});
+
+router.post('/remote/textgenerationwebui/encode', jsonParser, async function (request, response) {
+    if (!request.body) {
+        return response.sendStatus(400);
+    }
+    const text = String(request.body.text) || '';
     const baseUrl = String(request.body.url);
     const legacyApi = Boolean(request.body.legacy_api);
 
     try {
-        if (api == 'textgenerationwebui') {
-            const args = {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-            };
+        const args = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+        };
 
-            setAdditionalHeaders(request, args, null);
+        setAdditionalHeaders(request, args, null);
 
-            // Convert to string + remove trailing slash + /v1 suffix
-            let url = String(baseUrl).replace(/\/$/, '').replace(/\/v1$/, '');
+        // Convert to string + remove trailing slash + /v1 suffix
+        let url = String(baseUrl).replace(/\/$/, '').replace(/\/v1$/, '');
 
-            if (legacyApi) {
-                url += '/v1/token-count';
-                args.body = JSON.stringify({ 'prompt': text });
-            } else {
-                switch (request.body.api_type) {
-                    case TEXTGEN_TYPES.TABBY:
-                        url += '/v1/token/encode';
-                        args.body = JSON.stringify({ 'text': text });
-                        break;
-                    case TEXTGEN_TYPES.KOBOLDCPP:
-                        url += '/api/extra/tokencount';
-                        args.body = JSON.stringify({ 'prompt': text });
-                        break;
-                    default:
-                        url += '/v1/internal/encode';
-                        args.body = JSON.stringify({ 'text': text });
-                        break;
-                }
+        if (legacyApi) {
+            url += '/v1/token-count';
+            args.body = JSON.stringify({ 'prompt': text });
+        } else {
+            switch (request.body.api_type) {
+                case TEXTGEN_TYPES.TABBY:
+                    url += '/v1/token/encode';
+                    args.body = JSON.stringify({ 'text': text });
+                    break;
+                case TEXTGEN_TYPES.KOBOLDCPP:
+                    url += '/api/extra/tokencount';
+                    args.body = JSON.stringify({ 'prompt': text });
+                    break;
+                default:
+                    url += '/v1/internal/encode';
+                    args.body = JSON.stringify({ 'text': text });
+                    break;
             }
-
-            const result = await fetch(url, args);
-
-            if (!result.ok) {
-                console.log(`API returned error: ${result.status} ${result.statusText}`);
-                return response.send({ error: true });
-            }
-
-            const data = await result.json();
-            const count = legacyApi ? data?.results[0]?.tokens : (data?.length ?? data?.value);
-            const ids = legacyApi ? [] : (data?.tokens ?? []);
-
-            return response.send({ count, ids });
         }
 
-        else if (api == 'kobold') {
-            const args = {
-                method: 'POST',
-                body: JSON.stringify({ 'prompt': text }),
-                headers: { 'Content-Type': 'application/json' },
-            };
+        const result = await fetch(url, args);
 
-            let url = String(baseUrl).replace(/\/$/, '');
-            url += '/extra/tokencount';
-
-            const result = await fetch(url, args);
-
-            if (!result.ok) {
-                console.log(`API returned error: ${result.status} ${result.statusText}`);
-                return response.send({ error: true });
-            }
-
-            const data = await result.json();
-            const count = data['value'];
-            return response.send({ count: count, ids: [] });
-        }
-
-        else {
-            console.log('Unknown API', api);
+        if (!result.ok) {
+            console.log(`API returned error: ${result.status} ${result.statusText}`);
             return response.send({ error: true });
         }
+
+        const data = await result.json();
+        const count = legacyApi ? data?.results[0]?.tokens : (data?.length ?? data?.value);
+        const ids = legacyApi ? [] : (data?.tokens ?? []);
+
+        return response.send({ count, ids });
     } catch (error) {
         console.log(error);
         return response.send({ error: true });


### PR DESCRIPTION
Depends on #1502.

This PR builds on the previous one by further separating the Kobold and textgenerationwebui code, this time in the tokenizers module.

I've split up the `/tokenize_via_api` endpoint into two different ones for Kobold and textgenerationwebui. I don't think any extensions call the tokenizer APIs directly--it makes more sense to go through the tokenizers module. For that reason, I haven't added any redirects (the API has also changed--we can't really redirect *to* anything specific).

I also took this opportunity to further clean up the tokenizer code--we now only pass the API params that the specific endpoints actually need, I've replaced the switch-cases with a map of tokenizers to endpoint URLs, and I've consolidated the addition of token padding into one place.