### PR TITLE
fix: correct usage of fuzzy search in emotion detection by LLM

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1020,12 +1020,12 @@ function parseLlmResponse(emotionResponse, labels) {
         const parsedEmotion = JSON.parse(emotionResponse);
         return parsedEmotion?.emotion ?? fallbackExpression;
     } catch {
-        const fuse = new Fuse([emotionResponse]);
-        for (const label of labels) {
-            const result = fuse.search(label);
-            if (result.length > 0) {
-                return label;
-            }
+        const fuse = new Fuse(labels, {includeScore: true});
+        console.debug("Using fuzzy search in labels: " + labels.join(', '))
+        const result = fuse.search(emotionResponse);
+        if (result.length > 0) {
+            console.debug("fuzzy search found: " + result[0].item + " as closest for the LLM response: " + emotionResponse)
+            return result[0].item;
         }
     }
 


### PR DESCRIPTION
The matching of emotion from LLM is using https://www.fusejs.io/ but in incorrect way.
This PR fixes it. 
Here is the example and comparison I made:
```javascript
function getFallbackExpression() {
    return "neutral";
}

function parseLlmResponseOld(emotionResponse, labels) {
    console.debug("Emotion response from llm: " + emotionResponse)
    const fallbackExpression = getFallbackExpression();

    try {
        const parsedEmotion = JSON.parse(emotionResponse);
        console.debug("Parsed emotion response from llm: " + parsedEmotion)
        return parsedEmotion?.emotion ?? fallbackExpression;
    } catch {
        // todo: test this and report the bug
        const fuse = new Fuse([emotionResponse]);
        console.debug("Using fuzzy search in labels: " + labels.join(', '))
        for (const label of labels) {
            const result = fuse.search(label);
            if (result.length > 0) {
                console.debug("fuzzy search found: " + label + " as closest for the LLM response: " + emotionResponse)
                return label;
            }
        }
    }

    throw new Error('Could not parse emotion response ' + emotionResponse);
}

function parseLlmResponseNew(emotionResponse, labels) {
    console.debug("Emotion response from llm: " + emotionResponse)
    const fallbackExpression = getFallbackExpression();

    try {
        const parsedEmotion = JSON.parse(emotionResponse);
        console.debug("Parsed emotion response from llm: " + parsedEmotion)
        return parsedEmotion?.emotion ?? fallbackExpression;
    } catch {
        const fuse = new Fuse(labels, {includeScore: true});
        console.debug("Using fuzzy search in labels: " + labels.join(', '))
        const result = fuse.search(emotionResponse);
        if (result.length > 0) {
            console.debug("fuzzy search found: " + result[0].item + " as closest for the LLM response: " + emotionResponse)
            return result[0].item;
        }
    }

    throw new Error('Could not parse emotion response ' + emotionResponse);
}

function testThem() {
    const testing_data = ["sad", "angry", "natural", "angery", "admiration", "amusement", "anger", "annoyance", "approval", "caring", "confusion", "curiosity", "desire", "disappointment", "disapproval", "disgust", "embarrassment", "excitement", "fear", "gratitude", "grief", "joy", "love", "nervousness", "neutral", "optimism", "pride", "realization", "relief", "remorse", "sadness", "surprise"];
    const labels = ["admiration", "amusement", "anger", "annoyance", "approval", "caring", "confusion", "curiosity", "desire", "disappointment", "disapproval", "disgust", "embarrassment", "excitement", "fear", "gratitude", "grief", "joy", "love", "nervousness", "neutral", "optimism", "pride", "realization", "relief", "remorse", "sadness", "surprise"];
    // iterate over labels and test the function
    for (const label of testing_data) {
        // time the function
        console.time("parseLlmResponseOld");
        oldFunctionEmotion = parseLlmResponseOld(label, labels)
        console.timeEnd("parseLlmResponseOld")
        console.time("parseLlmResponseNew");
        newFunctionEmotion = parseLlmResponseNew(label, labels)
        console.timeEnd("parseLlmResponseNew")
        console.log("input: " + label +  ", old: " + oldFunctionEmotion + " new: " + newFunctionEmotion)
    }
}

testThem();

```
and here is the output:
```
parseLlmResponseOld: 2.14306640625 ms
parseLlmResponseNew: 0.4619140625 ms
input: sad, old: sadness new: sadness
parseLlmResponseOld: 0.210205078125 ms
parseLlmResponseNew: 0.366943359375 ms
input: angry, old: anger new: anger
parseLlmResponseOld: 0.21484375 ms
parseLlmResponseNew: 0.516845703125 ms
input: natural, old: approval new: neutral
parseLlmResponseOld: 0.161865234375 ms
parseLlmResponseNew: 0.407958984375 ms
input: angery, old: anger new: anger
parseLlmResponseOld: 0.3369140625 ms
parseLlmResponseNew: 0.368896484375 ms
input: admiration, old: admiration new: admiration
parseLlmResponseOld: 0.14208984375 ms
parseLlmResponseNew: 0.252197265625 ms
input: amusement, old: amusement new: amusement
parseLlmResponseOld: 0.693115234375 ms
parseLlmResponseNew: 0.4208984375 ms
input: anger, old: anger new: anger
parseLlmResponseOld: 0.1708984375 ms
parseLlmResponseNew: 0.254150390625 ms
input: annoyance, old: anger new: annoyance
parseLlmResponseOld: 0.132080078125 ms
parseLlmResponseNew: 0.39697265625 ms
input: approval, old: anger new: approval
parseLlmResponseOld: 0.2109375 ms
parseLlmResponseNew: 0.383056640625 ms
input: caring, old: caring new: caring
parseLlmResponseOld: 0.220947265625 ms
parseLlmResponseNew: 0.533935546875 ms
input: confusion, old: confusion new: confusion
parseLlmResponseOld: 0.337890625 ms
parseLlmResponseNew: 0.4130859375 ms
input: curiosity, old: caring new: curiosity
parseLlmResponseOld: 0.259033203125 ms
parseLlmResponseNew: 0.278076171875 ms
input: desire, old: desire new: desire
parseLlmResponseOld: 0.156982421875 ms
parseLlmResponseNew: 0.47900390625 ms
input: disappointment, old: admiration new: disappointment
parseLlmResponseOld: 0.205810546875 ms
parseLlmResponseNew: 0.883056640625 ms
input: disapproval, old: approval new: disapproval
parseLlmResponseOld: 0.218994140625 ms
parseLlmResponseNew: 0.47998046875 ms
input: disgust, old: disgust new: disgust
parseLlmResponseOld: 0.261962890625 ms
parseLlmResponseNew: 0.4169921875 ms
input: embarrassment, old: amusement new: embarrassment
parseLlmResponseOld: 0.14208984375 ms
parseLlmResponseNew: 0.264892578125 ms
input: excitement, old: amusement new: excitement
parseLlmResponseOld: 0.18212890625 ms
parseLlmResponseNew: 0.162841796875 ms
input: fear, old: fear new: fear
parseLlmResponseOld: 0.116943359375 ms
parseLlmResponseNew: 0.198974609375 ms
input: gratitude, old: admiration new: gratitude
parseLlmResponseOld: 0.129150390625 ms
parseLlmResponseNew: 0.174072265625 ms
input: grief, old: anger new: grief
parseLlmResponseOld: 0.175048828125 ms
parseLlmResponseNew: 0.156005859375 ms
input: joy, old: joy new: joy
parseLlmResponseOld: 0.18603515625 ms
parseLlmResponseNew: 0.1591796875 ms
input: love, old: love new: love
parseLlmResponseOld: 0.154052734375 ms
parseLlmResponseNew: 0.257080078125 ms
input: nervousness, old: anger new: nervousness
parseLlmResponseOld: 0.119873046875 ms
parseLlmResponseNew: 0.177001953125 ms
input: neutral, old: anger new: neutral
parseLlmResponseOld: 0.208984375 ms
parseLlmResponseNew: 0.180908203125 ms
input: optimism, old: optimism new: optimism
parseLlmResponseOld: 0.178955078125 ms
parseLlmResponseNew: 0.1630859375 ms
input: pride, old: gratitude new: pride
parseLlmResponseOld: 0.10205078125 ms
parseLlmResponseNew: 0.402099609375 ms
input: realization, old: admiration new: realization
parseLlmResponseOld: 0.148193359375 ms
parseLlmResponseNew: 0.216064453125 ms
input: relief, old: desire new: relief
parseLlmResponseOld: 0.18603515625 ms
parseLlmResponseNew: 0.192138671875 ms
input: remorse, old: grief new: remorse
parseLlmResponseOld: 0.23095703125 ms
parseLlmResponseNew: 0.196044921875 ms
input: sadness, old: sadness new: sadness
parseLlmResponseOld: 0.253173828125 ms
parseLlmResponseNew: 0.309814453125 ms
input: surprise, old: pride new: surprise
```
yes, it takes a bit more time, but it's still very negligible comparing to the call of llm, and you can see the fix is more correct in many cases, e.g.:
```
input: surprise, old: pride new: surprise
input: remorse, old: grief new: remorse
input: neutral, old: anger new: neutral
```

it's related to https://github.com/SillyTavern/SillyTavern/pull/1885 from where the code was taken.