### PR TITLE
Llama 2 Chat separator fix

### DIFF
--- a/public/instruct/Llama 2 Chat.json
+++ b/public/instruct/Llama 2 Chat.json
@@ -8,7 +8,7 @@
     "system_sequence_prefix": "[INST] <<SYS>>\n",
     "system_sequence_suffix": "\n<</SYS>>\n",
     "stop_sequence": "",
-    "separator_sequence": "\n",
+    "separator_sequence": " ",
     "wrap": false,
     "macro": true,
     "names": false,


### PR DESCRIPTION
Small fix inspired by https://github.com/SillyTavern/SillyTavern/issues/1538: Official separator is a space instead of a newline. That format itself is still FUBAR, but at least we get a little closer to what it was intended to look, I guess.