### PR TITLE
Fix expression list resolve

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1270,13 +1270,10 @@ async function getExpressionsList() {
      * @returns {Promise<string[]>}
      */
     async function resolveExpressionsList() {
-        // get something for offline mode (default images)
-        if (!modules.includes('classify') && extension_settings.expressions.api == EXPRESSION_API.extras) {
-            return DEFAULT_EXPRESSIONS;
-        }
-
+        // See if we can retrieve a specific expression list from the API
         try {
-            if (extension_settings.expressions.api == EXPRESSION_API.extras) {
+            // Check Extras api first, if enabled and that module active
+            if (extension_settings.expressions.api == EXPRESSION_API.extras && modules.includes('classify')) {
                 const url = new URL(getApiUrl());
                 url.pathname = '/api/classify/labels';
 
@@ -1291,7 +1288,10 @@ async function getExpressionsList() {
                     expressionsList = data.labels;
                     return expressionsList;
                 }
-            } else {
+            }
+
+            // If running the local classify model (not using the LLM), we ask that one
+            if (extension_settings.expressions.api == EXPRESSION_API.local) {
                 const apiResult = await fetch('/api/extra/classify/labels', {
                     method: 'POST',
                     headers: getRequestHeaders(),
@@ -1303,11 +1303,12 @@ async function getExpressionsList() {
                     return expressionsList;
                 }
             }
-        }
-        catch (error) {
+        } catch (error) {
             console.log(error);
-            return [];
         }
+
+        // If there was no specific list, or an error, just return the default expressions
+        return DEFAULT_EXPRESSIONS;
     }
 
     const result = await resolveExpressionsList();


### PR DESCRIPTION
- New expression api "LLM" still queried local classify model for expressions, fixed by returning default list
- Fixed failed API calls crashing Expressions extension


Well, I randomly stumbled over this when I had turned "break on exceptions" on while debugging.  
As we already found out, my local classify model was broken for whatever reason, so the API call errored out. Can happen. But because the function was written in a way that it did not return an array on errored API calls, the iterator call after made it crash.  
Wich meant I couldn't even switch to another expression API setting, like LLM, because settings did not update when the extension crashed.

I reworked the expression list method to always return the default expressions on error, at least.

Also, I am pretty sure it's wrong to query the local classification module for the possible expressions when the new "LLM" api option is chosen.  
In that case, we should just return the default expressions, extended by the custom ones the user has defined. Because all those get merged into the prompt supplied to the LLM.  
No need to query any model for options.