### PR TITLE
More comfyui flexibility

### DIFF
--- a/public/scripts/extensions/stable-diffusion/comfyWorkflowEditor.html
+++ b/public/scripts/extensions/stable-diffusion/comfyWorkflowEditor.html
@@ -25,6 +25,12 @@
                         <a href="javascript:;" class="notes-link"><span class="note-link-span" title="Will generate a new random seed in SillyTavern that is then used in the ComfyUI workflow.">?</span></a>
                     </li>
                 </ul>
+                <div>Custom</div>
+                <div class="sd_comfy_workflow_editor_placeholder_actions">
+                    <span id="sd_comfy_workflow_editor_placeholder_add" title="Add custom placeholder">+</span>
+                </div>
+                <ul class="sd_comfy_workflow_editor_placeholder_list" id="sd_comfy_workflow_editor_placeholder_list_custom">
+                </ul>
             </div>
         </div>
     </div>

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -832,10 +832,15 @@ function onComfyWorkflowChange() {
     extension_settings.sd.comfy_workflow = $('#sd_comfy_workflow').find(':selected').val();
     saveSettingsDebounced();
 }
-function changeComfyWorkflow(_, name) {
-    extension_settings.sd.comfy_workflow = name.replace(/(\.json)?$/i, '.json');
-    $('#sd_comfy_workflow').val(extension_settings.sd.comfy_workflow);
-    saveSettingsDebounced();
+async function changeComfyWorkflow(_, name) {
+    name = name.replace(/(\.json)?$/i, '.json');
+    if ($(`#sd_comfy_workflow > [value="${name}"]`).length > 0) {
+        extension_settings.sd.comfy_workflow = name;
+        $('#sd_comfy_workflow').val(extension_settings.sd.comfy_workflow);
+        saveSettingsDebounced();
+    } else {
+        toastr.error(`ComfyUI Workflow "${name}" does not exist.`);
+    }
 }
 
 async function validateAutoUrl() {

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -25,6 +25,7 @@ import { getMessageTimeStamp, humanizedDateTime } from '../../RossAscends-mods.j
 import { SECRET_KEYS, secret_state } from '../../secrets.js';
 import { getNovelUnlimitedImageGeneration, getNovelAnlas, loadNovelSubscriptionData } from '../../nai-settings.js';
 import { getMultimodalCaption } from '../shared.js';
+import { registerSlashCommand } from '../../slash-commands.js';
 export { MODULE_NAME };
 
 // Wraps a string into monospace font-face span
@@ -829,6 +830,11 @@ function onComfyUrlInput() {
 
 function onComfyWorkflowChange() {
     extension_settings.sd.comfy_workflow = $('#sd_comfy_workflow').find(':selected').val();
+    saveSettingsDebounced();
+}
+function changeComfyWorkflow(_, name) {
+    extension_settings.sd.comfy_workflow = name.replace(/(\.json)?$/i, '.json');
+    $('#sd_comfy_workflow').val(extension_settings.sd.comfy_workflow);
     saveSettingsDebounced();
 }
 
@@ -2530,6 +2536,7 @@ $('#sd_dropdown [id]').on('click', function () {
 
 jQuery(async () => {
     getContext().registerSlashCommand('imagine', generatePicture, ['sd', 'img', 'image'], helpString, true, true);
+    registerSlashCommand('imagine-comfy-workflow', changeComfyWorkflow, ['icw'], '(workflowName) - change the workflow to be used for image generation with ComfyUI, e.g. <tt>/imagine-comfy-workflow MyWorkflow</tt>')
 
     $('#extensions_settings').append(renderExtensionTemplate('stable-diffusion', 'settings', defaultSettings));
     $('#sd_source').on('change', onSourceChange);

--- a/public/scripts/extensions/stable-diffusion/style.css
+++ b/public/scripts/extensions/stable-diffusion/style.css
@@ -82,3 +82,17 @@
 .sd_comfy_workflow_editor_placeholder_list>li>.notes-link {
     cursor: help;
 }
+
+.sd_comfy_workflow_editor_placeholder_list input {
+    font-size: inherit;
+    margin: 0;
+}
+.sd_comfy_workflow_editor_custom_remove, #sd_comfy_workflow_editor_placeholder_add {
+    cursor: pointer;
+    font-weight: bold;
+    width: 1em;
+    opacity: 0.5;
+    &:hover {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
Two enhancements for the ComfyUI integration:

- Custom placeholders: User definable placeholders that use `substituteParams` on the replace text. This allows using macros like `{{char}}` and variables with `{{getvar::myvar}}` to be used in image generation with ComfyUI.
- Slash command `/imagine-comfy-workflow` to change the comfy workflow, e.g. switch to a workflow optimized for faces before requesting a selfie.

```
/imagine-comfy-workflow (workflowName)
- change the workflow to be used for image generation with ComfyUI, e.g. /imagine-comfy-workflow MyWorkflow (alias: /icw)
```