### PR TITLE
Performance improvement for /hide, /unhide

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -44,47 +44,29 @@ function isConvertible(type) {
 }
 
 /**
- * Mark message as hidden (system message).
- * @param {number} messageId Message ID
- * @param {JQuery<Element>} messageBlock Message UI element
+ * Mark a range of messages as hidden ("is_system") or not.
+ * @param {number} start Starting message ID
+ * @param {number} end Ending message ID (inclusive)
+ * @param {boolean} unhide If true, unhide the messages instead.
  * @returns
  */
-export async function hideChatMessage(messageId, messageBlock) {
-    const chatId = getCurrentChatId();
+export async function hideChatMessageRange(start, end, unhide) {
+    if (!getCurrentChatId()) return;
 
-    if (!chatId || isNaN(messageId)) return;
+    if (isNaN(start)) return;
+    if (!end) end = start;
+    const hide = !unhide;
 
-    const message = chat[messageId];
+    for (let messageId = start; messageId <= end; messageId++) {
+        const message = chat[messageId];
+        if (!message) continue;
 
-    if (!message) return;
+        const messageBlock = $(`.mes[mesid="${messageId}"]`);
+        if (!messageBlock.length) continue;
 
-    message.is_system = true;
-    messageBlock.attr('is_system', String(true));
-
-    // Reload swipes. Useful when a last message is hidden.
-    hideSwipeButtons();
-    showSwipeButtons();
-
-    saveChatDebounced();
-}
-
-/**
- * Mark message as visible (non-system message).
- * @param {number} messageId Message ID
- * @param {JQuery<Element>} messageBlock Message UI element
- * @returns
- */
-export async function unhideChatMessage(messageId, messageBlock) {
-    const chatId = getCurrentChatId();
-
-    if (!chatId || isNaN(messageId)) return;
-
-    const message = chat[messageId];
-
-    if (!message) return;
-
-    message.is_system = false;
-    messageBlock.attr('is_system', String(false));
+        message.is_system = hide;
+        messageBlock.attr('is_system', String(hide));
+    }
 
     // Reload swipes. Useful when a last message is hidden.
     hideSwipeButtons();
@@ -476,13 +458,13 @@ jQuery(function () {
     $(document).on('click', '.mes_hide', async function () {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        await hideChatMessage(messageId, messageBlock);
+        await hideChatMessageRange(messageId);
     });
 
     $(document).on('click', '.mes_unhide', async function () {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        await unhideChatMessage(messageId, messageBlock);
+        await hideChatMessageRange(messageId, messageId, true);
     });
 
     $(document).on('click', '.mes_file_delete', async function () {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -48,7 +48,7 @@ function isConvertible(type) {
  * @param {number} start Starting message ID
  * @param {number} end Ending message ID (inclusive)
  * @param {boolean} unhide If true, unhide the messages instead.
- * @returns
+ * @returns {void}
  */
 export async function hideChatMessageRange(start, end, unhide) {
     if (!getCurrentChatId()) return;
@@ -73,6 +73,28 @@ export async function hideChatMessageRange(start, end, unhide) {
     showSwipeButtons();
 
     saveChatDebounced();
+}
+
+/**
+ * Mark message as hidden (system message).
+ * @deprecated Use hideChatMessageRange.
+ * @param {number} messageId Message ID
+ * @param {JQuery<Element>} _messageBlock Unused
+ * @returns {void}
+ */
+export async function hideChatMessage(messageId, _messageBlock) {
+    hideChatMessageRange(messageId, messageId, false);
+}
+
+/**
+ * Mark message as visible (non-system message).
+ * @deprecated Use hideChatMessageRange.
+ * @param {number} messageId Message ID
+ * @param {JQuery<Element>} _messageBlock Unused
+ * @returns {void}
+ */
+export async function unhideChatMessage(messageId, _messageBlock) {
+    hideChatMessageRange(messageId, messageId, true);
 }
 
 /**

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -48,7 +48,7 @@ function isConvertible(type) {
  * @param {number} start Starting message ID
  * @param {number} end Ending message ID (inclusive)
  * @param {boolean} unhide If true, unhide the messages instead.
- * @returns {void}
+ * @returns {Promise<void>}
  */
 export async function hideChatMessageRange(start, end, unhide) {
     if (!getCurrentChatId()) return;
@@ -80,10 +80,10 @@ export async function hideChatMessageRange(start, end, unhide) {
  * @deprecated Use hideChatMessageRange.
  * @param {number} messageId Message ID
  * @param {JQuery<Element>} _messageBlock Unused
- * @returns {void}
+ * @returns {Promise<void>}
  */
 export async function hideChatMessage(messageId, _messageBlock) {
-    hideChatMessageRange(messageId, messageId, false);
+    return hideChatMessageRange(messageId, messageId, false);
 }
 
 /**
@@ -91,10 +91,10 @@ export async function hideChatMessage(messageId, _messageBlock) {
  * @deprecated Use hideChatMessageRange.
  * @param {number} messageId Message ID
  * @param {JQuery<Element>} _messageBlock Unused
- * @returns {void}
+ * @returns {Promise<void>}
  */
 export async function unhideChatMessage(messageId, _messageBlock) {
-    hideChatMessageRange(messageId, messageId, true);
+    return hideChatMessageRange(messageId, messageId, true);
 }
 
 /**
@@ -480,7 +480,7 @@ jQuery(function () {
     $(document).on('click', '.mes_hide', async function () {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        await hideChatMessageRange(messageId);
+        await hideChatMessageRange(messageId, messageId, false);
     });
 
     $(document).on('click', '.mes_unhide', async function () {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -38,7 +38,7 @@ import {
     this_chid,
 } from '../script.js';
 import { getMessageTimeStamp } from './RossAscends-mods.js';
-import { hideChatMessage, unhideChatMessage } from './chats.js';
+import { hideChatMessageRange } from './chats.js';
 import { getContext, saveMetadataDebounced } from './extensions.js';
 import { getRegexedString, regex_placement } from './extensions/regex/engine.js';
 import { findGroupMemberId, groups, is_group_generating, openGroupById, resetSelectedGroup, saveGroupChat, selected_group } from './group-chats.js';
@@ -917,16 +917,7 @@ async function hideMessageCallback(_, arg) {
         return;
     }
 
-    for (let messageId = range.start; messageId <= range.end; messageId++) {
-        const messageBlock = $(`.mes[mesid="${messageId}"]`);
-
-        if (!messageBlock.length) {
-            console.warn(`WARN: No message found with ID ${messageId}`);
-            return;
-        }
-
-        await hideChatMessage(messageId, messageBlock);
-    }
+    await hideChatMessageRange(range.start, range.end, false);
 }
 
 async function unhideMessageCallback(_, arg) {
@@ -942,17 +933,7 @@ async function unhideMessageCallback(_, arg) {
         return '';
     }
 
-    for (let messageId = range.start; messageId <= range.end; messageId++) {
-        const messageBlock = $(`.mes[mesid="${messageId}"]`);
-
-        if (!messageBlock.length) {
-            console.warn(`WARN: No message found with ID ${messageId}`);
-            return '';
-        }
-
-        await unhideChatMessage(messageId, messageBlock);
-    }
-
+    await hideChatMessageRange(range.start, range.end, true);
     return '';
 }
 


### PR DESCRIPTION
What this does:
1. DRYing
2. Makes it much faster to hide/unhide a large number of messages. In my setup, hiding 1000 messages(`/hide 0-999`) took around 21000 ms before this change and 900 ms after.

~~This PR removes `hideChatMessage()` and `unhideChatMessage()`. I don't think they're used anywhere outside chats.js and slash-commands.js, but I will add them back in if compatibility is desired.~~