### PR TITLE
Add a main {{systemPrompt}} macro

### DIFF
--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -519,6 +519,7 @@ function selectMatchingContextTemplate(name) {
  * Replaces instruct mode macros in the given input string.
  * @param {string} input Input string.
  * @param {Object<string, *>} env - Map of macro names to the values they'll be substituted with. If the param
+ * values are functions, those functions will be called and their return values are used.
  * @returns {string} String with macros replaced.
  */
 export function replaceInstructMacros(input, env) {

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -518,13 +518,15 @@ function selectMatchingContextTemplate(name) {
 /**
  * Replaces instruct mode macros in the given input string.
  * @param {string} input Input string.
+ * @param {Object<string, *>} env - Map of macro names to the values they'll be substituted with. If the param
  * @returns {string} String with macros replaced.
  */
-export function replaceInstructMacros(input) {
+export function replaceInstructMacros(input, env) {
     if (!input) {
         return '';
     }
     const instructMacros = {
+        'systemPrompt': (power_user.prefer_character_prompt && env.charPrompt ? env.charPrompt : power_user.instruct.system_prompt),
         'instructSystem|instructSystemPrompt': power_user.instruct.system_prompt,
         'instructSystemPromptPrefix': power_user.instruct.system_sequence_prefix,
         'instructSystemPromptSuffix': power_user.instruct.system_sequence_suffix,

--- a/public/scripts/macros.js
+++ b/public/scripts/macros.js
@@ -257,7 +257,7 @@ export function evaluateMacros(content, env) {
     }
 
     content = diceRollReplace(content);
-    content = replaceInstructMacros(content);
+    content = replaceInstructMacros(content, env);
     content = replaceVariableMacros(content);
     content = content.replace(/{{newline}}/gi, '\n');
     content = content.replace(/\n*{{trim}}\n*/gi, '');

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -49,6 +49,7 @@
     <li><tt>&lcub;&lcub;maxPrompt&rcub;&rcub;</tt> – max allowed prompt length in tokens = (context size - response length)</li>
     <li><tt>&lcub;&lcub;exampleSeparator&rcub;&rcub;</tt> – context template example dialogues separator</li>
     <li><tt>&lcub;&lcub;chatStart&rcub;&rcub;</tt> – context template chat start line</li>
+    <li><tt>&lcub;&lcub;systemPrompt&rcub;&rcub;</tt> – main system prompt (either character prompt override if chosen, or instructSystemPrompt)</li>
     <li><tt>&lcub;&lcub;instructSystemPrompt&rcub;&rcub;</tt> – instruct system prompt</li>
     <li><tt>&lcub;&lcub;instructSystemPromptPrefix&rcub;&rcub;</tt> – instruct system prompt prefix sequence</li>
     <li><tt>&lcub;&lcub;instructSystemPromptSuffix&rcub;&rcub;</tt> – instruct system prompt suffix sequence</li>


### PR DESCRIPTION
Right now there is no way to get the **real** system prompt via a macro.  
Meaning of the char override setting is chosen, the instruct template will build the system prompt with preference to char override - but the `{{instructSystemPrompt}}` didn't respect that.

Instead of removing the access to the main instruct system prompt as a macro, I just added another one where you can get the final resolved system prompt: `{{systemPrompt}}`.

@Cohee1207 Maybe we should even name that `{{system}}`, so it works the same as in the story string builder? the char fields are already the same...

Edit: The more I think about it, the more I think we should use `{{system}}` yeah. I can't see a real conflict, as the story string builder executes first, right? And then you can just use the same short macro forms for all character fields, system prompt field, etc.