### PR TITLE
ComfyUI request/prompt fix

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2286,7 +2286,7 @@ async function generateComfyImage(prompt, negativePrompt) {
         toastr.error(`Failed to load workflow.\n\n${text}`);
     }
     let workflow = (await workflowResponse.json()).replace('"%prompt%"', JSON.stringify(prompt));
-    workflow = (await workflowResponse.json()).replace('"%negative_prompt%"', JSON.stringify(negativePrompt));
+    workflow = workflow.replace('"%negative_prompt%"', JSON.stringify(negativePrompt));
     workflow = workflow.replace('"%seed%"', JSON.stringify(Math.round(Math.random() * Number.MAX_SAFE_INTEGER)));
     placeholders.forEach(ph => {
         workflow = workflow.replace(`"%${ph}%"`, JSON.stringify(extension_settings.sd[ph]));


### PR DESCRIPTION
In the current build, requesting to generate an image using ComfyUI results in the error:

> Image generation failed. Please try again. TypeError: Failed to execute 'json' on 'Response': body stream already read

This is due to consuming `workflowResponse.json()` more than once. This change fixes this JSON issue as well as avoids overwriting the replaced changes of `%prompt%` in the line above.