### PR TITLE
More QR editor options

### DIFF
--- a/public/scripts/extensions/quick-reply/html/qrEditor.html
+++ b/public/scripts/extensions/quick-reply/html/qrEditor.html
@@ -25,6 +25,10 @@
 					<span>Tab size:</span>
 					<input type="number" min="1" max="9" id="qr--modal-tabSize" class="text_pole">
 				</label>
+				<label class="checkbox_label">
+					<input type="checkbox" id="qr--modal-executeShortcut">
+					<span>Ctrl+Enter to execute</span>
+				</label>
 			</div>
 			<textarea class="monospace" id="qr--modal-message"></textarea>
 		</div>

--- a/public/scripts/extensions/quick-reply/html/qrEditor.html
+++ b/public/scripts/extensions/quick-reply/html/qrEditor.html
@@ -16,12 +16,16 @@
 			<label for="qr--modal-message">
 				Message / Command:
 			</label>
-			<small>
+			<div class="qr--modal-editorSettings">
 				<label class="checkbox_label">
 					<input type="checkbox" id="qr--modal-wrap">
 					<span>Word wrap</span>
 				</label>
-			</small>
+				<label class="checkbox_label">
+					<span>Tab size:</span>
+					<input type="number" min="1" max="9" id="qr--modal-tabSize" class="text_pole">
+				</label>
+			</div>
 			<textarea class="monospace" id="qr--modal-message"></textarea>
 		</div>
 	</div>

--- a/public/scripts/extensions/quick-reply/src/QuickReply.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReply.js
@@ -209,7 +209,7 @@ export class QuickReply {
             });
             /**@type {HTMLInputElement}*/
             const wrap = dom.querySelector('#qr--modal-wrap');
-            wrap.checked = JSON.parse(localStorage.getItem('qr--wrap'));
+            wrap.checked = JSON.parse(localStorage.getItem('qr--wrap') ?? 'false');
             wrap.addEventListener('click', () => {
                 localStorage.setItem('qr--wrap', JSON.stringify(wrap.checked));
                 updateWrap();

--- a/public/scripts/extensions/quick-reply/src/QuickReply.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReply.js
@@ -221,9 +221,20 @@ export class QuickReply {
                     message.style.whiteSpace = 'pre';
                 }
             };
+            /**@type {HTMLInputElement}*/
+            const tabSize = dom.querySelector('#qr--modal-tabSize');
+            tabSize.value = JSON.parse(localStorage.getItem('qr--tabSize') ?? '4');
+            const updateTabSize = () => {
+                message.style.tabSize = tabSize.value;
+            };
+            tabSize.addEventListener('change', () => {
+                localStorage.setItem('qr--tabSize', JSON.stringify(Number(tabSize.value)));
+                updateTabSize();
+            });
             /**@type {HTMLTextAreaElement}*/
             const message = dom.querySelector('#qr--modal-message');
             updateWrap();
+            updateTabSize();
             message.value = this.message;
             message.addEventListener('input', () => {
                 this.updateMessage(message.value);

--- a/public/scripts/extensions/quick-reply/src/QuickReply.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReply.js
@@ -44,6 +44,11 @@ export class QuickReply {
     /**@type {HTMLInputElement}*/ settingsDomLabel;
     /**@type {HTMLTextAreaElement}*/ settingsDomMessage;
 
+    /**@type {HTMLElement}*/ editorExecuteBtn;
+    /**@type {HTMLElement}*/ editorExecuteErrors;
+    /**@type {HTMLInputElement}*/ editorExecuteHide;
+    /**@type {Promise}*/ editorExecutePromise;
+
 
     get hasContext() {
         return this.contextList && this.contextList.length > 0;
@@ -231,6 +236,12 @@ export class QuickReply {
                 localStorage.setItem('qr--tabSize', JSON.stringify(Number(tabSize.value)));
                 updateTabSize();
             });
+            /**@type {HTMLInputElement}*/
+            const executeShortcut = dom.querySelector('#qr--modal-executeShortcut');
+            executeShortcut.checked = JSON.parse(localStorage.getItem('qr--executeShortcut') ?? 'true');
+            executeShortcut.addEventListener('click', () => {
+                localStorage.setItem('qr--executeShortcut', JSON.stringify(executeShortcut.checked));
+            });
             /**@type {HTMLTextAreaElement}*/
             const message = dom.querySelector('#qr--modal-message');
             updateWrap();
@@ -268,6 +279,12 @@ export class QuickReply {
                     message.selectionStart = start - 1;
                     message.selectionEnd = end - count;
                     this.updateMessage(message.value);
+                } else if (evt.key == 'Enter' && evt.ctrlKey && !evt.shiftKey && !evt.altKey) {
+                    evt.stopPropagation();
+                    evt.preventDefault();
+                    if (executeShortcut.checked) {
+                        this.executeFromEditor();
+                    }
                 }
             });
 
@@ -396,33 +413,39 @@ export class QuickReply {
 
             /**@type {HTMLElement}*/
             const executeErrors = dom.querySelector('#qr--modal-executeErrors');
+            this.editorExecuteErrors = executeErrors;
             /**@type {HTMLInputElement}*/
             const executeHide = dom.querySelector('#qr--modal-executeHide');
-            let executePromise;
+            this.editorExecuteHide = executeHide;
             /**@type {HTMLElement}*/
             const executeBtn = dom.querySelector('#qr--modal-execute');
+            this.editorExecuteBtn = executeBtn;
             executeBtn.addEventListener('click', async()=>{
-                if (executePromise) return;
-                executeBtn.classList.add('qr--busy');
-                executeErrors.innerHTML = '';
-                if (executeHide.checked) {
-                    document.querySelector('#shadow_popup').classList.add('qr--hide');
-                }
-                try {
-                    executePromise = this.execute();
-                    await executePromise;
-                } catch (ex) {
-                    executeErrors.textContent = ex.message;
-                }
-                executePromise = null;
-                executeBtn.classList.remove('qr--busy');
-                document.querySelector('#shadow_popup').classList.remove('qr--hide');
+                await this.executeFromEditor();
             });
 
             await popupResult;
         } else {
             warn('failed to fetch qrEditor template');
         }
+    }
+
+    async executeFromEditor() {
+        if (this.editorExecutePromise) return;
+        this.editorExecuteBtn.classList.add('qr--busy');
+        this.editorExecuteErrors.innerHTML = '';
+        if (this.editorExecuteHide.checked) {
+            document.querySelector('#shadow_popup').classList.add('qr--hide');
+        }
+        try {
+            this.editorExecutePromise = this.execute();
+            await this.editorExecutePromise;
+        } catch (ex) {
+            this.editorExecuteErrors.textContent = ex.message;
+        }
+        this.editorExecutePromise = null;
+        this.editorExecuteBtn.classList.remove('qr--busy');
+        document.querySelector('#shadow_popup').classList.remove('qr--hide');
     }
 
 

--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -269,6 +269,19 @@
   display: flex;
   flex-direction: column;
 }
+#dialogue_popup:has(#qr--modalEditor) #dialogue_popup_text > #qr--modalEditor > #qr--main > .qr--modal-messageContainer > .qr--modal-editorSettings {
+  display: flex;
+  flex-direction: row;
+  gap: 1em;
+  color: var(--grey70);
+  font-size: smaller;
+}
+#dialogue_popup:has(#qr--modalEditor) #dialogue_popup_text > #qr--modalEditor > #qr--main > .qr--modal-messageContainer > .qr--modal-editorSettings > .checkbox_label {
+  white-space: nowrap;
+}
+#dialogue_popup:has(#qr--modalEditor) #dialogue_popup_text > #qr--modalEditor > #qr--main > .qr--modal-messageContainer > .qr--modal-editorSettings > .checkbox_label > input {
+  font-size: inherit;
+}
 #dialogue_popup:has(#qr--modalEditor) #dialogue_popup_text > #qr--modalEditor > #qr--main > .qr--modal-messageContainer > #qr--modal-message {
   flex: 1 1 auto;
 }

--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -275,6 +275,7 @@
   gap: 1em;
   color: var(--grey70);
   font-size: smaller;
+  align-items: baseline;
 }
 #dialogue_popup:has(#qr--modalEditor) #dialogue_popup_text > #qr--modalEditor > #qr--main > .qr--modal-messageContainer > .qr--modal-editorSettings > .checkbox_label {
   white-space: nowrap;

--- a/public/scripts/extensions/quick-reply/style.less
+++ b/public/scripts/extensions/quick-reply/style.less
@@ -293,6 +293,19 @@
 					flex: 1 1 auto;
 					display: flex;
 					flex-direction: column;
+					> .qr--modal-editorSettings {
+						display: flex;
+						flex-direction: row;
+						gap: 1em;
+						color: var(--grey70);
+						font-size: smaller;
+						> .checkbox_label {
+							white-space: nowrap;
+							> input {
+								font-size: inherit;
+							}
+						}
+					}
 					> #qr--modal-message {
 						flex: 1 1 auto;
 					}

--- a/public/scripts/extensions/quick-reply/style.less
+++ b/public/scripts/extensions/quick-reply/style.less
@@ -299,6 +299,7 @@
 						gap: 1em;
 						color: var(--grey70);
 						font-size: smaller;
+						align-items: baseline;
 						> .checkbox_label {
 							white-space: nowrap;
 							> input {


### PR DESCRIPTION
With the parser rewrite, and IntelliSense on the QR editor, the editor gains relevancy. I suppose these changes can very well be added independently of the new parser, so here we go.

- Added a tab-size setting to the editor
- Added optional shortcut ctrl+enter to execute the QR from the editor