### PR TITLE
Remove count_view_mes

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1958,16 +1958,9 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
         }
     }
 
-    function getMessageId() {
-        if (typeof forceId == 'number') {
-            return forceId;
-        }
+    // Callers push the new message to chat before calling addOneMessage
+    const newMessageId = typeof forceId == 'number' ? forceId : chat.length - 1;
 
-        // Callers push the new message to chat before calling addOneMessage
-        return chat.length - 1;
-    }
-
-    const newMessageId = getMessageId();
     const newMessage = $(`#chat [mesid="${newMessageId}"]`);
     const isSmallSys = mes?.extra?.isSmallSys;
     newMessage.data('isSystem', isSystem);
@@ -2045,7 +2038,7 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
         const messageId = forceId ?? chat.length - 1;
         $('#chat').find(`[mesid="${messageId}"]`).find('.mes_text').append(messageText);
         appendMediaToMessage(mes, newMessage);
-        hideSwipeButtons(getMessageId());
+        hideSwipeButtons(newMessageId);
     }
 
     addCopyToCodeBlocks(newMessage);
@@ -2055,8 +2048,8 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
         $('#chat .mes').last().addClass('last_mes');
         $('#chat .mes').eq(-2).removeClass('last_mes');
 
-        hideSwipeButtons(getMessageId());
-        showSwipeButtons(getMessageId());
+        hideSwipeButtons(newMessageId);
+        showSwipeButtons(newMessageId);
         scrollChatToBottom();
     }
 }

--- a/public/script.js
+++ b/public/script.js
@@ -1900,9 +1900,6 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
         avatarImg = mes['force_avatar'];
     }
 
-    if (chat.length == 0) {
-        messageText = substituteParams(messageText);
-    }
     messageText = messageFormatting(
         messageText,
         mes.name,

--- a/public/script.js
+++ b/public/script.js
@@ -436,7 +436,6 @@ let settingsReady = false;
 let currentVersion = '0.0.0';
 
 const default_ch_mes = 'Hello';
-let count_view_mes = 0;
 let generatedPromptCache = '';
 let generation_started = new Date();
 let characters = [];
@@ -1470,14 +1469,13 @@ async function printMessages() {
     let count = power_user.chat_truncation || Number.MAX_SAFE_INTEGER;
 
     if (chat.length > count) {
-        count_view_mes = chat.length - count;
-        startIndex = count_view_mes;
+        startIndex = chat.length - count;
         $('#chat').append('<div id="show_more_messages">Show more messages</div>');
     }
 
     for (let i = startIndex; i < chat.length; i++) {
         const item = chat[i];
-        addOneMessage(item, { scroll: i === chat.length - 1 });
+        addOneMessage(item, { scroll: i === chat.length - 1, forceId: i });
     }
 
     // Scroll to bottom when all images are loaded
@@ -1505,7 +1503,6 @@ async function printMessages() {
 
 async function clearChat() {
     closeMessageEditor();
-    count_view_mes = 0;
     extension_prompts = {};
     if (is_delete_mode) {
         $('#dialogue_del_mes_cancel').trigger('click');
@@ -1521,7 +1518,6 @@ async function clearChat() {
 }
 
 async function deleteLastMessage() {
-    count_view_mes--;
     chat.length = chat.length - 1;
     $('#chat').children('.mes').last().remove();
     await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
@@ -1904,7 +1900,7 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
         avatarImg = mes['force_avatar'];
     }
 
-    if (count_view_mes == 0) {
+    if (chat.length == 0) {
         messageText = substituteParams(messageText);
     }
     messageText = messageFormatting(
@@ -1928,7 +1924,7 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
         }
     }*/
     let params = {
-        mesId: forceId ?? count_view_mes,
+        mesId: forceId ?? chat.length,
         characterName: mes.name,
         isUser: mes.is_user,
         avatarImg: avatarImg,
@@ -1967,7 +1963,7 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
             return forceId;
         }
 
-        return type == 'swipe' ? count_view_mes - 1 : count_view_mes;
+        return type == 'swipe' ? chat.length - 1 : chat.length;
     }
 
     const newMessageId = getMessageId();
@@ -2026,7 +2022,7 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
     });
 
     if (type === 'swipe') {
-        const swipeMessage = $('#chat').find(`[mesid="${count_view_mes - 1}"]`);
+        const swipeMessage = $('#chat').find(`[mesid="${chat.length - 1}"]`);
         swipeMessage.find('.mes_text').html('');
         swipeMessage.find('.mes_text').append(messageText);
         appendMediaToMessage(mes, swipeMessage);
@@ -2044,16 +2040,11 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
             swipeMessage.find('.mes_timer').html('');
             swipeMessage.find('.tokenCounterDisplay').html('');
         }
-    } else if (typeof forceId == 'number') {
-        $('#chat').find(`[mesid="${forceId}"]`).find('.mes_text').append(messageText);
-        appendMediaToMessage(mes, newMessage);
-        hideSwipeButtons();
-        showSwipeButtons();
     } else {
-        $('#chat').find(`[mesid="${count_view_mes}"]`).find('.mes_text').append(messageText);
+        const messageId = forceId ?? chat.length;
+        $('#chat').find(`[mesid="${messageId}"]`).find('.mes_text').append(messageText);
         appendMediaToMessage(mes, newMessage);
-        hideSwipeButtons();
-        count_view_mes++;
+        hideSwipeButtons(getMessageId());
     }
 
     addCopyToCodeBlocks(newMessage);
@@ -2063,8 +2054,8 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
         $('#chat .mes').last().addClass('last_mes');
         $('#chat .mes').eq(-2).removeClass('last_mes');
 
-        hideSwipeButtons();
-        showSwipeButtons();
+        hideSwipeButtons(getMessageId());
+        showSwipeButtons(getMessageId());
         scrollChatToBottom();
     }
 }
@@ -2510,7 +2501,7 @@ class StreamingProcessor {
         }
         else {
             await saveReply(this.type, text, true);
-            messageId = count_view_mes - 1;
+            messageId = chat.length - 1;
             this.showMessageButtons(messageId);
         }
 
@@ -2933,7 +2924,6 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
         }
         else if (type !== 'quiet' && type !== 'swipe' && !isImpersonate && !dryRun && chat.length) {
             chat.length = chat.length - 1;
-            count_view_mes -= 1;
             $('#chat').children().last().hide(250, function () {
                 $(this).remove();
             });
@@ -3892,7 +3882,7 @@ function unblockGeneration() {
 }
 
 export function getNextMessageId(type) {
-    return type == 'swipe' ? Number(count_view_mes - 1) : Number(count_view_mes);
+    return type == 'swipe' ? chat.length - 1 : chat.length;
 }
 
 /**
@@ -6494,7 +6484,7 @@ function callPopup(text, type, inputValue = '', { okButton, rows, wide, large } 
     });
 }
 
-function showSwipeButtons() {
+function showSwipeButtons(id = chat.length - 1) {
     if (chat.length === 0) {
         return;
     }
@@ -6505,7 +6495,7 @@ function showSwipeButtons() {
         $('.mes:last').attr('mesid') < 0 ||
         chat[chat.length - 1].is_user ||
         chat[chat.length - 1].extra?.image ||
-        count_view_mes < 1 ||
+        id < 1 ||
         (selected_group && is_group_generating)
     ) { return; }
 
@@ -6524,7 +6514,7 @@ function showSwipeButtons() {
         chat[chat.length - 1]['swipes'][0] = chat[chat.length - 1]['mes'];  //assign swipe array with last message from chat
     }
 
-    const currentMessage = $('#chat').children().filter(`[mesid="${count_view_mes - 1}"]`);
+    const currentMessage = $('#chat').children().filter(`[mesid="${id}"]`);
     const swipeId = chat[chat.length - 1].swipe_id;
     var swipesCounterHTML = (`${(swipeId + 1)}/${(chat[chat.length - 1].swipes.length)}`);
 
@@ -6549,10 +6539,10 @@ function showSwipeButtons() {
     //console.log(chat[chat.length - 1].swipes.length);
 }
 
-function hideSwipeButtons() {
+function hideSwipeButtons(id = chat.length - 1) {
     //console.log('hideswipebuttons entered');
-    $('#chat').children().filter(`[mesid="${count_view_mes - 1}"]`).children('.swipe_right').css('display', 'none');
-    $('#chat').children().filter(`[mesid="${count_view_mes - 1}"]`).children('.swipe_left').css('display', 'none');
+    $('#chat').children().filter(`[mesid="${id}"]`).children('.swipe_right').css('display', 'none');
+    $('#chat').children().filter(`[mesid="${id}"]`).children('.swipe_left').css('display', 'none');
 }
 
 export async function saveMetadata() {
@@ -7171,7 +7161,7 @@ function swipe_left() {      // when we swipe left..but no generation.
                         chat[chat.length - 1].extra = {};
                     }
 
-                    const swipeMessage = $('#chat').find(`[mesid="${count_view_mes - 1}"]`);
+                    const swipeMessage = $('#chat').find(`[mesid="${chat.length - 1}"]`);
                     const tokenCount = getTokenCount(chat[chat.length - 1].mes, 0);
                     chat[chat.length - 1]['extra']['token_count'] = tokenCount;
                     swipeMessage.find('.tokenCounterDisplay').text(`${tokenCount}t`);
@@ -7315,7 +7305,7 @@ const swipe_right = () => {
         run_swipe_right = true; //then prepare to do normal right swipe to show next message
     }
 
-    const currentMessage = $('#chat').children().filter(`[mesid="${count_view_mes - 1}"]`);
+    const currentMessage = $('#chat').children().filter(`[mesid="${chat.length - 1}"]`);
     let this_div = currentMessage.children('.swipe_right');
     let this_mes_div = this_div.parent();
 
@@ -7346,7 +7336,7 @@ const swipe_right = () => {
                 const is_animation_scroll = ($('#chat').scrollTop() >= ($('#chat').prop('scrollHeight') - $('#chat').outerHeight()) - 10);
                 //console.log(parseInt(chat[chat.length-1]['swipe_id']));
                 //console.log(chat[chat.length-1]['swipes'].length);
-                const swipeMessage = $('#chat').find('[mesid="' + (count_view_mes - 1) + '"]');
+                const swipeMessage = $('#chat').find('[mesid="' + (chat.length - 1) + '"]');
                 if (run_generate && parseInt(chat[chat.length - 1]['swipe_id']) === chat[chat.length - 1]['swipes'].length) {
                     //shows "..." while generating
                     swipeMessage.find('.mes_text').html('...');
@@ -8664,7 +8654,6 @@ jQuery(async function () {
                 .remove();
             $('.mes[mesid=\'' + this_del_mes + '\']').remove();
             chat.length = this_del_mes;
-            count_view_mes = this_del_mes;
             await saveChatConditional();
             var $textchat = $('#chat');
             $textchat.scrollTop($textchat[0].scrollHeight);
@@ -8864,7 +8853,7 @@ jQuery(async function () {
             let chatScrollPosition = $('#chat').scrollTop();
             if (this_edit_mes_id !== undefined) {
                 let mes_edited = $(`#chat [mesid="${this_edit_mes_id}"]`).find('.mes_edit_done');
-                if (Number(edit_mes_id) == count_view_mes - 1) { //if the generating swipe (...)
+                if (Number(edit_mes_id) == chat.length - 1) { //if the generating swipe (...)
                     let run_edit = true;
                     if (chat[edit_mes_id]['swipe_id'] !== undefined) {
                         if (chat[edit_mes_id]['swipes'].length === chat[edit_mes_id]['swipe_id']) {
@@ -8911,7 +8900,7 @@ jQuery(async function () {
                 edit_textarea.val().length,
                 edit_textarea.val().length,
             );
-            if (this_edit_mes_id == count_view_mes - 1) {
+            if (this_edit_mes_id == chat.length - 1) {
                 $('#chat').scrollTop(chatScrollPosition);
             }
 
@@ -9106,7 +9095,6 @@ jQuery(async function () {
         } else {
             chat.splice(this_edit_mes_id, 1);
             mes.remove();
-            count_view_mes--;
         }
 
         let startFromZero = Number(this_edit_mes_id) === 0;
@@ -9119,7 +9107,7 @@ jQuery(async function () {
         hideSwipeButtons();
         showSwipeButtons();
 
-        await eventSource.emit(event_types.MESSAGE_DELETED, count_view_mes);
+        await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
     });
 
     $(document).on('click', '.mes_edit_done', async function () {

--- a/public/script.js
+++ b/public/script.js
@@ -1924,7 +1924,7 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
         }
     }*/
     let params = {
-        mesId: forceId ?? chat.length,
+        mesId: forceId ?? chat.length - 1,
         characterName: mes.name,
         isUser: mes.is_user,
         avatarImg: avatarImg,
@@ -1963,7 +1963,8 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
             return forceId;
         }
 
-        return type == 'swipe' ? chat.length - 1 : chat.length;
+        // Callers push the new message to chat before calling addOneMessage
+        return chat.length - 1;
     }
 
     const newMessageId = getMessageId();
@@ -2041,7 +2042,7 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
             swipeMessage.find('.tokenCounterDisplay').html('');
         }
     } else {
-        const messageId = forceId ?? chat.length;
+        const messageId = forceId ?? chat.length - 1;
         $('#chat').find(`[mesid="${messageId}"]`).find('.mes_text').append(messageText);
         appendMediaToMessage(mes, newMessage);
         hideSwipeButtons(getMessageId());
@@ -6495,7 +6496,7 @@ function showSwipeButtons(id = chat.length - 1) {
         $('.mes:last').attr('mesid') < 0 ||
         chat[chat.length - 1].is_user ||
         chat[chat.length - 1].extra?.image ||
-        id < 1 ||
+        id < 0 ||
         (selected_group && is_group_generating)
     ) { return; }
 


### PR DESCRIPTION
As far as I can tell, the only time it goes out of sync with chat.length is in printMessages. For that use case, I just pass in the intended message ID to `forceID`, and I've allowed a message ID to be passed to `hideSwipeButtons` and `showSwipeButtons` so they can act on the proper message as well.