### PR TITLE
World Info: Improved sorting to actually align with the settings

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -752,7 +752,6 @@ function reloadMarkdownProcessor(render_formulas = false) {
 }
 
 function getCurrentChatId() {
-    console.debug(`selectedGroup:${selected_group}, this_chid:${this_chid}`);
     if (selected_group) {
         return groups.find(x => x.id == selected_group)?.chat_id;
     }


### PR DESCRIPTION
The world info entry sorting had a few smaller issues that I noticed, and tried to fix with this.

# Duplicate books didn't respect strategy
If a world was selected in multiple sources (global and character, etc) it removed the duplicated world without actually respecting the insertion strategy.
If I select "character first", I want to have entries from a character world on top, even if that world might also be marked as a global world. Same the other way around.

# Insert evenly didn't really did evenly
"Insert evenly" didn't really even out the entries. It took character and global lore, and then sorted both lists by `order`, keeping their original order available though.
So if you got a world with five entries order=1 and five with order=10, and another world with two order=1 and three order=10, it would actually be this order at the end:

world 🟢 - order= 🟥
world 🟢 - order= 🟥
world 🟢 - order= 🟥
world 🟢 - order= 🟥
world 🟢 - order= 🟥
world 🟡 - order= 🟥
world 🟡 - order= 🟥
world 🟡 - order= 🟥
world 🟢 - order= 🟦
world 🟢 - order= 🟦
world 🟢 - order= 🟦
world 🟢 - order= 🟦
world 🟢 - order= 🟦
world 🟡 - order= 🟦
world 🟡 - order= 🟦

Now it's like this:

world 🟢 - order= 🟥
world 🟡 - order= 🟥
world 🟢 - order= 🟥
world 🟡 - order= 🟥
world 🟢 - order= 🟥
world 🟡 - order= 🟥
world 🟢 - order= 🟥
world 🟢 - order= 🟥
world 🟡 - order= 🟦
world 🟢 - order= 🟦
world 🟡 - order= 🟦
world 🟢 - order= 🟦
world 🟢 - order= 🟦
world 🟢 - order= 🟦
world 🟢 - order= 🟦

Hope my explanation is good enough.