### PR TITLE
stop parser from complaining about space after closing quote of quoted argument

### DIFF
--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -109,7 +109,7 @@ export class SlashCommandParser {
         return this.text[this.index];
     }
     get endOfText() {
-        return this.index >= this.text.length || /^\s+$/.test(this.ahead);
+        return this.index >= this.text.length || (/\s/.test(this.char) && /^\s+$/.test(this.ahead));
     }
 
 


### PR DESCRIPTION
for #2268 