### PR TITLE
Initial support for Extras vectorizer, for Vector Storage

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -424,9 +424,18 @@ async function insertVectorItems(collectionId, items) {
         throw new Error('Vectors: API key missing', { cause: 'api_key_missing' });
     }
 
+    const headers = getRequestHeaders();
+    if (settings.source === 'extras') {
+        console.log(`Vector source is extras, populating API URL: ${extension_settings.apiUrl}`);
+        Object.assign(headers, {
+            'X-Extras-Url': extension_settings.apiUrl,
+            'X-Extras-Key': extension_settings.apiKey
+        });
+    }
+
     const response = await fetch('/api/vector/insert', {
         method: 'POST',
-        headers: getRequestHeaders(),
+        headers: headers,
         body: JSON.stringify({
             collectionId: collectionId,
             items: items,
@@ -468,9 +477,18 @@ async function deleteVectorItems(collectionId, hashes) {
  * @returns {Promise<{ hashes: number[], metadata: object[]}>} - Hashes of the results
  */
 async function queryCollection(collectionId, searchText, topK) {
+    const headers = getRequestHeaders();
+    if (settings.source === 'extras') {
+        console.log(`Vector source is extras, populating API URL: ${extension_settings.apiUrl}`);
+        Object.assign(headers, {
+            'X-Extras-Url': extension_settings.apiUrl,
+            'X-Extras-Key': extension_settings.apiKey
+        });
+    }
+
     const response = await fetch('/api/vector/query', {
         method: 'POST',
-        headers: getRequestHeaders(),
+        headers: headers,
         body: JSON.stringify({
             collectionId: collectionId,
             searchText: searchText,

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -11,6 +11,7 @@
                 </label>
                 <select id="vectors_source" class="text_pole">
                     <option value="transformers">Local (Transformers)</option>
+                    <option value="extras">Extras</option>
                     <option value="openai">OpenAI</option>
                     <option value="palm">Google MakerSuite (PaLM)</option>
                     <option value="mistral">MistralAI</option>

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -7,16 +7,19 @@ const { jsonParser } = require('../express-common');
 /**
  * Gets the vector for the given text from the given source.
  * @param {string} source - The source of the vector
+ * @param {Object} sourceSettings - Settings for the source, if it needs any
  * @param {string} text - The text to get the vector for
  * @returns {Promise<number[]>} - The vector for the text
  */
-async function getVector(source, text) {
+async function getVector(source, sourceSettings, text) {
     switch (source) {
         case 'mistral':
         case 'openai':
             return require('../openai-vectors').getOpenAIVector(text, source);
         case 'transformers':
             return require('../embedding').getTransformersVector(text);
+        case 'extras':
+            return require('../extras-vectors').getExtrasVector(text, sourceSettings.extrasUrl, sourceSettings.extrasKey);
         case 'palm':
             return require('../makersuite-vectors').getMakerSuiteVector(text);
     }
@@ -45,9 +48,10 @@ async function getIndex(collectionId, source, create = true) {
  * Inserts items into the vector collection
  * @param {string} collectionId - The collection ID
  * @param {string} source - The source of the vector
+ * @param {Object} sourceSettings - Settings for the source, if it needs any
  * @param {{ hash: number; text: string; index: number; }[]} items - The items to insert
  */
-async function insertVectorItems(collectionId, source, items) {
+async function insertVectorItems(collectionId, source, sourceSettings, items) {
     const store = await getIndex(collectionId, source);
 
     await store.beginUpdate();
@@ -56,7 +60,7 @@ async function insertVectorItems(collectionId, source, items) {
         const text = item.text;
         const hash = item.hash;
         const index = item.index;
-        const vector = await getVector(source, text);
+        const vector = await getVector(source, sourceSettings, text);
         await store.upsertItem({ vector: vector, metadata: { hash, text, index } });
     }
 
@@ -101,13 +105,14 @@ async function deleteVectorItems(collectionId, source, hashes) {
  * Gets the hashes of the items in the vector collection that match the search text
  * @param {string} collectionId - The collection ID
  * @param {string} source - The source of the vector
+ * @param {Object} sourceSettings - Settings for the source, if it needs any
  * @param {string} searchText - The text to search for
  * @param {number} topK - The number of results to return
  * @returns {Promise<{hashes: number[], metadata: object[]}>} - The metadata of the items that match the search text
  */
-async function queryCollection(collectionId, source, searchText, topK) {
+async function queryCollection(collectionId, source, sourceSettings, searchText, topK) {
     const store = await getIndex(collectionId, source);
-    const vector = await getVector(source, searchText);
+    const vector = await getVector(source, sourceSettings, searchText);
 
     const result = await store.queryItems(vector, topK);
     const metadata = result.map(x => x.item.metadata);
@@ -128,7 +133,19 @@ router.post('/query', jsonParser, async (req, res) => {
         const topK = Number(req.body.topK) || 10;
         const source = String(req.body.source) || 'transformers';
 
-        const results = await queryCollection(collectionId, source, searchText, topK);
+        // API settings for Extras embeddings provider
+        let extrasUrl = '';
+        let extrasKey = '';
+        if (source === 'extras') {
+            extrasUrl = String(req.headers['x-extras-url']);
+            extrasKey = String(req.headers['x-extras-key']);
+        }
+        const sourceSettings = {
+            extrasUrl: extrasUrl,
+            extrasKey: extrasKey
+        };
+
+        const results = await queryCollection(collectionId, source, sourceSettings, searchText, topK);
         return res.json(results);
     } catch (error) {
         console.error(error);
@@ -146,7 +163,19 @@ router.post('/insert', jsonParser, async (req, res) => {
         const items = req.body.items.map(x => ({ hash: x.hash, text: x.text, index: x.index }));
         const source = String(req.body.source) || 'transformers';
 
-        await insertVectorItems(collectionId, source, items);
+        // API settings for Extras embeddings provider
+        let extrasUrl = '';
+        let extrasKey = '';
+        if (source === 'extras') {
+            extrasUrl = String(req.headers['x-extras-url']);
+            extrasKey = String(req.headers['x-extras-key']);
+        }
+        const sourceSettings = {
+            extrasUrl: extrasUrl,
+            extrasKey: extrasKey
+        };
+
+        await insertVectorItems(collectionId, source, sourceSettings, items);
         return res.sendStatus(200);
     } catch (error) {
         console.error(error);

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -149,7 +149,7 @@ async function queryCollection(collectionId, source, sourceSettings, searchText,
  * @param {object} request - The HTTP request object.
  * @returns {object} - An object that can be used as `sourceSettings` in functions that take that parameter.
  */
-function extractSourceSettings(source, request) {
+function getSourceSettings(source, request) {
     // Extras API settings to connect to the Extras embeddings provider
     let extrasUrl = '';
     let extrasKey = '';
@@ -177,7 +177,7 @@ router.post('/query', jsonParser, async (req, res) => {
         const searchText = String(req.body.searchText);
         const topK = Number(req.body.topK) || 10;
         const source = String(req.body.source) || 'transformers';
-        const sourceSettings = extractSourceSettings(source, req);
+        const sourceSettings = getSourceSettings(source, req);
 
         const results = await queryCollection(collectionId, source, sourceSettings, searchText, topK);
         return res.json(results);
@@ -196,7 +196,7 @@ router.post('/insert', jsonParser, async (req, res) => {
         const collectionId = String(req.body.collectionId);
         const items = req.body.items.map(x => ({ hash: x.hash, text: x.text, index: x.index }));
         const source = String(req.body.source) || 'transformers';
-        const sourceSettings = extractSourceSettings(source, req);
+        const sourceSettings = getSourceSettings(source, req);
 
         await insertVectorItems(collectionId, source, sourceSettings, items);
         return res.sendStatus(200);

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -145,12 +145,11 @@ async function queryCollection(collectionId, source, sourceSettings, searchText,
 
 /**
  * Extracts settings for the vectorization sources from the HTTP request headers.
+ * @param {string} source - Which source to extract settings for.
  * @param {object} request - The HTTP request object.
  * @returns {object} - An object that can be used as `sourceSettings` in functions that take that parameter.
  */
-function extractSourceSettings(request) {
-    const source = String(request.body.source) || 'transformers';
-
+function extractSourceSettings(source, request) {
     // Extras API settings to connect to the Extras embeddings provider
     let extrasUrl = '';
     let extrasKey = '';
@@ -158,11 +157,11 @@ function extractSourceSettings(request) {
         extrasUrl = String(request.headers['x-extras-url']);
         extrasKey = String(request.headers['x-extras-key']);
     }
+
     const sourceSettings = {
         extrasUrl: extrasUrl,
         extrasKey: extrasKey
     };
-
     return sourceSettings;
 }
 
@@ -178,7 +177,7 @@ router.post('/query', jsonParser, async (req, res) => {
         const searchText = String(req.body.searchText);
         const topK = Number(req.body.topK) || 10;
         const source = String(req.body.source) || 'transformers';
-        const sourceSettings = extractSourceSettings(req);
+        const sourceSettings = extractSourceSettings(source, req);
 
         const results = await queryCollection(collectionId, source, sourceSettings, searchText, topK);
         return res.json(results);
@@ -197,7 +196,7 @@ router.post('/insert', jsonParser, async (req, res) => {
         const collectionId = String(req.body.collectionId);
         const items = req.body.items.map(x => ({ hash: x.hash, text: x.text, index: x.index }));
         const source = String(req.body.source) || 'transformers';
-        const sourceSettings = extractSourceSettings(req);
+        const sourceSettings = extractSourceSettings(source, req);
 
         await insertVectorItems(collectionId, source, sourceSettings, items);
         return res.sendStatus(200);

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -30,16 +30,19 @@ async function getVector(source, sourceSettings, text) {
 /**
  * Gets the vector for the given text batch from the given source.
  * @param {string} source - The source of the vector
+ * @param {Object} sourceSettings - Settings for the source, if it needs any
  * @param {string[]} texts - The array of texts to get the vector for
  * @returns {Promise<number[][]>} - The array of vectors for the texts
  */
-async function getBatchVector(source, texts) {
+async function getBatchVector(source, sourceSettings, texts) {
     switch (source) {
         case 'mistral':
         case 'openai':
             return require('../openai-vectors').getOpenAIBatchVector(texts, source);
         case 'transformers':
             return require('../embedding').getTransformersBatchVector(texts);
+        case 'extras':
+            return require('../extras-vectors').getExtrasBatchVector(texts, sourceSettings.extrasUrl, sourceSettings.extrasKey);
         case 'palm':
             return require('../makersuite-vectors').getMakerSuiteBatchVector(texts);
     }
@@ -76,7 +79,7 @@ async function insertVectorItems(collectionId, source, sourceSettings, items) {
 
     await store.beginUpdate();
 
-    const vectors = await getBatchVector(source, items.map(x => x.text));
+    const vectors = await getBatchVector(source, sourceSettings, items.map(x => x.text));
 
     for (let i = 0; i < items.length; i++) {
         const item = items[i];

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -149,7 +149,7 @@ async function queryCollection(collectionId, source, sourceSettings, searchText,
  * @returns {object} - An object that can be used as `sourceSettings` in functions that take that parameter.
  */
 function extractSourceSettings(request) {
-    const source = String(req.body.source) || 'transformers';
+    const source = String(request.body.source) || 'transformers';
 
     // Extras API settings to connect to the Extras embeddings provider
     let extrasUrl = '';

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -149,6 +149,8 @@ async function queryCollection(collectionId, source, sourceSettings, searchText,
  * @returns {object} - An object that can be used as `sourceSettings` in functions that take that parameter.
  */
 function extractSourceSettings(request) {
+    const source = String(req.body.source) || 'transformers';
+
     // Extras API settings to connect to the Extras embeddings provider
     let extrasUrl = '';
     let extrasKey = '';

--- a/src/extras-vectors.js
+++ b/src/extras-vectors.js
@@ -2,28 +2,34 @@ const fetch = require('node-fetch').default;
 
 /**
  * Gets the vector for the given text from SillyTavern-extras
- * @param {string[]} texts - The array of texts to get the vector for
+ * @param {string[]} texts - The array of texts to get the vectors for
  * @param {string} apiUrl - The Extras API URL
  * @param {string} - The Extras API key, or empty string if API key not enabled
  * @returns {Promise<number[][]>} - The array of vectors for the texts
  */
 async function getExtrasBatchVector(texts, apiUrl, apiKey) {
-    return getExtrasVector(texts, apiUrl, apiKey);  // The implementation supports batches transparently.
+    return getExtrasVectorImpl(texts, apiUrl, apiKey);
 }
-
-module.exports = {
-    getExtrasVector,
-    getExtrasBatchVector,
-};
 
 /**
  * Gets the vector for the given text from SillyTavern-extras
- * @param {string|string[]} text - The text or texts to get the vector for
+ * @param {string} text - The text to get the vector for
+ * @param {string} apiUrl - The Extras API URL
+ * @param {string} - The Extras API key, or empty string if API key not enabled
+ * @returns {Promise<number[]>} - The vector for the text
+ */
+async function getExtrasVector(text, apiUrl, apiKey) {
+    return getExtrasVectorImpl(text, apiUrl, apiKey);
+}
+
+/**
+ * Gets the vector for the given text from SillyTavern-extras
+ * @param {string|string[]} text - The text or texts to get the vector(s) for
  * @param {string} apiUrl - The Extras API URL
  * @param {string} - The Extras API key, or empty string if API key not enabled
  * @returns {Promise<number[]>|Promise<number[][]>} - The vector for a single text, or the array of vectors for multiple texts
  */
-async function getExtrasVector(text, apiUrl, apiKey) {
+async function getExtrasVectorImpl(text, apiUrl, apiKey) {
     let url;
     try {
         url = new URL(apiUrl);
@@ -65,3 +71,8 @@ async function getExtrasVector(text, apiUrl, apiKey) {
 
     return vector;
 }
+
+module.exports = {
+    getExtrasVector,
+    getExtrasBatchVector,
+};

--- a/src/extras-vectors.js
+++ b/src/extras-vectors.js
@@ -4,7 +4,7 @@ const fetch = require('node-fetch').default;
  * Gets the vector for the given text from SillyTavern-extras
  * @param {string[]} texts - The array of texts to get the vectors for
  * @param {string} apiUrl - The Extras API URL
- * @param {string} - The Extras API key, or empty string if API key not enabled
+ * @param {string} apiKey - The Extras API key, or empty string if API key not enabled
  * @returns {Promise<number[][]>} - The array of vectors for the texts
  */
 async function getExtrasBatchVector(texts, apiUrl, apiKey) {
@@ -15,7 +15,7 @@ async function getExtrasBatchVector(texts, apiUrl, apiKey) {
  * Gets the vector for the given text from SillyTavern-extras
  * @param {string} text - The text to get the vector for
  * @param {string} apiUrl - The Extras API URL
- * @param {string} - The Extras API key, or empty string if API key not enabled
+ * @param {string} apiKey - The Extras API key, or empty string if API key not enabled
  * @returns {Promise<number[]>} - The vector for the text
  */
 async function getExtrasVector(text, apiUrl, apiKey) {
@@ -26,8 +26,8 @@ async function getExtrasVector(text, apiUrl, apiKey) {
  * Gets the vector for the given text from SillyTavern-extras
  * @param {string|string[]} text - The text or texts to get the vector(s) for
  * @param {string} apiUrl - The Extras API URL
- * @param {string} - The Extras API key, or empty string if API key not enabled
- * @returns {Promise<number[]>|Promise<number[][]>} - The vector for a single text, or the array of vectors for multiple texts
+ * @param {string} apiKey - The Extras API key, or empty string if API key not enabled *
+ * @returns {Promise<Array>} - The vector for a single text if input is string, or the array of vectors for multiple texts if input is string[]
  */
 async function getExtrasVectorImpl(text, apiUrl, apiKey) {
     let url;

--- a/src/extras-vectors.js
+++ b/src/extras-vectors.js
@@ -2,10 +2,26 @@ const fetch = require('node-fetch').default;
 
 /**
  * Gets the vector for the given text from SillyTavern-extras
- * @param {string|Array} text - The text or texts to get the vector for
+ * @param {string[]} texts - The array of texts to get the vector for
  * @param {string} apiUrl - The Extras API URL
  * @param {string} - The Extras API key, or empty string if API key not enabled
- * @returns {Promise<number[]>} - The vector for a single text, or the array of vectors for multiple texts
+ * @returns {Promise<number[][]>} - The array of vectors for the texts
+ */
+async function getExtrasBatchVector(texts, apiUrl, apiKey) {
+    return getExtrasVector(texts, apiUrl, apiKey);  // The implementation supports batches transparently.
+}
+
+module.exports = {
+    getExtrasVector,
+    getExtrasBatchVector,
+};
+
+/**
+ * Gets the vector for the given text from SillyTavern-extras
+ * @param {string|string[]} text - The text or texts to get the vector for
+ * @param {string} apiUrl - The Extras API URL
+ * @param {string} - The Extras API key, or empty string if API key not enabled
+ * @returns {Promise<number[]>|Promise<number[][]>} - The vector for a single text, or the array of vectors for multiple texts
  */
 async function getExtrasVector(text, apiUrl, apiKey) {
     let url;
@@ -33,7 +49,7 @@ async function getExtrasVector(text, apiUrl, apiKey) {
         method: 'POST',
         headers: headers,
         body: JSON.stringify({
-            text: text,  // The backend accepts {string|Array} for one or multiple text items, respectively.
+            text: text,  // The backend accepts {string|string[]} for one or multiple text items, respectively.
         }),
     });
 
@@ -44,11 +60,7 @@ async function getExtrasVector(text, apiUrl, apiKey) {
     }
 
     const data = await response.json();
-    const vector = data.embedding;  // `embedding`: Array (one text item), or Array of Array (multiple text items).
+    const vector = data.embedding;  // `embedding`: number[] (one text item), or number[][] (multiple text items).
 
     return vector;
 }
-
-module.exports = {
-    getExtrasVector,
-};

--- a/src/extras-vectors.js
+++ b/src/extras-vectors.js
@@ -32,6 +32,7 @@ async function getExtrasVector(text, apiUrl, apiKey) {
     catch (error) {
         console.log('Failed to set up Extras API call:', error);
         console.log('Extras API URL given was:', apiUrl);
+        throw error;
     }
 
     const headers = {

--- a/src/extras-vectors.js
+++ b/src/extras-vectors.js
@@ -1,0 +1,54 @@
+const fetch = require('node-fetch').default;
+
+/**
+ * Gets the vector for the given text from SillyTavern-extras
+ * @param {string|Array} text - The text or texts to get the vector for
+ * @param {string} apiUrl - The Extras API URL
+ * @param {string} - The Extras API key, or empty string if API key not enabled
+ * @returns {Promise<number[]>} - The vector for a single text, or the array of vectors for multiple texts
+ */
+async function getExtrasVector(text, apiUrl, apiKey) {
+    let url;
+    try {
+        url = new URL(apiUrl);
+        url.pathname = '/api/embeddings/compute';
+    }
+    catch (error) {
+        console.log('Failed to set up Extras API call:', error);
+        console.log('Extras API URL given was:', apiUrl);
+    }
+
+    const headers = {
+        'Content-Type': 'application/json',
+    };
+
+    // Include the Extras API key, if enabled
+    if (apiKey && apiKey.length > 0) {
+        Object.assign(headers, {
+            'Authorization': `Bearer ${apiKey}`,
+        });
+    }
+
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify({
+            text: text,  // The backend accepts {string|Array} for one or multiple text items, respectively.
+        }),
+    });
+
+    if (!response.ok) {
+        const text = await response.text();
+        console.log('Extras request failed', response.statusText, text);
+        throw new Error('Extras request failed');
+    }
+
+    const data = await response.json();
+    const vector = data.embedding;  // `embedding`: Array (one text item), or Array of Array (multiple text items).
+
+    return vector;
+}
+
+module.exports = {
+    getExtrasVector,
+};


### PR DESCRIPTION
Here's the frontend part of supporting the Extras vectorizer in *Vector Storage*. Please review.

- *Vector Storage*: New backend `"Extras"` for faster local-ish computation of vector embeddings (vector DB keys).
  - This requires loading the new `"embeddings"` module in your ST-extras installation.
  - There is **no** need to load the `"chromadb"` module in ST-extras. This does **not** use `chromadb`.

By a quick ingestion test, the speed is as I suspected. The setup/teardown overhead eats much of the performance benefit. Batching will make a huge difference once it lands. (All new parts I added can already accept batches.)

~Also, seems something has diverged in the meantime, we'll have some merge conflict fixing to do.~ **EDIT**: Done.

**EDIT**: The matching Extras backend changes are in the PR https://github.com/SillyTavern/SillyTavern-Extras/pull/221