### PR TITLE
Extend update batch script for forks and branches

### DIFF
--- a/Update-Instructions.txt
+++ b/Update-Instructions.txt
@@ -22,6 +22,9 @@ You can also try running the 'UpdateAndStart.bat' file, which will almost do the
 Alternatively, if the command prompt gives you problems (and you have GitHub Desktop installed), you can use the 'Repository' menu and select 'Pull'.
 The updates are applied automatically and safely.
 
+If you are a developer and use a fork of ST or switch branches regularly, you can use the 'UpdateForkAndStart.bat', which works similarly to 'UpdateAndStart.bat',
+but automatically pulls changes into your fork and handles switched branches gracefully by asking if you want to switch back.
+
 Method 2 - ZIP
 
 If you insist on installing via a zip, here is the tedious process for doing the update:

--- a/UpdateForkAndStart.bat
+++ b/UpdateForkAndStart.bat
@@ -1,0 +1,103 @@
+@echo off
+@setlocal enabledelayedexpansion
+pushd %~dp0
+
+echo Checking Git installation
+git --version > nul 2>&1
+if %errorlevel% neq 0 (
+    echo Git is not installed on this system. Skipping update.
+    echo If you installed with a zip file, you will need to download the new zip and install it manually.
+    goto end
+)
+
+REM Checking current branch
+FOR /F "tokens=*" %%i IN ('git rev-parse --abbrev-ref HEAD') DO SET CURRENT_BRANCH=%%i
+echo Current branch: %CURRENT_BRANCH%
+
+REM Checking for automatic branch switching configuration
+set AUTO_SWITCH=
+FOR /F "tokens=*" %%j IN ('git config --local script.autoSwitch') DO SET AUTO_SWITCH=%%j
+
+SET TARGET_BRANCH=%CURRENT_BRANCH%
+
+if NOT "!AUTO_SWITCH!"=="" (
+    if "!AUTO_SWITCH!"=="s" (
+        goto autoswitch-staging
+    )
+    if "!AUTO_SWITCH!"=="r" (
+        goto autoswitch-release
+    )
+
+    if "!AUTO_SWITCH!"=="staging" (
+        :autoswitch-staging
+        echo Auto-switching to staging branch
+        git checkout staging
+        SET TARGET_BRANCH=staging
+        goto update
+    )
+    if "!AUTO_SWITCH!"=="release" (
+        :autoswitch-release
+        echo Auto-switching to release branch
+        git checkout release
+        SET TARGET_BRANCH=release
+        goto update
+    )
+    
+    echo Auto-switching defined to stay on current branch
+    goto update
+)
+
+if "!CURRENT_BRANCH!"=="staging" (
+    echo Staying on the current branch
+    goto update
+)
+if "!CURRENT_BRANCH!"=="release" (
+    echo Staying on the current branch
+    goto update
+)
+
+echo You are not on 'staging' or 'release'. You are on '!CURRENT_BRANCH!'.
+set /p "CHOICE=Do you want to switch to 'staging' (s), 'release' (r), or stay (any other key)? "
+if /i "!CHOICE!"=="s" (
+    echo Switching to staging branch
+    git checkout staging
+    SET TARGET_BRANCH=staging
+    goto update
+)
+if /i "!CHOICE!"=="r" (
+    echo Switching to release branch
+    git checkout release
+    SET TARGET_BRANCH=release
+    goto update
+)
+
+echo Staying on the current branch
+
+:update
+REM Checking for 'upstream' remote
+git remote | findstr "upstream" > nul
+if %errorlevel% equ 0 (
+    echo Updating and rebasing against 'upstream'
+    git fetch upstream
+    git rebase upstream/%TARGET_BRANCH% --autostash
+    goto install
+)
+
+echo Updating and rebasing against 'origin'
+git pull --rebase --autostash origin %TARGET_BRANCH%
+
+
+:install
+if %errorlevel% neq 0 (
+    echo There were errors while updating. Please check manually.
+    goto end
+)
+
+echo Installing npm packages and starting server
+set NODE_ENV=production
+call npm install --no-audit --no-fund --quiet --omit=dev
+node server.js %*
+
+:end
+pause
+popd


### PR DESCRIPTION
This started out mostly for me locally. Then I thought others might profit from this as well.  
I couldn't really use the `UpdateAndStart.bat` because it was rebasing on the branch name - which for forks is the one that is in my repo, and doesn't contain the latest changes unless I rebase that one with `upstream`.

So I rewrote the script. What it is in its base state the same as it was before. There are just a few more additional checks, options and failsaves
1. Rebase on `upstream` if this is a fork, not just on `origin`. (Does not automatically push yet if upstream, though maybe that would make sense)
3. Check if branch is not staging or release and ask user to switch
4. Local setting `script.autoSwitch` for automatic branch switching instead of question

Just an idea thrown in here, @Cohee1207. If you think this is too risky for production, have suggestions or would like to have it a separate script, I can make changes.

_(Ignore me fucking up git history/rebasing again, whoops)_