### PR TITLE
[docker/gitignore] persist extensions on restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ public/stats.json
 /config.yaml
 /config.conf.bak
 /docker/config
+/docker/user
+/docker/extensions
 .DS_Store
 public/settings.json
 /thumbnails

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
+      - "./extensions:/home/node/app/public/scripts/extensions/third-party"
       - "./config:/home/node/app/config"
       - "./user:/home/node/app/public/user"
     restart: unless-stopped


### PR DESCRIPTION
- currently the third party extensions will get wiped on each container restart and also there is no way to re-import extensions
- gitignore the docker created folders (incl. extensions)