### PR TITLE
clarified placeholder comfyui text

### DIFF
--- a/public/scripts/extensions/stable-diffusion/comfyWorkflowEditor.html
+++ b/public/scripts/extensions/stable-diffusion/comfyWorkflowEditor.html
@@ -4,7 +4,7 @@
         <div class="sd_comfy_workflow_editor_content">
             <div class="flex-container flexFlowColumn sd_comfy_workflow_editor_workflow_container">
                 <label for="sd_comfy_workflow_editor_workflow">Workflow (JSON)</label>
-                <textarea id="sd_comfy_workflow_editor_workflow" class="text_pole wide100p textarea_compact flex1" placeholder="Put the ComfyUI's workflow (JSON) here and replace the variable settings with placeholders."></textarea>
+                <textarea id="sd_comfy_workflow_editor_workflow" class="text_pole wide100p textarea_compact flex1" placeholder="Insert your ComfyUI workflow here by copying the JSON data obtained via the 'Save (API Format)' option. This option becomes available after enabling 'Dev Mode' in the settings. Remember to replace specific values within your workflow with placeholders as required for your use case."></textarea>
             </div>
             <div class="sd_comfy_workflow_editor_placeholder_container">
                 <div>Placeholders</div>


### PR DESCRIPTION
The existing placeholder text when creating a new ComfyUI workflow for sillytavern is misleading. It simply states that the JSON needs to be added, but the typical JSON wont work. It needs to be the JSON obtained from the special save API JSON that is only accessible if the dev mode options are activated. This placeholder text .

Here is one website that talks more about this special API save button, where you have to get the JSON: https://9elements.com/blog/hosting-a-comfyui-workflow-via-api