### PR TITLE
chore: disable merge conflict workflow on forks

### DIFF
--- a/.github/workflows/check-merge-conflicts.yml
+++ b/.github/workflows/check-merge-conflicts.yml
@@ -6,6 +6,7 @@ on:
     - staging
 jobs:
   check-conflicts:
+    if: github.repository == 'SillyTavern/SillyTavern'
     runs-on: ubuntu-latest
     steps:
       - uses: mschilde/auto-label-merge-conflicts@master

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'SillyTavern/SillyTavern'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR disables the merge conflict workflow for forks by only allowing the workflow to run on the ST repo.