### PR TITLE
Parser improvements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4116,6 +4116,12 @@
                             </div>
                             <div name="AutoCompleteToggle">
                                 <h4 data-i18n="AutoComplete Settings">AutoComplete Settings</h4>
+                                <label data-newbie-hidden class="checkbox_label" for="stscript_autocomplete_autoHide">
+                                    <input id="stscript_autocomplete_autoHide" type="checkbox" />
+                                    <small data-i18n="Automatically hide details">
+                                        Automatically hide details
+                                    </small>
+                                </label>
                                 <div class="flex-container">
                                     <div class="flex1" title="Determines how entries are found for autocomplete." data-i18n="[title]Determines how entries are found for autocomplete.">
                                         <label for="stscript_matching" data-i18n="Autocomplete Matching"><small>Matching</small></label>

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -259,6 +259,7 @@ let power_user = {
     stscript: {
         matching: 'fuzzy',
         autocomplete: {
+            autoHide: false,
             style: 'theme',
             font: {
                 scale: 0.8,
@@ -1618,6 +1619,7 @@ function loadPowerUserSettings(settings, data) {
     $('#token_padding').val(power_user.token_padding);
     $('#aux_field').val(power_user.aux_field);
 
+    $('#stscript_autocomplete_autoHide').prop('checked', power_user.stscript.autocomplete.autoHide ?? false).trigger('input');
     $('#stscript_matching').val(power_user.stscript.matching ?? 'fuzzy');
     $('#stscript_autocomplete_style').val(power_user.stscript.autocomplete_style ?? 'theme');
     document.body.setAttribute('data-stscript-style', power_user.stscript.autocomplete_style);
@@ -3643,6 +3645,11 @@ $(document).ready(() => {
         const value = $(this).find(':selected').val();
         power_user.aux_field = String(value);
         printCharactersDebounced();
+        saveSettingsDebounced();
+    });
+
+    $('#stscript_autocomplete_autoHide').on('input', function () {
+        power_user.stscript.autocomplete.autoHide = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 

--- a/public/scripts/slash-commands/SlashCommandAutoCompleteNameResult.js
+++ b/public/scripts/slash-commands/SlashCommandAutoCompleteNameResult.js
@@ -99,7 +99,7 @@ export class SlashCommandAutoCompleteNameResult extends AutoCompleteNameResult {
                 const result = new AutoCompleteSecondaryNameResult(
                     value,
                     start + name.length,
-                    cmdArg.enumList.map(it=>new SlashCommandEnumAutoCompleteOption(it)),
+                    cmdArg.enumList.map(it=>new SlashCommandEnumAutoCompleteOption(this.executor.command, it)),
                     true,
                 );
                 result.isRequired = true;
@@ -154,7 +154,7 @@ export class SlashCommandAutoCompleteNameResult extends AutoCompleteNameResult {
         const result = new AutoCompleteSecondaryNameResult(
             value,
             start,
-            cmdArg.enumList.map(it=>new SlashCommandEnumAutoCompleteOption(it)),
+            cmdArg.enumList.map(it=>new SlashCommandEnumAutoCompleteOption(this.executor.command, it)),
             false,
         );
         const isCompleteValue = cmdArg.enumList.find(it=>it.value == value);

--- a/public/scripts/slash-commands/SlashCommandEnumAutoCompleteOption.js
+++ b/public/scripts/slash-commands/SlashCommandEnumAutoCompleteOption.js
@@ -1,16 +1,20 @@
 import { AutoCompleteOption } from '../autocomplete/AutoCompleteOption.js';
+import { SlashCommand } from './SlashCommand.js';
 import { SlashCommandEnumValue } from './SlashCommandEnumValue.js';
 
 export class SlashCommandEnumAutoCompleteOption extends AutoCompleteOption {
+    /**@type {SlashCommand}*/ cmd;
     /**@type {SlashCommandEnumValue}*/ enumValue;
 
 
 
     /**
+     * @param {SlashCommand} cmd
      * @param {SlashCommandEnumValue} enumValue
      */
-    constructor(enumValue) {
+    constructor(cmd, enumValue) {
         super(enumValue.value, '◊');
+        this.cmd = cmd;
         this.enumValue = enumValue;
     }
 
@@ -25,22 +29,6 @@ export class SlashCommandEnumAutoCompleteOption extends AutoCompleteOption {
 
 
     renderDetails() {
-        const frag = document.createDocumentFragment();
-        const specs = document.createElement('div'); {
-            specs.classList.add('specs');
-            const name = document.createElement('div'); {
-                name.classList.add('name');
-                name.classList.add('monospace');
-                name.textContent = this.name;
-                specs.append(name);
-            }
-            frag.append(specs);
-        }
-        const help = document.createElement('span'); {
-            help.classList.add('help');
-            help.textContent = this.enumValue.description;
-            frag.append(help);
-        }
-        return frag;
+        return this.cmd.renderHelpDetails();
     }
 }

--- a/public/scripts/slash-commands/SlashCommandNamedArgumentAutoCompleteOption.js
+++ b/public/scripts/slash-commands/SlashCommandNamedArgumentAutoCompleteOption.js
@@ -27,22 +27,6 @@ export class SlashCommandNamedArgumentAutoCompleteOption extends AutoCompleteOpt
 
 
     renderDetails() {
-        const frag = document.createDocumentFragment();
-        const specs = document.createElement('div'); {
-            specs.classList.add('specs');
-            const name = document.createElement('div'); {
-                name.classList.add('name');
-                name.classList.add('monospace');
-                name.textContent = this.name;
-                specs.append(name);
-            }
-            frag.append(specs);
-        }
-        const help = document.createElement('span'); {
-            help.classList.add('help');
-            help.innerHTML = `${this.arg.isRequired ? '' : '(optional) '}${this.arg.description ?? ''}`;
-            frag.append(help);
-        }
-        return frag;
+        return this.cmd.renderHelpDetails();
     }
 }


### PR DESCRIPTION
- ctrl+space to show details on argument and ENUM autocomplete now shows command details, as those two did not really offer anything in there in the first place 
- escape to force hide command details when in unnamed arguments (stays hidden, even on further input) 
- user settings option to auto hide command details when in unnamed arguments (with at least one character typed), ctrl+space to force show them