### PR TITLE
removed some remnant debug logs

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -752,7 +752,6 @@ function reloadMarkdownProcessor(render_formulas = false) {
 }
 
 function getCurrentChatId() {
-    console.debug(`selectedGroup:${selected_group}, this_chid:${this_chid}`);
     if (selected_group) {
         return groups.find(x => x.id == selected_group)?.chat_id;
     }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2102,8 +2102,6 @@ async function checkWorldInfo(chat, maxContext) {
                     const substituted = substituteParams(key);
                     const textToScan = buffer.get(entry);
 
-                    console.debug(`${entry.uid}: ${substituted}`);
-
                     if (substituted && buffer.matchKeys(textToScan, substituted.trim(), entry)) {
                         console.debug(`WI UID ${entry.uid} found by primary match: ${substituted}.`);
 
@@ -2160,7 +2158,7 @@ async function checkWorldInfo(chat, maxContext) {
                             activatedNow.add(entry);
                             break primary;
                         }
-                    } else { console.debug(`No active entries for logic checks for word: ${substituted}.`); }
+                    }
                 }
             }
         }


### PR DESCRIPTION
An example of a console.debug origin is from the commit:

fix retrieval of currentChatID for renamed chars
304aa38f24219930b50bc3c2730d7e555866d76b

So it seems like a remnant that should be removed given the name.

They noticeably slow things down with World Info min activations looping chronologically through chat which also loops through every WI entry. `getCurrentChatId()` prints thrice each entry.

Before
![image](https://github.com/SillyTavern/SillyTavern/assets/21046091/182847fa-3eec-4a30-9084-68c694a0d186)

After
![image](https://github.com/SillyTavern/SillyTavern/assets/21046091/6305d313-be2a-44e2-b445-976d1a85e90d)
(from one 250 msg chat's WI loop and whatever triggers together with it, cleared logs beforehand)

Seems #2008 also removed the one in `getCurrentChatId()`.