### PR TITLE
Extend impersonate/continue/regenerate with possible custom prompts (via slash commands and popup menu)

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7864,9 +7864,9 @@ async function importFromURL(items, files) {
     }
 }
 
-async function doImpersonate() {
+async function doImpersonate(_, prompt) {
     $('#send_textarea').val('');
-    $('#option_impersonate').trigger('click', { fromSlashCommand: true });
+    $('#option_impersonate').trigger('click', { fromSlashCommand: true, additionalPrompt: prompt });
 }
 
 async function doDeleteChat() {
@@ -8682,6 +8682,13 @@ jQuery(async function () {
         const fromSlashCommand = customData?.fromSlashCommand || false;
         var id = $(this).attr('id');
 
+        // Check whether a custom prompt was provided via custom data (for example through a slash command), otherwise fall back and use the text from the textbox, if there is any
+        const additionalPrompt = (customData?.additionalPrompt && customData.additionalPrompt.trim()) || (String($('#send_textarea').val()).trim() || undefined);
+        const buildOrFillAdditionalArgs = (args = {}) => ({
+            ...args,
+            ...(additionalPrompt !== undefined && { quiet_prompt: additionalPrompt, quietToLoud: true }),
+        });
+
         if (id == 'option_select_chat') {
             if ((selected_group && !is_group_generating) || (this_chid !== undefined && !is_send_press) || fromSlashCommand) {
                 await displayPastChats();
@@ -8717,7 +8724,7 @@ jQuery(async function () {
                 }
                 else {
                     is_send_press = true;
-                    Generate('regenerate');
+                    Generate('regenerate', buildOrFillAdditionalArgs());
                 }
             }
         }
@@ -8725,14 +8732,14 @@ jQuery(async function () {
         else if (id == 'option_impersonate') {
             if (is_send_press == false || fromSlashCommand) {
                 is_send_press = true;
-                Generate('impersonate');
+                Generate('impersonate', buildOrFillAdditionalArgs());
             }
         }
 
         else if (id == 'option_continue') {
             if (is_send_press == false || fromSlashCommand) {
                 is_send_press = true;
-                Generate('continue');
+                Generate('continue', buildOrFillAdditionalArgs());
             }
         }
 

--- a/public/script.js
+++ b/public/script.js
@@ -8682,8 +8682,8 @@ jQuery(async function () {
         const fromSlashCommand = customData?.fromSlashCommand || false;
         var id = $(this).attr('id');
 
-        // Check whether a custom prompt was provided via custom data (for example through a slash command), otherwise fall back and use the text from the textbox, if there is any
-        const additionalPrompt = (customData?.additionalPrompt && customData.additionalPrompt.trim()) || (String($('#send_textarea').val()).trim() || undefined);
+        // Check whether a custom prompt was provided via custom data (for example through a slash command)
+        const additionalPrompt = customData?.additionalPrompt?.trim() || undefined;
         const buildOrFillAdditionalArgs = (args = {}) => ({
             ...args,
             ...(additionalPrompt !== undefined && { quiet_prompt: additionalPrompt, quietToLoud: true }),

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1168,7 +1168,7 @@ async function openChat(id) {
     await reloadCurrentChat();
 }
 
-function continueChatCallback() {
+function continueChatCallback(_, prompt) {
     setTimeout(async () => {
         try {
             await waitUntilCondition(() => !is_send_press && !is_group_generating, 10000, 100);
@@ -1179,7 +1179,7 @@ function continueChatCallback() {
 
         // Prevent infinite recursion
         $('#send_textarea').val('').trigger('input');
-        $('#option_continue').trigger('click', { fromSlashCommand: true });
+        $('#option_continue').trigger('click', { fromSlashCommand: true, additionalPrompt: prompt });
     }, 1);
 
     return '';


### PR DESCRIPTION
- Use custom prompt provided via slash command arguments (similar to /sysgen and others)
- Use written text from textbox, if the popout menu actions are clicked

This is a simple addition. I was already expecting this to work by default with how I'd expect the commands to work, especially the impersonate one.  
Not many changes were needed for this though.

Didn't really rewrite much, as the functionality for quiet to loud prompting was already there, and all the heavy lifting for impersonate to go into textbox, swiping to do another swipe card etc was already there. It's basically just going to add the given additional prompt as a "system message", like `/sysgen` does.  
I did not verify how the final prompt for the model looks, as I do not understand yet how the prompting deep down there works, but I figured this should still be consistent with all the other commands.