### PR TITLE
Regex: Updates

### DIFF
--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -56,7 +56,7 @@
                 <div>
                     <textarea
                         class="regex_replace_string text_pole wide100p textarea_compact"
-                        placeholder="Use {{match}} to include the matched text from the Find Regex"
+                        placeholder="Use {{match}} to include the matched text from the Find Regex or $1, $2, etc. for capture groups."
                         rows="2"
                     ></textarea>
                 </div>
@@ -115,9 +115,9 @@
                     <input type="checkbox" name="run_on_edit" />
                     <span data-i18n="Run On Edit">Run On Edit</span>
                 </label>
-                <label class="checkbox flex-container">
+                <label class="checkbox flex-container" title="Substitute {{macros}} in Find Regex before running it">
                     <input type="checkbox" name="substitute_regex" />
-                    <span data-i18n="Substitute Regex">Substitute Regex</span>
+                    <span data-i18n="Substitute Regex">Substitute Regex (?)</span>
                 </label>
             </div>
             <div class="flex-container flexFlowColumn alignitemsstart">

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -124,7 +124,7 @@
                 <small>Replacement Strategy</small>
                 <select name="replace_strategy_select" class="margin0">
                     <option value="0">Replace</option>
-                    <option value="1">Overlay</option>
+                    <option value="1">Overlay (currently broken)</option>
                 </select>
             </div>
         </div>

--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -112,10 +112,17 @@ function runRegexScript(regexScript, rawString, { characterOverride } = {}) {
     // Run replacement. Currently does not support the Overlay strategy
     newString = rawString.replace(findRegex, function(match) {
         const args = [...arguments];
-        const replaceString = regexScript.replaceString.replace('{{match}}', '$1');
+        const replaceString = regexScript.replaceString.replace(/{{match}}/gi, '$0');
         const replaceWithGroups = replaceString.replaceAll(/\$(\d)+/g, (_, num) => {
-            // match is found here
+            // Get a full match or a capture group
             const match = args[Number(num)];
+
+            // No match found - return the empty string
+            if (!match) {
+                return '';
+            }
+
+            // Remove trim strings from the match
             const filteredMatch = filterString(match, regexScript.trimStrings, { characterOverride });
 
             // TODO: Handle overlay here

--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -139,10 +139,10 @@ function runRegexScript(regexScript, rawString, { characterOverride } = {}) {
  */
 function filterString(rawString, trimStrings, { characterOverride } = {}) {
     let finalString = rawString;
-    for (const trimString of trimStrings) {
+    trimStrings.forEach((trimString) => {
         const subTrimString = substituteParams(trimString, undefined, characterOverride);
         finalString = finalString.replaceAll(subTrimString, '');
-    }
+    });
 
     return finalString;
 }


### PR DESCRIPTION
Moves over to the simpler capturing group system. Currently doesn't support overlay (future update, so the code's still there), but existing overlay scripts can be migrated over by adding trim strings or checking `Only Format Display` AND `Only Format Prompt`