### PR TITLE
Modify start scripts to pass parameters

### DIFF
--- a/Start.bat
+++ b/Start.bat
@@ -1,5 +1,5 @@
 pushd %~dp0
 call npm install --no-audit
-node server.js
+node server.js %*
 pause
 popd

--- a/UpdateAndStart.bat
+++ b/UpdateAndStart.bat
@@ -12,6 +12,6 @@ if %errorlevel% neq 0 (
     )
 )
 call npm install
-node server.js
+node server.js %*
 pause
 popd

--- a/start.sh
+++ b/start.sh
@@ -31,4 +31,4 @@ echo "Installing Node Modules..."
 npm i --no-audit
 
 echo "Entering SillyTavern..."
-node "$(dirname "$0")/server.js"
+node "$(dirname "$0")/server.js" "$@"


### PR DESCRIPTION
`--disableCsrf` and other command line parameters can't actually be passed, despite (in the case of `--disableCsrf`) the program actually telling the user they can do so.  There are some other use cases where the command line is the only way to control configuration, but the hardcoded start scripts are under source control.  It's probably easier just to let the user pass parameters.

- Modify start.sh to pass parameters.
- Modify Start.bat to pass parameters