### PR TITLE
(Small) Add Handling for Dangling Characters in "trimToEndSentence" - utils.js

### DIFF
--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -471,14 +471,18 @@ export function sortByCssOrder(a, b) {
  * trimToEndSentence('Hello, world! I am from'); // 'Hello, world!'
  */
 export function trimToEndSentence(input, include_newline = false) {
-    const punctuation = new Set(['.', '!', '?', '*', '"', ')', '}', '`', ']', '$', '。', '！', '？', '”', '）', '】', '】', '’', '」', '】']); // extend this as you see fit
+    const punctuation = new Set(['.', '!', '?', '*', '"', ')', '}', '`', ']', '$', '。', '！', '？', '”', '）', '】', '’', '」']); // extend this as you see fit
     let last = -1;
 
     for (let i = input.length - 1; i >= 0; i--) {
         const char = input[i];
 
         if (punctuation.has(char)) {
-            last = i;
+            if (i > 0 && (input[i - 1] === ' ' || input[i - 1] === '\n')) {
+                last = i - 1;
+            } else {
+                last = i;
+            }
             break;
         }
 

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -478,7 +478,7 @@ export function trimToEndSentence(input, include_newline = false) {
         const char = input[i];
 
         if (punctuation.has(char)) {
-            if (i > 0 && (input[i - 1] === ' ' || input[i - 1] === '\n')) {
+            if (i > 0 && /[\s\n]/.test(input[i - 1])) {
                 last = i - 1;
             } else {
                 last = i;


### PR DESCRIPTION
Added: Consider the presence of whitespace or newline characters preceding the punctuation for accurate trimming. 

This pull request enhances the `trimToEndSentence` function to better handle incomplete sentences with dangling characters at the end -  scenarios where incomplete sentences might contain trailing characters.

The primary motivation for this change was to ensure accurate sentence trimming and avoid leaving extra characters behind in certain scenarios, aimed to incorporate the simpler alternative suggested in addressing self raised issue https://github.com/SillyTavern/SillyTavern/issues/1778 (also for example this can be mentioned happening with NovelAI in the TL;DR [here](https://www.reddit.com/r/SillyTavernAI/comments/15tey49/novelai_tip/), so hitting continue endlessly isn't as necessary just to not end with incomplete sentences), ~~as a draft~~ for evaluation of the necessity of a UI implementation of this feature, or if this change that already solves the current occurrences is sufficient.

Goals:
* Address the issue of extra characters being left behind in incomplete sentences.
* Enhance the accuracy of sentence trimming, providing more reliable results under smaller and quantized models used in hardware constrained environments.