### PR TITLE
fix: logprobs for Aphrodite

### DIFF
--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -712,6 +712,7 @@ function parseTextgenLogprobs(token, logprobs) {
     }
 
     switch (settings.type) {
+        case APHRODITE:
         case OOBA: {
              /** @type {Record<string, number>[]} */
             const topLogprobs = logprobs.top_logprobs;


### PR DESCRIPTION
Since Aphrodite follows the same logprobs style as ooba, we can enable it easily.