### PR TITLE
Display TranslateProvider link

### DIFF
--- a/public/scripts/extensions/translate/index.js
+++ b/public/scripts/extensions/translate/index.js
@@ -598,13 +598,18 @@ jQuery(() => {
             'deeplx': 'http://127.0.0.1:1188/translate',
         };
         const popupText = `<h3>${optionText} API URL</h3><i>Example: <tt>${String(exampleURLs[extension_settings.translate.provider])}</tt></i>`;
-        const url = await callPopup(popupText, 'input');
 
+        const provider_name = extension_settings.translate.provider + '_url'
+        const saved_url     = ( Boolean(secret_state[provider_name]) ) ? await findSecret(provider_name) : '';
+
+        const url = await callPopup(popupText, 'input', saved_url);
+        
         if (url == false) {
             return;
         }
+        
+        await writeSecret(provider_name, url);
 
-        await writeSecret(extension_settings.translate.provider + '_url', url);
         toastr.success('API URL saved');
         $('#translate_url_button').addClass('success');
     });

--- a/public/scripts/extensions/translate/index.js
+++ b/public/scripts/extensions/translate/index.js
@@ -11,7 +11,7 @@ import {
     updateMessageBlock,
 } from '../../../script.js';
 import { extension_settings, getContext } from '../../extensions.js';
-import { secret_state, writeSecret } from '../../secrets.js';
+import { findSecret, secret_state, writeSecret } from '../../secrets.js';
 import { splitRecursive } from '../../utils.js';
 
 export const autoModeOptions = {
@@ -599,16 +599,16 @@ jQuery(() => {
         };
         const popupText = `<h3>${optionText} API URL</h3><i>Example: <tt>${String(exampleURLs[extension_settings.translate.provider])}</tt></i>`;
 
-        const provider_name = extension_settings.translate.provider + '_url'
-        const saved_url     = ( Boolean(secret_state[provider_name]) ) ? await findSecret(provider_name) : '';
+        const secretKey = extension_settings.translate.provider + '_url';
+        const savedUrl = secret_state[secretKey] ? await findSecret(secretKey) : '';
 
-        const url = await callPopup(popupText, 'input', saved_url);
-        
-        if (url == false) {
+        const url = await callPopup(popupText, 'input', savedUrl);
+
+        if (url == false || url == '') {
             return;
         }
-        
-        await writeSecret(provider_name, url);
+
+        await writeSecret(secretKey, url);
 
         toastr.success('API URL saved');
         $('#translate_url_button').addClass('success');

--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -124,6 +124,11 @@ export async function readSecretState() {
     }
 }
 
+/**
+ * Finds a secret value by key.
+ * @param {string} key Secret key
+ * @returns {Promise<string | undefined>} Secret value, or undefined if keys are not exposed
+ */
 export async function findSecret(key) {
     try {
         const response = await fetch('/api/secrets/find', {

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -213,12 +213,13 @@ router.post('/view', jsonParser, async (_, response) => {
 router.post('/find', jsonParser, (request, response) => {
     const allowKeysExposure = getConfigValue('allowKeysExposure', false);
 
-    if (!allowKeysExposure) {
+    const key = request.body.key;
+    
+    if (!allowKeysExposure && key.slice(key.length-4) !== '_url' ) {
         console.error('Cannot fetch secrets unless allowKeysExposure in config.yaml is set to true');
         return response.sendStatus(403);
     }
 
-    const key = request.body.key;
 
     try {
         const secret = readSecret(key);

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -32,6 +32,14 @@ const SECRET_KEYS = {
     OOBA: 'api_key_ooba',
 };
 
+// These are the keys that are safe to expose, even if allowKeysExposure is false
+const EXPORTABLE_KEYS = [
+    SECRET_KEYS.LIBRE_URL,
+    SECRET_KEYS.LINGVA_URL,
+    SECRET_KEYS.ONERING_URL,
+    SECRET_KEYS.DEEPLX_URL,
+];
+
 /**
  * Writes a secret to the secrets file
  * @param {string} key Secret key
@@ -212,14 +220,12 @@ router.post('/view', jsonParser, async (_, response) => {
 
 router.post('/find', jsonParser, (request, response) => {
     const allowKeysExposure = getConfigValue('allowKeysExposure', false);
-
     const key = request.body.key;
-    
-    if (!allowKeysExposure && key.slice(key.length-4) !== '_url' ) {
+
+    if (!allowKeysExposure && !EXPORTABLE_KEYS.includes(key)) {
         console.error('Cannot fetch secrets unless allowKeysExposure in config.yaml is set to true');
         return response.sendStatus(403);
     }
-
 
     try {
         const secret = readSecret(key);


### PR DESCRIPTION
This patch will display the saved url from secrets.json in the input field of the modal with TranslateProvider. I made an exception for variables ending with '_url' to separate them from api_key. It seems like this shouldn't compromise the system's security.