### PR TITLE
add optional arguments to /world command

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2310,8 +2310,8 @@ function onWorldInfoChange(args, text) {
             });
             $('#world_info').trigger('change');
         } else { // if no args, unset all worlds
-            toastr.success('Deactivated all worlds');
-            if (!silent) selected_world_info = [];
+            if (!silent) toastr.success('Deactivated all worlds');
+            selected_world_info = [];
             $('#world_info').val(null).trigger('change');
         }
     } else { //if it's a pointer selection

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2267,7 +2267,7 @@ export async function importEmbeddedWorldInfo(skipPopup = false) {
 
 function onWorldInfoChange(args, text) {
     if (args !== '__notSlashCommand__') { // if it's a slash command
-        const silent = args.silent == 'true';
+        const silent = isTrueBoolean(args.silent);
         if (text.trim() !== '') { // and args are provided
             const slashInputSplitText = text.trim().toLowerCase().split(',');
 


### PR DESCRIPTION
- deactivate a single world
- toggle a world
- suppress toast messages

> `/world [optional state=off|toggle] [optional silent=true] (optional name)` – sets active World, or unsets if no args provided, use `state=off` and `state=toggle` to deactivate or toggle a World, use `silent=true` to suppress toast messages
