### PR TITLE
WI global settings style changes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3316,7 +3316,7 @@
                         </div>
                     </div>
                     <div data-newbie-hidden class="inline-drawer wide100p flexFlowColumn">
-                        <div class="inline-drawer-toggle inline-drawer-header" title="Global World Info/Lorebook activation settings&#10;&#10;Click to expand" data-i18n="[title]Global World Info/Lorebook activation settings&#10;&#10;Click to expand">
+                        <div class="standoutHeader inline-drawer-toggle inline-drawer-header" title="Global World Info/Lorebook activation settings&#10;&#10;Click to expand" data-i18n="[title]Global World Info/Lorebook activation settings&#10;&#10;Click to expand">
                             <b><span data-i18n="Global Activation Settings">Global Activation Settings</span></b>
                             <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -3316,8 +3316,8 @@
                         </div>
                     </div>
                     <div data-newbie-hidden class="inline-drawer wide100p flexFlowColumn">
-                        <div class="inline-drawer-toggle inline-drawer-header">
-                            <b><span data-i18n="Activation Settings">Activation Settings</span></b>
+                        <div class="inline-drawer-toggle inline-drawer-header" title="Global World Info/Lorebook settings&#10;&#10;Click to expand" data-i18n="[title]Global World Info/Lorebook settings&#10;&#10;Click to expand">
+                            <b><span data-i18n="Global Settings">Global Settings</span></b>
                             <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                         </div>
                         <div class="inline-drawer-content">
@@ -3448,6 +3448,9 @@
                     </div>
                     <div id="world_popup">
                         <hr>
+                        <div class="inline-drawer-header" title="World Info/Lorebook settings" data-i18n="[title]World Info/Lorebook settings">
+                            <b><span data-i18n="World Settings">World Settings</span></b>
+                        </div>
                         <div class="flex-container alignitemscenter gap3px">
                             <input type="file" id="world_import_file" accept=".json,.lorebook,.png" name="avatar" hidden>
                             <div id="world_create_button" class="menu_button menu_button_icon">

--- a/public/index.html
+++ b/public/index.html
@@ -3316,8 +3316,8 @@
                         </div>
                     </div>
                     <div data-newbie-hidden class="inline-drawer wide100p flexFlowColumn">
-                        <div class="inline-drawer-toggle inline-drawer-header" title="Global World Info/Lorebook settings&#10;&#10;Click to expand" data-i18n="[title]Global World Info/Lorebook settings&#10;&#10;Click to expand">
-                            <b><span data-i18n="Global Settings">Global Settings</span></b>
+                        <div class="inline-drawer-toggle inline-drawer-header" title="Global World Info/Lorebook activation settings&#10;&#10;Click to expand" data-i18n="[title]Global World Info/Lorebook activation settings&#10;&#10;Click to expand">
+                            <b><span data-i18n="Global Activation Settings">Global Activation Settings</span></b>
                             <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                         </div>
                         <div class="inline-drawer-content">

--- a/public/style.css
+++ b/public/style.css
@@ -3536,6 +3536,9 @@ body:has(#character_popup.open) #top-settings-holder:has(.drawer-content.openDra
     justify-content: space-between;
     align-items: center;
     padding: 5px 0;
+}
+
+.inline-drawer-header:has(> .inline-drawer-icon) {
     cursor: pointer;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -3437,6 +3437,18 @@ a {
     transition: all 250ms;
 }
 
+.standoutHeader.inline-drawer-header {
+    padding: 5px;
+    margin-bottom: 0;
+}
+
+.standoutHeader~.inline-drawer-content {
+    border: 1px solid var(--SmartThemeBorderColor);
+    padding: 5px;
+    border-radius: 10px;
+    background-color: var(--black30a);
+}
+
 #ui_language_select {
     width: 8em;
 }


### PR DESCRIPTION
Seems like quite a few people miss that the setting in the WI panel can actually be opened to show the global settings.
Suggested change to make it more obvious and rename it.
Suggestion taken from [here](https://discord.com/channels/1100685673633153084/1100685673633153087/1238269314981822467).

Looks like this now:

![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/6fb0b443-5ffc-453d-a966-ede94b00d09e)
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/99356033-5434-4f7b-b49b-d2ca61ea32cb)
