### PR TITLE
Improve performance of drawing WI panel

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -743,7 +743,12 @@ function nullWorldInfo() {
 function displayWorldEntries(name, data, navigation = navigation_option.none) {
     updateEditor = (navigation) => displayWorldEntries(name, data, navigation);
 
-    $('#world_popup_entries_list').empty().show();
+    const worldEntriesList = $('#world_popup_entries_list');
+
+    // We save costly performance by removing all events before emptying. Because we know there are no relevant event handlers reacting on removing elements
+    // This prevents jQuery from actually going through all registered events on the controls for each entry when removing it
+    worldEntriesList.find('*').off();
+    worldEntriesList.empty().show();
 
     if (!data || !('entries' in data)) {
         $('#world_popup_new').off('click').on('click', nullWorldInfo);
@@ -751,7 +756,7 @@ function displayWorldEntries(name, data, navigation = navigation_option.none) {
         $('#world_popup_export').off('click').on('click', nullWorldInfo);
         $('#world_popup_delete').off('click').on('click', nullWorldInfo);
         $('#world_duplicate').off('click').on('click', nullWorldInfo);
-        $('#world_popup_entries_list').hide();
+        worldEntriesList.hide();
         $('#world_info_pagination').html('');
         return;
     }
@@ -794,7 +799,11 @@ function displayWorldEntries(name, data, navigation = navigation_option.none) {
         formatNavigator: PAGINATION_TEMPLATE,
         showNavigator: true,
         callback: function (/** @type {object[]} */ page) {
-            $('#world_popup_entries_list').empty();
+            // We save costly performance by removing all events before emptying. Because we know there are no relevant event handlers reacting on removing elements
+            // This prevents jQuery from actually going through all registered events on the controls for each entry when removing it
+            worldEntriesList.find('*').off();
+            worldEntriesList.empty();
+
             const keywordHeaders = `
             <div id="WIEntryHeaderTitlesPC" class="flex-container wide100p spaceBetween justifyCenter textAlignCenter" style="padding:0 4.5em;">
             <small class="flex1">
@@ -823,8 +832,8 @@ function displayWorldEntries(name, data, navigation = navigation_option.none) {
                     block.find('.drag-handle').remove();
                 });
             }
-            $('#world_popup_entries_list').append(keywordHeaders);
-            $('#world_popup_entries_list').append(blocks);
+            worldEntriesList.append(keywordHeaders);
+            worldEntriesList.append(blocks);
         },
         afterSizeSelectorChange: function (e) {
             localStorage.setItem(storageKey, e.target.value);
@@ -835,6 +844,8 @@ function displayWorldEntries(name, data, navigation = navigation_option.none) {
             });
         },
     });
+
+
 
     if (typeof navigation === 'number' && Number(navigation) >= 0) {
         const selector = `#world_popup_entries_list [uid="${navigation}"]`;
@@ -937,12 +948,12 @@ function displayWorldEntries(name, data, navigation = navigation_option.none) {
     });
 
     // Check if a sortable instance exists
-    if ($('#world_popup_entries_list').sortable('instance') !== undefined) {
+    if (worldEntriesList.sortable('instance') !== undefined) {
         // Destroy the instance
-        $('#world_popup_entries_list').sortable('destroy');
+        worldEntriesList.sortable('destroy');
     }
 
-    $('#world_popup_entries_list').sortable({
+    worldEntriesList.sortable({
         delay: getSortableDelay(),
         handle: '.drag-handle',
         stop: async function (event, ui) {


### PR DESCRIPTION
- Fix performance issue by unsubscribing events before redrawing the panel

Copying my explanation on this from Discord...

> Well, I just "solved" the biggest performance issue on the world info panel, without touching much.
> 
> I ran performance profiler multiple times, and tracked most of the issues down to **emptying** the list, not even drawing, lol.
> It's not just a jQuery issue either (@ Lenny).
> We just have like nearly 50 events registered for each and every single world entry row, on its controls.
> 
> We likely should refactor this to events subscribed to the list instead of the rows itself, but oh well... with how huge the function is, I didn't bother.
> 
> Thing is, calling `.empty()` utilizes jQuery's cleanup routine of correctly unregistering all events handlers to prevent memory leaks. But because all the events are still registered, they are all reacting on the "remove" of the row itself.
> 
> So... because we don't have any remove animations or something, I just call
> ```js
> worldEntriesList.find('*').off();
> worldEntriesList.empty().show();
> ```
> And we are done.


This is the performance difference on my chrome profiler, for printing a lorebook with 137 entries with 100 entries displayed per page.

## Before
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/fb2733ab-b4d0-43d2-beea-e1b3f8e3fcc0)

## After
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/be68b0e9-3e46-4add-ae2c-04594db0b64e)
