### PR TITLE
Fix: Handle InformaticAI Endpoint response without message in response payload

### DIFF
--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -325,7 +325,7 @@ router.post('/generate', jsonParser, async function (request, response) {
 
                 // Map InfermaticAI response to OAI completions format
                 if (apiType === TEXTGEN_TYPES.INFERMATICAI) {
-                    data['choices'] = (data?.choices || []).map(choice => ({ text: choice.message.content }));
+                    data['choices'] = (data?.choices || []).map(choice => ({ text: choice?.message?.content || choice.text }));
                 }
 
                 return response.send(data);


### PR DESCRIPTION
# Problem:
When utilizing the objectives extension, noticed informaticAI replies would not complete due to error:
```
Endpoint response: {
  id: 'chatcmpl-026cc97b-4692-4dfb-a3ea-272e077262c7',
  object: 'text_completion',
  created: 1713868043,
  model: 'wolfram/miquliz-120b-v2.0',
  choices: [
    {
      finish_reason: 'eos_token',
      index: 0,
      text: ' False',
      logprobs: {
        tokens: [ ' False', '</s>' ],
        token_logprobs: [ -0.2590332, -0.5649414 ],
        text_offset: [ 0, 6 ],
        top_logprobs: [ {}, {} ]
      }
    }
  ],
  usage: { prompt_tokens: 12644, completion_tokens: 1, total_tokens: 12645 }
}
Endpoint error: TypeError: Cannot read properties of undefined (reading 'content')
    at E:\Downloads\SillyTavern\src\endpoints\backends\text-completions.js:328:99
    at Array.map (<anonymous>)
    at E:\Downloads\SillyTavern\src\endpoints\backends\text-completions.js:328:61
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
 ```
 
 # Solution:
 Adding handling for informaticAI replies when choice.message is missing in reply. If neither choice.message or choice.text is available, we should error out due to invalid response structure. 
 
 # Post-fix:
 ```
 Endpoint response: {
  id: 'chatcmpl-b431c1b5-51f0-4103-865a-19eb05492e28',
  object: 'text_completion',
  created: 1713868624,
  model: 'wolfram/miquliz-120b-v2.0',
  choices: [
    {
      finish_reason: 'eos_token',
      index: 0,
      text: ' False',
      logprobs: {
        tokens: [ ' False', '</s>' ],
        token_logprobs: [ -0.2590332, -0.5649414 ],
        text_offset: [ 0, 6 ],
        top_logprobs: [ {}, {} ]
      }
    }
  ],
  usage: { prompt_tokens: 12644, completion_tokens: 1, total_tokens: 12645 }
}
```