### PR TITLE
feat: shortening prompt for expression classification.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2398,7 +2398,8 @@ export function getStoppingStrings(isImpersonate, isContinue) {
  * @param {string} quietName Name to use for the quiet prompt (defaults to "System:")
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
  * @param {Function} [promptPreprocessing] Function to preprocess the prompt before sending it to the AI
- * @param {Function} [chatPreprocessing] Function to preprocess the chat before sending it to the AI * @returns
+ * @param {Function} [chatPreprocessing] Function to preprocess the chat before sending it to the AI
+ * @returns
  */
 export async function generateQuietPrompt(quiet_prompt, quietToLoud, skipWIAN, quietImage = null, quietName = null, responseLength = null, promptPreprocessing = identity, chatPreprocessing = identity) {
     console.log('got into genQuietPrompt');

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1113,7 +1113,7 @@ async function getExpressionLabel(text) {
                 const expressionsList = await getExpressionsList();
                 const prompt = await getLlmPrompt(expressionsList);
                 eventSource.once(event_types.TEXT_COMPLETION_SETTINGS_READY, onTextGenSettingsReady);
-                const emotionResponse = await generateQuietPrompt(prompt, false, true, null, null, null, expressionPromptPreprocessing, expressionChatPreprocessing );
+                const emotionResponse = await generateQuietPrompt(prompt, false, false, null, null, null, expressionPromptPreprocessing, expressionChatPreprocessing );
                 return parseLlmResponse(emotionResponse, expressionsList);
             }
             // Extras

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1029,7 +1029,7 @@ function parseLlmResponse(emotionResponse, labels) {
         if (emotionResponse.includes('\n') && !emotionResponse.startsWith('\n')) {
             emotionResponse = emotionResponse.split("\n")[0]
         }
-        const result = fuse.search(emotionResponse.toLowerCase());
+        const result = fuse.search(emotionResponse);
         if (result.length > 0) {
             console.debug(`fuzzy search found: ${result[0].item} as closest for the LLM response:`, emotionResponse);
             return result[0].item;

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1,30 +1,14 @@
-import {
-    callPopup,
-    event_types,
-    eventSource,
-    generateQuietPrompt,
-    getRequestHeaders,
-    saveSettingsDebounced,
-    substituteParams
-} from '../../../script.js';
-import {dragElement, isMobile} from '../../RossAscends-mods.js';
-import {
-    doExtrasFetch,
-    extension_settings,
-    getApiUrl,
-    getContext,
-    modules,
-    ModuleWorkerWrapper,
-    renderExtensionTemplateAsync
-} from '../../extensions.js';
-import {loadMovingUIState, power_user} from '../../power-user.js';
-import {debounce, getCharaFilename, onlyUnique, trimToEndSentence, trimToStartSentence} from '../../utils.js';
-import {hideMutedSprites} from '../../group-chats.js';
-import {isJsonSchemaSupported} from '../../textgen-settings.js';
-import {debounce_timeout} from '../../constants.js';
-import {SlashCommandParser} from '../../slash-commands/SlashCommandParser.js';
-import {SlashCommand} from '../../slash-commands/SlashCommand.js';
-import {ARGUMENT_TYPE, SlashCommandArgument} from '../../slash-commands/SlashCommandArgument.js';
+import { callPopup, eventSource, event_types, generateQuietPrompt, getRequestHeaders, saveSettingsDebounced, substituteParams } from '../../../script.js';
+import { dragElement, isMobile } from '../../RossAscends-mods.js';
+import { getContext, getApiUrl, modules, extension_settings, ModuleWorkerWrapper, doExtrasFetch, renderExtensionTemplateAsync } from '../../extensions.js';
+import { loadMovingUIState, power_user } from '../../power-user.js';
+import { onlyUnique, debounce, getCharaFilename, trimToEndSentence, trimToStartSentence } from '../../utils.js';
+import { hideMutedSprites } from '../../group-chats.js';
+import { isJsonSchemaSupported } from '../../textgen-settings.js';
+import { debounce_timeout } from '../../constants.js';
+import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
+import { SlashCommand } from '../../slash-commands/SlashCommand.js';
+import { ARGUMENT_TYPE, SlashCommandArgument } from '../../slash-commands/SlashCommandArgument.js';
 
 export { MODULE_NAME };
 

--- a/public/scripts/extensions/expressions/settings.html
+++ b/public/scripts/extensions/expressions/settings.html
@@ -36,6 +36,18 @@
                 </label>
                 <small>Will be used if the API doesn't support JSON schemas.</small>
                 <textarea id="expression_llm_prompt" type="text" class="text_pole textarea_compact" rows="2" placeholder="Use &lcub;&lcub;labels&rcub;&rcub; special macro."></textarea>
+                <label for="expression_llm_last_messages" class="title_restorable">
+                    <span>Use last N messages.</span>
+                    <a href="https://docs.sillytavern.app/usage/core-concepts/advancedformatting/#token-padding" class="notes-link" target="_blank">
+                        <span class="fa-solid fa-circle-question note-link-span"></span>
+                    </a>
+                </label>
+                <small>If 0, it's ignored and whole chat history is used. If > 0, only that number of last messages is used. Can greatly lower number of tokens.</small>
+                <input id="expression_llm_last_messages" class="text_pole textarea_compact" type="number" min="0" max="1000" />
+                <label class="checkbox_label" for="expression_llm_only_conversation">
+                    <input id="expression_llm_only_conversation" type="checkbox">
+                    <span>Use only the conversation, omitting all world info, author's note and character description. Works only if chat_start is not empty.</span>
+                </label>
             </div>
             <div class="expression_fallback_block m-b-1 m-t-1">
                 <label for="expression_fallback">Default / Fallback Expression</label>

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1653,3 +1653,7 @@ export function highlightRegex(regexStr) {
 
     return `<span class="regex-highlight">${regexStr}</span>`;
 }
+
+export function identity(x) {
+    return x;
+}


### PR DESCRIPTION
The LLM option on character expressions is a great feature, but currently it sends the whole prompt into the LLM, which is usually quite large, and includes lots of information unnecessary for the classification itself.
This PR adds 2 new options:
- keeping only the conversation, skipping the world info, author's note, character description, scenario etc.
- using only last N messages from the conversation

I have performed experiments on Czech language using conversation with 12 responses from the character, and there using only the 3 last messages from the conversation, and skipping everything before conversation started almost did not degrade the classification quality and it shortened the number of tokens 20x times.
In short experiment with Seraphina, using only last 3 messages lowers the amount of tokens 4x, which is still great I think. 
In case of using paid LLM this makes the expression classification much more affordable.