### PR TITLE
don't replace codeblock textContent with innerText in hljs

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -423,8 +423,6 @@ const characterContextMenu = new CharacterContextMenu(characterGroupOverlay);
 eventSource.on(event_types.CHARACTER_PAGE_LOADED, characterGroupOverlay.onPageLoad);
 console.debug('Character context menu initialized', characterContextMenu);
 
-hljs.addPlugin({ 'before:highlightElement': ({ el }) => { el.textContent = el.innerText; } });
-
 // Markdown converter
 export let mesForShowdownParse; //intended to be used as a context to compare showdown strings against
 let converter;


### PR DESCRIPTION
It seems that the only reason this was added was to preserve `<br>` linebreaks in code blocks (see https://github.com/highlightjs/highlight.js/issues/3530). However, this breaks all code blocks that are hidden when hljs is applied as `innerText`'s value depends on the current rendering state; i.e., if the element is currently hidden, its value is an empty string.

The way showdown translates markdown to HTML, there should never be any actual HTML elements inside code blocks anyways, as all tags are rendered as literal characters.