### PR TITLE
Import PygmalionAI/JanitorAI/Chub Bots via UUID

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9972,10 +9972,10 @@ jQuery(async function () {
         const html = `<h3>Enter the URL of the content to import</h3>
         Supported sources:<br>
         <ul class="justifyLeft">
-            <li>Chub characters (direct link or id)<br>Example: <tt>Anonymous/example-character</tt></li>
-            <li>Chub lorebooks (direct link or id)<br>Example: <tt>lorebooks/bartleby/example-lorebook</tt></li>
-            <li>JanitorAI character (direct link or id)<br>Example: <tt>https://janitorai.com/characters/ddd1498a-a370-4136-b138-a8cd9461fdfe_character-aqua-the-useless-goddess</tt></li>
-            <li>Pygmalion.chat character (link)<br>Example: <tt>https://pygmalion.chat/character/a7ca95a1-0c88-4e23-91b3-149db1e78ab9</tt></li>
+            <li>Chub Character (Direct Link or ID)<br>Example: <tt>Anonymous/example-character</tt></li>
+            <li>Chub Lorebook (Direct Link or ID)<br>Example: <tt>lorebooks/bartleby/example-lorebook</tt></li>
+            <li>JanitorAI Character (Direct Link or UUID)<br>Example: <tt>ddd1498a-a370-4136-b138-a8cd9461fdfe_character-aqua-the-useless-goddess</tt></li>
+            <li>Pygmalion.chat Character (Direct Link or UUID)<br>Example: <tt>a7ca95a1-0c88-4e23-91b3-149db1e78ab9</tt></li>
             <li>More coming soon...</li>
         <ul>`;
         const input = await callPopup(html, 'input', '', { okButton: 'Import', rows: 4 });
@@ -9986,13 +9986,23 @@ jQuery(async function () {
         }
 
         const url = input.trim();
-        console.debug('Custom content import started', url);
+        var request;
 
-        const request = await fetch('/api/content/import', {
-            method: 'POST',
-            headers: getRequestHeaders(),
-            body: JSON.stringify({ url }),
-        });
+        if (url.includes("https")) {
+            console.debug('Custom content import started for URL: ', url);
+            request = await fetch('/api/content/importURL', {
+                method: 'POST',
+                headers: getRequestHeaders(),
+                body: JSON.stringify({ url }),
+            });
+        } else {
+            console.debug('Custom content import started for Char UUID: ', url);
+            request = await fetch('/api/content/importUUID', {
+                method: 'POST',
+                headers: getRequestHeaders(),
+                body: JSON.stringify({ url }),
+            });
+        }
 
         if (!request.ok) {
             toastr.info(request.statusText, 'Custom content import failed');

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -357,7 +357,7 @@ function getUuidFromUrl(url) {
 
 const router = express.Router();
 
-router.post('/import', jsonParser, async (request, response) => {
+router.post('/importURL', jsonParser, async (request, response) => {
     if (!request.body.url) {
         return response.sendStatus(400);
     }
@@ -406,6 +406,50 @@ router.post('/import', jsonParser, async (request, response) => {
         if (result.fileType) response.set('Content-Type', result.fileType);
         response.set('Content-Disposition', `attachment; filename="${result.fileName}"`);
         response.set('X-Custom-Content-Type', type);
+        return response.send(result.buffer);
+    } catch (error) {
+        console.log('Importing custom content failed', error);
+        return response.sendStatus(500);
+    }
+});
+
+router.post('/importUUID', jsonParser, async (request, response) => {
+    if (!request.body.url) {
+        return response.sendStatus(400);
+    }
+
+    try {
+        const uuid = request.body.url;
+        let result;
+
+        const isJannny = uuid.includes("_character")
+        const isPygmalion = (!isJannny && uuid.length == 36)
+        const uuidType = uuid.includes("lorebook") ? "lorebook" : "character";
+
+        if (isPygmalion) {
+            console.debug("We have a Pyg character")
+            result = await downloadPygmalionCharacter(uuid);
+        } else if (isJannny) {
+            console.debug("We have a Janny character")
+            result = await downloadJannyCharacter(uuid.split("_")[0]);
+        } else {
+            console.debug("We have something from Chub?")
+            if (uuidType === 'character') {
+                console.log('Downloading chub character:', uuid);
+                result = await downloadChubCharacter(uuid);
+            }
+            else if (uuidType === 'lorebook') {
+                console.log('Downloading chub lorebook:', uuid);
+                result = await downloadChubLorebook(uuid);
+            }
+            else {
+                return response.sendStatus(404);
+            }
+        }
+
+        if (result.fileType) response.set('Content-Type', result.fileType);
+        response.set('Content-Disposition', `attachment; filename="${result.fileName}"`);
+        response.set('X-Custom-Content-Type', uuidType);
         return response.send(result.buffer);
     } catch (error) {
         console.log('Importing custom content failed', error);


### PR DESCRIPTION
This PR does the following:
- Adds `/api/content/importUUID` API to import bots to SillyTavern from PygmalionAI, JanitorAI, and Chub
> This feature also includes Chub Lorebooks albeit with `lorebook/` still being present.
- Renamed `/api/content/import` as `api/content/importURL` to differ between URL and UUID import code.
- Update Import HTML Text