### PR TITLE
Do not double-parse WI content on "always on"

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2373,7 +2373,6 @@ async function checkWorldInfo(chat, maxContext) {
             }
 
             if (entry.constant || buffer.isExternallyActivated(entry)) {
-                entry.content = substituteParams(entry.content);
                 activatedNow.add(entry);
                 continue;
             }
@@ -2466,7 +2465,9 @@ async function checkWorldInfo(chat, maxContext) {
                 continue;
             } else { console.debug(`uid:${entry.uid} passed probability check, inserting to prompt`); }
 
-            newContent += `${substituteParams(entry.content)}\n`;
+            // Substitute macros inline, for both this checking and also future processing
+            entry.content = substituteParams(entry.content);
+            newContent += `${entry.content}\n`;
 
             if ((textToScanTokens + (await getTokenCountAsync(newContent))) >= budget) {
                 console.debug('WI budget reached, stopping');
@@ -2499,7 +2500,7 @@ async function checkWorldInfo(chat, maxContext) {
             const text = newEntries
                 .filter(x => !failedProbabilityChecks.has(x))
                 .filter(x => !x.preventRecursion)
-                .map(x => substituteParams(x.content)).join('\n');
+                .map(x => x.content).join('\n');
             buffer.addRecurse(text);
             allActivatedText = (text + '\n' + allActivatedText);
         }


### PR DESCRIPTION
Small PR that fixes "always on" WI entries from being double-parse for macro substitution.

So, best case this would not make a difference at all. But it's wrong to pars macros multiple times on both entry activation and then later when all activated entries are added to the context

Whatever happened here before, macros were parsed up to **three times** - which is not really good.