### PR TITLE
Fix multi char import on import button click not importing tags

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9907,14 +9907,14 @@ jQuery(async function () {
         $('#character_import_file').click();
     });
 
-    $('#character_import_file').on('change', function (e) {
+    $('#character_import_file').on('change', async function (e) {
         $('#rm_info_avatar').html('');
         if (!e.target.files.length) {
             return;
         }
 
         for (const file of e.target.files) {
-            importCharacter(file);
+            await importCharacter(file);
         }
     });
 


### PR DESCRIPTION
- Fixes #1983

`importCharacter` has to be async await to await user input on tag creation