### PR TITLE
Prevent presets without a max context/response value from unchecking unlocked context

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5951,7 +5951,7 @@ async function saveSettings(type) {
 }
 
 export function setGenerationParamsFromPreset(preset) {
-    const needsUnlock = preset.max_length > MAX_CONTEXT_DEFAULT || preset.genamt > MAX_RESPONSE_DEFAULT;
+    const needsUnlock = (preset.max_length ?? max_context) > MAX_CONTEXT_DEFAULT || (preset.genamt ?? amount_gen) > MAX_RESPONSE_DEFAULT;
     $('#max_context_unlocked').prop('checked', needsUnlock).trigger('change');
 
     if (preset.genamt !== undefined) {


### PR DESCRIPTION
Note: Such presets can still uncheck it if both `max_context` and `amount_gen` are already below the thresholds. Not sure whether that case should be covered too.