### PR TITLE
add rounding (round, ceil, floor) to /rand

### DIFF
--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -637,9 +637,19 @@ function lenValuesCallback(value) {
     return parsedValue.length;
 }
 
-function randValuesCallback(from, to) {
+function randValuesCallback(from, to, args) {
     const range = to - from;
-    return from + Math.random() * range;
+    const value = from + Math.random() * range;
+    if (args.round == 'round') {
+        return Math.round(value);
+    }
+    if (args.round == 'ceil') {
+        return Math.ceil(value);
+    }
+    if (args.round == 'floor') {
+        return Math.floor(value);
+    }
+    return value;
 }
 
 export function registerVariableCommands() {
@@ -673,5 +683,5 @@ export function registerVariableCommands() {
     registerSlashCommand('sqrt', (_, value) => sqrtValuesCallback(value), [], '<span class="monospace">(a)</span> – performs a square root operation of a value and passes the result down the pipe, can use variable names, e.g. <tt>/sqrt i</tt>', true, true);
     registerSlashCommand('round', (_, value) => roundValuesCallback(value), [], '<span class="monospace">(a)</span> – rounds a value and passes the result down the pipe, can use variable names, e.g. <tt>/round i</tt>', true, true);
     registerSlashCommand('len', (_, value) => lenValuesCallback(value), [], '<span class="monospace">(a)</span> – gets the length of a value and passes the result down the pipe, can use variable names, e.g. <tt>/len i</tt>', true, true);
-    registerSlashCommand('rand', (args, value) => randValuesCallback(Number(args.from ?? 0), Number(args.to ?? (value.length ? value : 1))), [], '<span class="monospace">(from=number=0 to=number=1)</span> – returns a random number between from and to, e.g. <tt>/rand</tt> or <tt>/rand 10</tt> or <tt>/rand from=5 to=10</tt>', true, true);
+    registerSlashCommand('rand', (args, value) => randValuesCallback(Number(args.from ?? 0), Number(args.to ?? (value.length ? value : 1)), args), [], '<span class="monospace">(from=number=0 to=number=1 round=round|ceil|floor)</span> – returns a random number between from and to, e.g. <tt>/rand</tt> or <tt>/rand 10</tt> or <tt>/rand from=5 to=10</tt>', true, true);
 }


### PR DESCRIPTION
```
/rand (from=number=0 to=number=1 round=round|ceil|floor)
– returns a random number between from and to, e.g. /rand or /rand 10 or /rand from=5 to=10
```