### PR TITLE
Fixes WI word matching not working for non-words

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -192,7 +192,8 @@ class WorldInfoBuffer {
                 return haystack.includes(transformedString);
             }
             else {
-                const regex = new RegExp(`\\b${escapeRegex(transformedString)}\\b`);
+                // Use custom boundaries to include punctuation and other non-alphanumeric characters
+                const regex = new RegExp(`(?:^|\\W)(${escapeRegex(transformedString)})(?:$|\\W)`);
                 if (regex.test(haystack)) {
                     return true;
                 }


### PR DESCRIPTION
- Fixes the regex that matched WI keys as "whole words" not working correctly if the key itself was not a word

Well. This is quite a edge-case, but we should still make sure it works.
Issue was that if the key itself was not a full word - meaning starting/ending on special characters -, it wasn't really a word for the regex, so word boundaries did not apply.
I switched the regex over to check that the character before and after are either string start/end or a non-word character.  
That should be good enough.

You can check it in work here: https://regex101.com/r/qlUdR4/1

Fixes #2167.