### PR TITLE
Add tip to AllTalk endpoint field.

### DIFF
--- a/public/scripts/extensions/tts/alltalk.js
+++ b/public/scripts/extensions/tts/alltalk.js
@@ -120,10 +120,14 @@ class AllTalkTtsProvider {
             <option value="xttsv2_local">XTTSv2 Local</option>
         </select>
         </div>
+        </div>
+
+        <div class="at-model-endpoint-row">
 
         <div class="at-endpoint-option">
             <label for="at_server">AllTalk Endpoint:</label>
             <input id="at_server" type="text" class="text_pole" maxlength="80" value="${this.settings.provider_endpoint}"/>
+            <i><b>Important:</b> Must match IP address & port in AllTalk settings.</i>
         </div>
    </div>`;
 


### PR DESCRIPTION
It isn't totally clear what the user should set the IP address when they're on a network.

In AllTalk, right in the config (which you can modify from the settings page,, you specify the IP address. You can set it to anything you want, even things that won't work (eg. 'foo'), but in my case, I had to set it to the IP address that the AllTalk machine was assigned on the network, if I wanted it to work on the network. The default of 127.0.0.1 would only work if you were trying to use it on the local machine.

I happen to be using zero tier one as my networking solution, so I can access SillyTavern on the road using my android, or any other device in my zero tier one network.

Now that I set AllTalk to the IP address assigned to the machine by Zero Tier One, AllTalk will be responsive when it's API is used remotely by SillyTavern, using the right address.

I also broke out the endpoint field into it's own row, so the note would fit better.