### PR TITLE
Clean up Generate(), part 4

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3780,6 +3780,7 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
 
     // Fetches the combined prompt for both negative and positive prompts
     const cfgGuidanceScale = getGuidanceScale();
+    const useCfgPrompt = cfgGuidanceScale && cfgGuidanceScale.value !== 1;
 
     // For prompt bit itemization
     let mesSendString = '';
@@ -3787,7 +3788,7 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
     function getCombinedPrompt(isNegative) {
         // Only return if the guidance scale doesn't exist or the value is 1
         // Also don't return if constructing the neutral prompt
-        if (isNegative && (!cfgGuidanceScale || cfgGuidanceScale?.value === 1)) {
+        if (isNegative && !useCfgPrompt) {
             return;
         }
 
@@ -3800,7 +3801,7 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
         let finalMesSend = structuredClone(mesSend);
 
         let cfgPrompt = {};
-        if (cfgGuidanceScale && cfgGuidanceScale?.value !== 1) {
+        if (useCfgPrompt) {
             cfgPrompt = getCfgPrompt(cfgGuidanceScale, isNegative);
         }
 
@@ -3900,7 +3901,7 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
     let finalPrompt = getCombinedPrompt(false);
 
     // Include the entire guidance scale object
-    const cfgValues = cfgGuidanceScale && cfgGuidanceScale?.value !== 1 ? ({ guidanceScale: cfgGuidanceScale, negativePrompt: negativePrompt }) : null;
+    const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale, negativePrompt: negativePrompt } : null;
 
     let maxLength = Number(amount_gen); // how many tokens the AI will be requested to generate
     let thisPromptBits = [];

--- a/public/script.js
+++ b/public/script.js
@@ -3800,22 +3800,20 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
         // Deep clone
         let finalMesSend = structuredClone(mesSend);
 
-        let cfgPrompt = {};
         if (useCfgPrompt) {
-            cfgPrompt = getCfgPrompt(cfgGuidanceScale, isNegative);
-        }
-
-        if (cfgPrompt && cfgPrompt.value) {
-            if (cfgPrompt.depth === 0) {
-                finalMesSend[finalMesSend.length - 1].message +=
-                    /\s/.test(finalMesSend[finalMesSend.length - 1].message.slice(-1))
-                        ? cfgPrompt.value
-                        : ` ${cfgPrompt.value}`;
-            } else {
-                // TODO: Make all extension prompts use an array/splice method
-                const lengthDiff = mesSend.length - cfgPrompt.depth;
-                const cfgDepth = lengthDiff >= 0 ? lengthDiff : 0;
-                finalMesSend[cfgDepth].extensionPrompts.push(`${cfgPrompt.value}\n`);
+            const cfgPrompt = getCfgPrompt(cfgGuidanceScale, isNegative);
+            if (cfgPrompt.value) {
+                if (cfgPrompt.depth === 0) {
+                    finalMesSend[finalMesSend.length - 1].message +=
+                        /\s/.test(finalMesSend[finalMesSend.length - 1].message.slice(-1))
+                            ? cfgPrompt.value
+                            : ` ${cfgPrompt.value}`;
+                } else {
+                    // TODO: Make all extension prompts use an array/splice method
+                    const lengthDiff = mesSend.length - cfgPrompt.depth;
+                    const cfgDepth = lengthDiff >= 0 ? lengthDiff : 0;
+                    finalMesSend[cfgDepth].extensionPrompts.push(`${cfgPrompt.value}\n`);
+                }
             }
         }
 

--- a/public/script.js
+++ b/public/script.js
@@ -4016,16 +4016,14 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
             userPersona: (power_user.persona_description || ''),
         };
 
-        thisPromptBits = additionalPromptStuff;
-
-        //console.log(thisPromptBits);
-        const itemizedIndex = itemizedPrompts.findIndex((item) => item.mesId === thisPromptBits['mesId']);
+        //console.log(additionalPromptStuff);
+        const itemizedIndex = itemizedPrompts.findIndex((item) => item.mesId === additionalPromptStuff.mesId);
 
         if (itemizedIndex !== -1) {
-            itemizedPrompts[itemizedIndex] = thisPromptBits;
+            itemizedPrompts[itemizedIndex] = additionalPromptStuff;
         }
         else {
-            itemizedPrompts.push(thisPromptBits);
+            itemizedPrompts.push(additionalPromptStuff);
         }
 
         console.debug(`pushed prompt bits to itemizedPrompts array. Length is now: ${itemizedPrompts.length}`);

--- a/public/script.js
+++ b/public/script.js
@@ -3906,13 +3906,13 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
     let thisPromptBits = [];
 
     // TODO: Make this a switch
-    if (main_api == 'koboldhorde' && horde_settings.auto_adjust_response_length) {
-        maxLength = Math.min(maxLength, adjustedParams.maxLength);
-        maxLength = Math.max(maxLength, MIN_LENGTH); // prevent validation errors
-    }
-
     let generate_data;
     if (main_api == 'koboldhorde' || main_api == 'kobold') {
+        if (main_api == 'koboldhorde' && horde_settings.auto_adjust_response_length) {
+            maxLength = Math.min(maxLength, adjustedParams.maxLength);
+            maxLength = Math.max(maxLength, MIN_LENGTH); // prevent validation errors
+        }
+
         generate_data = {
             prompt: finalPrompt,
             gui_settings: true,

--- a/public/script.js
+++ b/public/script.js
@@ -3805,8 +3805,8 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
             cfgPrompt = getCfgPrompt(cfgGuidanceScale, isNegative);
         }
 
-        if (cfgPrompt && cfgPrompt?.value) {
-            if (cfgPrompt?.depth === 0) {
+        if (cfgPrompt && cfgPrompt.value) {
+            if (cfgPrompt.depth === 0) {
                 finalMesSend[finalMesSend.length - 1].message +=
                     /\s/.test(finalMesSend[finalMesSend.length - 1].message.slice(-1))
                         ? cfgPrompt.value

--- a/public/script.js
+++ b/public/script.js
@@ -3896,12 +3896,7 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
         return !data.combinedPrompt ? combine() : data.combinedPrompt;
     }
 
-    // Get the negative prompt first since it has the unmodified mesSend array
-    let negativePrompt = main_api == 'textgenerationwebui' ? getCombinedPrompt(true) : undefined;
     let finalPrompt = getCombinedPrompt(false);
-
-    // Include the entire guidance scale object
-    const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale, negativePrompt: negativePrompt } : null;
 
     let maxLength = Number(amount_gen); // how many tokens the AI will be requested to generate
     let thisPromptBits = [];
@@ -3930,10 +3925,13 @@ async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, qu
                 generate_data = getKoboldGenerationData(finalPrompt, presetSettings, maxLength, maxContext, isHorde, type);
             }
             break;
-        case 'textgenerationwebui':
+        case 'textgenerationwebui': {
+            const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale, negativePrompt: getCombinedPrompt(true) } : null;
             generate_data = getTextGenGenerationData(finalPrompt, maxLength, isImpersonate, isContinue, cfgValues, type);
             break;
+        }
         case 'novel': {
+            const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale } : null;
             const presetSettings = novelai_settings[novelai_setting_names[nai_settings.preset_settings_novel]];
             generate_data = getNovelGenerationData(finalPrompt, presetSettings, maxLength, isImpersonate, isContinue, cfgValues, type);
             break;


### PR DESCRIPTION
Trying to separate out the backend-specific logic as much as possible. As with previous refactorings, most commits include some descriptive messages and hence this should not be squash-merged.