### PR TITLE
[feat] GENERATION_ENDED event

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -362,6 +362,7 @@ export const event_types = {
     CHAT_CHANGED: 'chat_id_changed',
     GENERATION_STARTED: 'generation_started',
     GENERATION_STOPPED: 'generation_stopped',
+    GENERATION_ENDED: 'generation_ended',
     EXTENSIONS_FIRST_LOAD: 'extensions_first_load',
     SETTINGS_LOADED: 'settings_loaded',
     SETTINGS_UPDATED: 'settings_updated',
@@ -2453,7 +2454,11 @@ function showStopButton() {
 }
 
 function hideStopButton() {
-    $('#mes_stop').css({ 'display': 'none' });
+    // prevent NOOP, because hideStopButton() gets called multiple times
+    if($('#mes_stop').css('display') !== 'none') {
+        $('#mes_stop').css({ 'display': 'none' });
+        eventSource.emit(event_types.GENERATION_ENDED, chat.length);
+    }
 }
 
 class StreamingProcessor {


### PR DESCRIPTION
uses hideStopButton() to trigger the event, because all other paths are conditional and would require the event to be triggered in multiple functions, compared to hideStopButton() already being called at the end of all the generations

unblockGeneration() was another candidate, but it is not consistently executed to be viable