### PR TITLE
fix: css `decodeStyles`: remove `</br>` tags before parsing

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -395,7 +395,8 @@ export function decodeStyleTags(text) {
 
     return text.replaceAll(styleDecodeRegex, (_, style) => {
         try {
-            const ast = css.parse(unescape(style));
+			let styleCleaned = unescape(style).replaceAll(/<br\/>/g, '');
+            const ast = css.parse(styleCleaned);
             const rules = ast?.stylesheet?.rules;
             if (rules) {
                 for (const rule of rules) {


### PR DESCRIPTION
To reproduce error on current staging, put the following in any chat message:
```
<style>
  @keyframes pulse {
    0% {
      transform: scale(1);
    }
    50% {
      transform: scale(1.2);
    }
    100% {
      transform: scale(1);
    }
  }
</style>
```

Without this fix, the message, after your done editing, says:
`CSS ERROR: Error: :1:26: missing '}'`
because that's returned from a caught error in `decodeStyleTags` from calling `css.parse(style)`.

With this fix, it works.

For some reason, the style `decodeStyleTags` receives (encoded) has `</br>` tags in it.
In the example above the encoded string that enters as `style` inside the `replaceAll` is `%3Cbr/%3E%20%20@keyframes%20pulse%20%7B%3Cbr/%3E%20%20%20%200%25%20%7B%3Cbr/%3E%20%20%20%20%20%20transform%3A%20scale%281%29%3B%3Cbr/%3E%20%20%20%20%7D%3Cbr/%3E%20%20%20%2050%25%20%7B%3Cbr/%3E%20%20%20%20%20%20transform%3A%20scale%281.2%29%3B%3Cbr/%3E%20%20%20%20%7D%3Cbr/%3E%20%20%20%20100%25%20%7B%3Cbr/%3E%20%20%20%20%20%20transform%3A%20scale%281%29%3B%3Cbr/%3E%20%20%20%20%7D%3Cbr/%3E%20%20%7D%3Cbr/%3E`
The `</br>` tags should be visible.

It's possible this only happens with certain options turned on or off, relating to `<tags>`, but idk.