### PR TITLE
Fix the wrong tags for the scheduled nightly build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,31 +24,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      ## Workaround for GitHub repo names containing uppercase characters
+      # Workaround for GitHub repo names containing uppercase characters
       - name: Set lowercase repo name
         run: |
-          echo "IMAGE_NAME=${REPO,,}" >>${GITHUB_ENV}
+          echo "IMAGE_NAME=${REPO,,}" >> ${GITHUB_ENV}
 
       # Using the following workaround because currently GitHub Actions 
       # does not support logical AND/OR operations on triggers
       # It's currently not possible to have `branches` under the `schedule` trigger
       - name: Checkout the release branch (on release)
-        if: ${{ github.event_name == 'release' }}
-        uses: actions/checkout@v3
-        with:
-          ref: "release"
-
-      - name: Checkout the release branch (on push)
-        if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@v3
+        if: ${{ github.event_name == 'release' || github.event_name == 'push' }}
+        uses: actions/checkout@v4.1.2
         with:
           ref: "release"
 
       - name: Checkout the staging branch
         if: ${{ github.event_name == 'schedule' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.2
         with:
           ref: "staging"
+
+      # Get current branch name
+      # This is also part of the workaround for Actions not allowing logical
+      # AND/OR operators on triggers
+      # Otherwise the action triggered by schedule always has ref_name = release
+      - name: Get the current branch name
+        run: |
+          echo "BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)" >> ${GITHUB_ENV}
 
       # Setting up QEMU for multi-arch image build
       - name: Set up QEMU
@@ -62,7 +64,7 @@ jobs:
         id: metadata
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: ${{ github.ref_name }}
+          tags: ${{ env.BRANCH_NAME }}
 
       # Login into package repository as the person who created the release
       - name: Log in to the Container registry


### PR DESCRIPTION
This is a follow-up pull request for #2015.

## Changelog

* Simplified the checkout process
* Fixed the wrong tags for the scheduled builds (used to be `release` for all builds, now it should be `staging` for nightly builds and `release` for `push` and `release` builds)
* Upgraded the `checkout` action to v4.1.2 (no warnings anymore)