### PR TITLE
Character card import from generic sources (specifically Discord, Catbox.moe)

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -48,6 +48,12 @@ allowKeysExposure: false
 skipContentCheck: false
 # Disable automatic chats backup
 disableChatBackup: false
+# Allowed hosts for card downloads
+whitelistImportDomains:
+  - localhost
+  - cdn.discordapp.com
+  - files.catbox.moe
+  - raw.githubusercontent.com
 # API request overrides (for KoboldAI and Text Completion APIs)
 ## Note: host includes the port number if it's not the default (80 or 443)
 ## Format is an array of objects:

--- a/public/script.js
+++ b/public/script.js
@@ -10542,9 +10542,7 @@ jQuery(async function () {
             <li>JanitorAI Character (Direct Link or UUID)<br>Example: <tt>ddd1498a-a370-4136-b138-a8cd9461fdfe_character-aqua-the-useless-goddess</tt></li>
             <li>Pygmalion.chat Character (Direct Link or UUID)<br>Example: <tt>a7ca95a1-0c88-4e23-91b3-149db1e78ab9</tt></li>
             <li>AICharacterCard.com Character (Direct Link or ID)<br>Example: <tt>AICC/aicharcards/the-game-master</tt></li>
-            <li>Catbox.moe Character image link<br>Example: <tt>https://files.catbox.moe/notarealfile.png</tt></li>
-            <li>Discord Character image link<br>Example: <tt>https://cdn.discordapp.com/attachments/.../alsonotreal.png?...</tt></li>
-            <li>More coming soon...</li>
+            <li>Direct PNG Link (refer to <code>config.yaml</code> for allowed hosts)<br>Example: <tt>https://files.catbox.moe/notarealfile.png</tt></li>
         <ul>`;
         const input = await callPopup(html, 'input', '', { okButton: 'Import', rows: 4 });
 

--- a/public/script.js
+++ b/public/script.js
@@ -10542,6 +10542,8 @@ jQuery(async function () {
             <li>JanitorAI Character (Direct Link or UUID)<br>Example: <tt>ddd1498a-a370-4136-b138-a8cd9461fdfe_character-aqua-the-useless-goddess</tt></li>
             <li>Pygmalion.chat Character (Direct Link or UUID)<br>Example: <tt>a7ca95a1-0c88-4e23-91b3-149db1e78ab9</tt></li>
             <li>AICharacterCard.com Character (Direct Link or ID)<br>Example: <tt>AICC/aicharcards/the-game-master</tt></li>
+            <li>Catbox.moe Character image link<br>Example: <tt>https://files.catbox.moe/notarealfile.png</tt></li>
+            <li>Discord Character image link<br>Example: <tt>https://cdn.discordapp.com/attachments/.../alsonotreal.png?...</tt></li>
             <li>More coming soon...</li>
         <ul>`;
         const input = await callPopup(html, 'input', '', { okButton: 'Import', rows: 4 });


### PR DESCRIPTION
Addresses #1958 

- Added support for importing from valid character card urls
- Added examples in import popup

Could also potentially import from any image source, but that sounds really scary to let happen with the new shift to a multiuser design. Opted for having a whitelist array of domain hosts. Future trusted sources could be added to whitelist, or moved to config file.

![image](https://github.com/SillyTavern/SillyTavern/assets/97203016/7009933b-0691-4206-89f4-168b119f64e8)
