### PR TITLE
WI search bar now flexibly scales width

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -157,7 +157,11 @@
     width: 10em;
 }
 
-#world_info_search,
+#world_info_search {
+    width: 10em;
+    min-width: 10em;
+    flex-grow: 1;
+}
 #world_info_sort_order {
     width: 7em;
 }


### PR DESCRIPTION
I didn't like it that the search bar for WI was so small, even when there was space on the screen.

![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/ed75b042-44f9-468e-a723-b962415b3d11)
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/280e34ff-ff83-49e0-83e7-bdadfdcfe8ae)
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/955edc16-f157-4909-80f1-e1c010951b00)
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/8f973006-6742-448c-a6a9-75240e5a9689)

I also resized it very slightly be default, increasing its min width from `7em` to `10em`. I don't think it should be smaller than the WI book name dropdown.  
It *might* look a bit awkward if you are right in between desktop and mobile widths, because the search bar moves to the next line and is really wide, but well... the space is there, so why not?  
If you say that looks bad, we can also apply a max-width.
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/04954c0a-2fde-4684-adf7-e8b79f10a51f)
