### PR TITLE
CLI server args precedency fix and new --port --listen args

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,15 +55,29 @@ if (process.versions && process.versions.node && process.versions.node.match(/20
 // Set default DNS resolution order to IPv4 first
 dns.setDefaultResultOrder('ipv4first');
 
+const DEFAULT_PORT = 8000;
+const DEFAULT_AUTORUN = false;
+const DEFAULT_LISTEN = false;
+const DEFAULT_CORS_PROXY = false;
+
 const cliArguments = yargs(hideBin(process.argv))
-    .option('autorun', {
+    .usage('Usage: <your-start-script> <command> [options]')
+    .option('port', {
+        type: 'number',
+        default: null,
+        describe: `Sets the port under which SillyTavern will run.\nIf not provided falls back to yaml config 'port'.\n[config default: ${DEFAULT_PORT}]`,
+    }).option('autorun', {
         type: 'boolean',
-        default: false,
-        describe: 'Automatically launch SillyTavern in the browser.',
+        default: null,
+        describe: `Automatically launch SillyTavern in the browser.\nAutorun is automatically disabled if --ssl is set to true.\nIf not provided falls back to yaml config 'autorun'.\n[config default: ${DEFAULT_AUTORUN}]`,
+    }).option('listen', {
+        type: 'boolean',
+        default: null,
+        describe: `SillyTavern is listening on all network interfaces (Wi-Fi, LAN, localhost). If false, will limit it only to internal localhost (127.0.0.1).\nIf not provided falls back to yaml config 'listen'.\n[config default: ${DEFAULT_LISTEN}]`,
     }).option('corsProxy', {
         type: 'boolean',
-        default: false,
-        describe: 'Enables CORS proxy',
+        default: null,
+        describe: `Enables CORS proxy\nIf not provided falls back to yaml config 'enableCorsProxy'.\n[config default: ${DEFAULT_CORS_PROXY}]`,
     }).option('disableCsrf', {
         type: 'boolean',
         default: false,
@@ -91,10 +105,10 @@ const app = express();
 app.use(compression());
 app.use(responseTime());
 
-const server_port = process.env.SILLY_TAVERN_PORT || getConfigValue('port', 8000);
-
-const autorun = (getConfigValue('autorun', false) || cliArguments.autorun) && !cliArguments.ssl;
-const listen = getConfigValue('listen', false);
+const server_port = cliArguments.port ?? process.env.SILLY_TAVERN_PORT ?? getConfigValue('port', DEFAULT_PORT);
+const autorun = (cliArguments.autorun ?? getConfigValue('autorun', DEFAULT_AUTORUN)) && !cliArguments.ssl;
+const listen = cliArguments.listen ?? getConfigValue('listen', DEFAULT_LISTEN);
+const enableCorsProxy = cliArguments.corsProxy ?? getConfigValue('enableCorsProxy', DEFAULT_CORS_PROXY)
 
 const { DIRECTORIES, UPLOADS_PATH } = require('./src/constants');
 
@@ -144,7 +158,7 @@ if (!cliArguments.disableCsrf) {
     });
 }
 
-if (getConfigValue('enableCorsProxy', false) || cliArguments.corsProxy) {
+if (enableCorsProxy) {
     const bodyParser = require('body-parser');
     app.use(bodyParser.json({
         limit: '200mb',


### PR DESCRIPTION
Today I tried using the cli arguments for the start/server script for the first time. I ran into an unexpected issue with unclear precedence.

I was not able to disable the autorun with `--autorun=false` provided, because the current implementation for all settings that had both a yaml config entry and a cli argument took the combination of both. If one was true, the setting resolved to true.  
Which is not how one would expect the behavior from similar tools with cli arguments.  
Manually provided cli arguments should always have precedence, even if they are falsey.

Generally, I propose the following settings precedence order:

> manual cli argument > (node env variable) > yaml entry > fallback default value

I have implemented those for both the existing `autorun` and the `corsProxy`/`enableCorsProxy` setting.

I also took the liberty to add optional cli arguments for `port` and `listen` so that one could be able to build scripts that manually set them however needed. I think that's good practice.

If you have objections to the precedence order, let me know.