### PR TITLE
Add event when world info is updated

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -324,6 +324,7 @@ export const event_types = {
     OAI_PRESET_CHANGED_BEFORE: 'oai_preset_changed_before',
     OAI_PRESET_CHANGED_AFTER: 'oai_preset_changed_after',
     WORLDINFO_SETTINGS_UPDATED: 'worldinfo_settings_updated',
+    WORLDINFO_UPDATED: 'worldinfo_updated',
     CHARACTER_EDITED: 'character_edited',
     CHARACTER_PAGE_LOADED: 'character_page_loaded',
     CHARACTER_GROUP_OVERLAY_STATE_CHANGE_BEFORE: 'character_group_overlay_state_change_before',

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1420,6 +1420,7 @@ async function _save(name, data) {
         headers: getRequestHeaders(),
         body: JSON.stringify({ name: name, data: data }),
     });
+    eventSource.emit(event_types.WORLDINFO_UPDATED, name, data);
 }
 
 async function saveWorldInfo(name, data, immediately) {


### PR DESCRIPTION
```javascript
event_types.WORLDINFO_UPDATED
```

The event will be emitted whenever world info is updated / saved.

The existing event `WORLDINFO_SETTINGS_UPDATED` does not fire on CRUD of world info entries, only on general world info settings and activating / deactivating of books.