### PR TITLE
Fix broken avatar thumbnail upon deleting last member of a group

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -598,6 +598,11 @@ function getGroupAvatar(group) {
         return groupAvatar;
     }
 
+    // catch edge case where group had one member and that member is deleted
+    if (avatarCount === 0) {
+        return $('<div class="missing-avatar fa-solid fa-user-slash"></div>');
+    }
+
     // default avatar
     const groupAvatar = $('#group_avatars_template .collage_1').clone();
     groupAvatar.find('.img_1').attr('src', group.avatar_url || system_avatar);


### PR DESCRIPTION
Deleting a character from ST when they're the last character in a group will result in the group's thumbnail breaking and showing a default missing image icon. This fixes this by properly returning the missing avatar icon used elsewhere.