### PR TITLE
add /emote support to talkinghead

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1113,14 +1113,29 @@ async function setExpression(character, expression, force) {
 
         talkingHeadCheck().then(result => {
             if (result) {
-                // Find the <img> element with id="expression-image" and class="expression"
-                const imgElement = document.querySelector('img#expression-image.expression');
-                //console.log("searching");
-                if (imgElement && imgElement instanceof HTMLImageElement) {
-                    //console.log("setting value");
-                    imgElement.src = getApiUrl() + '/api/talkinghead/result_feed';
-                }
-
+                // Set the talkinghead emotion to the specified expression
+                // TODO: For now, talkinghead emote only supported when VN mode is off; see also updateVisualNovelMode.
+                const url = new URL(getApiUrl());
+                url.pathname = '/api/talkinghead/set_emotion';
+                doExtrasFetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ emotion_name: expression }),
+                })
+                    .then(response => {
+                        // Find the <img> element with id="expression-image" and class="expression"
+                        const imgElement = document.querySelector('img#expression-image.expression');
+                        //console.log("searching");
+                        if (imgElement && imgElement instanceof HTMLImageElement) {
+                            //console.log("setting value");
+                            imgElement.src = getApiUrl() + '/api/talkinghead/result_feed';
+                        }
+                    })
+                    .catch(error => {
+                        console.error(error);
+                    })
             } else {
                 //console.log("The fetch failed!");
             }

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1111,8 +1111,7 @@ async function setExpression(character, expression, force) {
     } else {
         // Set the talkinghead emotion to the specified expression
         // TODO: For now, talkinghead emote only supported when VN mode is off; see also updateVisualNovelMode.
-        try
-        {
+        try {
             let result = await talkingHeadCheck();
             if (result) {
                 const url = new URL(getApiUrl());

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1109,39 +1109,39 @@ async function setExpression(character, expression, force) {
         document.getElementById('expression-holder').style.display = '';
 
     } else {
-
-
-        talkingHeadCheck().then(result => {
+        // Set the talkinghead emotion to the specified expression
+        // TODO: For now, talkinghead emote only supported when VN mode is off; see also updateVisualNovelMode.
+        try
+        {
+            let result = await talkingHeadCheck();
             if (result) {
-                // Set the talkinghead emotion to the specified expression
-                // TODO: For now, talkinghead emote only supported when VN mode is off; see also updateVisualNovelMode.
                 const url = new URL(getApiUrl());
                 url.pathname = '/api/talkinghead/set_emotion';
-                doExtrasFetch(url, {
+                await doExtrasFetch(url, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                     },
                     body: JSON.stringify({ emotion_name: expression }),
-                })
-                    .then(response => {
-                        // Find the <img> element with id="expression-image" and class="expression"
-                        const imgElement = document.querySelector('img#expression-image.expression');
-                        //console.log("searching");
-                        if (imgElement && imgElement instanceof HTMLImageElement) {
-                            //console.log("setting value");
-                            imgElement.src = getApiUrl() + '/api/talkinghead/result_feed';
-                        }
-                    })
-                    .catch(error => {
-                        console.error(error);
-                    })
-            } else {
-                //console.log("The fetch failed!");
+                });
             }
-        });
+        }
+        catch (error) {
+            // `set_emotion` is not present in old versions, so let it 404.
+        }
 
-
+        try {
+            // Find the <img> element with id="expression-image" and class="expression"
+            const imgElement = document.querySelector('img#expression-image.expression');
+            //console.log("searching");
+            if (imgElement && imgElement instanceof HTMLImageElement) {
+                //console.log("setting value");
+                imgElement.src = getApiUrl() + '/api/talkinghead/result_feed';
+            }
+        }
+        catch (error) {
+            //console.log("The fetch failed!");
+        }
     }
 }
 


### PR DESCRIPTION
Add `/emote xxx` support for talkinghead (at least for now, only when VN mode is off; that's something I'd like to discuss the pros/cons of).

This depends on https://github.com/SillyTavern/SillyTavern-Extras/pull/213 for backend support, as it needs the new API endpoint `/api/talkinghead/set_emotion`.

**NOTE**: This is a quick prototype. Due to some validation code in `setSpriteSlashCommand`, there currently **must** be a static sprite for the given expression name for that expression name to be detected as valid. So beside `talkinghead.png`, your character also needs the static sprite for emotion `"xxx"` for `"/emote xxx"` to work, although `talkinghead` doesn't use the static sprites.

My suggestion is that, before making this PR final, we could check `extension_settings.expressions.talkinghead` in `setSpriteSlashCommand`, and skip the validation check in `talkinghead` mode. There is a check at the server end to default to `"neutral"` (and log a warning) if the expression name sent by the client is not recognized.

As for the code, I'm modding this [as a pythonista](https://github.com/Technologicat/js-for-pythonistas). `async/await` syntax would read much nicer, but we're inside an arrow function that handles a response from a promise, so I suppose that in order to use `async/await` here, we would also need to convert the call to `talkingHeadCheck` to use `async/await` instead of bare promises.

Comments?