### PR TITLE
Add json extension to exported oai and LogitBias presets

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3250,7 +3250,8 @@ async function onExportPresetClick() {
     delete preset.proxy_password;
 
     const presetJsonString = JSON.stringify(preset, null, 4);
-    download(presetJsonString, oai_settings.preset_settings_openai, 'application/json');
+    const presetFileName = `${oai_settings.preset_settings_openai}.json`;
+    download(presetJsonString, presetFileName, 'application/json');
 }
 
 async function onLogitBiasPresetImportFileChange(e) {
@@ -3298,7 +3299,8 @@ function onLogitBiasPresetExportClick() {
     }
 
     const presetJsonString = JSON.stringify(oai_settings.bias_presets[oai_settings.bias_preset_selected], null, 4);
-    download(presetJsonString, oai_settings.bias_preset_selected, 'application/json');
+    const presetFileName = `${oai_settings.bias_preset_selected}.json`;
+    download(presetJsonString, presetFileName, 'application/json');
 }
 
 async function onDeletePresetClick() {


### PR DESCRIPTION
According to issue #1960, The chat completion preset files currently being exported don't include a file extension. But when importing presets, a json extension is required unless user manually choose "all files". This can lead to some confusion. Therefore, I explicitly added the file extension to the `fileName` parameter of the download function in `public/scripts/openai.js`.