### PR TITLE
Server: Update CORS proxy body limit

### DIFF
--- a/server.js
+++ b/server.js
@@ -222,7 +222,9 @@ if (!cliArguments.disableCsrf) {
 
 if (getConfigValue('enableCorsProxy', false) || cliArguments.corsProxy) {
     const bodyParser = require('body-parser');
-    app.use(bodyParser.json());
+    app.use(bodyParser.json({
+        limit: '200mb',
+    }));
     console.log('Enabling CORS proxy');
 
     app.use('/proxy/:url(*)', async (req, res) => {


### PR DESCRIPTION
The body-parser middleware only accepted 50mb of data, bump this value to 200mb.