### PR TITLE
Include swipeid to all messages in chat

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1855,6 +1855,7 @@ function insertSVGIcon(mes, extra) {
 
 function getMessageFromTemplate({
     mesId,
+    swipeId,
     characterName,
     isUser,
     avatarImg,
@@ -1872,6 +1873,7 @@ function getMessageFromTemplate({
     const mes = messageTemplate.clone();
     mes.attr({
         'mesid': mesId,
+        'swipeid': swipeId,
         'ch_name': characterName,
         'is_user': isUser,
         'is_system': !!isSystem,
@@ -2018,6 +2020,7 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
 
     let params = {
         mesId: forceId ?? chat.length - 1,
+        swipeId: mes.swipes?.indexOf(mes.mes) ?? mes.swipe_id ?? 0,
         characterName: mes.name,
         isUser: mes.is_user,
         avatarImg: avatarImg,

--- a/public/script.js
+++ b/public/script.js
@@ -2020,7 +2020,7 @@ function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true
 
     let params = {
         mesId: forceId ?? chat.length - 1,
-        swipeId: mes.swipes?.indexOf(mes.mes) ?? mes.swipe_id ?? 0,
+        swipeId: mes.swipe_id ?? 0,
         characterName: mes.name,
         isUser: mes.is_user,
         avatarImg: avatarImg,


### PR DESCRIPTION
For ease of access in extensions, and mostly even just CSS magic, I added the `swipeid` attribute for every message.

This will allow anyone to write small Custom CSS to modify the swipe arrows or any other elements of the message however they want without the need to build actual JS code.