### PR TITLE
Scored search sorting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4582,6 +4582,7 @@
                             <div id="rm_button_group_chats" title="Create New Chat Group" data-i18n="[title]Create New Chat Group" class="menu_button fa-solid fa-users-gear "></div>
                             <input id="character_search_bar" class="text_pole width100p" type="search" data-i18n="[placeholder]Search..." placeholder="Search..." maxlength="100" />
                             <select id="character_sort_order" title="Characters sorting order" data-i18n="[title]Characters sorting order">
+                                <option data-field="search" data-order="desc" data-i18n="Search" hidden>Search</option>
                                 <option data-field="name" data-order="asc" data-i18n="A-Z">A-Z</option>
                                 <option data-field="name" data-order="desc" data-i18n="Z-A">Z-A</option>
                                 <option data-field="create_date" data-order="desc" data-i18n="Newest">Newest</option>

--- a/public/index.html
+++ b/public/index.html
@@ -3410,6 +3410,7 @@
                             <div id="world_popup_delete" class="menu_button fa-solid fa-trash-can redWarningBG" title="Delete World Info" data-i18n="[title]Delete World Info"></div>
                             <input type="search" class="text_pole textarea_compact" data-i18n="[placeholder]Search..." id="world_info_search" placeholder="Search...">
                             <select id="world_info_sort_order" class="margin0">
+                                <option data-rule="search" value="14" data-i18n="Search" hidden>Search</option>
                                 <option data-rule="priority" value="0" data-i18n="Priority">Priority</option>
                                 <option data-rule="custom" value="13" data-i18n="Custom">Custom</option>
                                 <option data-order="asc" data-field="comment" value="1" data-i18n="Title A-Z">Title A-Z</option>

--- a/public/index.html
+++ b/public/index.html
@@ -4186,6 +4186,7 @@
                                 </div>
                                 <input id="persona_search_bar" class="text_pole width100p flex1 margin0" type="search" data-i18n="[placeholder]Search..." placeholder="Search..." maxlength="100">
                                 <select id="persona_sort_order" class="margin0">
+                                    <option value="search" data-i18n="Search" hidden>Search</option>
                                     <option value="asc">A-Z</option>
                                     <option value="desc">Z-A</option>
                                 </select>

--- a/public/script.js
+++ b/public/script.js
@@ -6010,8 +6010,8 @@ function sortPersonas(personas) {
     const option = $('#persona_sort_order').find(':selected');
     if (option.attr('value') === 'search') {
         personas.sort((a, b) => {
-            const aScore = personasFilter.getScore(FILTER_TYPES.WORLD_INFO_SEARCH, a);
-            const bScore = personasFilter.getScore(FILTER_TYPES.WORLD_INFO_SEARCH, b);
+            const aScore = personasFilter.getScore(FILTER_TYPES.PERSONA_SEARCH, a);
+            const bScore = personasFilter.getScore(FILTER_TYPES.PERSONA_SEARCH, b);
             return (aScore - bScore);
         });
     } else {

--- a/public/script.js
+++ b/public/script.js
@@ -1465,7 +1465,7 @@ export function getEntitiesList({ doFilter = false, doSort = true } = {}) {
             const subCount = subEntities.length;
             subEntities = filterByTagState(entities, { subForEntity: entity });
             if (doFilter) {
-                subEntities = entitiesFilter.applyFilters(subEntities);
+                subEntities = entitiesFilter.applyFilters(subEntities, { clearScoreCache: false });
             }
             entity.entities = subEntities;
             entity.hidden = subCount - subEntities.length;

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -151,9 +151,7 @@ export class FilterHelper {
         }
 
         const fuzzySearchResults = fuzzySearchWorldInfo(data, term);
-
-        var wiScoreMap = new Map(fuzzySearchResults.map(i => [i.item?.uid, i.score]));
-        this.cacheScores(FILTER_TYPES.WORLD_INFO_SEARCH, wiScoreMap);
+        this.cacheScores(FILTER_TYPES.WORLD_INFO_SEARCH, new Map(fuzzySearchResults.map(i => [i.item?.uid, i.score])));
 
         const filteredData = data.filter(entity => fuzzySearchResults.find(x => x.item === entity));
         return filteredData;
@@ -172,7 +170,10 @@ export class FilterHelper {
         }
 
         const fuzzySearchResults = fuzzySearchPersonas(data, term);
-        return data.filter(entity => fuzzySearchResults.includes(entity));
+        this.cacheScores(FILTER_TYPES.PERSONA_SEARCH, new Map(fuzzySearchResults.map(i => [i.item.key, i.score])));
+
+        const filteredData = data.filter(name => fuzzySearchResults.find(x => x.item.key === name));
+        return filteredData;
     }
 
     /**
@@ -362,7 +363,7 @@ export class FilterHelper {
             typeScores.set(uid, score);
         }
         this.scoreCache.set(type, typeScores);
-        console.debug('scores chached', type, typeScores);
+        console.debug('search scores chached', type, typeScores);
     }
 
     /**

--- a/public/scripts/filters.js
+++ b/public/scripts/filters.js
@@ -1,5 +1,6 @@
 import { fuzzySearchCharacters, fuzzySearchGroups, fuzzySearchPersonas, fuzzySearchTags, fuzzySearchWorldInfo, power_user } from './power-user.js';
 import { tag_map } from './tags.js';
+import { includesIgnoreCaseAndAccents } from './utils.js';
 
 
 /**
@@ -306,7 +307,7 @@ export class FilterHelper {
             }
             else {
                 // Compare insensitive and without accents
-                return entity.item?.name?.localeCompare(searchValue, undefined, { sensitivity: 'base' }) === 0;
+                return includesIgnoreCaseAndAccents(entity.item?.name, searchValue);
             }
         }
 

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -635,7 +635,9 @@ export function initPersonas() {
     $('#personas_restore').on('click', () => $('#personas_restore_input').trigger('click'));
     $('#personas_restore_input').on('change', onPersonasRestoreInput);
     $('#persona_sort_order').val(power_user.persona_sort_order).on('input', function () {
-        power_user.persona_sort_order = String($(this).val());
+        const value = String($(this).val());
+        // Save sort order, but do not save search sorting, as this is a temporary sorting option
+        if (value !== 'search') power_user.persona_sort_order = value;
         getUserAvatars(true, user_avatar);
         saveSettingsDebounced();
     });

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1885,6 +1885,7 @@ export function fuzzySearchCharacters(searchValue) {
         ],
         includeScore: true,
         ignoreLocation: true,
+        useExtendedSearch: true,
         threshold: 0.2,
     });
 
@@ -1913,6 +1914,7 @@ export function fuzzySearchWorldInfo(data, searchValue) {
         ],
         includeScore: true,
         ignoreLocation: true,
+        useExtendedSearch: true,
         threshold: 0.2,
     });
 
@@ -1937,6 +1939,7 @@ export function fuzzySearchPersonas(data, searchValue) {
         ],
         includeScore: true,
         ignoreLocation: true,
+        useExtendedSearch: true,
         threshold: 0.2,
     });
 
@@ -1958,6 +1961,7 @@ export function fuzzySearchTags(searchValue) {
         ],
         includeScore: true,
         ignoreLocation: true,
+        useExtendedSearch: true,
         threshold: 0.2,
     });
 
@@ -1982,6 +1986,7 @@ export function fuzzySearchGroups(searchValue) {
         ],
         includeScore: true,
         ignoreLocation: true,
+        useExtendedSearch: true,
         threshold: 0.2,
     });
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -36,7 +36,7 @@ import {
 } from './instruct-mode.js';
 
 import { registerSlashCommand } from './slash-commands.js';
-import { tag_map, tags } from './tags.js';
+import { getTagsList, tag_map, tags } from './tags.js';
 import { tokenizers } from './tokenizers.js';
 import { BIAS_CACHE } from './logit-bias.js';
 import { renderTemplateAsync } from './templates.js';
@@ -1872,6 +1872,7 @@ export function fuzzySearchCharacters(searchValue) {
     const fuse = new Fuse(characters, {
         keys: [
             { name: 'data.name', weight: 8 },
+            { name: '#tags.name', weight: 5, getFn: (character) => getTagsList(character.avatar).map(x => x.name).join('||') },
             { name: 'data.description', weight: 3 },
             { name: 'data.mes_example', weight: 3 },
             { name: 'data.scenario', weight: 2 },

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1861,6 +1861,7 @@ function highlightDefaultContext() {
 }
 
 export function fuzzySearchCharacters(searchValue) {
+    // @ts-ignore
     const fuse = new Fuse(characters, {
         keys: [
             { name: 'data.name', weight: 8 },
@@ -1885,7 +1886,14 @@ export function fuzzySearchCharacters(searchValue) {
     return indices;
 }
 
+/**
+ * Fuzzy search world info entries by a search term
+ * @param {*[]} data - WI items data array
+ * @param {string} searchValue - The search term
+ * @returns {{item?: *, refIndex: number, score: number}[]} Results as items with their score
+ */
 export function fuzzySearchWorldInfo(data, searchValue) {
+    // @ts-ignore
     const fuse = new Fuse(data, {
         keys: [
             { name: 'key', weight: 3 },
@@ -1901,11 +1909,12 @@ export function fuzzySearchWorldInfo(data, searchValue) {
 
     const results = fuse.search(searchValue);
     console.debug('World Info fuzzy search results for ' + searchValue, results);
-    return results.map(x => x.item?.uid);
+    return results;
 }
 
 export function fuzzySearchPersonas(data, searchValue) {
     data = data.map(x => ({ key: x, description: power_user.persona_descriptions[x]?.description ?? '', name: power_user.personas[x] ?? '' }));
+    // @ts-ignore
     const fuse = new Fuse(data, {
         keys: [
             { name: 'name', weight: 4 },
@@ -1922,6 +1931,7 @@ export function fuzzySearchPersonas(data, searchValue) {
 }
 
 export function fuzzySearchTags(searchValue) {
+    // @ts-ignore
     const fuse = new Fuse(tags, {
         keys: [
             { name: 'name', weight: 1 },
@@ -1938,6 +1948,7 @@ export function fuzzySearchTags(searchValue) {
 }
 
 export function fuzzySearchGroups(searchValue) {
+    // @ts-ignore
     const fuse = new Fuse(groups, {
         keys: [
             { name: 'name', weight: 3 },
@@ -2745,6 +2756,7 @@ function setAvgBG() {
 }
 
 async function setThemeCallback(_, text) {
+    // @ts-ignore
     const fuse = new Fuse(themes, {
         keys: [
             { name: 'name', weight: 1 },
@@ -2767,6 +2779,7 @@ async function setThemeCallback(_, text) {
 }
 
 async function setmovingUIPreset(_, text) {
+    // @ts-ignore
     const fuse = new Fuse(movingUIPresets, {
         keys: [
             { name: 'name', weight: 1 },

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1912,8 +1912,14 @@ export function fuzzySearchWorldInfo(data, searchValue) {
     return results;
 }
 
+/**
+ * Fuzzy search persona entries by a search term
+ * @param {*[]} data - persona data array
+ * @param {string} searchValue - The search term
+ * @returns {{item?: *, refIndex: number, score: number}[]} Results as items with their score
+ */
 export function fuzzySearchPersonas(data, searchValue) {
-    data = data.map(x => ({ key: x, description: power_user.persona_descriptions[x]?.description ?? '', name: power_user.personas[x] ?? '' }));
+    data = data.map(x => ({ key: x, name: power_user.personas[x] ?? '', description: power_user.persona_descriptions[x]?.description ?? '' }));
     // @ts-ignore
     const fuse = new Fuse(data, {
         keys: [
@@ -1927,7 +1933,7 @@ export function fuzzySearchPersonas(data, searchValue) {
 
     const results = fuse.search(searchValue);
     console.debug('Personas fuzzy search results for ' + searchValue, results);
-    return results.map(x => x.item?.key);
+    return results;
 }
 
 export function fuzzySearchTags(searchValue) {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1871,8 +1871,8 @@ export function fuzzySearchCharacters(searchValue) {
     // @ts-ignore
     const fuse = new Fuse(characters, {
         keys: [
-            { name: 'data.name', weight: 8 },
-            { name: '#tags', weight: 5, getFn: (character) => getTagsList(character.avatar).map(x => x.name).join('||') },
+            { name: 'data.name', weight: 20 },
+            { name: '#tags', weight: 10, getFn: (character) => getTagsList(character.avatar).map(x => x.name).join('||') },
             { name: 'data.description', weight: 3 },
             { name: 'data.mes_example', weight: 3 },
             { name: 'data.scenario', weight: 2 },
@@ -1903,13 +1903,13 @@ export function fuzzySearchWorldInfo(data, searchValue) {
     // @ts-ignore
     const fuse = new Fuse(data, {
         keys: [
-            { name: 'key', weight: 8 },
-            { name: 'group', weight: 6 },
-            { name: 'comment', weight: 5 },
-            { name: 'keysecondary', weight: 5 },
+            { name: 'key', weight: 20 },
+            { name: 'group', weight: 15 },
+            { name: 'comment', weight: 10 },
+            { name: 'keysecondary', weight: 10 },
             { name: 'content', weight: 3 },
             { name: 'uid', weight: 1 },
-            { name: 'automationId', weight: 0.25 },
+            { name: 'automationId', weight: 1 },
         ],
         includeScore: true,
         ignoreLocation: true,
@@ -1932,8 +1932,8 @@ export function fuzzySearchPersonas(data, searchValue) {
     // @ts-ignore
     const fuse = new Fuse(data, {
         keys: [
-            { name: 'name', weight: 4 },
-            { name: 'description', weight: 1 },
+            { name: 'name', weight: 20 },
+            { name: 'description', weight: 3 },
         ],
         includeScore: true,
         ignoreLocation: true,
@@ -1975,9 +1975,9 @@ export function fuzzySearchGroups(searchValue) {
     // @ts-ignore
     const fuse = new Fuse(groups, {
         keys: [
-            { name: 'name', weight: 8 },
-            { name: 'members', weight: 5 },
-            { name: '#tags', weight: 5, getFn: (group) => getTagsList(group.id).map(x => x.name).join('||') },
+            { name: 'name', weight: 20 },
+            { name: 'members', weight: 15 },
+            { name: '#tags', weight: 10, getFn: (group) => getTagsList(group.id).map(x => x.name).join('||') },
             { name: 'id', weight: 1 },
         ],
         includeScore: true,

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1903,11 +1903,13 @@ export function fuzzySearchWorldInfo(data, searchValue) {
     // @ts-ignore
     const fuse = new Fuse(data, {
         keys: [
-            { name: 'key', weight: 3 },
+            { name: 'key', weight: 8 },
+            { name: 'group', weight: 6 },
+            { name: 'comment', weight: 5 },
+            { name: 'keysecondary', weight: 5 },
             { name: 'content', weight: 3 },
-            { name: 'comment', weight: 2 },
-            { name: 'keysecondary', weight: 2 },
             { name: 'uid', weight: 1 },
+            { name: 'automationId', weight: 0.25 },
         ],
         includeScore: true,
         ignoreLocation: true,

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1872,7 +1872,7 @@ export function fuzzySearchCharacters(searchValue) {
     const fuse = new Fuse(characters, {
         keys: [
             { name: 'data.name', weight: 8 },
-            { name: '#tags.name', weight: 5, getFn: (character) => getTagsList(character.avatar).map(x => x.name).join('||') },
+            { name: '#tags', weight: 5, getFn: (character) => getTagsList(character.avatar).map(x => x.name).join('||') },
             { name: 'data.description', weight: 3 },
             { name: 'data.mes_example', weight: 3 },
             { name: 'data.scenario', weight: 2 },
@@ -1975,8 +1975,10 @@ export function fuzzySearchGroups(searchValue) {
     // @ts-ignore
     const fuse = new Fuse(groups, {
         keys: [
-            { name: 'name', weight: 3 },
-            { name: 'members', weight: 1 },
+            { name: 'name', weight: 8 },
+            { name: 'members', weight: 5 },
+            { name: '#tags', weight: 5, getFn: (group) => getTagsList(group.id).map(x => x.name).join('||') },
+            { name: 'id', weight: 1 },
         ],
         includeScore: true,
         ignoreLocation: true,

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1430,3 +1430,22 @@ export function flashHighlight(element, timespan = 2000) {
     element.addClass('flash animated');
     setTimeout(() => element.removeClass('flash animated'), timespan);
 }
+
+/**
+ * Performs a case-insensitive and accent-insensitive substring search.
+ * This function normalizes the strings to remove diacritical marks and converts them to lowercase to ensure the search is insensitive to case and accents.
+ *
+ * @param {string} text - The text in which to search for the substring.
+ * @param {string} searchTerm - The substring to search for in the text.
+ * @returns {boolean} - Returns true if the searchTerm is found within the text, otherwise returns false.
+ */
+export function includesIgnoreCaseAndAccents(text, searchTerm) {
+    if (!text || !searchTerm) return false; // Return false if either string is empty
+
+    // Normalize and remove diacritics, then convert to lower case
+    const normalizedText = text.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+    const normalizedSearchTerm = searchTerm.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+
+    // Check if the normalized text includes the normalized search term
+    return normalizedText.includes(normalizedSearchTerm);
+}

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -681,7 +681,7 @@ function sortEntries(data) {
     if (!data.length) return data;
 
     // If we have a search term for WI, we are sorting by weighting scores
-    if ('search') {
+    if (sortRule === 'search') {
         data.sort((a, b) => {
             const aScore = worldInfoFilter.getScore(FILTER_TYPES.WORLD_INFO_SEARCH, a.uid);
             const bScore = worldInfoFilter.getScore(FILTER_TYPES.WORLD_INFO_SEARCH, b.uid);
@@ -767,7 +767,7 @@ function displayWorldEntries(name, data, navigation = navigation_option.none) {
     }
 
     // Before printing the WI, we check if we should enable/disable search sorting
-    verifySearchSortRule();
+    verifyWorldInfoSearchSortRule();
 
     function getDataArray(callback) {
         // Convert the data.entries object into an array
@@ -1011,13 +1011,13 @@ const originalDataKeyMap = {
 };
 
 /** Checks the state of the current search, and adds/removes the search sorting option accordingly */
-function verifySearchSortRule() {
+function verifyWorldInfoSearchSortRule() {
     const searchTerm = worldInfoFilter.getFilterData(FILTER_TYPES.WORLD_INFO_SEARCH);
     const searchOption = $('#world_info_sort_order option[data-rule="search"]');
     const selector = $('#world_info_sort_order');
     const isHidden = searchOption.attr('hidden') !== undefined;
 
-    // If we have a search term for WI, we are displaying the sorting option for it
+    // If we have a search term, we are displaying the sorting option for it
     if (searchTerm && isHidden) {
         searchOption.removeAttr('hidden');
         selector.val(searchOption.attr('value') || '0');
@@ -3088,9 +3088,7 @@ jQuery(() => {
     $('#world_info_sort_order').on('change', function () {
         const value = String($(this).find(':selected').val());
         // Save sort order, but do not save search sorting, as this is a temporary sorting option
-        if (value !== 'search') {
-            localStorage.setItem(SORT_ORDER_KEY, value);
-        }
+        if (value !== 'search') localStorage.setItem(SORT_ORDER_KEY, value);
         updateEditor(navigation_option.none);
     });
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -678,7 +678,17 @@ function sortEntries(data) {
     const sortRule = option.data('rule');
     const orderSign = sortOrder === 'asc' ? 1 : -1;
 
-    if (sortRule === 'custom') {
+    if (!data.length) return data;
+
+    // If we have a search term for WI, we are sorting by weighting scores
+    if ('search') {
+        data.sort((a, b) => {
+            const aScore = worldInfoFilter.getScore(FILTER_TYPES.WORLD_INFO_SEARCH, a.uid);
+            const bScore = worldInfoFilter.getScore(FILTER_TYPES.WORLD_INFO_SEARCH, b.uid);
+            return (aScore - bScore);
+        });
+    }
+    else if (sortRule === 'custom') {
         // First by display index, then by order, then by uid
         data.sort((a, b) => {
             const aValue = a.displayIndex;
@@ -756,6 +766,9 @@ function displayWorldEntries(name, data, navigation = navigation_option.none) {
         return;
     }
 
+    // Before printing the WI, we check if we should enable/disable search sorting
+    verifySearchSortRule();
+
     function getDataArray(callback) {
         // Convert the data.entries object into an array
         let entriesArray = Object.keys(data.entries).map(uid => {
@@ -764,10 +777,11 @@ function displayWorldEntries(name, data, navigation = navigation_option.none) {
             return entry;
         });
 
-        // Sort the entries array by displayIndex and uid
-        entriesArray.sort((a, b) => a.displayIndex - b.displayIndex || a.uid - b.uid);
-        entriesArray = sortEntries(entriesArray);
+        // Apply the filter and do the chosen sorting
         entriesArray = worldInfoFilter.applyFilters(entriesArray);
+        entriesArray = sortEntries(entriesArray)
+
+        // Run the callback for printing this
         typeof callback === 'function' && callback(entriesArray);
         return entriesArray;
     }
@@ -995,6 +1009,26 @@ const originalDataKeyMap = {
     'vectorized': 'extensions.vectorized',
     'groupOverride': 'extensions.group_override',
 };
+
+/** Checks the state of the current search, and adds/removes the search sorting option accordingly */
+function verifySearchSortRule() {
+    const searchTerm = worldInfoFilter.getFilterData(FILTER_TYPES.WORLD_INFO_SEARCH);
+    const searchOption = $('#world_info_sort_order option[data-rule="search"]');
+    const selector = $('#world_info_sort_order');
+    const isHidden = searchOption.attr('hidden') !== undefined;
+
+    // If we have a search term for WI, we are displaying the sorting option for it
+    if (searchTerm && isHidden) {
+        searchOption.removeAttr('hidden');
+        selector.val(searchOption.attr('value') || '0');
+        flashHighlight(selector);
+    }
+    // If search got cleared, we make sure to hide the option and go back to the one before
+    if (!searchTerm && !isHidden) {
+        searchOption.attr('hidden', '');
+        selector.val(localStorage.getItem(SORT_ORDER_KEY) || '0');
+    }
+}
 
 function setOriginalDataValue(data, uid, key, value) {
     if (data.originalData && Array.isArray(data.originalData.entries)) {
@@ -3053,7 +3087,10 @@ jQuery(() => {
 
     $('#world_info_sort_order').on('change', function () {
         const value = String($(this).find(':selected').val());
-        localStorage.setItem(SORT_ORDER_KEY, value);
+        // Save sort order, but do not save search sorting, as this is a temporary sorting option
+        if (value !== 'search') {
+            localStorage.setItem(SORT_ORDER_KEY, value);
+        }
         updateEditor(navigation_option.none);
     });
 


### PR DESCRIPTION
We were already using a library for fuzzy search in all the search bars that had score results. We just ignored them.
I modified the character/entities search, persona search and the world info search to utilize a scored sorting.

## How the sorting works
- If a search term is entered, a new sort option "Search" pops up and is automatically selected
- Can be switched back and forth between other sort options, to still have the real sorting methods
- This sort method is not saved/persisted, it's temporary
- If the search term is cleared, the "Search" sort option will be removed and the setting from before selected

Instead of changing the whole API of our filters and the returned filtered results, I added a score cache to the filter class itself, which you can query to get the score for any data entry that was searched with the last search.

### More changes
- **Unix-style search syntax** ([Fuse.js - Examples - Extended Search](https://www.fusejs.io/examples.html#extended-search))
- Added the **real** tags to both characters and groups for the fuzzy search
- Added inclusion group to world info search
- Modified some weightings for fuzzy searches
- With disabled Advanced Characters search, it'll now be a bit more lenient and ignore accents and special stuff