### PR TITLE
Add option in config.yaml to use png for avatar thumbs

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -25,6 +25,9 @@ autorun: true
 disableThumbnails: false
 # Thumbnail quality (0-100)
 thumbnailsQuality: 95
+# Generate avatar thumbnails as PNG instead of JPG (preserves transparency but increases filesize by about 100%)
+#  Changing this only affects new thumbnails. To recreate the old ones, clear out your ST/thumbnails/ folder.
+avatarThumbnailsPng: false
 # Allow secret keys exposure via API
 allowKeysExposure: false
 # Skip new default content checks

--- a/src/endpoints/thumbnails.js
+++ b/src/endpoints/thumbnails.js
@@ -111,7 +111,8 @@ async function generateThumbnail(type, file) {
         try {
             const quality = getConfigValue('thumbnailsQuality', 95);
             const image = await jimp.read(pathToOriginalFile);
-            buffer = await image.cover(mySize[0], mySize[1]).quality(quality).getBufferAsync('image/jpeg');
+            const imgType = type == 'avatar' && getConfigValue('avatarThumbnailsPng', false) ? 'image/png' : 'image/jpeg';
+            buffer = await image.cover(mySize[0], mySize[1]).quality(quality).getBufferAsync(imgType);
         }
         catch (inner) {
             console.warn(`Thumbnailer can not process the image: ${pathToOriginalFile}. Using original size`);


### PR DESCRIPTION
```yaml
# Generate avatar thumbnails as PNG instead of JPG (preserves transparency but increases filesize by about 100%)
#  Changing this only affects new thumbnails. To recreate the old ones, clear out your ST/thumbnails/ folder.
avatarThumbnailsPng: false
```