### PR TITLE
Add /getchatname command

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6089,6 +6089,14 @@ export async function getPastCharacterChats(characterId = null) {
     return data;
 }
 
+function getCurrentChatDetails() {  // helper for `displayPastChats`, to make the same info consistently available for other functions
+    const group = selected_group ? groups.find(x => x.id === selected_group) : null;
+    const currentChat = selected_group ? group?.chat_id : characters[this_chid]['chat'];
+    const displayName = selected_group ? group?.name : characters[this_chid].name;
+    const avatarImg = selected_group ? group?.avatar_url : getThumbnailUrl('avatar', characters[this_chid]['avatar']);
+    return { sessionName: currentChat, group: group, characterName: displayName, avatarImgURL: avatarImg };
+}
+
 /**
  * Displays the past chats for a character or a group based on the selected context.
  * The function first fetches the chats, processes them, and then displays them in
@@ -6099,7 +6107,6 @@ export async function displayPastChats() {
     $('#select_chat_div').empty();
     $('#select_chat_search').val('').off('input');
 
-    const group = selected_group ? groups.find(x => x.id === selected_group) : null;
     const data = await (selected_group ? getGroupPastChats(selected_group) : getPastCharacterChats());
 
     if (!data) {
@@ -6107,10 +6114,14 @@ export async function displayPastChats() {
         return;
     }
 
-    const currentChat = selected_group ? group?.chat_id : characters[this_chid]['chat'];
-    const displayName = selected_group ? group?.name : characters[this_chid].name;
-    const avatarImg = selected_group ? group?.avatar_url : getThumbnailUrl('avatar', characters[this_chid]['avatar']);
+    const chatDetails = getCurrentChatDetails();
+    const group = chatDetails.group;
+    const currentChat = chatDetails.sessionName;
+    const displayName = chatDetails.characterName;
+    const avatarImg = chatDetails.avatarImgURL;
+
     const rawChats = await getChatsFromFiles(data, selected_group);
+
     // Sort by last message date descending
     data.sort((a, b) => sortMoments(timestampToMoment(a.last_mes), timestampToMoment(b.last_mes)));
     console.log(data);
@@ -7825,9 +7836,7 @@ async function doDeleteChat() {
 }
 
 async function doGetChatName() {  // `/getchatname` slash command
-    const group = selected_group ? groups.find(x => x.id === selected_group) : null;
-    const currentChat = selected_group ? group?.chat_id : characters[this_chid]['chat'];
-    return currentChat;
+    return getCurrentChatDetails().sessionName;
 }
 
 const isPwaMode = window.navigator.standalone;

--- a/public/script.js
+++ b/public/script.js
@@ -6089,7 +6089,14 @@ export async function getPastCharacterChats(characterId = null) {
     return data;
 }
 
-function getCurrentChatDetails() {  // helper for `displayPastChats`, to make the same info consistently available for other functions
+/**
+ * Helper for `displayPastChats`, to make the same info consistently available for other functions
+ */
+function getCurrentChatDetails() {
+    if (!characters[this_chid] && !selected_group) {
+        return { sessionName: '', group: null, characterName: '', avatarImgURL: '' };
+    }
+
     const group = selected_group ? groups.find(x => x.id === selected_group) : null;
     const currentChat = selected_group ? group?.chat_id : characters[this_chid]['chat'];
     const displayName = selected_group ? group?.name : characters[this_chid].name;
@@ -7835,7 +7842,10 @@ async function doDeleteChat() {
     $('#dialogue_popup_ok').trigger('click', { fromSlashCommand: true });
 }
 
-async function doGetChatName() {  // `/getchatname` slash command
+/**
+ * /getchatname` slash command
+ */
+async function doGetChatName() {
     return getCurrentChatDetails().sessionName;
 }
 
@@ -7990,7 +8000,7 @@ jQuery(async function () {
     registerSlashCommand('api', connectAPISlash, [], `<span class="monospace">(${Object.keys(CONNECT_API_MAP).join(', ')})</span> – connect to an API`, true, true);
     registerSlashCommand('impersonate', doImpersonate, ['imp'], '– calls an impersonation response', true, true);
     registerSlashCommand('delchat', doDeleteChat, [], '– deletes the current chat', true, true);
-    registerSlashCommand('getchatname', doGetChatName, [], '- returns the name of the current chat file into the pipe', false, true);
+    registerSlashCommand('getchatname', doGetChatName, [], '– returns the name of the current chat file into the pipe', false, true);
     registerSlashCommand('closechat', doCloseChat, [], '– closes the current chat', true, true);
     registerSlashCommand('panels', doTogglePanels, ['togglepanels'], '– toggle UI panels on/off', true, true);
     registerSlashCommand('forcesave', doForceSave, [], '– forces a save of the current chat and settings', true, true);

--- a/public/script.js
+++ b/public/script.js
@@ -7990,7 +7990,7 @@ jQuery(async function () {
     registerSlashCommand('api', connectAPISlash, [], `<span class="monospace">(${Object.keys(CONNECT_API_MAP).join(', ')})</span> – connect to an API`, true, true);
     registerSlashCommand('impersonate', doImpersonate, ['imp'], '– calls an impersonation response', true, true);
     registerSlashCommand('delchat', doDeleteChat, [], '– deletes the current chat', true, true);
-    registerSlashCommand('getchatname', doGetChatName, [], '- gets the name of the current chat file', false, true);
+    registerSlashCommand('getchatname', doGetChatName, [], '- returns the name of the current chat file into the pipe', false, true);
     registerSlashCommand('closechat', doCloseChat, [], '– closes the current chat', true, true);
     registerSlashCommand('panels', doTogglePanels, ['togglepanels'], '– toggle UI panels on/off', true, true);
     registerSlashCommand('forcesave', doForceSave, [], '– forces a save of the current chat and settings', true, true);

--- a/public/script.js
+++ b/public/script.js
@@ -7824,6 +7824,12 @@ async function doDeleteChat() {
     $('#dialogue_popup_ok').trigger('click', { fromSlashCommand: true });
 }
 
+async function doGetChatName() {  // `/getchatname` slash command
+    const group = selected_group ? groups.find(x => x.id === selected_group) : null;
+    const currentChat = selected_group ? group?.chat_id : characters[this_chid]['chat'];
+    return currentChat;
+}
+
 const isPwaMode = window.navigator.standalone;
 if (isPwaMode) { $('body').addClass('PWA'); }
 
@@ -7975,6 +7981,7 @@ jQuery(async function () {
     registerSlashCommand('api', connectAPISlash, [], `<span class="monospace">(${Object.keys(CONNECT_API_MAP).join(', ')})</span> – connect to an API`, true, true);
     registerSlashCommand('impersonate', doImpersonate, ['imp'], '– calls an impersonation response', true, true);
     registerSlashCommand('delchat', doDeleteChat, [], '– deletes the current chat', true, true);
+    registerSlashCommand('getchatname', doGetChatName, [], '- gets the name of the current chat file', false, true);
     registerSlashCommand('closechat', doCloseChat, [], '– closes the current chat', true, true);
     registerSlashCommand('panels', doTogglePanels, ['togglepanels'], '– toggle UI panels on/off', true, true);
     registerSlashCommand('forcesave', doForceSave, [], '– forces a save of the current chat and settings', true, true);


### PR DESCRIPTION
Here's a proposed implementation for #1773.

Usage example:

```
/getchatname | /echo {{pipe}}
```

I got the logic to get the chat file name from `displayPastChats`, which was the best candidate from a fragment search for `current chat` in `script.js`. :)
