### PR TITLE
Added toastr messages to tts index file

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -465,6 +465,7 @@ async function processAudioJobQueue() {
         playAudioData(currentAudioJob);
         talkingAnimation(true);
     } catch (error) {
+        toastr.error(error.toString());
         console.error(error);
         audioQueueProcessorReady = true;
     }
@@ -579,6 +580,7 @@ async function processTtsQueue() {
         }
         tts(text, voiceId, char);
     } catch (error) {
+        toastr.error(error.toString());
         console.error(error);
         currentTtsJob = null;
     }
@@ -648,6 +650,7 @@ function onRefreshClick() {
         initVoiceMap();
         updateVoiceMap();
     }).catch(error => {
+        toastr.error(error.toString());
         console.error(error);
         setTtsStatus(error, false);
     });

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -578,7 +578,7 @@ async function processTtsQueue() {
             toastr.error(`Specified voice for ${char} was not found. Check the TTS extension settings.`);
             throw `Unable to attain voiceId for ${char}`;
         }
-        tts(text, voiceId, char);
+        await tts(text, voiceId, char);
     } catch (error) {
         toastr.error(error.toString());
         console.error(error);


### PR DESCRIPTION
When users experience TTS various TTS issues, there is information in the console log. This is fine for developers using a desktop browser, but for non developers, or even for developers on a mobile device, the error messages are not visible. By replicating the already existing error messages with toastr messages, users will be able to know why TTS isn't working for them.