### PR TITLE
Talkinghead nospritecheck

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1277,7 +1277,7 @@ async function onClickExpressionUpload(event) {
         e.target.form.reset();
 
         // In talkinghead mode, when a new talkinghead image is uploaded, refresh the live char.
-        if (extension_settings.expressions.talkinghead && id === "talkinghead") {
+        if (extension_settings.expressions.talkinghead && !extension_settings.expressions.local && id === "talkinghead") {
             await loadLiveChar();
         }
     };

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -735,11 +735,12 @@ async function setSpriteSlashCommand(_, spriteId) {
     }
 
     spriteId = spriteId.trim().toLowerCase();
-    const currentLastMessage = getLastCharacterMessage();
-    const spriteFolderName = getSpriteFolderName(currentLastMessage, currentLastMessage.name);
 
     // In talkinghead mode, don't check for the existence of the sprite
     // (emotion names are the same as for sprites, but it only needs "talkinghead.png").
+    const currentLastMessage = getLastCharacterMessage();
+    const spriteFolderName = getSpriteFolderName(currentLastMessage, currentLastMessage.name);
+    let label = '';
     if (extension_settings.expressions.local || !extension_settings.expressions.talkinghead) {
         await validateImages(spriteFolderName);
 
@@ -752,10 +753,15 @@ async function setSpriteSlashCommand(_, spriteId) {
             console.log('No sprite found for search term ' + spriteId);
             return;
         }
+
+        label = spriteItem.label;
+    }
+    else {
+        label = spriteId;
     }
 
     const vnMode = isVisualNovelMode();
-    await sendExpressionCall(spriteFolderName, spriteItem.label, true, vnMode);
+    await sendExpressionCall(spriteFolderName, label, true, vnMode);
 }
 
 /**

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -736,18 +736,22 @@ async function setSpriteSlashCommand(_, spriteId) {
 
     spriteId = spriteId.trim().toLowerCase();
 
-    const currentLastMessage = getLastCharacterMessage();
-    const spriteFolderName = getSpriteFolderName(currentLastMessage, currentLastMessage.name);
-    await validateImages(spriteFolderName);
+    // In talkinghead mode, don't check for the existence of the sprite
+    // (emotion names are the same as for sprites, but it only needs "talkinghead.png").
+    if (extension_settings.expressions.local || !extension_settings.expressions.talkinghead) {
+        const currentLastMessage = getLastCharacterMessage();
+        const spriteFolderName = getSpriteFolderName(currentLastMessage, currentLastMessage.name);
+        await validateImages(spriteFolderName);
 
-    // Fuzzy search for sprite
-    const fuse = new Fuse(spriteCache[spriteFolderName], { keys: ['label'] });
-    const results = fuse.search(spriteId);
-    const spriteItem = results[0]?.item;
+        // Fuzzy search for sprite
+        const fuse = new Fuse(spriteCache[spriteFolderName], { keys: ['label'] });
+        const results = fuse.search(spriteId);
+        const spriteItem = results[0]?.item;
 
-    if (!spriteItem) {
-        console.log('No sprite found for search term ' + spriteId);
-        return;
+        if (!spriteItem) {
+            console.log('No sprite found for search term ' + spriteId);
+            return;
+        }
     }
 
     const vnMode = isVisualNovelMode();

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -611,6 +611,10 @@ async function moduleWorker() {
     }
 }
 
+/**
+ * Checks whether the current character has a talkinghead image available.
+ * @returns {Boolean}
+ */
 async function talkingHeadCheck() {
     let spriteFolderName = getSpriteFolderName();
 

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -735,12 +735,12 @@ async function setSpriteSlashCommand(_, spriteId) {
     }
 
     spriteId = spriteId.trim().toLowerCase();
+    const currentLastMessage = getLastCharacterMessage();
+    const spriteFolderName = getSpriteFolderName(currentLastMessage, currentLastMessage.name);
 
     // In talkinghead mode, don't check for the existence of the sprite
     // (emotion names are the same as for sprites, but it only needs "talkinghead.png").
     if (extension_settings.expressions.local || !extension_settings.expressions.talkinghead) {
-        const currentLastMessage = getLastCharacterMessage();
-        const spriteFolderName = getSpriteFolderName(currentLastMessage, currentLastMessage.name);
         await validateImages(spriteFolderName);
 
         // Fuzzy search for sprite

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1265,6 +1265,11 @@ async function onClickExpressionUpload(event) {
 
         // Reset the input
         e.target.form.reset();
+
+        // In talkinghead mode, when a new talkinghead image is uploaded, refresh the live char.
+        if (extension_settings.expressions.talkinghead && id === "talkinghead") {
+            await loadLiveChar();
+        }
     };
 
     $('#expression_upload')


### PR DESCRIPTION
- In `talkinghead` mode, don't check for existence of static expression sprite when using `/emote`.
  - We still handle the actual send of `set_emotion` in `setExpression`, to set the expression in a centralized way whether or not `talkinghead` is being used.
- When uploading a new `talkinghead` image, refresh the live char immediately (without needing to toggle `talkinghead` mode off and back on).
- Add a comment for what `talkingHeadCheck` does.
