### PR TITLE
Fix right click closing the zoomed avatar image

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -10260,7 +10260,7 @@ jQuery(async function () {
             }
 
             $('.zoomed_avatar').on('mouseup', (e) => {
-                if (e.target.closest('.drag-grabber') || e.button === 2) {
+                if (e.target.closest('.drag-grabber') || e.button !== 0) {
                     return;
                 }
                 $(`.zoomed_avatar[forChar="${charname}"]`).fadeOut(animation_duration, () => {

--- a/public/script.js
+++ b/public/script.js
@@ -10260,7 +10260,7 @@ jQuery(async function () {
             }
 
             $('.zoomed_avatar').on('mouseup', (e) => {
-                if (e.target.closest('.drag-grabber')) {
+                if (e.target.closest('.drag-grabber') || e.button === 2) {
                     return;
                 }
                 $(`.zoomed_avatar[forChar="${charname}"]`).fadeOut(animation_duration, () => {


### PR DESCRIPTION
Fixes the click event handler for the zoomed avatar image to only close on mouse left click.
This might be an issue on right-handed mice, but MDN isn't fully clear on that, and I don't know if we can detect that.