### PR TITLE
[Claude] Implements Assistant Impersonation Prefill

### DIFF
--- a/default/content/presets/openai/Default.json
+++ b/default/content/presets/openai/Default.json
@@ -231,6 +231,7 @@
     "api_url_scale": "",
     "show_external_models": false,
     "assistant_prefill": "",
+    "assistant_impersonation": "",
     "human_sysprompt_message": "Let's get started. Please generate your response based on the information and instructions provided above.",
     "use_ai21_tokenizer": false,
     "use_google_tokenizer": false,

--- a/default/content/settings.json
+++ b/default/content/settings.json
@@ -624,6 +624,7 @@
         "show_external_models": false,
         "proxy_password": "",
         "assistant_prefill": "",
+        "assistant_impersonation": "",
         "use_ai21_tokenizer": false
     }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1734,6 +1734,8 @@
                                         <div class="wide100p">
                                             <span id="claude_assistant_prefill_text" data-i18n="Assistant Prefill">Assistant Prefill</span>
                                             <textarea id="claude_assistant_prefill" class="text_pole textarea_compact" name="assistant_prefill autoSetHeight" rows="3" maxlength="10000" data-i18n="[placeholder]Start Claude's answer with..." placeholder="Start Claude's answer with..."></textarea>
+                                            <span id="claude_assistant_impersonation_text" data-i18n="Assistant Impersonation Prefill">Assistant Impersonation Prefill</span>
+                                            <textarea id="claude_assistant_impersonation" class="text_pole textarea_compact" name="assistant_impersonation autoSetHeight" rows="3" maxlength="10000" data-i18n="[placeholder]Start Claude's answer with..." placeholder="Start Claude's answer with..."></textarea>
                                         </div>
                                         <label for="claude_use_sysprompt" class="checkbox_label widthFreeExpand">
                                             <input id="claude_use_sysprompt" type="checkbox" />


### PR DESCRIPTION
As discussed in Discord – I more or less figured out how to do what I wanted myself.

Adds a new Assistant Impersonation Prefill box for Claude.

This means that Assistant Prefill is _not_ added to Impersonate Prompts, **however**, when loading a preset, if Assistant Prefill is defined but Assistant Impersonation Prefill is not, it will inherit from Assistant Prefill so that preexisting presets behave as they did before.

I don't know if I'm supposed to add locales myself or if that's handled with a fancy bot. I'm guessing the latter.