### PR TITLE
Improve server version logging info

### DIFF
--- a/server.js
+++ b/server.js
@@ -479,10 +479,7 @@ const setupTasks = async function () {
     console.log();
     console.log(`SillyTavern ${version.pkgVersion}`);
     console.log(version.gitBranch ? `Running '${version.gitBranch}' (${version.gitRevision}) - ${version.commitDate}` : '');
-    if (version.gitBranch && !['staging', 'release'].includes(version.gitBranch)) {
-        console.log('INFO: Currently running a dev branch.');
-        console.log(`      If this isn't a dev environment, consider switching via 'git switch staging' or 'git switch release'.`);
-    } else if (version.gitBranch && !version.isLatest) {
+    if (version.gitBranch && !version.isLatest && ['staging', 'release'].includes(version.gitBranch)) {
         console.log('INFO: Currently not on the latest commit.');
         console.log(`      Run 'git pull' to upate. If you have any conflicts, run 'git reset --hard' and 'git pull' to reset your branch.`)
     }

--- a/server.js
+++ b/server.js
@@ -481,7 +481,7 @@ const setupTasks = async function () {
     console.log(version.gitBranch ? `Running '${version.gitBranch}' (${version.gitRevision}) - ${version.commitDate}` : '');
     if (version.gitBranch && !version.isLatest && ['staging', 'release'].includes(version.gitBranch)) {
         console.log('INFO: Currently not on the latest commit.');
-        console.log(`      Run 'git pull' to upate. If you have any conflicts, run 'git reset --hard' and 'git pull' to reset your branch.`)
+        console.log('      Run \'git pull\' to update. If you have any merge conflicts, run \'git reset --hard\' and \'git pull\' to reset your branch.');
     }
     console.log();
 

--- a/server.js
+++ b/server.js
@@ -475,7 +475,18 @@ const autorunUrl = new URL(
 const setupTasks = async function () {
     const version = await getVersion();
 
-    console.log(`SillyTavern ${version.pkgVersion}` + (version.gitBranch ? ` '${version.gitBranch}' (${version.gitRevision})` : ''));
+    // Print formatted header
+    console.log();
+    console.log(`SillyTavern ${version.pkgVersion}`);
+    console.log(version.gitBranch ? `Running '${version.gitBranch}' (${version.gitRevision}) - ${version.commitDate}` : '');
+    if (version.gitBranch && !['staging', 'release'].includes(version.gitBranch)) {
+        console.log('INFO: Currently running a dev branch.');
+        console.log(`      If this isn't a dev environment, consider switching via 'git switch staging' or 'git switch release'.`);
+    } else if (version.gitBranch && !version.isLatest) {
+        console.log('INFO: Currently not on the latest commit.');
+        console.log(`      Run 'git pull' to upate. If you have any conflicts, run 'git reset --hard' and 'git pull' to reset your branch.`)
+    }
+    console.log();
 
     // TODO: do endpoint init functions depend on certain directories existing or not existing? They should be callable
     // in any order for encapsulation reasons, but right now it's unknown if that would break anything.

--- a/src/util.js
+++ b/src/util.js
@@ -92,9 +92,11 @@ async function getVersion() {
             gitBranch = await git.cwd(cwd).revparse(['--abbrev-ref', 'HEAD']);
             commitDate = await git.cwd(cwd).show(['-s', '--format=%ci', gitRevision]);
 
+            const trackingBranch = await git.cwd(cwd).revparse(['--abbrev-ref', '@{u}']);
+
             // Might fail, but exception is caught. Just don't run anything relevant after in this block...
             const localLatest = await git.cwd(cwd).revparse(['HEAD']);
-            const remoteLatest = await git.cwd(cwd).revparse([`origin/${gitBranch}`]);
+            const remoteLatest = await git.cwd(cwd).revparse([trackingBranch]);
             isLatest = localLatest === remoteLatest;
         }
     }

--- a/src/util.js
+++ b/src/util.js
@@ -73,19 +73,29 @@ function getBasicAuthHeader(auth) {
 /**
  * Returns the version of the running instance. Get the version from the package.json file and the git revision.
  * Also returns the agent string for the Horde API.
- * @returns {Promise<{agent: string, pkgVersion: string, gitRevision: string | null, gitBranch: string | null}>} Version info object
+ * @returns {Promise<{agent: string, pkgVersion: string, gitRevision: string | null, gitBranch: string | null, commitDate: string | null, isLatest: boolean}>} Version info object
  */
 async function getVersion() {
     let pkgVersion = 'UNKNOWN';
     let gitRevision = null;
     let gitBranch = null;
+    let commitDate = null;
+    let isLatest = true;
+
     try {
         const pkgJson = require(path.join(process.cwd(), './package.json'));
         pkgVersion = pkgJson.version;
         if (!process['pkg'] && commandExistsSync('git')) {
             const git = simpleGit();
-            gitRevision = await git.cwd(process.cwd()).revparse(['--short', 'HEAD']);
-            gitBranch = await git.cwd(process.cwd()).revparse(['--abbrev-ref', 'HEAD']);
+            const cwd = process.cwd();
+            gitRevision = await git.cwd(cwd).revparse(['--short', 'HEAD']);
+            gitBranch = await git.cwd(cwd).revparse(['--abbrev-ref', 'HEAD']);
+            commitDate = await git.cwd(cwd).show(['-s', '--format=%ci', gitRevision]);
+
+            // Might fail, but exception is caught. Just don't run anything relevant after in this block...
+            const localLatest = await git.cwd(cwd).revparse(['HEAD']);
+            const remoteLatest = await git.cwd(cwd).revparse([`origin/${gitBranch}`]);
+            isLatest = localLatest === remoteLatest;
         }
     }
     catch {
@@ -93,7 +103,7 @@ async function getVersion() {
     }
 
     const agent = `SillyTavern:${pkgVersion}:Cohee#1207`;
-    return { agent, pkgVersion, gitRevision, gitBranch };
+    return { agent, pkgVersion, gitRevision, gitBranch, commitDate: commitDate?.trim() ?? null, isLatest };
 }
 
 /**


### PR DESCRIPTION
Had a dummy idea. Just for people to get a quicker view on which version they are running, and why they may have issues.  
Also helps when someone provides output or screenshot.

- Capture commit date and print that next to the branch
- Info for being on a dev branch
- Info for not being on the latest commit (fetch should've gotten it, if update script was run)

![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/a413b265-7845-4449-9f6e-9fb5b2f8d3fc)
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/e1c5354e-8284-4e82-9f9f-7042f771d432)
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/290de9bd-7343-4335-98dd-c8fe1071ee20)
