### PR TITLE
Protect eyes from being blinded when loading pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,7 @@
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>
 
-<body class="no-blur">
+<body class="no-blur" style="background-color:black">
     <div id="preloader"></div>
     <div id="bg_custom"></div>
     <div id="bg1"></div>

--- a/public/login.html
+++ b/public/login.html
@@ -28,7 +28,7 @@
     <title>SillyTavern</title>
 </head>
 
-<body class="login">
+<body class="login" style="background-color:black">
     <div id="shadow_popup" style="opacity: 0;">
         <div id="dialogue_popup">
             <div id="dialogue_popup_holder">


### PR DESCRIPTION
When I use Firefox with SillyTavern, it always loads a white background page first, causing serious damage to my eyes.
This PR fixes that.