### PR TITLE
fix missing substituteParams when executing non-command QRs

### DIFF
--- a/public/scripts/extensions/quick-reply/src/QuickReplySet.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReplySet.js
@@ -1,4 +1,4 @@
-import { getRequestHeaders } from '../../../../script.js';
+import { getRequestHeaders, substituteParams } from '../../../../script.js';
 import { executeSlashCommands } from '../../../slash-commands.js';
 import { debounceAsync, warn } from '../index.js';
 import { QuickReply } from './QuickReply.js';
@@ -123,7 +123,7 @@ export class QuickReplySet {
             return typeof result === 'object' ? result?.pipe : '';
         }
 
-        ta.value = input;
+        ta.value = substituteParams(input);
         ta.focus();
 
         if (!this.disableSend) {


### PR DESCRIPTION
Noticed non-command QRs did not call substituteParams before sending. Only really affects {{input}} as all others should be replaced later (outside of QR) anyways.