### PR TITLE
Reverse proxy presets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -747,47 +747,69 @@
                                     </div>
                                 </div>
                                 <hr data-source="openai,claude">
-                                <div class="range-block" data-source="openai,claude">
-                                    <div class="range-block-title justifyLeft" data-i18n="OpenAI Reverse Proxy">
-                                        OpenAI / Claude Reverse Proxy
+                                <div data-newbie-hidden class="inline-drawer wide100p" data-source="openai,claude">
+                                    <div class="inline-drawer-toggle inline-drawer-header">
+                                        <b data-i18n="Reverse Proxy">Reverse Proxy</b>
+                                        <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                     </div>
-                                    <div class="toggle-description justifyLeft">
-                                        <span data-i18n="Alternative server URL (leave empty to use the default value).">
-                                            Alternative server URL (leave empty to use the default value).<br>
-                                        </span>
-                                        <div id="ReverseProxyWarningMessage" class="reverse_proxy_warning">
-                                            <b data-i18n="Remove your real OAI API Key from the API panel BEFORE typing anything into this box">
-                                                Remove your real OAI API Key from the API panel BEFORE typing anything
-                                                into this box.
-                                            </b>
-                                            <hr>
-                                            <b data-i18n="We cannot provide support for problems encountered while using an unofficial OpenAI proxy">
-                                                We cannot provide support for problems encountered while using an
-                                                unofficial OpenAI proxy.
-                                            </b>
+                                    <div class="inline-drawer-content">
+                                        <div class="range-block-title justifyLeft" data-i18n="Proxy Name">
+                                            Proxy Name
+                                        </div>
+                                        <div class="toggle-description justifyLeft">
+                                            <span data-i18n="This will show up as your saved preset.">
+                                                This will show up as your saved preset.<br>
+                                            </span>
+                                        </div>
+                                        <div class="wide100p">
+                                            <input id="openai_reverse_proxy_name" type="text" class="text_pole" placeholder="..." maxlength="100" />
+                                        </div>
+                                        <div class="range-block-title justifyLeft" data-i18n="Proxy Server URL">
+                                            Proxy Server URL
+                                        </div>
+                                        <div class="toggle-description justifyLeft">
+                                            <span data-i18n="Alternative server URL (leave empty to use the default value).">
+                                                Alternative server URL (leave empty to use the default value).<br>
+                                            </span>
+                                            <div id="ReverseProxyWarningMessage" class="reverse_proxy_warning">
+                                                <b data-i18n="Remove your real OAI API Key from the API panel BEFORE typing anything into this box">
+                                                    Remove your real OAI API Key from the API panel BEFORE typing anything
+                                                    into this box.
+                                                </b>
+                                                <hr>
+                                                <b data-i18n="We cannot provide support for problems encountered while using an unofficial OpenAI proxy">
+                                                    We cannot provide support for problems encountered while using an
+                                                    unofficial OpenAI proxy.
+                                                </b>
+                                            </div>
+                                        </div>
+                                        <div class="wide100p">
+                                            <input id="openai_reverse_proxy" type="text" class="text_pole" placeholder="https://api.openai.com/v1" maxlength="500" />
+                                            <small class="reverse_proxy_warning">
+                                                Doesn't work? Try adding <code>/v1</code> at the end!
+                                            </small>
+                                        </div>
+                                        <div class="range-block-title justifyLeft" data-i18n="Proxy Password">
+                                            Proxy Password
+                                        </div>
+                                        <div class="toggle-description justifyLeft">
+                                            <span data-i18n="Will be used as a password for the proxy instead of API key.">
+                                                Will be used as a password for the proxy instead of API key.<br>
+                                            </span>
+                                        </div>
+                                        <div class="flex-container width100p">
+                                            <input id="openai_proxy_password" type="password" class="text_pole flex1" placeholder="" maxlength="500" form="openai_form" />
+                                            <div id="openai_proxy_password_show" title="Peek a password" class="menu_button fa-solid fa-eye-slash fa-fw"></div>
+                                        </div>
+                                        <div class="openai_logit_bias_preset_form">
+                                            <select id="openai_proxy_preset">
+                                            </select>
+                                            <i id="save_proxy" class="menu_button fa-solid fa-save" title="Save Proxy" data-i18n="[title]Save Proxy"></i>
+                                            <i id="delete_proxy" class="menu_button fa-solid fa-trash" title="Delete Proxy" data-i18n="[title]Delete Proxy"></i>
                                         </div>
                                     </div>
-                                    <div class="wide100p">
-                                        <input id="openai_reverse_proxy" type="text" class="text_pole" placeholder="https://api.openai.com/v1" maxlength="500" />
-                                        <small class="reverse_proxy_warning">
-                                            Doesn't work? Try adding <code>/v1</code> at the end!
-                                        </small>
-                                    </div>
                                 </div>
-                                <div class="range-block" data-source="openai,claude">
-                                    <div class="range-block-title justifyLeft" data-i18n="Proxy Password">
-                                        Proxy Password
-                                    </div>
-                                    <div class="toggle-description justifyLeft">
-                                        <span data-i18n="Will be used as a password for the proxy instead of API key.">
-                                            Will be used as a password for the proxy instead of API key.<br>
-                                        </span>
-                                    </div>
-                                    <div class="flex-container width100p">
-                                        <input id="openai_proxy_password" type="password" class="text_pole flex1" placeholder="" maxlength="500" form="openai_form" />
-                                        <div id="openai_proxy_password_show" title="Peek a password" class="menu_button fa-solid fa-eye-slash fa-fw"></div>
-                                    </div>
-                                </div>
+                                <hr data-source="openai,claude">
                                 <div data-newbie-hidden class="range-block" data-source="openai,openrouter,mistralai,custom">
                                     <div class="range-block-title justifyLeft" data-i18n="Seed">
                                         Seed

--- a/public/index.html
+++ b/public/index.html
@@ -707,8 +707,8 @@
                                         </div>
                                     </div>
                                 </div>
-                                <hr data-source="openai,claude">
-                                <div class="range-block" data-source="openai,claude">
+                                <hr data-source="openai,claude,mistralai">
+                                <div class="range-block" data-source="openai,claude,mistralai">
                                     <div class="range-block-title justifyLeft" data-i18n="OpenAI Reverse Proxy">
                                         OpenAI / Claude Reverse Proxy
                                     </div>
@@ -735,7 +735,7 @@
                                         </small>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,claude">
+                                <div class="range-block" data-source="openai,claude,mistralai">
                                     <div class="range-block-title justifyLeft" data-i18n="Proxy Password">
                                         Proxy Password
                                     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -2065,7 +2065,7 @@
                                 <div class="range-block-title justifyLeft" data-i18n="Proxy Server URL">
                                     Proxy Server URL
                                 </div>
-                                <div class="toggle-description justifyLeft">
+                                <div class="toggle-description justifyLeft wide100p">
                                     <span data-i18n="Alternative server URL (leave empty to use the default value).">
                                         Alternative server URL (leave empty to use the default value).<br>
                                     </span>

--- a/public/index.html
+++ b/public/index.html
@@ -746,70 +746,6 @@
                                         </div>
                                     </div>
                                 </div>
-                                <hr data-source="openai,claude,mistralai">
-                                <div data-newbie-hidden class="inline-drawer wide100p" data-source="openai,claude,mistralai">
-                                    <div class="inline-drawer-toggle inline-drawer-header">
-                                        <b data-i18n="Reverse Proxy">Reverse Proxy</b>
-                                        <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
-                                    </div>
-                                    <div class="inline-drawer-content">
-                                        <div class="range-block-title justifyLeft" data-i18n="Proxy Name">
-                                            Proxy Name
-                                        </div>
-                                        <div class="toggle-description justifyLeft">
-                                            <span data-i18n="This will show up as your saved preset.">
-                                                This will show up as your saved preset.<br>
-                                            </span>
-                                        </div>
-                                        <div class="wide100p">
-                                            <input id="openai_reverse_proxy_name" type="text" class="text_pole" placeholder="..." maxlength="100" />
-                                        </div>
-                                        <div class="range-block-title justifyLeft" data-i18n="Proxy Server URL">
-                                            Proxy Server URL
-                                        </div>
-                                        <div class="toggle-description justifyLeft">
-                                            <span data-i18n="Alternative server URL (leave empty to use the default value).">
-                                                Alternative server URL (leave empty to use the default value).<br>
-                                            </span>
-                                            <div id="ReverseProxyWarningMessage" class="reverse_proxy_warning">
-                                                <b data-i18n="Remove your real OAI API Key from the API panel BEFORE typing anything into this box">
-                                                    Remove your real OAI API Key from the API panel BEFORE typing anything
-                                                    into this box.
-                                                </b>
-                                                <hr>
-                                                <b data-i18n="We cannot provide support for problems encountered while using an unofficial OpenAI proxy">
-                                                    We cannot provide support for problems encountered while using an
-                                                    unofficial OpenAI proxy.
-                                                </b>
-                                            </div>
-                                        </div>
-                                        <div class="wide100p">
-                                            <input id="openai_reverse_proxy" type="text" class="text_pole" placeholder="https://api.openai.com/v1" maxlength="500" />
-                                            <small class="reverse_proxy_warning">
-                                                Doesn't work? Try adding <code>/v1</code> at the end!
-                                            </small>
-                                        </div>
-                                        <div class="range-block-title justifyLeft" data-i18n="Proxy Password">
-                                            Proxy Password
-                                        </div>
-                                        <div class="toggle-description justifyLeft">
-                                            <span data-i18n="Will be used as a password for the proxy instead of API key.">
-                                                Will be used as a password for the proxy instead of API key.<br>
-                                            </span>
-                                        </div>
-                                        <div class="flex-container width100p">
-                                            <input id="openai_proxy_password" type="password" class="text_pole flex1" placeholder="" maxlength="500" form="openai_form" />
-                                            <div id="openai_proxy_password_show" title="Peek a password" class="menu_button fa-solid fa-eye-slash fa-fw"></div>
-                                        </div>
-                                        <div class="openai_logit_bias_preset_form">
-                                            <select id="openai_proxy_preset">
-                                            </select>
-                                            <i id="save_proxy" class="menu_button fa-solid fa-save" title="Save Proxy" data-i18n="[title]Save Proxy"></i>
-                                            <i id="delete_proxy" class="menu_button fa-solid fa-trash" title="Delete Proxy" data-i18n="[title]Delete Proxy"></i>
-                                        </div>
-                                    </div>
-                                </div>
-                                <hr data-source="openai,claude,mistralai">
                                 <div data-newbie-hidden class="range-block" data-source="openai,openrouter,mistralai,custom">
                                     <div class="range-block-title justifyLeft" data-i18n="Seed">
                                         Seed
@@ -2095,6 +2031,76 @@
                             <option value="mistralai">MistralAI</option>
                             <option value="custom">Custom (OpenAI-compatible)</option>
                         </select>
+                        <div data-newbie-hidden class="inline-drawer wide100p" data-source="openai,claude,mistralai">
+                            <div class="inline-drawer-toggle inline-drawer-header">
+                                <b data-i18n="Reverse Proxy">Reverse Proxy</b>
+                                <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                            </div>
+                            <div class="inline-drawer-content">
+                                <div class="range-block-title justifyLeft" data-i18n="Proxy Presets">
+                                    Proxy Presets
+                                </div>
+                                <div class="toggle-description justifyLeft">
+                                    <span data-i18n="Saved addresses and passwords.">
+                                        Saved addresses and passwords.<br>
+                                    </span>
+                                </div>
+                                <div class="openai_logit_bias_preset_form">
+                                    <select id="openai_proxy_preset">
+                                    </select>
+                                    <i id="save_proxy" class="menu_button fa-solid fa-save" title="Save Proxy" data-i18n="[title]Save Proxy"></i>
+                                    <i id="delete_proxy" class="menu_button fa-solid fa-trash" title="Delete Proxy" data-i18n="[title]Delete Proxy"></i>
+                                </div>
+                                <div class="range-block-title justifyLeft" data-i18n="Proxy Name">
+                                    Proxy Name
+                                </div>
+                                <div class="toggle-description justifyLeft">
+                                    <span data-i18n="This will show up as your saved preset.">
+                                        This will show up as your saved preset.<br>
+                                    </span>
+                                </div>
+                                <div class="wide100p">
+                                    <input id="openai_reverse_proxy_name" type="text" class="text_pole" placeholder="..." maxlength="100" />
+                                </div>
+                                <div class="range-block-title justifyLeft" data-i18n="Proxy Server URL">
+                                    Proxy Server URL
+                                </div>
+                                <div class="toggle-description justifyLeft">
+                                    <span data-i18n="Alternative server URL (leave empty to use the default value).">
+                                        Alternative server URL (leave empty to use the default value).<br>
+                                    </span>
+                                    <div id="ReverseProxyWarningMessage" class="reverse_proxy_warning">
+                                        <b data-i18n="Remove your real OAI API Key from the API panel BEFORE typing anything into this box">
+                                            Remove your real OAI API Key from the API panel BEFORE typing anything
+                                            into this box.
+                                        </b>
+                                        <hr>
+                                        <b data-i18n="We cannot provide support for problems encountered while using an unofficial OpenAI proxy">
+                                            We cannot provide support for problems encountered while using an
+                                            unofficial OpenAI proxy.
+                                        </b>
+                                    </div>
+                                </div>
+                                <div class="wide100p">
+                                    <input id="openai_reverse_proxy" type="text" class="text_pole" placeholder="https://api.openai.com/v1" maxlength="500" />
+                                    <small class="reverse_proxy_warning">
+                                        Doesn't work? Try adding <code>/v1</code> at the end!
+                                    </small>
+                                </div>
+                                <div class="range-block-title justifyLeft" data-i18n="Proxy Password">
+                                    Proxy Password
+                                </div>
+                                <div class="toggle-description justifyLeft">
+                                    <span data-i18n="Will be used as a password for the proxy instead of API key.">
+                                        Will be used as a password for the proxy instead of API key.<br>
+                                    </span>
+                                </div>
+                                <div class="flex-container width100p">
+                                    <input id="openai_proxy_password" type="password" class="text_pole flex1" placeholder="" maxlength="500" form="openai_form" />
+                                    <div id="openai_proxy_password_show" title="Peek a password" class="menu_button fa-solid fa-eye-slash fa-fw"></div>
+                                </div>
+                            </div>
+                        </div>
                         <form id="openai_form" data-source="openai" action="javascript:void(null);" method="post" enctype="multipart/form-data">
                             <h4><span data-i18n="OpenAI API key">OpenAI API key</span></h4>
                             <div>

--- a/public/script.js
+++ b/public/script.js
@@ -93,6 +93,9 @@ import {
     chat_completion_sources,
     getChatCompletionModel,
     isOpenRouterWithInstruct,
+    proxies,
+    loadProxyPresets,
+    selected_proxy,
 } from './scripts/openai.js';
 
 import {
@@ -5650,6 +5653,9 @@ async function getSettings() {
         // Load background
         loadBackgroundSettings(settings);
 
+        // Load proxy presets
+        loadProxyPresets(settings);
+
         // Allow subscribers to mutate settings
         eventSource.emit(event_types.SETTINGS_LOADED_AFTER, settings);
 
@@ -5728,7 +5734,6 @@ async function saveSettings(type) {
     }
 
     //console.log('Entering settings with name1 = '+name1);
-
     return jQuery.ajax({
         type: 'POST',
         url: '/api/settings/save',
@@ -5756,6 +5761,8 @@ async function saveSettings(type) {
             kai_settings: kai_settings,
             oai_settings: oai_settings,
             background: background_settings,
+            proxies: proxies,
+            selected_proxy: selected_proxy,
         }, null, 4),
         beforeSend: function () { },
         cache: false,

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1562,8 +1562,8 @@ async function sendOpenAIRequest(type, messages, signal) {
         delete generate_data.stop;
     }
 
-    // Proxy is only supported for Claude and OpenAI
-    if (oai_settings.reverse_proxy && [chat_completion_sources.CLAUDE, chat_completion_sources.OPENAI].includes(oai_settings.chat_completion_source)) {
+    // Proxy is only supported for Claude, OpenAI and Mistral
+    if (oai_settings.reverse_proxy && [chat_completion_sources.CLAUDE, chat_completion_sources.OPENAI, chat_completion_sources.MISTRALAI].includes(oai_settings.chat_completion_source)) {
         validateReverseProxy();
         generate_data['reverse_proxy'] = oai_settings.reverse_proxy;
         generate_data['proxy_password'] = oai_settings.proxy_password;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -12,7 +12,7 @@ const { getTokenizerModel, getSentencepiceTokenizer, getTiktokenTokenizer, sente
 
 const API_OPENAI = 'https://api.openai.com/v1';
 const API_CLAUDE = 'https://api.anthropic.com/v1';
-
+const API_MISTRAL = 'https://api.mistral.ai/v1';
 /**
  * Sends a request to Claude API.
  * @param {express.Request} request Express request
@@ -431,7 +431,8 @@ async function sendAI21Request(request, response) {
  * @param {express.Response} response Express response
  */
 async function sendMistralAIRequest(request, response) {
-    const apiKey = readSecret(SECRET_KEYS.MISTRALAI);
+    const apiUrl = new URL(request.body.reverse_proxy || API_MISTRAL).toString();
+    const apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(SECRET_KEYS.MISTRALAI);
 
     if (!apiKey) {
         console.log('MistralAI API key is missing.');
@@ -495,7 +496,7 @@ async function sendMistralAIRequest(request, response) {
 
         console.log('MisralAI request:', requestBody);
 
-        const generateResponse = await fetch('https://api.mistral.ai/v1/chat/completions', config);
+        const generateResponse = await fetch(apiUrl + '/chat/completions', config);
         if (request.body.stream) {
             forwardFetchResponse(generateResponse, response);
         } else {
@@ -538,8 +539,8 @@ router.post('/status', jsonParser, async function (request, response_getstatus_o
         // OpenRouter needs to pass the referer: https://openrouter.ai/docs
         headers = { 'HTTP-Referer': request.headers.referer };
     } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.MISTRALAI) {
-        api_url = 'https://api.mistral.ai/v1';
-        api_key_openai = readSecret(SECRET_KEYS.MISTRALAI);
+        api_url = new URL(request.body.reverse_proxy || API_MISTRAL).toString();
+        api_key_openai = request.body.reverse_proxy ? request.body.proxy_password : readSecret(SECRET_KEYS.MISTRALAI);
     } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM) {
         api_url = request.body.custom_url;
         api_key_openai = readSecret(SECRET_KEYS.CUSTOM);


### PR DESCRIPTION
This PR addresses #1241 by allowing the user to create and apply different reverse proxy presets without the need to edit their OpenAI presets. Also adds proxy support for the Mistral adapter as most proxy providers have been supporting the service for a while now.