### PR TITLE
Fix autoscroll stop not working on Firefox

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -8587,7 +8587,7 @@ jQuery(async function () {
         $('#groupCurrentMemberListToggle .inline-drawer-icon').trigger('click');
     }, 200);
 
-    $('#chat').on('mousewheel touchstart', () => {
+    $('#chat').on('wheel touchstart', () => {
         scrollLock = true;
     });
 


### PR DESCRIPTION
`mousewheel` is deprecated, non-standard and doesn't work on Firefox.  
It was replaced by `wheel`, which works in all modern browsers except Safari on iOS. And for that one we already have touch as a handler anyway.

Source: https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event