### PR TITLE
populate parser flag doclinks in user settings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4171,14 +4171,14 @@
                                     <label class="checkbox_label" title="Switch to stricter escaping, allowing all delimiting characters to be escaped with a backslash, and backslashes to be escaped as well." data-i18n="[title]Switch to stricter escaping, allowing all dellimiting characters to be escaped with a backslash, and backslashes to be escaped as well.">
                                         <input id="stscript_parser_flag_strict_escaping" type="checkbox" />
                                         <span data-i18n="STRICT_ESCAPING"><small>STRICT_ESCAPING</small></span>
-                                        <a href="https://docs.sillytavern.app/" target="_blank" class="notes-link">
+                                        <a href="https://docs.sillytavern.app/usage/st-script/#strict-escaping" target="_blank" class="notes-link">
                                             <span class="fa-solid fa-circle-question note-link-span"></span>
                                         </a>
                                     </label>
                                     <label class="checkbox_label" title="Replace all {{getvar::}} and {{getglobalvar::}} macros with scoped variables to avoid double macro substitution." data-i18n="[title]Replace all {{getvar::}} and {{getglobalvar::}} macros with scoped variables to avoid double macro substitution.">
                                         <input id="stscript_parser_flag_replace_getvar" type="checkbox" />
                                         <span data-i18n="REPLACE_GETVAR"><small>REPLACE_GETVAR</small></span>
-                                        <a href="https://docs.sillytavern.app/" target="_blank" class="notes-link">
+                                        <a href="https://docs.sillytavern.app/usage/st-script/#replace-variable-macros" target="_blank" class="notes-link">
                                             <span class="fa-solid fa-circle-question note-link-span"></span>
                                         </a>
                                     </label>


### PR DESCRIPTION
They just linked to the docs homepage. Now that the docs are updated, the links can point to the relevant sections.

![image](https://github.com/SillyTavern/SillyTavern/assets/7149120/1c5c544c-a5d2-4296-8634-090cfc8f3f28)
