### PR TITLE
Fix pick macro rerolling on branches/renames

### DIFF
--- a/public/scripts/macros.js
+++ b/public/scripts/macros.js
@@ -189,10 +189,10 @@ function pickReplace(input, rawContent, emptyListPlaceholder = '') {
     const pickPattern = /{{pick\s?::?([^}]+)}}/gi;
 
     // We need to have a consistent chat hash, otherwise we'll lose rolls on chat file rename or branch switches
+    // No need to save metadata here - branching and renaming will implicitly do the save for us, and until then loading it like this is consistent
     const chatIdHash = chat_metadata['chat_id_hash'];
     if (!chatIdHash) {
-        chat_metadata['chat_id_hash'] = getStringHash(getCurrentChatId());
-        saveMetadataDebounced();
+        chat_metadata['chat_id_hash'] = getStringHash(chat_metadata['main_chat'] ?? getCurrentChatId());
     }
     const rawContentHash = getStringHash(rawContent);
 


### PR DESCRIPTION
`{{pick}}` macro being bound to the chat id (aka file name) led to multiple smaller inconsistencies.

- If you move to a branch, the file name changes. Something like this: `Branch #2 - 2024-4-7@04h35m35s.jsonl`
  But the pick should still say the same, because we are still in the same chat context
- If you rename a chat file (via chat management, or manually in file system), it was being rerolled too.

Now to make this easier, we we are actually saving the chat id hash inside the chat metadata. Same as the main branch name for the branch was already saved, and some more meta settings per chat.  
This value will be carried over to a new branch, and will now actually stay consistent, until a new chat is being started.