### PR TITLE
Iterate over textChunks to find character data

### DIFF
--- a/src/character-card-parser.js
+++ b/src/character-card-parser.js
@@ -18,11 +18,16 @@ const parse = async (cardUrl, format) => {
             });
 
             if (textChunks.length === 0) {
-                console.error('PNG metadata does not contain any character data.');
+                console.error('PNG metadata does not contain any text chunks.');
                 throw new Error('No PNG metadata.');
             }
 
             let index = textChunks.findIndex((chunk) => chunk.keyword.toLowerCase() == 'chara');
+
+            if (index === -1) {
+                console.error('PNG metadata does not contain any character data.');
+                throw new Error('No PNG metadata.');
+            }
 
             return Buffer.from(textChunks[index].text, 'base64').toString('utf8');
         }

--- a/src/character-card-parser.js
+++ b/src/character-card-parser.js
@@ -22,7 +22,9 @@ const parse = async (cardUrl, format) => {
                 throw new Error('No PNG metadata.');
             }
 
-            return Buffer.from(textChunks[0].text, 'base64').toString('utf8');
+            let index = textChunks.findIndex((chunk) => chunk.keyword.toLowerCase() == 'chara');
+
+            return Buffer.from(textChunks[index].text, 'base64').toString('utf8');
         }
         default:
             break;


### PR DESCRIPTION
Adding an index lookup to `src/character-card-parser.js` to allow it to locate the index the metadata is stored in.

When an image contains more metadata than just the `Chara` field, it'll be extracted along with it. Depending on how that extra metadata is ordered/added, it'll mean the `Chara` is not guaranteed to be the first entry in the list. This patch takes that into account.


To illustrate the example, I've created the character card attached to this PR. It has been "corrupted" on purpose, by injecting some metadata in before the `Chara` field. Examine it with your exif tool of choice to verify that it has both the non-standard fields `Software` and `Chara`.

Attempting to import it will cause Silly Tavern to claim it is invalid or corrupted, despite the fact it has all valid data. Applying this patch will cause it to correctly identify the index of the character data, assuming its present at all.

Admittedly, this **is** an edge case, since most users will get their cards from chub or janitor, or even make them themselves using Tavern, which all filter out excess metadata. The only reason I found this bug was because I wanted a square card instead of a 2:3, and I figured it was easier to just inject the metadata than trying to modify the cropping tool.

![Examplator](https://github.com/SillyTavern/SillyTavern/assets/32297912/6546a519-c04f-4795-b989-e450876bd241)