### PR TITLE
fix: openai: avoid skipping example chats in a dialogue when close to quota

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -818,18 +818,20 @@ function populateDialogueExamples(prompts, chatCompletion, messageExamples) {
 
             if (chatCompletion.canAfford(newExampleChat)) chatCompletion.insert(newExampleChat, 'dialogueExamples');
 
-            dialogue.forEach((prompt, promptIndex) => {
+            for (let promptIndex = 0; promptIndex < dialogue.length; promptIndex++) {
+                const prompt = dialogue[promptIndex];
                 const role = 'system';
                 const content = prompt.content || '';
                 const identifier = `dialogueExamples ${dialogueIndex}-${promptIndex}`;
 
                 const chatMessage = new Message(role, content, identifier);
                 chatMessage.setName(prompt.name);
-                if (chatCompletion.canAfford(chatMessage)) {
-                    chatCompletion.insert(chatMessage, 'dialogueExamples');
-                    examplesAdded++;
+                if (!chatCompletion.canAfford(chatMessage)) {
+                    break;
                 }
-            });
+                chatCompletion.insert(chatMessage, 'dialogueExamples');
+                examplesAdded++;
+            }
 
             if (0 === examplesAdded) {
                 chatCompletion.removeLastFrom('dialogueExamples');


### PR DESCRIPTION
Currently, example dialogues are populated with a forEach loop, and messages are skipped when they can't be afforded, but the loop isn't being broken. This means that, when close to reaching the quota, the example dialogue can turn out broken by skipping messages and including later ones, breaking chronology/progression, on frequent use cases, like so:

```
<Start>
{{user}}: [Small message 1]
{{char}}: [Big message 1]
{{user}}: [Small message 2]
{{char}}: [Big message 2]
{{user}}: [Small message 3]
{{char}}: [Big message 3]
{{user}}: [Small message 4]
{{char}}: [Big message 4]
```
When close to reaching token quota, this could become:

```
<Start>
{{user}}: [Small message 1]
{{char}}: [Big message 1]
{{user}}: [Small message 2]
{{user}}: [Small message 3]
{{user}}: [Small message 4]
```

As big messages fail the check and small ones go through until they fill it.
The result can often be nonsensical.