### PR TITLE
Add SD character-specific prompt prefix options to free-mode

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -1758,7 +1758,7 @@ function generateFreeCharacterPrompt(trigger) {
         }
         for (let i = context.chat.length - 1; i >= 0; i--) {
             const message = context.chat[i];
-            if (context.is_user || message.is_system) {
+            if (message.is_user || message.is_system) {
                 continue;
             } else if (typeof message.original_avatar === 'string') {
                 return message.original_avatar.replace(/\.[^/.]+$/, '');


### PR DESCRIPTION
This PR adds the `char` subcommand and `{{charPrefix}}` pseudo-macro to the *Stable Diffusion* extension script. This enables a mode similar to free-mode, except that the prompt is prefixed with the *Character-specific prompt prefix* from the *Image Generation* settings. The idea behind this character-specific free-mode is to enable the creation of images without relying on the LLM to describe the scene, but avoid having to prompt common character appearance each time you want an image.

![image](https://github.com/SillyTavern/SillyTavern/assets/198601/b4afd3ec-4cfe-41e2-a7b7-0cd713a6c0af)

## Subcommand Example

If I have a *Character-specific prompt prefix* set to this:

```
1girl, brown hair, short hair, red eyes,
```

And enter the `char` subcommand like this:

```
/sd char red dress, living room
```

Then the prompt will become this:

```
1girl, brown hair, short hair, red eyes, red dress, living room
```

## Pseudo-macro Example

If I have a *Character-specific prompt prefix* set to this:

```
1girl, brown hair, short hair, red eyes
```

And enter the pseudo-macro like this:

```
/sd red dress, {{charPrefix}}, living room
```

Then the prompt will become this:

```
red dress, 1girl, brown hair, short hair, red eyes, living room
```

## Regression

The code is written to have as little influence on other commands as possible, but writing `/sd char` will add the character-specific prompt prefix. It is no longer possible to use `/sd char something else` without having `char` replaced with the prompt prefix, but I doubt that was a reasonable prompt to begin with. Who begins a free-mode prompt with `char`?

## Behavior

* Supports regular conversations.
* Supports group conversations. Last character to speak is used for *Character-specific prompt prefix*.
* If there is no *Character-specific prompt prefix*, the `char` subcommand removes `char` and the following whitespace.
* If there is no *Character-specific prompt prefix*, the `{{charPrefix}}` pseudo-macro is removed.