### PR TITLE
Fix Claude 3 inline images when "Add Character Names" setting is enabled

### DIFF
--- a/src/endpoints/prompt-converters.js
+++ b/src/endpoints/prompt-converters.js
@@ -159,7 +159,6 @@ function convertClaudeMessages(messages, prefillString, useSysPrompt, humanMsgFi
                     content[i].text = `${message.name}: ${content[i].text}`;
                 }
             }
-            console.log(message.content);
             delete message.name;
         }
     });

--- a/src/endpoints/prompt-converters.js
+++ b/src/endpoints/prompt-converters.js
@@ -151,13 +151,10 @@ function convertClaudeMessages(messages, prefillString, useSysPrompt, humanMsgFi
     // Take care of name properties since claude messages don't support them
     mergedMessages.forEach((message) => {
         if (message.name) {
-            const content = Array.isArray(message.content) ? message.content : [message.content];
-            for (let i = 0; i < content.length; i++) {
-                if (typeof content[i] === 'string') {
-                    content[i] = `${message.name}: ${content[i]}`;
-                } else if (typeof content[i].text === 'string') {
-                    content[i].text = `${message.name}: ${content[i].text}`;
-                }
+            if (Array.isArray(message.content)) {
+                message.content[0].text = `${message.name}: ${message.content[0].text}`;
+            } else {
+                message.content = `${message.name}: ${message.content}`;
             }
             delete message.name;
         }

--- a/src/endpoints/prompt-converters.js
+++ b/src/endpoints/prompt-converters.js
@@ -151,7 +151,15 @@ function convertClaudeMessages(messages, prefillString, useSysPrompt, humanMsgFi
     // Take care of name properties since claude messages don't support them
     mergedMessages.forEach((message) => {
         if (message.name) {
-            message.content = `${message.name}: ${message.content}`;
+            const content = Array.isArray(message.content) ? message.content : [message.content];
+            for (let i = 0; i < content.length; i++) {
+                if (typeof content[i] === 'string') {
+                    content[i] = `${message.name}: ${content[i]}`;
+                } else if (typeof content[i].text === 'string') {
+                    content[i].text = `${message.name}: ${content[i].text}`;
+                }
+            }
+            console.log(message.content);
             delete message.name;
         }
     });


### PR DESCRIPTION
When using Claude 3, if "Send inline images" is selected along with "Add character names" in the chat completion preset's settings, any attached images in the chat log are incorrectly coerced to a string by the code in `prompt-converters` which attempts to prepend names onto each message.

Accordingly, you end up with results like:
```javascript
{
  role: 'user',
  content: 'Khanon: [object Object],[object Object]'
}
```

This PR adjusts the logic to only prepend names to string `content`, or to `content` elements with type `text`.
This means you now get:
```javascript
{ 
  role: 'user',
  content: [
    { type: "text", text: "Khanon: What do you think about this image?" },
    { type: "image", source: { ... } },
    { type: "text", text: "Khanon: Cute huh" },
  ]
}
```
The name is prepended to each text block. I could modify it to only prepend to the first but I didn't observe any meaningful difference between the approaches.