### PR TITLE
Fix name trim

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4411,8 +4411,9 @@ function cleanUpMessage(getMessage, isImpersonate, isContinue, displayIncomplete
         nameToTrim = power_user.allow_name1_display ? '' : name1;
     }
 
-    if (nameToTrim && getMessage.indexOf(`${nameToTrim}:`) == 0) {
-        getMessage = getMessage.substring(`${nameToTrim}:`.length);
+    if (nameToTrim && getMessage.startsWith(nameToTrim + ':')) {
+        getMessage = getMessage.replace(nameToTrim + ':', '');
+        getMessage = getMessage.trimStart();
     }
     if (nameToTrim && getMessage.indexOf(`\n${nameToTrim}:`) >= 0) {
         getMessage = getMessage.substring(0, getMessage.indexOf(`\n${nameToTrim}:`));

--- a/public/script.js
+++ b/public/script.js
@@ -4412,7 +4412,7 @@ function cleanUpMessage(getMessage, isImpersonate, isContinue, displayIncomplete
     }
 
     if (nameToTrim && getMessage.indexOf(`${nameToTrim}:`) == 0) {
-        getMessage = getMessage.substring(0, getMessage.indexOf(`${nameToTrim}:`));
+        getMessage = getMessage.substring(`${nameToTrim}:`.length);
     }
     if (nameToTrim && getMessage.indexOf(`\n${nameToTrim}:`) >= 0) {
         getMessage = getMessage.substring(0, getMessage.indexOf(`\n${nameToTrim}:`));


### PR DESCRIPTION
Sorry for my english, I am french.

Currently, when the cleanUpMessage function finds "{{user}}:" or "{{char}}:" at the beginning of a generation, it simply destroys the whole string instead of just removing the prefix. It caused problems for the image generation extension because most of the replies from the AI would start with "{{char}}:" and the whole string would be destroyed causing the extension to say "The model produced no response, please retry" or something similar.

I fixed that.

Also I choosed to merged it in the branch "staging" but I don't know if it's the good way to do it.