### PR TITLE
(Minor) Wi for combine prompts event

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3655,6 +3655,8 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
                 scenario,
                 char: name2,
                 user: name1,
+                worldInfoBefore,
+                worldInfoAfter,
                 beforeScenarioAnchor,
                 afterScenarioAnchor,
                 mesExmString,


### PR DESCRIPTION
Adds world info to the prompt bits passed to GENERATE_BEFORE_COMBINE_PROMPTS.

Allows subscribers to use world info when composing the prompt.