### PR TITLE
Fix the /send command

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4387,7 +4387,8 @@ function formatMessageHistoryItem(chatItem, isInstruct, forceOutputSequence) {
     const itemName = chatItem.is_user ? chatItem['name'] : characterName;
     const shouldPrependName = !isNarratorType;
 
-    let textResult = shouldPrependName ? `${itemName}: ${chatItem.mes}\n` : `${chatItem.mes}\n`;
+    // Don't include a name if it's empty
+    let textResult = chatItem?.name && shouldPrependName ? `${itemName}: ${chatItem.mes}\n` : `${chatItem.mes}\n`;
 
     if (isInstruct) {
         textResult = formatInstructModeChat(itemName, chatItem.mes, chatItem.is_user, isNarratorType, chatItem.force_avatar, name1, name2, forceOutputSequence);

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -340,8 +340,11 @@ export function formatInstructModeChat(name, mes, isUser, isNarrator, forceAvata
     }
 
     const separator = power_user.instruct.wrap ? '\n' : '';
-    const textArray = includeNames ? [prefix, `${name}: ${mes}` + suffix] : [prefix, mes + suffix];
+
+    // Don't include the name if it's empty
+    const textArray = includeNames && name ? [prefix, `${name}: ${mes}` + suffix] : [prefix, mes + suffix];
     const text = textArray.filter(x => x).join(separator);
+
     return text;
 }
 


### PR DESCRIPTION
If name is blank with the /send command, then don't append the name in the prompt with an empty ` :`