### PR TITLE
More subcommand shenanigans

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2834,6 +2834,7 @@ async function executeSlashCommandsWithOptions(text, options = {}) {
         const result = await closure.execute();
         if (result.isAborted && !result.isQuietlyAborted) {
             toastr.warning(result.abortReason, 'Command execution aborted');
+            closure.abortController.signal.isQuiet = true;
         }
         return result;
     } catch (e) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2708,7 +2708,7 @@ const clearCommandProgressDebounced = debounce(clearCommandProgress);
  * @prop {boolean} [handleParserErrors] (true) Whether to handle parser errors (show toast on error) or throw.
  * @prop {SlashCommandScope} [scope] (null) The scope to be used when executing the commands.
  * @prop {boolean} [handleExecutionErrors] (false) Whether to handle execution errors (show toast on error) or throw
- * @prop {PARSER_FLAG[]} [parserFlags] (null) Parser flags to apply
+ * @prop {{[id:PARSER_FLAG]:boolean}} [parserFlags] (null) Parser flags to apply
  * @prop {SlashCommandAbortController} [abortController] (null) Controller used to abort or pause command execution
  * @prop {(done:number, total:number)=>void} [onProgress] (null) Callback to handle progress events
  */
@@ -2716,7 +2716,7 @@ const clearCommandProgressDebounced = debounce(clearCommandProgress);
 /**
  * @typedef ExecuteSlashCommandsOnChatInputOptions
  * @prop {SlashCommandScope} [scope] (null) The scope to be used when executing the commands.
- * @prop {PARSER_FLAG[]} [parserFlags] (null) Parser flags to apply
+ * @prop {{[id:PARSER_FLAG]:boolean}} [parserFlags] (null) Parser flags to apply
  * @prop {boolean} [clearChatInput] (false) Whether to clear the chat input textarea
  */
 

--- a/public/scripts/slash-commands/SlashCommand.js
+++ b/public/scripts/slash-commands/SlashCommand.js
@@ -13,7 +13,7 @@ import { SlashCommandScope } from './SlashCommandScope.js';
  * _scope:SlashCommandScope,
  * _parserFlags:{[id:PARSER_FLAG]:boolean},
  * _abortController:SlashCommandAbortController,
- * [id:string]:string,
+ * [id:string]:string|SlashCommandClosure,
  * }} NamedArguments
  */
 

--- a/public/scripts/slash-commands/SlashCommandClosure.js
+++ b/public/scripts/slash-commands/SlashCommandClosure.js
@@ -224,6 +224,15 @@ export class SlashCommandClosure {
                         ?.replace(/\\\{/g, '{')
                         ?.replace(/\\\}/g, '}')
                     ;
+                } else if (Array.isArray(value)) {
+                    value = value.map(v=>{
+                        if (typeof v == 'string') {
+                            return v
+                                ?.replace(/\\\{/g, '{')
+                                ?.replace(/\\\}/g, '}');
+                        }
+                        return v;
+                    });
                 }
 
                 let abortResult = await this.testAbortController();

--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -114,7 +114,6 @@ export class SlashCommandParser {
 
 
     constructor() {
-        //TODO should not be re-registered from every instance
         // add dummy commands for help strings / autocomplete
         if (!Object.keys(this.commands).includes('parser-flag')) {
             const help = {};

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -316,14 +316,21 @@ function listVariablesCallback() {
     sendSystemMessage(system_message_types.GENERIC, htmlMessage);
 }
 
-async function whileCallback(args, command) {
+/**
+ *
+ * @param {import('./slash-commands/SlashCommand.js').NamedArguments} args
+ * @param {(string|SlashCommandClosure)[]} value
+ */
+async function whileCallback(args, value) {
     const isGuardOff = isFalseBoolean(args.guard);
     const iterations = isGuardOff ? Number.MAX_SAFE_INTEGER : MAX_LOOPS;
-    if (command) {
-        if (command[0] instanceof SlashCommandClosure) {
-            command = command[0];
+    /**@type {string|SlashCommandClosure} */
+    let command;
+    if (value) {
+        if (value[0] instanceof SlashCommandClosure) {
+            command = value[0];
         } else {
-            command = command.join(' ');
+            command = value.join(' ');
         }
     }
 

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -575,7 +575,7 @@ function evalBoolean(rule, a, b) {
  * Executes a slash command from a string (may be enclosed in quotes) and returns the result.
  * @param {string} command Command to execute. May contain escaped macro and batch separators.
  * @param {SlashCommandScope} [scope] The scope to use.
- * @param {PARSER_FLAG[]} [parserFlags] The parser flags to use.
+ * @param {{[id:PARSER_FLAG]:boolean}} [parserFlags] The parser flags to use.
  * @param {SlashCommandAbortController} [abortController] The abort controller to use.
  * @returns {Promise<SlashCommandClosureResult>} Closure execution result
  */

--- a/public/style.css
+++ b/public/style.css
@@ -698,7 +698,7 @@ body .panelControlBar {
             display: flex;
         }
     }
-    &.paused {
+    &.script_paused {
         #rightSendForm > div:not(.mes_send).stscript_btn {
             &.stscript_pause {
                 display: none;


### PR DESCRIPTION
- fixed: macros inside unnamed argument arrays were not unescaped
- fixed: /abort toast from closures were suppressed
- fixed: /times did not break out of loop on /abort and had toast issues as well (same as /while did)
- use AbortController from root execution in /if
- fixed: /if had issues with longer subcommand strings
- fixed: pause script button did not switch play/resume button on pause
- moved silencing of loud /abort into executeSlashCommandsWithOptions (show toast, then set signal to quiet) to avoid having to do that wherever subcommands are used
- corrected some more typehints