### PR TITLE
Link to character's source page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3990,6 +3990,9 @@
                                                     <option id="renameCharButton" data-i18n="Rename">
                                                         Rename
                                                     </option>
+                                                    <option id="character_source" data-i18n="Link to Source">
+                                                        Link to Source
+                                                    </option>
                                                     <!--<option id="dupe_button">
                                                             Duplicate
                                                         </option>

--- a/public/script.js
+++ b/public/script.js
@@ -6478,6 +6478,13 @@ export function select_selected_character(chid) {
     setWorldInfoButtonClass(chid);
     checkEmbeddedWorld(chid);
 
+    // Disable or enable Link to Source dropdown menu item depending on the presence of 'full_path' property
+    $('#character_source').prop( "disabled", true );
+    const chidSourceData = Object.values(characters[this_chid].data.extensions)
+    Object.entries(chidSourceData).forEach(function([key, value]) {
+        if (Object.keys(value).includes('full_path')) $('#character_source').prop( "disabled", false );
+    });
+    
     $('#form_create').attr('actiontype', 'editcharacter');
     $('.form_create_bottom_buttons_block .chat_lorebook_button').show();
     saveSettingsDebounced();
@@ -9806,6 +9813,22 @@ jQuery(async function () {
                 await importEmbeddedWorldInfo();
                 saveCharacterDebounced();
                 break;
+            case 'character_source':
+                const chidSourceData = characters[this_chid].data.extensions
+                switch(true) {
+                    case Object.hasOwn(chidSourceData, 'chub') :
+                        window.open('https://chub.ai/characters/' + chidSourceData.chub.full_path, '_blank');
+                        break;
+                    case Object.hasOwn(chidSourceData, 'janitorai') : // not implemented yet
+                        window.open('https://janitorai.com/characters/' + chidSourceData.janitorai.full_path, '_blank');
+                        break;
+                    case Object.hasOwn(chidSourceData, 'pygmalion') : // not implemented yet
+                        window.open('https://pygmalion.chat/character/' + chidSourceData.pygmalion.full_path, '_blank');
+                        break;
+                    default: toastr.info("This character doesn't seem to have a source.");
+                }
+                break;
+                
             /*case 'delete_button':
                 popup_type = "del_ch";
                 callPopup(`


### PR DESCRIPTION
Added a dropdown menu item to go to the original character page. Works only with characters from chub.ai, as other providers do not export such properties.
<img width="285" alt="Screenshot 2024-03-02 at 23 23 14" src="https://github.com/SillyTavern/SillyTavern/assets/33601955/a72e833a-0ee7-4e48-b402-908fe335e13c">
