### PR TITLE
Persona retrigger first message consistency fix

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5720,9 +5720,6 @@ export function setUserName(value) {
         toastr.success(`Your messages will now be sent as ${name1}`, 'Current persona updated');
     }
     saveSettingsDebounced();
-
-    // force firstMes {{user}} update on persona switch
-    retriggerFirstMessageOnEmptychat();
 }
 
 /**
@@ -5736,12 +5733,9 @@ export function setUserAvatar(imgfile) {
     selectCurrentPersona();
     saveSettingsDebounced();
     $('.zoomed_avatar[forchar]').remove();
-
-    // force firstMes {{user}} update on persona switch
-    retriggerFirstMessageOnEmptychat();
 }
 
-function retriggerFirstMessageOnEmptychat() {
+export function retriggerFirstMessageOnEmptyChat() {
     if (this_chid >= 0 && !selected_group && chat.length === 1) {
         $('#firstmessage_textarea').trigger('input');
     }
@@ -8479,6 +8473,9 @@ jQuery(async function () {
     $(document).on('click', '#user_avatar_block .avatar-container', function () {
         const imgfile = $(this).attr('imgfile');
         setUserAvatar(imgfile);
+
+        // force firstMes {{user}} update on persona switch
+        retriggerFirstMessageOnEmptyChat();
     });
     $(document).on('click', '#user_avatar_block .avatar_upload', function () {
         $('#avatar_upload_overwrite').val('');
@@ -9582,6 +9579,7 @@ jQuery(async function () {
         const userName = String($('#your_name').val()).trim();
         setUserName(userName);
         await updatePersonaNameIfExists(user_avatar, userName);
+        retriggerFirstMessageOnEmptyChat();
     });
 
     $('#sync_name_button').on('click', async function () {

--- a/public/script.js
+++ b/public/script.js
@@ -5720,6 +5720,9 @@ export function setUserName(value) {
         toastr.success(`Your messages will now be sent as ${name1}`, 'Current persona updated');
     }
     saveSettingsDebounced();
+
+    // force firstMes {{user}} update on persona switch
+    retriggerFirstMessageOnEmptychat();
 }
 
 /**
@@ -5733,6 +5736,15 @@ export function setUserAvatar(imgfile) {
     selectCurrentPersona();
     saveSettingsDebounced();
     $('.zoomed_avatar[forchar]').remove();
+
+    // force firstMes {{user}} update on persona switch
+    retriggerFirstMessageOnEmptychat();
+}
+
+function retriggerFirstMessageOnEmptychat() {
+    if (this_chid >= 0 && !selected_group && chat.length === 1) {
+        $('#firstmessage_textarea').trigger('input');
+    }
 }
 
 async function uploadUserAvatar(e) {
@@ -8467,11 +8479,6 @@ jQuery(async function () {
     $(document).on('click', '#user_avatar_block .avatar-container', function () {
         const imgfile = $(this).attr('imgfile');
         setUserAvatar(imgfile);
-
-        // force firstMes {{user}} update on persona switch
-        if (this_chid >= 0 && !selected_group && chat.length === 1) {
-            $('#firstmessage_textarea').trigger('input');
-        }
     });
     $(document).on('click', '#user_avatar_block .avatar_upload', function () {
         $('#avatar_upload_overwrite').val('');

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -22,6 +22,7 @@ import {
     name1,
     reloadCurrentChat,
     removeMacros,
+    retriggerFirstMessageOnEmptyChat,
     saveChatConditional,
     sendMessageAsUser,
     sendSystemMessage,
@@ -1340,12 +1341,14 @@ function setNameCallback(_, name) {
     for (let persona of Object.values(power_user.personas)) {
         if (persona.toLowerCase() === name.toLowerCase()) {
             autoSelectPersona(name);
+            retriggerFirstMessageOnEmptyChat();
             return;
         }
     }
 
     // Otherwise, set just the name
     setUserName(name); //this prevented quickReply usage
+    retriggerFirstMessageOnEmptyChat();
 }
 
 async function setNarratorName(_, text) {


### PR DESCRIPTION
When changing the persona via the persona menu, the first message of a character chat gets retriggered, as long as the chat is empty. (aka only contains the first message)

When using the slash command `/persona`, id didn't, because the actual logic was implemented in the on-click behavior of the persona selector list.  
I moved it to the appropriate function where the persona gets selected, and also added it to the function where a persona name gets set via slash command without an actual persona data behind. Because if the user name changes, the first message should be retriggered as well.

This should be more consistent now.