### PR TITLE
ZenSlider - Default 10 steps to 20

### DIFF
--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -533,7 +533,7 @@ async function CreateZenSliders(elmnt) {
     var sliderMax = Number(originalSlider.attr('max'));
     var sliderValue = originalSlider.val();
     var sliderRange = sliderMax - sliderMin;
-    var numSteps = 10;
+    var numSteps = 20;
     var decimals = 2;
     var offVal, allVal;
     var stepScale;


### PR DESCRIPTION
With `20 steps`, this allows sliders to go up in `0.05` increments vs `0.1` increments when a slider goes `1.0` to `2.0` or `0.0` to `1.0`.

A `0.05` increment is much more valuable for the various sliders, especially those that are logarithmic or exponential. This also helps reduce the need for typing in exact values as often. 20 steps is also still mobile-friendly, iirc, but feel free to try it out!