### PR TITLE
fix for #1640 - jQuery sortable breaking select elements

### DIFF
--- a/public/scripts/extensions/quick-reply/src/QuickReplySetLink.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReplySetLink.js
@@ -39,6 +39,8 @@ export class QuickReplySetLink {
             }
             const set = document.createElement('select'); {
                 set.classList.add('qr--set');
+                // fix for jQuery sortable breaking childrens' touch events
+                set.addEventListener('touchstart', (evt)=>evt.stopPropagation());
                 set.addEventListener('change', ()=>{
                     this.set = QuickReplySet.get(set.value);
                     this.update();

--- a/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
@@ -158,6 +158,7 @@ export class SettingsUi {
         // @ts-ignore
         $(qrsDom).sortable({
             delay: getSortableDelay(),
+            handle: '.drag-handle',
             stop: ()=>this.onQrListSort(),
         });
     }

--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -156,6 +156,9 @@
   align-items: baseline;
   padding: 0 0.5em;
 }
+#qr--settings .qr--setList > .qr--item > .drag-handle {
+  padding: 0.75em;
+}
 #qr--settings .qr--setList > .qr--item > .qr--visible {
   flex: 0 0 auto;
   display: flex;
@@ -188,6 +191,9 @@
 }
 #qr--settings #qr--set-qrList .qr--set-qrListContents > .qr--set-item > :nth-child(5) {
   flex: 0 0 auto;
+}
+#qr--settings #qr--set-qrList .qr--set-qrListContents > .qr--set-item > .drag-handle {
+  padding: 0.75em;
 }
 #qr--settings #qr--set-qrList .qr--set-qrListContents > .qr--set-item .qr--set-itemLabel,
 #qr--settings #qr--set-qrList .qr--set-qrListContents > .qr--set-item .qr--action {

--- a/public/scripts/extensions/quick-reply/style.less
+++ b/public/scripts/extensions/quick-reply/style.less
@@ -174,6 +174,9 @@
 			gap: 0.5em;
 			align-items: baseline;
 			padding: 0 0.5em;
+			> .drag-handle {
+				padding: 0.75em;
+			}
 			> .qr--visible {
 				flex: 0 0 auto;
 				display: flex;
@@ -200,6 +203,9 @@
 				> :nth-child(3) { flex: 0 0 auto; }
 				> :nth-child(4) { flex: 1 1 75%; }
 				> :nth-child(5) { flex: 0 0 auto; }
+				> .drag-handle {
+					padding: 0.75em;
+				}
 				.qr--set-itemLabel, .qr--action {
 					margin: 0;
 				}


### PR DESCRIPTION
This should fix touch events on selects inside sortable elements in QR settings, as mentioned in #1640.
Also made the drag handles a bit wider for easier touch interaction.