### PR TITLE
Change the naming rule of regex exporting

### DIFF
--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -94,7 +94,7 @@ async function loadRegexScripts() {
             await onRegexEditorOpenClick(scriptHtml.attr('id'));
         });
         scriptHtml.find('.export_regex').on('click', async function () {
-            const fileName = `${script.scriptName.replace(/[^a-z0-9]/gi, '_').toLowerCase()}.json`;
+            const fileName = `${script.scriptName.replace(/[\s.<>:"/\\|?*\x00-\x1F\x7F]/g, '_').toLowerCase()}.json`;
             const fileData = JSON.stringify(script, null, 4);
             download(fileData, fileName, 'application/json');
         });


### PR DESCRIPTION
Fix issue #1960, probably.
Well, I'm not quite familiar with regex itself. I changed searchValue from `/[^a-z0-9]/gi` to `/[\s.<>:"/\\|?*\x00-\x1F\x7F]/g`. Here are some test results:

|  script name   | file name  |
|  ----  | ----  |
| 我不会正则表达式  | 我不会正则表达式.json |
| マイスクリプト part1 | マイスクリプト_part1.json |
| abc  <>:"/\|?* DEF | abc____________def.json |
