### PR TITLE
Fragment search (a.k.a. swoop) for Manage chat files

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6270,6 +6270,14 @@ export async function displayPastChats() {
         const searchQuery = $(this).val();
         debouncedDisplay(searchQuery);
     });
+
+    // UX convenience: Focus the search field when the Manage Chat Files view opens.
+    setTimeout(function () {
+        const textSearchElement = $('#select_chat_search');
+        textSearchElement.click();
+        textSearchElement.focus();
+        textSearchElement.select();  // select content (if any) for easy erasing
+    }, 200);
 }
 
 function selectRightMenuWithAnimation(selectedMenuId) {


### PR DESCRIPTION
This PR implements #1797 in a minimal way.

In the *Manage chat files* view:

- The search field is now a *fragment search* a.k.a. swoop.
  - The search query consists of whitespace-separated strings, called *fragments*. The search ANDs them, i.e. all fragments must match. The ordering of the fragments in the query doesn't matter. E.g. the query `frag mat que` would find this line, and this line only.
  - For a chat file to match, all fragments must be present in the same message.
- UX: When the view opens, auto-focus the search field.

I shortened the implementation a bit by using `Array.every`. If we want to save one more line, we could drop the braces around the body of the empty-text check.

@Cohee1207: Opinion, please?