### PR TITLE
Sampler order for llama.cpp server backend

### DIFF
--- a/default/settings.json
+++ b/default/settings.json
@@ -61,6 +61,14 @@
             "min_p",
             "mirostat"
         ],
+        "samplers": [
+            "top_k",
+            "tfs_z",
+            "typical_p",
+            "top_p",
+            "min_p",
+            "temperature"
+        ],
         "mirostat_mode": 0,
         "mirostat_tau": 5,
         "mirostat_eta": 0.1,

--- a/public/index.html
+++ b/public/index.html
@@ -1550,6 +1550,27 @@
                                             <span data-i18n="Load default order">Load default order</span>
                                         </div>
                                     </div>
+                                    <div data-newbie-hidden data-tg-type="llamacpp" class="range-block flexFlowColumn wide100p">
+                                        <hr class="wide100p">
+                                        <h4 class="range-block-title justifyCenter">
+                                            <span data-i18n="Samplers Order">Samplers Order</span>
+                                            <div class="margin5 fa-solid fa-circle-info opacity50p" title="llama.cpp only. Determines the order of samplers. If Mirostat mode is not 0, sampler order is ignored."></div>
+                                        </h4>
+                                        <div class="toggle-description widthUnset" data-i18n="llama.cpp only. Determines the order of samplers. If Mirostat mode is not 0, sampler order is ignored.">
+                                            llama.cpp only. Determines the order of samplers. If Mirostat mode is not 0, sampler order is ignored.
+                                        </div>
+                                        <div id="llamacpp_samplers_sortable" class="prompt_order">
+                                            <div data-name="temperature" draggable="true"><span>Temperature</span><small></small></div>
+                                            <div data-name="top_k" draggable="true"><span>Top K</span><small></small></div>
+                                            <div data-name="top_p" draggable="true"><span>Top P</span><small></small></div>
+                                            <div data-name="typical_p" draggable="true"><span>Typical P</span><small></small></div>
+                                            <div data-name="tfs_z" draggable="true"><span>Tail Free Sampling</span><small></small></div>
+                                            <div data-name="min_p" draggable="true"><span>Min P</span><small></small></div>
+                                        </div>
+                                        <div id="llamacpp_samplers_default_order" class="menu_button menu_button_icon">
+                                            <span data-i18n="Load default order">Load default order</span>
+                                        </div>
+                                    </div>
                                     <div data-newbie-hidden data-tg-type="ooba" class="range-block flexFlowColumn wide100p">
                                         <hr class="wide100p">
                                         <h4 class="range-block-title justifyCenter">

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -636,7 +636,7 @@ jQuery(function () {
         for (const [id, value] of Object.entries(inputs)) {
             const inputElement = $(`#${id}`);
             if (inputElement.prop('type') === 'checkbox') {
-                inputElement.prop('checked', value);
+                inputElement.prop('checked', value).trigger('input');
             } else if (inputElement.prop('type') === 'number') {
                 inputElement.val(value).trigger('input');
             } else {

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -34,6 +34,14 @@ export const textgen_types = {
 };
 
 const { MANCER, APHRODITE, TABBY, TOGETHERAI, OOBA, OLLAMA, LLAMACPP } = textgen_types;
+const LLAMACPP_DEFAULT_ORDER = [
+    'top_k',
+    'tfs_z',
+    'typical_p',
+    'top_p',
+    'min_p',
+    'temperature',
+];
 const OOBA_DEFAULT_ORDER = [
     'temperature',
     'dynamic_temperature',
@@ -111,6 +119,7 @@ const settings = {
     grammar_string: '',
     banned_tokens: '',
     sampler_priority: OOBA_DEFAULT_ORDER,
+    samplers: LLAMACPP_DEFAULT_ORDER,
     //n_aphrodite: 1,
     //best_of_aphrodite: 1,
     ignore_eos_token_aphrodite: false,
@@ -186,6 +195,7 @@ const setting_names = [
     //'prompt_log_probs_aphrodite'
     'sampler_order',
     'sampler_priority',
+    'samplers',
     'n',
     'logit_bias',
     'custom_model',
@@ -449,6 +459,16 @@ function sortKoboldItemsByOrder(orderArray) {
     }
 }
 
+function sortLlamacppItemsByOrder(orderArray) {
+    console.debug('Preset samplers order: ', orderArray);
+    const $container = $('#llamacpp_samplers_sortable');
+
+    orderArray.forEach((name) => {
+        const $item = $container.find(`[data-name="${name}"]`).detach();
+        $container.append($item);
+    });
+}
+
 function sortOobaItemsByOrder(orderArray) {
     console.debug('Preset samplers order: ', orderArray);
     const $container = $('#sampler_priority_container');
@@ -476,6 +496,26 @@ jQuery(function () {
     $('#koboldcpp_default_order').on('click', function () {
         settings.sampler_order = KOBOLDCPP_ORDER;
         sortKoboldItemsByOrder(settings.sampler_order);
+        saveSettingsDebounced();
+    });
+
+    $('#llamacpp_samplers_sortable').sortable({
+        delay: getSortableDelay(),
+        stop: function () {
+            const order = [];
+            $('#llamacpp_samplers_sortable').children().each(function () {
+                order.push($(this).data('name'));
+            });
+            settings.samplers = order;
+            console.log('Samplers reordered:', settings.samplers);
+            saveSettingsDebounced();
+        },
+    });
+
+    $('#llamacpp_samplers_default_order').on('click', function () {
+        sortLlamacppItemsByOrder(LLAMACPP_DEFAULT_ORDER);
+        settings.samplers = LLAMACPP_DEFAULT_ORDER;
+        console.log('Default samplers order loaded:', settings.samplers);
         saveSettingsDebounced();
     });
 
@@ -671,6 +711,13 @@ function setSettingByName(setting, value, trigger) {
         value = Array.isArray(value) ? value : OOBA_DEFAULT_ORDER;
         sortOobaItemsByOrder(value);
         settings.sampler_priority = value;
+        return;
+    }
+
+    if ('samplers' === setting) {
+        value = Array.isArray(value) ? value : LLAMACPP_DEFAULT_ORDER;
+        sortLlamacppItemsByOrder(value);
+        settings.samplers = value;
         return;
     }
 
@@ -882,6 +929,7 @@ export function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, 
         'dynatemp_exponent': settings.dynatemp ? settings.dynatemp_exponent : 1,
         'smoothing_factor': settings.smoothing_factor,
         'sampler_priority': settings.type === OOBA ? settings.sampler_priority : undefined,
+        'samplers': settings.type === LLAMACPP ? settings.samplers : undefined,
         'stopping_strings': getStoppingStrings(isImpersonate, isContinue),
         'stop': getStoppingStrings(isImpersonate, isContinue),
         'truncation_length': max_context,


### PR DESCRIPTION
Borrowing heavily from #1811, this PR adds sampler order support for the llama.cpp text completion backend.

Available parameters and their default order were taken from [llama.cpp server's README](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md).

When Mirostat mode is set to anything other than 0, the [sampler queue is ignored](https://github.com/ggerganov/llama.cpp/blob/fd43d66f46ee3b5345fb8a74a252d86ccd34a409/common/sampling.cpp#L243), so this behaviour is noted in the UI for clarity.

![Screenshot 2024-02-23 at 23 22 01](https://github.com/SillyTavern/SillyTavern/assets/1689220/825ceec6-5098-4e80-8aa1-18b39eafb812)
