### PR TITLE
WI world search allows quick-select

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -197,13 +197,20 @@
     display: none;
 }
 
+#world_info+span.select2-container .select2-selection__choice__remove,
 #world_info+span.select2-container .select2-selection__choice__display {
     cursor: pointer;
-    margin-left: 1px; /* Fix weird alignment on the left side */
+    transition: background-color 0.3s;
+    color: var(--SmartThemeBodyColor);
+    background-color: var(--black50a);
 }
 
+#world_info+span.select2-container .select2-selection__choice__display {
+    /* Fix weird alignment on the left side */
+    margin-left: 1px;
+}
+
+#world_info+span.select2-container .select2-selection__choice__remove:hover,
 #world_info+span.select2-container .select2-selection__choice__display:hover {
-    background-color: #f1f1f1;
-    color: #333;
-    outline: none;
- }
+    background-color: var(--white30a);
+}

--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -196,3 +196,14 @@
 .WIEntryHeaderTitleMobile {
     display: none;
 }
+
+#world_info+span.select2-container .select2-selection__choice__display {
+    cursor: pointer;
+    margin-left: 1px; /* Fix weird alignment on the left side */
+}
+
+#world_info+span.select2-container .select2-selection__choice__display:hover {
+    background-color: #f1f1f1;
+    color: #333;
+    outline: none;
+ }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -379,6 +379,7 @@ function setWorldInfoSettings(settings, data) {
     });
 
     $('#world_info_sort_order').val(localStorage.getItem(SORT_ORDER_KEY) || '0');
+    $('#world_info').trigger('change');
     $('#world_editor_select').trigger('change');
 
     eventSource.on(event_types.CHAT_CHANGED, () => {
@@ -3113,6 +3114,23 @@ jQuery(() => {
             placeholder: 'No Worlds active. Click here to select.',
             allowClear: true,
             closeOnSelect: false,
+        });
+
+        // Subscribe world loading to the select2 multiselect items (We need to target the specific select2 control)
+        $('#world_info + span.select2-container').on('click', function (event) {
+            if ($(event.target).hasClass('select2-selection__choice__display')) {
+                event.preventDefault();
+
+                // select2 still bubbles the event to open the dropdown. So we close it here
+                $('#world_info').select2('close');
+
+                const name = $(event.target).text();
+                const selectedIndex = world_names.indexOf(name);
+                if (selectedIndex !== -1) {
+                    $('#world_editor_select').val(selectedIndex).trigger('change');
+                    console.log('Quick selection of world', name);
+                }
+            }
         });
     }
 


### PR DESCRIPTION
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/d25e3241-2d08-43eb-831b-b6d1a6f6eac7)

A little "hacky", but that select2 is rude with tunnelling and canceling default events.  
This should work though. Had to close the dropdown though, so on slow PCs it might flicker. Nothing I can do against afaik.

I also fixed that on UI load the selection is filled, but the change event is never triggered.  
I stumbled upon this while testing different ways of implementing this event. Wasn't needed before, but for consistency we should fire this here. It's done in all the other places too where we change the selected elements of this.