### PR TITLE
add /times slash command

### DIFF
--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -3,11 +3,7 @@ import { extension_settings, saveMetadataDebounced } from './extensions.js';
 import { executeSlashCommands, registerSlashCommand } from './slash-commands.js';
 import { isFalseBoolean } from './utils.js';
 
-
-
 const MAX_LOOPS = 100;
-
-
 
 function getLocalVariable(name, args = {}) {
     if (!chat_metadata.variables) {

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -2,6 +2,12 @@ import { chat_metadata, getCurrentChatId, saveSettingsDebounced, sendSystemMessa
 import { extension_settings, saveMetadataDebounced } from './extensions.js';
 import { executeSlashCommands, registerSlashCommand } from './slash-commands.js';
 
+
+
+const MAX_LOOPS = 100;
+
+
+
 function getLocalVariable(name, args = {}) {
     if (!chat_metadata.variables) {
         chat_metadata.variables = {};
@@ -301,7 +307,6 @@ function listVariablesCallback() {
 }
 
 async function whileCallback(args, command) {
-    const MAX_LOOPS = 100;
     const isGuardOff = ['off', 'false', '0'].includes(args.guard?.toLowerCase());
     const iterations = isGuardOff ? Number.MAX_SAFE_INTEGER : MAX_LOOPS;
 
@@ -322,7 +327,6 @@ async function whileCallback(args, command) {
 async function timesCallback(args, value) {
     const [repeats, ...commandParts] = value.split(' ');
     const command = commandParts.join(' ');
-    const MAX_LOOPS = 100;
     const isGuardOff = ['off', 'false', '0'].includes(args.guard?.toLowerCase());
     const iterations = Math.min(Number(repeats), isGuardOff ? Number.MAX_SAFE_INTEGER : MAX_LOOPS);
 

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -1,6 +1,7 @@
 import { chat_metadata, getCurrentChatId, saveSettingsDebounced, sendSystemMessage, system_message_types } from '../script.js';
 import { extension_settings, saveMetadataDebounced } from './extensions.js';
 import { executeSlashCommands, registerSlashCommand } from './slash-commands.js';
+import { isFalseBoolean } from './utils.js';
 
 
 
@@ -307,7 +308,7 @@ function listVariablesCallback() {
 }
 
 async function whileCallback(args, command) {
-    const isGuardOff = ['off', 'false', '0'].includes(args.guard?.toLowerCase());
+    const isGuardOff = isFalseBoolean(args.guard);
     const iterations = isGuardOff ? Number.MAX_SAFE_INTEGER : MAX_LOOPS;
 
     for (let i = 0; i < iterations; i++) {
@@ -327,7 +328,7 @@ async function whileCallback(args, command) {
 async function timesCallback(args, value) {
     const [repeats, ...commandParts] = value.split(' ');
     const command = commandParts.join(' ');
-    const isGuardOff = ['off', 'false', '0'].includes(args.guard?.toLowerCase());
+    const isGuardOff = isFalseBoolean(args.guard);
     const iterations = Math.min(Number(repeats), isGuardOff ? Number.MAX_SAFE_INTEGER : MAX_LOOPS);
 
     for (let i = 0; i < iterations; i++) {


### PR DESCRIPTION
```
/times (repeats) "(command)"
– execute any valid slash command enclosed in quotes repeats number of times, e.g. /setvar key=i 1 | /times 5 "/addvar key=i 1" adds 1 to the value of "i" 5 times.
{{timesIndex}} is replaced with the iteration number (zero-based), e.g. /times 4 "/echo {{timesIndex}}" echos the numbers 0 through 4.
Loops are limited to 100 iterations by default, pass guard=off to disable.
```