### PR TITLE
add TTS option to skip codeblock narration

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -482,6 +482,12 @@ async function processTtsQueue() {
     console.debug('New message found, running TTS');
     currentTtsJob = ttsJobQueue.shift();
     let text = extension_settings.tts.narrate_translated_only ? (currentTtsJob?.extra?.display_text || currentTtsJob.mes) : currentTtsJob.mes;
+
+    if (extension_settings.tts.skip_codeblocks) {
+        text = text.replace(/^\s{4}.*$/gm, '').trim();
+        text = text.replace(/```.*?```/gs, '').trim();
+    }
+
     text = extension_settings.tts.narrate_dialogues_only
         ? text.replace(/\*[^*]*?(\*|$)/g, '').trim() // remove asterisks content
         : text.replaceAll('*', '').trim(); // remove just the asterisks
@@ -636,6 +642,11 @@ function onNarrateQuotedClick() {
 
 function onNarrateTranslatedOnlyClick() {
     extension_settings.tts.narrate_translated_only = !!$('#tts_narrate_translated_only').prop('checked');
+    saveSettingsDebounced();
+}
+
+function onSkipCodeblocksClick() {
+    extension_settings.tts.skip_codeblocks = !!$('#tts_skip_codeblocks').prop('checked');
     saveSettingsDebounced();
 }
 
@@ -952,6 +963,10 @@ $(document).ready(function () {
                             <input type="checkbox" id="tts_narrate_translated_only">
                             <small>Narrate only the translated text</small>
                         </label>
+                        <label class="checkbox_label" for="tts_skip_codeblocks">
+                            <input type="checkbox" id="tts_skip_codeblocks">
+                            <small>Skip codeblocks</small>
+                        </label>
                     </div>
                     <div id="tts_voicemap_block">
                     </div>
@@ -972,6 +987,7 @@ $(document).ready(function () {
         $('#tts_narrate_dialogues').on('click', onNarrateDialoguesClick);
         $('#tts_narrate_quoted').on('click', onNarrateQuotedClick);
         $('#tts_narrate_translated_only').on('click', onNarrateTranslatedOnlyClick);
+        $('#tts_skip_codeblocks').on('click', onSkipCodeblocksClick);
         $('#tts_auto_generation').on('click', onAutoGenerationClick);
         $('#tts_narrate_user').on('click', onNarrateUserClick);
         $('#tts_voices').on('click', onTtsVoicesClick);


### PR DESCRIPTION
Lines with four spaces at the start and stuff between triple backticks will be excluded with that option enabled.