### PR TITLE
Changed fs.renameSync() to fs.copyFileSync()

### DIFF
--- a/post-install.js
+++ b/post-install.js
@@ -60,7 +60,8 @@ function convertConfig() {
         try {
             console.log(color.blue('Converting config.conf to config.yaml. Your old config.conf will be renamed to config.conf.bak'));
             const config = require(path.join(process.cwd(), './config.conf'));
-            fs.renameSync('./config.conf', './config.conf.bak');
+            fs.copyFileSync('./config.conf', './config.conf.bak');
+            fs.rmSync('./config.conf');
             fs.writeFileSync('./config.yaml', yaml.stringify(config));
             console.log(color.green('Conversion successful. Please check your config.yaml and fix it if necessary.'));
         } catch (error) {

--- a/src/endpoints/assets.js
+++ b/src/endpoints/assets.js
@@ -227,7 +227,8 @@ router.post('/download', jsonParser, async (request, response) => {
 
         // Move into asset place
         console.debug('Download finished, moving file from', temp_path, 'to', file_path);
-        fs.renameSync(temp_path, file_path);
+        fs.copyFileSync(temp_path, file_path);
+        fs.rmSync(temp_path);
         response.sendStatus(200);
     }
     catch (error) {

--- a/src/endpoints/backgrounds.js
+++ b/src/endpoints/backgrounds.js
@@ -51,7 +51,8 @@ router.post('/rename', jsonParser, function (request, response) {
         return response.sendStatus(400);
     }
 
-    fs.renameSync(oldFileName, newFileName);
+    fs.copyFileSync(oldFileName, newFileName);
+    fs.rmSync(oldFileName);
     invalidateThumbnail(request.user.directories, 'bg', request.body.old_bg);
     return response.send('ok');
 });
@@ -63,7 +64,8 @@ router.post('/upload', urlencodedParser, function (request, response) {
     const filename = request.file.originalname;
 
     try {
-        fs.renameSync(img_path, path.join(request.user.directories.backgrounds, filename));
+        fs.copyFileSync(img_path, path.join(request.user.directories.backgrounds, filename));
+        fs.rmSync(img_path);
         invalidateThumbnail(request.user.directories, 'bg', filename);
         response.send(filename);
     } catch (err) {

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -680,7 +680,7 @@ router.post('/rename', jsonParser, async function (request, response) {
 
         // Rename chats folder
         if (fs.existsSync(oldChatsPath) && !fs.existsSync(newChatsPath)) {
-            fs.cpSync(oldChatsPath, newChatsPath);
+            fs.cpSync(oldChatsPath, newChatsPath, { recursive: true });
             fs.rmSync(oldChatsPath, { recursive: true, force: true });
         }
 

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -680,7 +680,8 @@ router.post('/rename', jsonParser, async function (request, response) {
 
         // Rename chats folder
         if (fs.existsSync(oldChatsPath) && !fs.existsSync(newChatsPath)) {
-            fs.renameSync(oldChatsPath, newChatsPath);
+            fs.cpSync(oldChatsPath, newChatsPath);
+            fs.rmSync(oldChatsPath, { recursive: true, force: true });
         }
 
         // Remove the old character file

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -213,8 +213,9 @@ router.post('/rename', jsonParser, async function (request, response) {
         return response.status(400).send({ error: true });
     }
 
+    fs.copyFileSync(pathToOriginalFile, pathToRenamedFile);
+    fs.rmSync(pathToOriginalFile);
     console.log('Successfully renamed.');
-    fs.renameSync(pathToOriginalFile, pathToRenamedFile);
     return response.send({ ok: true });
 });
 

--- a/src/users.js
+++ b/src/users.js
@@ -286,12 +286,14 @@ async function migrateUserData() {
                 // Copy the file to the new location
                 fs.cpSync(migration.old, migration.new, { force: true });
                 // Move the file to the backup location
-                fs.renameSync(migration.old, path.join(backupDirectory, path.basename(migration.old)));
+                fs.cpSync(migration.old, path.join(backupDirectory, path.basename(migration.old)));
+                fs.rmSync(migration.old, { recursive: true, force: true });
             } else {
                 // Copy the directory to the new location
                 fs.cpSync(migration.old, migration.new, { recursive: true, force: true });
                 // Move the directory to the backup location
-                fs.renameSync(migration.old, path.join(backupDirectory, path.basename(migration.old)));
+                fs.cpSync(migration.old, path.join(backupDirectory, path.basename(migration.old)));
+                fs.rmSync(migration.old, { recursive: true, force: true });
             }
         } catch (error) {
             console.error(color.red(`Error migrating ${migration.old} to ${migration.new}:`), error.message);

--- a/src/users.js
+++ b/src/users.js
@@ -286,13 +286,21 @@ async function migrateUserData() {
                 // Copy the file to the new location
                 fs.cpSync(migration.old, migration.new, { force: true });
                 // Move the file to the backup location
-                fs.cpSync(migration.old, path.join(backupDirectory, path.basename(migration.old)));
+                fs.cpSync(
+                    migration.old,
+                    path.join(backupDirectory, path.basename(migration.old)),
+                    { recursive: true, force: true }
+                );
                 fs.rmSync(migration.old, { recursive: true, force: true });
             } else {
                 // Copy the directory to the new location
                 fs.cpSync(migration.old, migration.new, { recursive: true, force: true });
                 // Move the directory to the backup location
-                fs.cpSync(migration.old, path.join(backupDirectory, path.basename(migration.old)));
+                fs.cpSync(
+                    migration.old,
+                    path.join(backupDirectory, path.basename(migration.old)),
+                    { recursive: true, force: true }
+                );
                 fs.rmSync(migration.old, { recursive: true, force: true });
             }
         } catch (error) {


### PR DESCRIPTION
Changes all `fs.renameSync()` calls to use `fs.copyFileSync()` + `fs.rmSync()` for files and `fs.cpSync()` + `fs.rmSync()` for folders.

This provides identical behavior as `fs.renameSync()` but allows them to work across Docker volumes.

Fixes issue #2104.