### PR TITLE
add possibility for extensions to register new macros

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2230,6 +2230,7 @@ function substituteParams(content, _name1, _name2, _original, _group, _replaceCh
  * Register a new {{macro}}.
  * @param {RegExp} findRegex A regular expression that is used to find the {{macro}} to be replaced
  * @param {Function} replaceCallback A synchronous callback function that returns the text to replace the {{macro}}
+ * @param {String} helpMacro Sample macro (without {{ and }}) to be shown on /help macros, e.g. for {{getvar::name}} this should be getvar::name
  * @param {String} helpText Descriptive text to be shown on /help macros
  */
 function registerMacro(findRegex, replaceCallback, helpMacro, helpText) {
@@ -2241,6 +2242,10 @@ function registerMacro(findRegex, replaceCallback, helpMacro, helpText) {
     });
 }
 
+/**
+ * Generates the help HTML for all registered macros provided by extensions.
+ * @returns Items for the list of extension macros on the "/help macros" page.
+ */
 function getExtensionMacrosHelp() {
     const escape = document.createElement('div');
     return extensionMacros.map(macro=>`

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -72,3 +72,10 @@
     <li><tt>&lcub;&lcub;incglobalvar::name&rcub;&rcub;</tt> – replaced with the result of the increment of value of the global variable "name" by 1</li>
     <li><tt>&lcub;&lcub;decglobalvar::name&rcub;&rcub;</tt> – replaced with the result of the decrement of value of the global variable "name" by 1</li>
 </ul>
+<div>
+    Macros provided by extensions:
+</div>
+<ul>
+    <div id="REPLACE-EXTENSION-MACROS"></div>
+</ul>
+


### PR DESCRIPTION
Example:

```javascript
import { registerMacro } from '../../../../script.js';
registerMacro(
  /{{list::((?:(?!(?:::)).)+)}}/gi,
  (fullMatch, firstCapture) => {
    return firstCapture.split(/\s*,\s*/).map(it => `- ${it}`).join('\n');
  },
  'list::item1,item2,item3',
  'replaced with a markdown list of the comma separated values'
);
```