### PR TITLE
refactor: separate function for obtaining params and setting the command registration

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -231,7 +231,7 @@ class SlashCommandParser {
     }
 }
 
-const parser = new SlashCommandParser();
+export const parser = new SlashCommandParser();
 
 /**
  * Registers a slash command in the parser.

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -237,8 +237,12 @@ const parser = new SlashCommandParser();
  * Registers a slash command in the parser.
 * @type {(command: string, callback: function, aliases: string[], helpString: string, interruptsGeneration?: boolean, purgeFromMessage?: boolean) => void}
 */
-export const registerSlashCommand = parser.addCommand.bind(parser);
+export let registerSlashCommand = parser.addCommand.bind(parser);
 export const getSlashCommandsHelp = parser.getHelpString.bind(parser);
+// https://stackoverflow.com/questions/48168601/change-the-value-of-imported-variable-in-es6
+export function setRegisterSlashCommand(fn) {
+    registerSlashCommand = fn;
+}
 
 parser.addCommand('?', helpCommandCallback, ['help'], ' – get help on macros, chat formatting and commands', true, true);
 parser.addCommand('name', setNameCallback, ['persona'], '<span class="monospace">(name)</span> – sets user name and persona avatar (if set)', true, true);


### PR DESCRIPTION
There are 2 changes
- prompt itemization is refactored a bit, big portion moved to 2 separate functions, which are exported. 
  - Motivation and use-case for this one: I want to easily obtain the itemized prompt from my browser or other extension for easy analysis/export without more interacting with UI, and this helps me to do so. I believe more people could find it useful.
- the `registerSlashCommand` can be modified and has setter for it and `parser` is exported so it can be directly used by other extensions. 
  - Motivation and use-case for this one: I am working on a tech demo where Silly Tavern is used and we want to let users interact with the personas in more controlled environment, utilizing most of the nice features of Silly Tavern, but taking some level of control, by removing the slash commands. I am doing this in my own extensions, but this is needed to make it work.