### PR TITLE
move expression buttons above Sprite set

### DIFF
--- a/public/scripts/extensions/expressions/settings.html
+++ b/public/scripts/extensions/expressions/settings.html
@@ -64,10 +64,6 @@
                     <input id="expression_override" type="text" class="text_pole" placeholder="Override folder name" />
                     <input id="expression_override_button" class="menu_button" type="submit" value="Submit" />
                 </div>
-                <h3 id="image_list_header">
-                    <strong>Sprite set:</strong>&nbsp;<span id="image_list_header_name"></span>
-                </h3>
-                <div id="image_list"></div>
                 <div class="expression_buttons flex-container spaceEvenly">
                     <div id="expression_upload_pack_button" class="menu_button">
                         <i class="fa-solid fa-file-zipper"></i>
@@ -80,6 +76,11 @@
                 </div>
                 <p class="hint"><b>Hint:</b> <i>Create new folder in the <b>/characters/</b> folder of your user data directory and name it as the name of the character.
                 Put images with expressions there. File names should follow the pattern: <tt>[expression_label].[image_format]</tt></i></p>
+                <h3 id="image_list_header">
+                    <strong>Sprite set:</strong>&nbsp;<span id="image_list_header_name"></span>
+                </h3>
+                <div id="image_list"></div>
+
             </div>
         </div>
     </div>


### PR DESCRIPTION
+moves the buttons above the Sprite set so user does not have to scroll all the way down to find the buttons now it will be directly visiable

Before:
![image](https://github.com/SillyTavern/SillyTavern/assets/61471128/c69b98bc-21c8-44d2-8fee-0e67f872a956)


After:
![image](https://github.com/SillyTavern/SillyTavern/assets/61471128/6b3f940f-d4c3-4c66-bab7-74f763f3900f)
