### PR TITLE
Add Gemini 1.5 Flash to Google MakerSuite

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2669,6 +2669,7 @@
                                     </optgroup>
                                     <optgroup label="Sub-versions">
                                         <option value="gemini-1.5-pro-latest">Gemini 1.5 Pro</option>
+                                        <option value="gemini-1.5-flash-latest">Gemini 1.5 Flash</option>
                                         <option value="gemini-1.0-pro-latest">Gemini 1.0 Pro</option>
                                         <option value="gemini-1.0-pro-vision-latest">Gemini 1.0 Pro Vision</option>
                                         <option value="gemini-1.0-ultra-latest">Gemini 1.0 Ultra</option>


### PR DESCRIPTION
This pull request integrates the `gemini 1.5 flash` lightweight model into Google MakerSuite.

![2024-05-16 12 15 00](https://github.com/SillyTavern/SillyTavern/assets/144279817/e44e038b-44f4-4b2d-a6cb-54c30edffcee)

- Reference
  - [Google Updates May 2024](https://blog.google/technology/developers/gemini-gemma-developer-updates-may-2024/)