### PR TITLE
Group chat-specific join prefix/suffix for char fields

### DIFF
--- a/public/css/rm-groups.css
+++ b/public/css/rm-groups.css
@@ -58,6 +58,11 @@
     cursor: unset;
 }
 
+#rm_group_buttons textarea {
+    margin: 0px;
+    min-width: 200px;
+}
+
 #rm_group_members,
 #rm_group_add_members {
     margin-top: 0.25rem;

--- a/public/index.html
+++ b/public/index.html
@@ -4360,23 +4360,43 @@
                                     </div>
                                     <div name="GroupStragegyAndOrder" id="rm_group_buttons" class="flex-container paddingLeftRight5 flex2">
                                         <div class="flex1 flexGap5">
-                                            <div class="flex-container flexnowrap width100p whitespacenowrap">
+                                            <label for="rm_group_activation_strategy" class="flexnowrap width100p whitespacenowrap">
                                                 <span data-i18n="Group reply strategy">Group reply strategy</span>
-                                            </div>
+                                            </label>
                                             <select id="rm_group_activation_strategy">
                                                 <option value="0" data-i18n="Natural order">Natural order</option>
                                                 <option value="1" data-i18n="List order">List order</option>
                                             </select>
                                         </div>
                                         <div class="flex1 flexGap5">
-                                            <div class="flex-container flexnowrap width100p whitespacenowrap">
+                                            <label for="rm_group_generation_mode" class="flexnowrap width100p whitespacenowrap">
                                                 <span data-i18n="Group generation handling mode">Group generation handling mode</span>
-                                            </div>
+                                            </label>
                                             <select id="rm_group_generation_mode">
                                                 <option value="0" data-i18n="Swap character cards">Swap character cards</option>
                                                 <option value="1" data-i18n="Join character cards (exclude muted)">Join character cards (exclude muted)</option>
                                                 <option value="2" data-i18n="Join character cards (include muted)">Join character cards (include muted)</option>
                                             </select>
+                                        </div>
+                                        <div class="flex1 flexGap5" title="Inserted before each part of the joined fields.">
+                                            <label for="rm_group_generation_mode_join_prefix" class="flexnowrap width100p whitespacenowrap">
+                                                <span data-i18n="Join Prefix">Join Prefix</span>
+                                                <div class="fa-solid fa-circle-info opacity50p"
+                                                    data-i18n="[title]When 'Join character cards' is selected, all respective fields of the characters are being joined together.&#13;This means that in the story string for example all character descriptions will be joined to one big text.&#13;If you want those fields to be separated, you can define a prefix or suffix here.&#13;&#13;This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)"
+                                                    title="When 'Join character cards' is selected, all respective fields of the characters are being joined together.&#13;This means that in the story string for example all character descriptions will be joined to one big text.&#13;If you want those fields to be separated, you can define a prefix or suffix here.&#13;&#13;This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)">
+                                                </div>
+                                            </label>
+                                            <textarea id="rm_group_generation_mode_join_prefix" class="text_pole wide100p textarea_compact autoSetHeight" maxlength="2000" placeholder="&mdash;" rows="1"></textarea>
+                                        </div>
+                                        <div class="flex1 flexGap5" title="Inserted after each part of the joined fields.">
+                                            <label for="rm_group_generation_mode_join_suffix" class="flexnowrap width100p whitespacenowrap">
+                                                <span data-i18n="Join Suffix">Join Suffix</span>
+                                                <div class="fa-solid fa-circle-info opacity50p"
+                                                    data-i18n="[title]When 'Join character cards' is selected, all respective fields of the characters are being joined together.&#13;This means that in the story string for example all character descriptions will be joined to one big text.&#13;If you want those fields to be separated, you can define a prefix or suffix here.&#13;&#13;This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)"
+                                                    title="When 'Join character cards' is selected, all respective fields of the characters are being joined together.&#13;This means that in the story string for example all character descriptions will be joined to one big text.&#13;If you want those fields to be separated, you can define a prefix or suffix here.&#13;&#13;This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)">
+                                                </div>
+                                            </label>
+                                            <textarea id="rm_group_generation_mode_join_suffix" class="text_pole wide100p textarea_compact autoSetHeight" maxlength="2000" placeholder="&mdash;" rows="1"></textarea>
                                         </div>
                                     </div>
                                     <div id="GroupFavDelOkBack" class="flex-container flexGap5 spaceEvenly flex1">

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1119,9 +1119,7 @@ async function onGroupGenerationModeInput(e) {
         _thisGroup.generation_mode = Number(e.target.value);
         await editGroup(openGroupId, false, false);
 
-        const isJoin = [group_generation_mode.APPEND, group_generation_mode.APPEND_DISABLED].includes(_thisGroup.generation_mode);
-        $('#rm_group_generation_mode_join_prefix').parent().toggle(isJoin);
-        $('#rm_group_generation_mode_join_suffix').parent().toggle(isJoin);
+        toggleHiddenControls(_thisGroup);
     }
 }
 
@@ -1308,6 +1306,12 @@ async function onHideMutedSpritesClick(value) {
     }
 }
 
+function toggleHiddenControls(group, generationMode = null) {
+    const isJoin = [group_generation_mode.APPEND, group_generation_mode.APPEND_DISABLED].includes(generationMode ?? group?.generation_mode);
+    $('#rm_group_generation_mode_join_prefix').parent().toggle(isJoin);
+    $('#rm_group_generation_mode_join_suffix').parent().toggle(isJoin);
+}
+
 function select_group_chats(groupId, skipAnimation) {
     openGroupId = groupId;
     newGroupMembers = [];
@@ -1343,8 +1347,9 @@ function select_group_chats(groupId, skipAnimation) {
     $('#rm_group_hidemutedsprites').prop('checked', group && group.hideMutedSprites);
     $('#rm_group_automode_delay').val(group?.auto_mode_delay ?? DEFAULT_AUTO_MODE_DELAY);
 
-    $('#rm_group_generation_mode_join_prefix').val(group?.generation_mode_join_prefix).attr('setting', 'generation_mode_join_prefix');
-    $('#rm_group_generation_mode_join_suffix').val(group?.generation_mode_join_suffix).attr('setting', 'generation_mode_join_suffix');
+    $('#rm_group_generation_mode_join_prefix').val(group?.generation_mode_join_prefix ?? '').attr('setting', 'generation_mode_join_prefix');
+    $('#rm_group_generation_mode_join_suffix').val(group?.generation_mode_join_suffix ?? '').attr('setting', 'generation_mode_join_suffix');
+    toggleHiddenControls(group, generationMode);
 
     // bottom buttons
     if (openGroupId) {
@@ -1378,6 +1383,11 @@ function select_group_chats(groupId, skipAnimation) {
     else {
         $('#rm_group_automode_label').hide();
     }
+
+    // Toggle textbox sizes, as input events have not fired here
+    $('#rm_group_chats_block .autoSetHeight').each(element => {
+        resetScrollHeight(element);
+    });
 
     eventSource.emit('groupSelected', { detail: { id: openGroupId, group: group } });
 }

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -10,6 +10,7 @@ import {
     PAGINATION_TEMPLATE,
     getBase64Async,
     resetScrollHeight,
+    initScrollHeight,
 } from './utils.js';
 import { RA_CountCharTokens, humanizedDateTime, dragElement, favsToHotswap, getMessageTimeStamp } from './RossAscends-mods.js';
 import { power_user, loadMovingUIState, sortEntitiesList } from './power-user.js';
@@ -1310,6 +1311,8 @@ function toggleHiddenControls(group, generationMode = null) {
     const isJoin = [group_generation_mode.APPEND, group_generation_mode.APPEND_DISABLED].includes(generationMode ?? group?.generation_mode);
     $('#rm_group_generation_mode_join_prefix').parent().toggle(isJoin);
     $('#rm_group_generation_mode_join_suffix').parent().toggle(isJoin);
+    initScrollHeight($('#rm_group_generation_mode_join_prefix'));
+    initScrollHeight($('#rm_group_generation_mode_join_suffix'));
 }
 
 function select_group_chats(groupId, skipAnimation) {

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -373,7 +373,7 @@ export function getGroupCharacterCards(groupId, characterId) {
         // Also run the macro replacement on the actual content
         value = customBaseChatReplace(value, fieldName, characterName);
 
-        return `${prefix}${separator}${value}${separator}${suffix}`;
+        return `${prefix ? prefix + separator : ''}${value}${suffix ? separator + suffix : ''}`;
     }
 
     const scenarioOverride = chat_metadata['scenario'];


### PR DESCRIPTION
I got this idea from #1828  
Want/need this for myself too though.

- Add group chat setting fields for "prefix" and "suffix"
- Settings will be visible when any "join" setting is selected
- each part will be surrounded, which optional macro replacements on the prefix/suffix

![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/d2e735b7-a13b-4690-a5f8-15558de1306a)
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/8f07cdaa-cc26-4ec4-8b63-191f9e39338d)

Join will respect empty fields and filter them out like before.
A joined description also depends on the story string of course, but could look like this:
(the square brackets are coming from my story string)
```
-- Personality --
[--- Join of Personality for Miria ---
The full personality description for Miria here
-- END: Miria Suffix --]

-- Scenario --
[--- Join of Scenario for Riko ---
This is Riko's scenario here
-- END: Riko Suffix --
--- Join of Scenario for Miria ---
A scenario description for the character Miria
-- END: Miria Suffix --]
```
