### PR TITLE
WI entry setting "Delay until recursion"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5276,6 +5276,12 @@
                                                             Prevent further recursion (this entry will not activate others)
                                                         </span>
                                                     </label>
+                                                    <label class="checkbox flex-container alignitemscenter flexNoGap">
+                                                        <input type="checkbox" name="delay_until_recursion" />
+                                                        <span data-i18n="Delay until recursion (this entry will only be checked on recursive checking)">
+                                                            Delay until recursion (this entry will only be checked on recursive checking)
+                                                        </span>
+                                                    </label>
                                                 </div>
                                             </span>
                                         </small>

--- a/public/index.html
+++ b/public/index.html
@@ -5278,8 +5278,8 @@
                                                     </label>
                                                     <label class="checkbox flex-container alignitemscenter flexNoGap">
                                                         <input type="checkbox" name="delay_until_recursion" />
-                                                        <span data-i18n="Delay until recursion (this entry will only be checked on recursive checking)">
-                                                            Delay until recursion (this entry will only be checked on recursive checking)
+                                                        <span data-i18n="Delay until recursion (this entry can only be activated on recursive checking)">
+                                                            Delay until recursion (this entry can only be activated on recursive checking)
                                                         </span>
                                                     </label>
                                                 </div>

--- a/public/scripts/char-data.js
+++ b/public/scripts/char-data.js
@@ -24,6 +24,7 @@
  * @property {boolean} group_override - Overrides any existing group assignment for the extension.
  * @property {number} group_weight - A value used for prioritizing extensions within the same group.
  * @property {boolean} prevent_recursion - Completely disallows recursive application of the extension.
+ * @property {boolean} delay_until_recursion - Will only be checked during recursion.
  * @property {number} scan_depth - The maximum depth to search for matches when applying the extension.
  * @property {boolean} match_whole_words - Specifies if only entire words should be matched during extension application.
  * @property {boolean} use_group_scoring - Indicates if group weight is considered when selecting extensions.

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2165,6 +2165,7 @@ const newEntryTemplate = {
     position: 0,
     disable: false,
     excludeRecursion: false,
+    preventRecursion: false,
     delayUntilRecursion: false,
     probability: 100,
     useProbability: true,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1234,6 +1234,7 @@ const originalDataKeyMap = {
     'displayIndex': 'extensions.display_index',
     'excludeRecursion': 'extensions.exclude_recursion',
     'preventRecursion': 'extensions.prevent_recursion',
+    'delayUntilRecursion': 'extensions.delay_until_recursion',
     'selectiveLogic': 'selectiveLogic',
     'comment': 'comment',
     'constant': 'constant',
@@ -1891,6 +1892,18 @@ function getWorldEntry(name, data, entry) {
     });
     preventRecursionInput.prop('checked', entry.preventRecursion).trigger('input');
 
+    // delay until recursion
+    const delayUntilRecursionInput = template.find('input[name="delay_until_recursion"]');
+    delayUntilRecursionInput.data('uid', entry.uid);
+    delayUntilRecursionInput.on('input', function () {
+        const uid = $(this).data('uid');
+        const value = $(this).prop('checked');
+        data.entries[uid].delayUntilRecursion = value;
+        setOriginalDataValue(data, uid, 'extensions.delay_until_recursion', data.entries[uid].delayUntilRecursion);
+        saveWorldInfo(name, data);
+    });
+    delayUntilRecursionInput.prop('checked', entry.delayUntilRecursion).trigger('input');
+
     // duplicate button
     const duplicateButton = template.find('.duplicate_entry_button');
     duplicateButton.data('uid', entry.uid);
@@ -2152,6 +2165,7 @@ const newEntryTemplate = {
     position: 0,
     disable: false,
     excludeRecursion: false,
+    delayUntilRecursion: false,
     probability: 100,
     useProbability: true,
     depth: DEFAULT_DEPTH,
@@ -2519,7 +2533,7 @@ async function checkWorldInfo(chat, maxContext) {
                 continue;
             }
 
-            if (allActivatedEntries.has(entry) || entry.disable == true || (count > 1 && world_info_recursive && entry.excludeRecursion)) {
+            if (allActivatedEntries.has(entry) || entry.disable == true || (count > 1 && world_info_recursive && entry.excludeRecursion) || (count == 1 && entry.delayUntilRecursion)) {
                 continue;
             }
 
@@ -2887,6 +2901,7 @@ function convertAgnaiMemoryBook(inputObj) {
             disable: !entry.enabled,
             addMemo: !!entry.name,
             excludeRecursion: false,
+            delayUntilRecursion: false,
             displayIndex: index,
             probability: 100,
             useProbability: true,
@@ -2925,6 +2940,7 @@ function convertRisuLorebook(inputObj) {
             disable: false,
             addMemo: true,
             excludeRecursion: false,
+            delayUntilRecursion: false,
             displayIndex: index,
             probability: entry.activationPercent ?? 100,
             useProbability: entry.activationPercent ?? true,
@@ -2968,6 +2984,7 @@ function convertNovelLorebook(inputObj) {
             disable: !entry.enabled,
             addMemo: addMemo,
             excludeRecursion: false,
+            delayUntilRecursion: false,
             displayIndex: index,
             probability: 100,
             useProbability: true,
@@ -3008,6 +3025,7 @@ function convertCharacterBook(characterBook) {
             position: entry.extensions?.position ?? (entry.position === 'before_char' ? world_info_position.before : world_info_position.after),
             excludeRecursion: entry.extensions?.exclude_recursion ?? false,
             preventRecursion: entry.extensions?.prevent_recursion ?? false,
+            delayUntilRecursion: entry.extensions?.delay_until_recursion ?? false,
             disable: !entry.enabled,
             addMemo: entry.comment ? true : false,
             displayIndex: entry.extensions?.display_index ?? index,

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -436,6 +436,7 @@ function convertWorldInfoToCharacterBook(name, entries) {
                 group_override: entry.groupOverride ?? false,
                 group_weight: entry.groupWeight ?? null,
                 prevent_recursion: entry.preventRecursion ?? false,
+                delay_until_recursion: entry.delayUntilRecursion ?? false,
                 scan_depth: entry.scanDepth ?? null,
                 match_whole_words: entry.matchWholeWords ?? null,
                 use_group_scoring: entry.useGroupScoring ?? false,


### PR DESCRIPTION
I tried other approaches. But right now, there is really no way to delay WI entry checking until some other stuff is done.
Either checking against inclusion groups with different ordering, or most importantly the "NOT" check conditions for secondary keys...  
It was not possible to write an entry that cannot be inserted, if another entry was triggered.

See also #2213

This is something that *might* be possible with the new script language, but eh. I think with the other two recursion switches, it's okay to have this one too.

Example:
![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/fbe0d576-d130-4426-9a03-375b6d050626)
