### PR TITLE
Summarize the chat messages handed to the embedding beforehand

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -1,4 +1,15 @@
-import { eventSource, event_types, extension_prompt_types, getCurrentChatId, getRequestHeaders, is_send_press, saveSettingsDebounced, setExtensionPrompt, substituteParams } from '../../../script.js';
+import {
+    eventSource,
+    event_types,
+    extension_prompt_types,
+    getCurrentChatId,
+    getRequestHeaders,
+    is_send_press,
+    saveSettingsDebounced,
+    setExtensionPrompt,
+    substituteParams,
+    generateRaw,
+} from '../../../script.js';
 import { ModuleWorkerWrapper, extension_settings, getContext, modules, renderExtensionTemplateAsync } from '../../extensions.js';
 import { collapseNewlines } from '../../power-user.js';
 import { SECRET_KEYS, secret_state, writeSecret } from '../../secrets.js';
@@ -140,6 +151,11 @@ async function synchronizeChat(batchSize = 5) {
 
         const newVectorItems = hashedMessages.filter(x => !hashesInCollection.includes(x.hash));
         const deletedHashes = hashesInCollection.filter(x => !hashedMessages.some(y => y.hash === x));
+
+        const sysPrompt = 'Pause your roleplay. Summarize the most important parts of the message. Your response should include nothing but the summary.';
+        for (let i = 0; i < hashedMessages.length; i++) {
+            hashedMessages[i].text = await generateRaw(hashedMessages[i].text, '', false, false, sysPrompt);
+        }
 
         if (newVectorItems.length > 0) {
             const chunkedBatch = splitByChunks(newVectorItems.slice(0, batchSize));

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -25,6 +25,7 @@ const settings = {
     include_wi: false,
     togetherai_model: 'togethercomputer/m2-bert-80M-32k-retrieval',
     openai_model: 'text-embedding-ada-002',
+    summarize: false,
 
     // For chats
     enabled_chats: false,
@@ -152,9 +153,11 @@ async function synchronizeChat(batchSize = 5) {
         const newVectorItems = hashedMessages.filter(x => !hashesInCollection.includes(x.hash));
         const deletedHashes = hashesInCollection.filter(x => !hashedMessages.some(y => y.hash === x));
 
-        const sysPrompt = 'Pause your roleplay. Summarize the most important parts of the message. Your response should include nothing but the summary.';
-        for (let i = 0; i < hashedMessages.length; i++) {
-            hashedMessages[i].text = await generateRaw(hashedMessages[i].text, '', false, false, sysPrompt);
+        if (settings.summarize) {
+            const sysPrompt = 'Pause your roleplay. Summarize the most important parts of the message. Limit yourself to 250 words or less. Your response should include nothing but the summary.';
+            for (const element of hashedMessages) {
+                element.text = await generateRaw(element.text, '', false, false, sysPrompt);
+            }
         }
 
         if (newVectorItems.length > 0) {
@@ -769,6 +772,12 @@ jQuery(async () => {
 
     $('#vectors_include_wi').prop('checked', settings.include_wi).on('input', () => {
         settings.include_wi = !!$('#vectors_include_wi').prop('checked');
+        Object.assign(extension_settings.vectors, settings);
+        saveSettingsDebounced();
+    });
+
+    $('#vectors_summarize').prop('checked', settings.summarize).on('input', () => {
+        settings.summarize = !!$('#vectors_summarize').prop('checked');
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -26,6 +26,7 @@ const settings = {
     togetherai_model: 'togethercomputer/m2-bert-80M-32k-retrieval',
     openai_model: 'text-embedding-ada-002',
     summarize: false,
+    summary_source: 'main',
 
     // For chats
     enabled_chats: false,
@@ -125,6 +126,57 @@ function splitByChunks(items) {
     return chunkedItems;
 }
 
+async function summarizeExtra(hashedMessages) {
+    for (const element of hashedMessages) {
+        try {
+            const url = new URL(getApiUrl());
+            url.pathname = '/api/summarize';
+
+            const apiResult = await doExtrasFetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Bypass-Tunnel-Reminder': 'bypass',
+                },
+                body: JSON.stringify({
+                    text: element.text,
+                    params: {},
+                }),
+            });
+
+            if (apiResult.ok) {
+                const data = await apiResult.json();
+                element.text = data.summary;
+            }
+        }
+        catch (error) {
+            console.log(error);
+        }
+    }
+
+    return hashedMessages;
+}
+
+async function summarizeMain(hashedMessages) {
+    const sysPrompt = 'Pause your roleplay. Summarize the most important parts of the message. Limit yourself to 250 words or less. Your response should include nothing but the summary.';
+    for (const element of hashedMessages) {
+        element.text = await generateRaw(element.text, '', false, false, sysPrompt);
+    }
+
+    return hashedMessages;
+}
+
+async function summarize(hashedMessages, endpoint = 'main') {
+    switch (endpoint) {
+        case 'main':
+            return await summarizeMain(hashedMessages);
+        case 'extras':
+            return await summarizeExtra(hashedMessages);
+        default:
+            console.error('Unsupported endpoint', endpoint);
+    }
+}
+
 async function synchronizeChat(batchSize = 5) {
     if (!settings.enabled_chats) {
         return -1;
@@ -147,21 +199,20 @@ async function synchronizeChat(batchSize = 5) {
             return -1;
         }
 
-        const hashedMessages = context.chat.filter(x => !x.is_system).map(x => ({ text: String(x.mes), hash: getStringHash(x.mes), index: context.chat.indexOf(x) }));
+        let hashedMessages = context.chat.filter(x => !x.is_system).map(x => ({ text: String(substituteParams(x.mes)), hash: getStringHash(substituteParams(x.mes)), index: context.chat.indexOf(x) }));
         const hashesInCollection = await getSavedHashes(chatId);
+
+        if (settings.summarize) {
+            hashedMessages = await summarize(hashedMessages, settings.summary_source);
+        }
 
         const newVectorItems = hashedMessages.filter(x => !hashesInCollection.includes(x.hash));
         const deletedHashes = hashesInCollection.filter(x => !hashedMessages.some(y => y.hash === x));
 
-        if (settings.summarize) {
-            const sysPrompt = 'Pause your roleplay. Summarize the most important parts of the message. Limit yourself to 250 words or less. Your response should include nothing but the summary.';
-            for (const element of hashedMessages) {
-                element.text = await generateRaw(element.text, '', false, false, sysPrompt);
-            }
-        }
 
         if (newVectorItems.length > 0) {
             const chunkedBatch = splitByChunks(newVectorItems.slice(0, batchSize));
+
             console.log(`Vectors: Found ${newVectorItems.length} new items. Processing ${batchSize}...`);
             await insertVectorItems(chatId, chunkedBatch);
         }
@@ -358,7 +409,7 @@ async function rearrangeChat(chat) {
             if (retainMessages.includes(message) || !message.mes) {
                 continue;
             }
-            const hash = getStringHash(message.mes);
+            const hash = getStringHash(substituteParams(message.mes));
             if (queryHashes.includes(hash) && !insertedHashes.has(hash)) {
                 queriedMessages.push(message);
                 insertedHashes.add(hash);
@@ -367,7 +418,7 @@ async function rearrangeChat(chat) {
 
         // Rearrange queried messages to match query order
         // Order is reversed because more relevant are at the lower indices
-        queriedMessages.sort((a, b) => queryHashes.indexOf(getStringHash(b.mes)) - queryHashes.indexOf(getStringHash(a.mes)));
+        queriedMessages.sort((a, b) => queryHashes.indexOf(getStringHash(substituteParams(b.mes))) - queryHashes.indexOf(getStringHash(substituteParams(a.mes))));
 
         // Remove queried messages from the original chat array
         for (const message of chat) {
@@ -408,13 +459,19 @@ const onChatEvent = debounce(async () => await moduleWorker.update(), 500);
  * @param {object[]} chat Chat messages
  * @returns {string} Text to query
  */
-function getQueryText(chat) {
+async function getQueryText(chat) {
     let queryText = '';
     let i = 0;
 
-    for (const message of chat.slice().reverse()) {
-        if (message.mes) {
-            queryText += message.mes + '\n';
+    let hashedMessages = chat.map(x => ({ text: String(substituteParams(x.mes)) }));
+
+    if (settings.summarize) {
+        hashedMessages = await summarize(hashedMessages, settings.summary_source);
+    }
+
+    for (const message of hashedMessages.slice().reverse()) {
+        if (message.text) {
+            queryText += message.text + '\n';
             i++;
         }
 
@@ -655,7 +712,7 @@ async function onViewStatsClick() {
 
     const chat = getContext().chat;
     for (const message of chat) {
-        if (hashesInCollection.includes(getStringHash(message.mes))) {
+        if (hashesInCollection.includes(getStringHash(substituteParams(message.mes)))) {
             const messageElement = $(`.mes[mesid="${chat.indexOf(message)}"]`);
             messageElement.addClass('vectorized');
         }
@@ -778,6 +835,12 @@ jQuery(async () => {
 
     $('#vectors_summarize').prop('checked', settings.summarize).on('input', () => {
         settings.summarize = !!$('#vectors_summarize').prop('checked');
+        Object.assign(extension_settings.vectors, settings);
+        saveSettingsDebounced();
+    });
+
+    $('#vectors_summary_source').val(settings.togetherai_model).on('change', () => {
+        settings.summary_source = String($('#vectors_summary_source').val());
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -88,7 +88,7 @@
                     Summarize chat messages
                 </label>
                 <label for="vectors_summary_source">Summarize with:</label>
-                <select id="vectors_summary_source">
+                <select id="vectors_summary_source" class="text_pole">
                     <option value="main">Main API</option>
                     <option value="extras">Extras API</option>
                 </select>

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -82,33 +82,6 @@
 
             <hr>
 
-            <div class="flex-container flexFlowColumn">
-                <span>Summarization for vectors is an experimental feature that may improve vectors or may worsen them. Use at your own discretion.</span>
-                <label class="checkbox_label expander" for="vectors_summarize" title="Summarize chat messages before generating embeddings.">
-                    <input id="vectors_summarize" type="checkbox" class="checkbox">
-                    Summarize chat messages for vector generation
-                </label>
-                <i class="failure">Warning: This will slow down vector generation drastically, as all messages have to be summarized first.</i>
-
-                <label class="checkbox_label expander" for="vectors_summarize_user" title="Summarize sent chat messages before generating embeddings.">
-                    <input id="vectors_summarize_user" type="checkbox" class="checkbox">
-                    Summarize chat messages when sending
-                </label>
-                <i class="failure">Warning: This might cause your sent messages to take a bit to process and slow down response time.</i>
-
-                <label for="vectors_summary_source">Summarize with:</label>
-                <select id="vectors_summary_source" class="text_pole">
-                    <option value="main">Main API</option>
-                    <option value="extras">Extras API</option>
-                </select>
-
-                <label for="vectors_summary_prompt">Summary Prompt:</label>
-                <small>Only used when Main API is selected.</small>
-                <textarea id="vectors_summary_prompt" class="text_pole textarea_compact" rows="6" placeholder="This prompt will be sent to AI to request the summary generation."></textarea>
-            </div>
-
-            <hr>
-
             <h4>
                 File vectorization settings
             </h4>
@@ -119,7 +92,6 @@
             </label>
 
             <div id="vectors_files_settings">
-
                 <div class="flex-container">
                     <div class="flex1" title="Only files past this size will be vectorized.">
                         <label for="vectors_size_threshold">
@@ -151,6 +123,33 @@
                 <input id="vectors_enabled_chats" type="checkbox" class="checkbox">
                 Enabled for chat messages
             </label>
+
+            <hr>
+
+            <div class="flex-container flexFlowColumn">
+                <span>Summarization for vectors is an experimental feature that may improve vectors or may worsen them. Use at your own discretion.</span>
+                <label class="checkbox_label expander" for="vectors_summarize" title="Summarize chat messages before generating embeddings.">
+                    <input id="vectors_summarize" type="checkbox" class="checkbox">
+                    Summarize chat messages for vector generation
+                </label>
+                <i class="failure">Warning: This will slow down vector generation drastically, as all messages have to be summarized first.</i>
+
+                <label class="checkbox_label expander" for="vectors_summarize_user" title="Summarize sent chat messages before generating embeddings.">
+                    <input id="vectors_summarize_user" type="checkbox" class="checkbox">
+                    Summarize chat messages when sending
+                </label>
+                <i class="failure">Warning: This might cause your sent messages to take a bit to process and slow down response time.</i>
+
+                <label for="vectors_summary_source">Summarize with:</label>
+                <select id="vectors_summary_source" class="text_pole">
+                    <option value="main">Main API</option>
+                    <option value="extras">Extras API</option>
+                </select>
+
+                <label for="vectors_summary_prompt">Summary Prompt:</label>
+                <small>Only used when Main API is selected.</small>
+                <textarea id="vectors_summary_prompt" class="text_pole textarea_compact" rows="6" placeholder="This prompt will be sent to AI to request the summary generation."></textarea>
+            </div>
 
             <div id="vectors_chats_settings">
                 <div id="vectors_advanced_settings">

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -78,10 +78,20 @@
                     <input id="vectors_include_wi" type="checkbox" class="checkbox">
                     Include in World Info Scanning
                 </label>
+            </div>
+
+            <hr>
+
+            <div class="flex-container flexFlowColumn">
                 <label class="checkbox_label expander" for="vectors_summarize" title="Summarize chat messages before generating embeddings.">
                     <input id="vectors_summarize" type="checkbox" class="checkbox">
                     Summarize chat messages
                 </label>
+                <label for="vectors_summary_source">Summarize with:</label>
+                <select id="vectors_summary_source">
+                    <option value="main">Main API</option>
+                    <option value="extras">Extras API</option>
+                </select>
             </div>
 
             <hr>

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -126,36 +126,6 @@
 
             <hr>
 
-            <div class="flex-container flexFlowColumn">
-                <div class="flex-container alignitemscenter justifyCenter">
-                    <i class="fa-solid fa-flask" title="Summarization for vectors is an experimental feature that may improve vectors or may worsen them. Use at your own discretion."></i>
-                    <span>Vector Summarization</span>
-                </div>
-                <label class="checkbox_label expander" for="vectors_summarize" title="Summarize chat messages before generating embeddings.">
-                    <input id="vectors_summarize" type="checkbox" class="checkbox">
-                    Summarize chat messages for vector generation
-                </label>
-                <i class="failure">Warning: This will slow down vector generation drastically, as all messages have to be summarized first.</i>
-
-                <label class="checkbox_label expander" for="vectors_summarize_user" title="Summarize sent chat messages before generating embeddings.">
-                    <input id="vectors_summarize_user" type="checkbox" class="checkbox">
-                    Summarize chat messages when sending
-                </label>
-                <i class="failure">Warning: This might cause your sent messages to take a bit to process and slow down response time.</i>
-
-                <label for="vectors_summary_source">Summarize with:</label>
-                <select id="vectors_summary_source" class="text_pole">
-                    <option value="main">Main API</option>
-                    <option value="extras">Extras API</option>
-                </select>
-
-                <label for="vectors_summary_prompt">Summary Prompt:</label>
-                <small>Only used when Main API is selected.</small>
-                <textarea id="vectors_summary_prompt" class="text_pole textarea_compact" rows="6" placeholder="This prompt will be sent to AI to request the summary generation."></textarea>
-            </div>
-
-            <hr>
-
             <div id="vectors_chats_settings">
                 <div id="vectors_advanced_settings">
                     <label for="vectors_template">
@@ -197,6 +167,34 @@
                             </label>
                             <input type="number" id="vectors_insert" class="text_pole widthUnset" min="1" max="9999" />
                         </div>
+                    </div>
+                    <hr class="m-b-1">
+                    <div class="flex-container flexFlowColumn">
+                        <div class="flex-container alignitemscenter justifyCenter">
+                            <i class="fa-solid fa-flask" title="Summarization for vectors is an experimental feature that may improve vectors or may worsen them. Use at your own discretion."></i>
+                            <span>Vector Summarization</span>
+                        </div>
+                        <label class="checkbox_label expander" for="vectors_summarize" title="Summarize chat messages before generating embeddings.">
+                            <input id="vectors_summarize" type="checkbox" class="checkbox">
+                            Summarize chat messages for vector generation
+                        </label>
+                        <i class="failure">Warning: This will slow down vector generation drastically, as all messages have to be summarized first.</i>
+
+                        <label class="checkbox_label expander" for="vectors_summarize_user" title="Summarize sent chat messages before generating embeddings.">
+                            <input id="vectors_summarize_user" type="checkbox" class="checkbox">
+                            Summarize chat messages when sending
+                        </label>
+                        <i class="failure">Warning: This might cause your sent messages to take a bit to process and slow down response time.</i>
+
+                        <label for="vectors_summary_source">Summarize with:</label>
+                        <select id="vectors_summary_source" class="text_pole">
+                            <option value="main">Main API</option>
+                            <option value="extras">Extras API</option>
+                        </select>
+
+                        <label for="vectors_summary_prompt">Summary Prompt:</label>
+                        <small>Only used when Main API is selected.</small>
+                        <textarea id="vectors_summary_prompt" class="text_pole textarea_compact" rows="6" placeholder="This prompt will be sent to AI to request the summary generation."></textarea>
                     </div>
                 </div>
                 <small>

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -151,6 +151,8 @@
                 <textarea id="vectors_summary_prompt" class="text_pole textarea_compact" rows="6" placeholder="This prompt will be sent to AI to request the summary generation."></textarea>
             </div>
 
+            <hr>
+
             <div id="vectors_chats_settings">
                 <div id="vectors_advanced_settings">
                     <label for="vectors_template">

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -73,10 +73,16 @@
                 <input type="number" id="vectors_query" class="text_pole widthUnset" min="1" max="99" />
             </div>
 
-            <label class="checkbox_label" for="vectors_include_wi" title="Query results can activate World Info entries.">
-                <input id="vectors_include_wi" type="checkbox" class="checkbox">
-                Include in World Info Scanning
-            </label>
+            <div class="flex-container">
+                <label class="checkbox_label expander" for="vectors_include_wi" title="Query results can activate World Info entries.">
+                    <input id="vectors_include_wi" type="checkbox" class="checkbox">
+                    Include in World Info Scanning
+                </label>
+                <label class="checkbox_label expander" for="vectors_summarize" title="Summarize chat messages before generating embeddings.">
+                    <input id="vectors_summarize" type="checkbox" class="checkbox">
+                    Summarize chat messages
+                </label>
+            </div>
 
             <hr>
 

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -83,15 +83,28 @@
             <hr>
 
             <div class="flex-container flexFlowColumn">
+                <span>Summarization for vectors is an experimental feature that may improve vectors or may worsen them. Use at your own discretion.</span>
                 <label class="checkbox_label expander" for="vectors_summarize" title="Summarize chat messages before generating embeddings.">
                     <input id="vectors_summarize" type="checkbox" class="checkbox">
-                    Summarize chat messages
+                    Summarize chat messages for vector generation
                 </label>
+                <i class="failure">Warning: This will slow down vector generation drastically, as all messages have to be summarized first.</i>
+
+                <label class="checkbox_label expander" for="vectors_summarize_user" title="Summarize sent chat messages before generating embeddings.">
+                    <input id="vectors_summarize_user" type="checkbox" class="checkbox">
+                    Summarize chat messages when sending
+                </label>
+                <i class="failure">Warning: This might cause your sent messages to take a bit to process and slow down response time.</i>
+
                 <label for="vectors_summary_source">Summarize with:</label>
                 <select id="vectors_summary_source" class="text_pole">
                     <option value="main">Main API</option>
                     <option value="extras">Extras API</option>
                 </select>
+
+                <label for="vectors_summary_prompt">Summary Prompt:</label>
+                <small>Only used when Main API is selected.</small>
+                <textarea id="vectors_summary_prompt" class="text_pole textarea_compact" rows="6" placeholder="This prompt will be sent to AI to request the summary generation."></textarea>
             </div>
 
             <hr>

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -127,7 +127,10 @@
             <hr>
 
             <div class="flex-container flexFlowColumn">
-                <span>Summarization for vectors is an experimental feature that may improve vectors or may worsen them. Use at your own discretion.</span>
+                <div class="flex-container alignitemscenter justifyCenter">
+                    <i class="fa-solid fa-flask" title="Summarization for vectors is an experimental feature that may improve vectors or may worsen them. Use at your own discretion."></i>
+                    <span>Vector Summarization</span>
+                </div>
                 <label class="checkbox_label expander" for="vectors_summarize" title="Summarize chat messages before generating embeddings.">
                     <input id="vectors_summarize" type="checkbox" class="checkbox">
                     Summarize chat messages for vector generation


### PR DESCRIPTION
This feature allows chat messages to be summarized before the embeddings are generated.

The idea behind this is that the summaries have a higher chance of having overlap with each other than the raw text messages have, thus possibly resulting in better matches. Personal testing seemed to confirm it to some degree. Another benefit is that the added messages are smaller by default, as they are summaries, thus saving on context length.

The drawback is that generation of vectors takes a lot longer when summarizing them beforehand.