### PR TITLE
Don't trim trailing whitespace in markdown files (editorconfig)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ trim_trailing_whitespace = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
`trim_trailing_whitespace` breaks simple line breaks in markdown files.

To create a line break in the same paragraph you enter: `textLine1<space><space><linefeed>textLine2`