### PR TITLE
Add Alpaca-Single-Turn context templates

### DIFF
--- a/public/context/Alpaca-Single-Turn.json
+++ b/public/context/Alpaca-Single-Turn.json
@@ -1,0 +1,11 @@
+{
+    "story_string": "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:\n{{#if system}}{{system}}\n{{/if}}{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{persona}}\n{{/if}}",
+    "example_separator": "",
+    "chat_start": "",
+    "use_stop_strings": false,
+    "always_force_name2": false,
+    "trim_sentences": false,
+    "include_newline": false,
+    "single_line": false,
+    "name": "Alpaca-Single-Turn"
+}

--- a/public/instruct/Alpaca-Single-Turn.json
+++ b/public/instruct/Alpaca-Single-Turn.json
@@ -1,0 +1,17 @@
+{
+    "system_prompt": "Write {{char}}'s next reply in a fictional roleplay chat between {{user}} and {{char}}.\nWrite 1 reply only, italicize actions, and avoid quotation marks. Use markdown. Be proactive, creative, and drive the plot and conversation forward. Include dialog as well as narration.",
+    "input_sequence": "",
+    "output_sequence": "",
+    "first_output_sequence": "<START OF ROLEPLAY>",
+    "last_output_sequence": "\n### Response:",
+    "system_sequence_prefix": "",
+    "system_sequence_suffix": "",
+    "stop_sequence": "",
+    "separator_sequence": "",
+    "wrap": true,
+    "macro": true,
+    "names": false,
+    "names_force_groups": true,
+    "activation_regex": "",
+    "name": "Alpaca-Single-Turn"
+}


### PR DESCRIPTION
This template pair more closely follows the Alpaca prompting style. It will result in a single Instruction/Response pair, with the entire context under Instruction.

Here is the current ST Alpaca/Alpaca after user sends 2 chatlines:
![image](https://github.com/SillyTavern/SillyTavern/assets/128647114/03944f3a-6784-4516-95e6-ce7539ef95b8)


Here is Alpaca-Single-Turn/Alpaca-Single-Turn:
![image](https://github.com/SillyTavern/SillyTavern/assets/128647114/b12483e5-925e-49d4-a866-a969183a6441)

The only flaw is having the character name written under Response. I feel unchecking "Include Names" causes bigger issues since Char's replies are unlabeled and will confuse weaker LLMs. If anyone can come up with a fix, please do.