### PR TITLE
Qr another startup fix

### DIFF
--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -198,6 +198,9 @@ const init = async () => {
     slash.init();
     autoExec = new AutoExecuteHandler(settings);
 
+    eventSource.on(event_types.APP_READY, ()=>finalizeInit());
+};
+const finalizeInit = async () => {
     log('executing startup');
     await autoExec.handleStartup();
     log('/executing startup');
@@ -211,7 +214,7 @@ const init = async () => {
     isReady = true;
     log('READY');
 };
-init();
+await init();
 
 const onChatChanged = async (chatIdx) => {
     log('CHAT_CHANGED', chatIdx);

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -198,7 +198,7 @@ const init = async () => {
     slash.init();
     autoExec = new AutoExecuteHandler(settings);
 
-    eventSource.on(event_types.APP_READY, ()=>finalizeInit());
+    eventSource.on(event_types.APP_READY, async()=>await finalizeInit());
 };
 const finalizeInit = async () => {
     log('executing startup');


### PR DESCRIPTION
There were still potential timing issues with the app ready / qr ready queue fix from yesterday because qr did not actually wait for APP_READY before processing the auto-exec queue.

Now init is awaited, which should prevent APP_READY ever happening before QR is ready, and QR runs through the on-startup auto-execs and the queued ones after the APP_READY event is received.