### PR TITLE
style: `.mes_block { overflow-y: clip; }`

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1000,6 +1000,7 @@ body .panelControlBar {
     padding-left: 10px;
     width: 100%;
     overflow-x: hidden;
+    overflow-y: clip;
 }
 
 .mes_text {


### PR DESCRIPTION
1 line style addition.

Currently text animations that have vertical movement cause `.mes_block` `div`s to overflow creating an inner (double) scrollbar (which breaks lines and unbreaks them periodically) and (sometimes) moving the whole message up and down.

See red arrow drawn in paint (green arrow is the normal chat's scrollbar):

![image](https://github.com/SillyTavern/SillyTavern/assets/21046091/91e2dc6b-c431-49f1-91d5-9358a3eb69e9)

Worst case scenario the whole chat keeps moving up and down with the spin animation (scrolling to the bottom when it spins, and going up again when it finishes the spin)

Adding this style clause fixes this by clipping it.
Otherwise, far as I can see, having this doubled inner scrollbar is never desirable.

To test you can put this intro on a blank new card, and turn on <tags>
https://pastebin.com/mQMULypR