### PR TITLE
{{model}} substitution to get name of current LLM

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2179,6 +2179,7 @@ function substituteParams(content, _name1, _name2, _original, _group, _replaceCh
     environment.user = _name1 ?? name1;
     environment.char = _name2 ?? name2;
     environment.group = environment.charIfNotGroup = _group ?? name2;
+    environment.model = online_status;
 
     return evaluateMacros(content, environment);
 }

--- a/public/script.js
+++ b/public/script.js
@@ -2179,7 +2179,7 @@ function substituteParams(content, _name1, _name2, _original, _group, _replaceCh
     environment.user = _name1 ?? name1;
     environment.char = _name2 ?? name2;
     environment.group = environment.charIfNotGroup = _group ?? name2;
-    environment.model = online_status;
+    environment.model = getGeneratingModel();
 
     return evaluateMacros(content, environment);
 }


### PR DESCRIPTION
Here's a proposed implementation for #1774.

This is useful in the character card for an AI assistant, especially if you upgrade the LLM at the backend often, and want to be able to ask the AI which one you're running. At least with the Dolphin-Mistral 7B series, as long as this information is in the character card, the LLM reports it reliably. If the information is missing, it will hallucinate.

`{{model}}` gets replaced with:

- The LLM name when connected to a Textgen or Kobold backend,
  - On Textgen, the result is something like `dolphin-2.6-mistral-7b-dpo-laser.Q5_K_M.gguf`
- The tier when connected to a Novel backend,
- "Connected" when connected to a Horde backend, or
- "no_connection" when not connected, regardless of backend.

(See the various `getStatus...` functions in `SillyTavern/public/script.js`.)

Tested with the Textgen backend, but should work with the others too.