### PR TITLE
JSON schema fixes

### DIFF
--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -568,7 +568,7 @@ jQuery(function () {
         const json_schema_string = String($(this).val());
 
         try {
-            settings.json_schema = JSON.parse(json_schema_string ?? '{}');
+            settings.json_schema = JSON.parse(json_schema_string || '{}');
         } catch {
             // Ignore errors from here
         }


### PR DESCRIPTION
The JSON schema input didn't fall back on an empty string (or a cleared textbox) which means that settings wasn't cleared.