### PR TITLE
fix: "Squash system messages" would fail to skip example messages

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2233,8 +2233,12 @@ export class ChatCompletion {
                 continue;
             }
 
-            if (!excludeList.includes(message.identifier) && message.role === 'system' && !message.name) {
-                if (lastMessage && lastMessage.role === 'system') {
+            const shouldSquash = (message) => {
+                return !excludeList.includes(message.identifier) && message.role === 'system' && !message.name;
+            }
+
+            if (shouldSquash(message)) {
+                if (lastMessage && shouldSquash(lastMessage)) {
                     lastMessage.content += '\n' + message.content;
                     lastMessage.tokens = tokenHandler.count({ role: lastMessage.role, content: lastMessage.content });
                 }


### PR DESCRIPTION
Context: When `Squash system messages` is on/ticked on a chat completion preset.

Currently, system messages after example messages are squashed into them (the example messages above the system's)

### Table of contents:
- Example message order preset.
- Example without squashing.
- Same example with current wrong squashing, with explanation of what is wrong.
- Same example with fixed squashing and explanation.

### Message order preset

`<Story Setting>` and the closing tag are custom system messages, the content is just the tag itself, see on the example below this
![image](https://github.com/SillyTavern/SillyTavern/assets/21046091/5fbf5e1e-d7ac-4c8a-82e6-59fd68d2d0bc)

### Example without squashing

```json
[
  {
    "role": "system",
    "content": "Main Prompt"
  },
  {
    "role": "system",
    "content": "<Story Setting>"
  },
  {
    "role": "system",
    "content": "Char Description"
  },
  {
    "role": "system",
    "content": "[Start chat]"
  },
  {
    "role": "system",
    "name": "example_assistant",
    "content": "Example message 1."
  },
  {
    "role": "system",
    "content": "</Story Setting>"
  },
  {
    "role": "system",
    "content": "[Circumstances and context of the dialogue: Char Scenario.]"
  }
]
```

### Same example with current wrong squashing

Explanation of what is wrong: Char Scenario, and custom system messages after it (in this case "</Story Setting>"), get squashed in to a message with name example_assistant, which is wholly undesirable, as it is not, in fact, part of example anything.

```json
[
  {
    "role": "system",
    "content": "Main Prompt\n<Story Setting>\nChar Description"
  },
  {
    "role": "system",
    "content": "[Start chat]"
  },
  {
    "role": "system",
    "content": "Example message 1.\n</Story Setting>\n[Circumstances and context of the dialogue: Char Scenario.]",
    "name": "example_assistant"
  }
]
```

### Same example with fixed squashing

Fix results in system messages after example messages to be squashed into their own system message without name "example_x"
In code: checks if lastMessage it will append squashed messages into also passes the criteria to be squashed (e.g. not be an example message)

```json
[
  {
    "role": "system",
    "content": "Main Prompt\n<Story Setting>\nChar Description"
  },
  {
    "role": "system",
    "content": "[Start chat]"
  },
  {
    "role": "system",
    "content": "Example message 1.",
    "name": "example_assistant"
  },
  {
    "role": "system",
    "content": "</Story Setting>\n[Circumstances and context of the dialogue: Char Scenario.]"
  }
]
```