### PR TITLE
fix escape sequences in setentryfield slash command

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -360,6 +360,8 @@ function registerWorldInfoSlashCommands() {
             return '';
         }
 
+        value = value.replace(/\\([{}|])/g, '$1');
+
         const data = await loadWorldInfoData(file);
 
         if (!data || !('entries' in data)) {


### PR DESCRIPTION
It was impossible to make a WI entry contain macros from `/setentryfield`.

This gets evaluated before the slash command is sent:
```
/setentryfield book=MyBook uid=0 {{random:12,3}}
```
The entry ends up as:
```
1
```

This never got evaluated:
```
/setentryfield book=MyBook uid=0 \{\{random:12,3\}\}
```
The entry ended up as:
```
\{\{random:1,2,3\}\}
```
Now it results in:
```
{{random:1,2,3}}
```