### PR TITLE
Parse macros when updating message

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6014,7 +6014,7 @@ function openMessageDelete(fromSlashCommand) {
 }
 
 function messageEditAuto(div) {
-    const { mesBlock, text, mes } = updateMessage(div);
+    const { mesBlock, text, mes, bias } = updateMessage(div);
 
     mesBlock.find('.mes_text').val('');
     mesBlock.find('.mes_text').val(messageFormatting(
@@ -6024,6 +6024,8 @@ function messageEditAuto(div) {
         mes.is_user,
         this_edit_mes_id,
     ));
+    mesBlock.find('.mes_bias').empty();
+    mesBlock.find('.mes_bias').append(messageFormatting(bias, '', false, false, -1));
     saveChatDebounced();
 }
 

--- a/public/script.js
+++ b/public/script.js
@@ -5967,7 +5967,11 @@ function updateMessage(div) {
         text = text.trim();
     }
 
-    const bias = extractMessageBias(text);
+    const bias = substituteParams(extractMessageBias(text));
+    text = substituteParams(text);
+    if (bias) {
+        text = removeMacros(text);
+    }
     mes['mes'] = text;
     if (mes['swipe_id'] !== undefined) {
         mes['swipes'][mes['swipe_id']] = text;


### PR DESCRIPTION
Macro substitution is not being performed when a message is edited, resulting in 3 problems:

1. Prompt bias string was not removed from the text of the edited message.
2. Macro substitition was not performed in the prompt bias string.
3. Macro substitution was not performed in the edited message text.

The following are samples of text sent to the completion API after editing a message, where the contents of the edit message textarea contained macros.

Before this PR:
```
### Input:
Say {{char}}, what do you think of pudding? {{bias "What a strange question, {{user}}"}}
### Response:
 What a strange question, Deci
```

After this PR:

```
### Input:
Say Val, what do you think of pudding?
### Response:
 What a strange question, Deci\n
```

Even though the response portion was correctly prepended with the bias string in both cases, the input portion contained raw macro strings.