### PR TITLE
Implement failsafe for world creation with same name

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -154,6 +154,7 @@ import {
     isValidUrl,
     ensureImageFormatSupported,
     flashHighlight,
+    checkOverwriteExistingData,
 } from './scripts/utils.js';
 import { debounce_timeout } from './scripts/constants.js';
 
@@ -6465,7 +6466,8 @@ export async function getChatsFromFiles(data, isGroupChat) {
  * @param {null|number} [characterId=null] - When set, the function will use this character id instead of this_chid.
  *
  * @returns {Promise<Array>} - An array containing metadata of all past chats of the character, sorted
- * in descending order by file name. Returns `undefined` if the fetch request is unsuccessful.
+ * in descending order by file name. Returns an empty array if the fetch request is unsuccessful or the
+ * response is an object with an `error` property set to `true`.
  */
 export async function getPastCharacterChats(characterId = null) {
     characterId = characterId ?? this_chid;
@@ -6481,10 +6483,13 @@ export async function getPastCharacterChats(characterId = null) {
         return [];
     }
 
-    let data = await response.json();
-    data = Object.values(data);
-    data = data.sort((a, b) => a['file_name'].localeCompare(b['file_name'])).reverse();
-    return data;
+    const data = await response.json();
+    if (typeof data === 'object' && data.error === true) {
+        return [];
+    }
+
+    const chats = Object.values(data);
+    return chats.sort((a, b) => a['file_name'].localeCompare(b['file_name'])).reverse();
 }
 
 /**
@@ -8449,17 +8454,34 @@ function doCloseChat() {
  * @param {string} this_chid - The character ID to be deleted.
  * @param {boolean} delete_chats - Whether to delete chats or not.
  */
-export async function handleDeleteCharacter(popup_type, this_chid, delete_chats) {
+async function handleDeleteCharacter(popup_type, this_chid, delete_chats) {
     if (popup_type !== 'del_ch' ||
         !characters[this_chid]) {
         return;
     }
 
-    const avatar = characters[this_chid].avatar;
-    const name = characters[this_chid].name;
-    const pastChats = await getPastCharacterChats();
+    await deleteCharacter(characters[this_chid].avatar, { deleteChats: delete_chats });
+}
 
-    const msg = { avatar_url: avatar, delete_chats: delete_chats };
+/**
+ * Deletes a character completely, including associated chats if specified
+ *
+ * @param {string} characterKey - The key (avatar) of the character to be deleted
+ * @param {Object} [options] - Optional parameters for the deletion
+ * @param {boolean} [options.deleteChats=true] - Whether to delete associated chats or not
+ * @return {Promise<void>} - A promise that resolves when the character is successfully deleted
+ */
+export async function deleteCharacter(characterKey, { deleteChats = true } = {}) {
+    const character = characters.find(x => x.avatar == characterKey);;
+    if (!character) {
+        toastr.warning(`Character ${characterKey} not found. Cannot be deleted.`);
+        return;
+    }
+
+    const chid = characters.indexOf(character);
+    const pastChats = await getPastCharacterChats(chid);
+
+    const msg = { avatar_url: character.avatar, delete_chats: deleteChats };
 
     const response = await fetch('/api/characters/delete', {
         method: 'POST',
@@ -8468,17 +8490,17 @@ export async function handleDeleteCharacter(popup_type, this_chid, delete_chats)
         cache: 'no-cache',
     });
 
-    if (response.ok) {
-        await deleteCharacter(name, avatar);
+    if (!response.ok) {
+        throw new Error(`Failed to delete character: ${response.status} ${response.statusText}`);
+    }
 
-        if (delete_chats) {
-            for (const chat of pastChats) {
-                const name = chat.file_name.replace('.jsonl', '');
-                await eventSource.emit(event_types.CHAT_DELETED, name);
-            }
+    await removeCharacterFromUI(character.name, character.avatar);
+
+    if (deleteChats) {
+        for (const chat of pastChats) {
+            const name = chat.file_name.replace('.jsonl', '');
+            await eventSource.emit(event_types.CHAT_DELETED, name);
         }
-    } else {
-        console.error('Failed to delete character: ', response.status, response.statusText);
     }
 }
 
@@ -8495,7 +8517,7 @@ export async function handleDeleteCharacter(popup_type, this_chid, delete_chats)
  * @param {string} avatar - The avatar URL of the character to be deleted.
  * @param {boolean} reloadCharacters - Whether the character list should be refreshed after deletion.
  */
-export async function deleteCharacter(name, avatar, reloadCharacters = true) {
+async function removeCharacterFromUI(name, avatar, reloadCharacters = true) {
     await clearChat();
     $('#character_cross').click();
     this_chid = undefined;

--- a/public/script.js
+++ b/public/script.js
@@ -8454,7 +8454,7 @@ function doCloseChat() {
  * @param {string} this_chid - The character ID to be deleted.
  * @param {boolean} delete_chats - Whether to delete chats or not.
  */
-async function handleDeleteCharacter(popup_type, this_chid, delete_chats) {
+export async function handleDeleteCharacter(popup_type, this_chid, delete_chats) {
     if (popup_type !== 'del_ch' ||
         !characters[this_chid]) {
         return;
@@ -8472,7 +8472,7 @@ async function handleDeleteCharacter(popup_type, this_chid, delete_chats) {
  * @return {Promise<void>} - A promise that resolves when the character is successfully deleted
  */
 export async function deleteCharacter(characterKey, { deleteChats = true } = {}) {
-    const character = characters.find(x => x.avatar == characterKey);;
+    const character = characters.find(x => x.avatar == characterKey);
     if (!character) {
         toastr.warning(`Character ${characterKey} not found. Cannot be deleted.`);
         return;

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -4,7 +4,6 @@ import {
     characterGroupOverlay,
     callPopup,
     characters,
-    deleteCharacter,
     event_types,
     eventSource,
     getCharacters,
@@ -13,6 +12,7 @@ import {
     buildAvatarList,
     characterToEntity,
     printCharactersDebounced,
+    deleteCharacter,
 } from '../script.js';
 
 import { favsToHotswap } from './RossAscends-mods.js';
@@ -115,24 +115,7 @@ class CharacterContextMenu {
     static delete = async (characterId, deleteChats = false) => {
         const character = CharacterContextMenu.#getCharacter(characterId);
 
-        return fetch('/api/characters/delete', {
-            method: 'POST',
-            headers: getRequestHeaders(),
-            body: JSON.stringify({ avatar_url: character.avatar, delete_chats: deleteChats }),
-            cache: 'no-cache',
-        }).then(response => {
-            if (response.ok) {
-                eventSource.emit(event_types.CHARACTER_DELETED, { id: characterId, character: character });
-                return deleteCharacter(character.name, character.avatar, false).then(() => {
-                    if (deleteChats) getPastCharacterChats(characterId).then(pastChats => {
-                        for (const chat of pastChats) {
-                            const name = chat.file_name.replace('.jsonl', '');
-                            eventSource.emit(event_types.CHAT_DELETED, name);
-                        }
-                    });
-                });
-            }
-        });
+        await deleteCharacter(character.avatar, { deleteChats: deleteChats });
     };
 
     static #getCharacter = (characterId) => characters[characterId] ?? null;

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1022,6 +1022,36 @@ export function extractDataFromPng(data, identifier = 'chara') {
 }
 
 /**
+ * Sends a request to the server to sanitize a given filename
+ *
+ * @param {string} fileName - The name of the file to sanitize
+ * @returns {Promise<string>} A Promise that resolves to the sanitized filename if successful, or rejects with an error message if unsuccessful
+ */
+export async function getSanitizedFilename(fileName) {
+    try {
+        const result = await fetch('/api/files/sanitize-filename', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                fileName: fileName,
+            }),
+        });
+
+        if (!result.ok) {
+            const error = await result.text();
+            throw new Error(error);
+        }
+
+        const responseData = await result.json();
+        return responseData.fileName;
+    } catch (error) {
+        toastr.error(String(error), 'Could not sanitize fileName');
+        console.error('Could not sanitize fileName', error);
+        throw error;
+    }
+}
+
+/**
  * Sends a base64 encoded image to the backend to be saved as a file.
  *
  * @param {string} base64Data - The base64 encoded image data.

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1470,22 +1470,46 @@ export function flashHighlight(element, timespan = 2000) {
 }
 
 /**
+ * A common base function for case-insensitive and accent-insensitive string comparisons.
+ *
+ * @param {string} a - The first string to compare.
+ * @param {string} b - The second string to compare.
+ * @param {(a:string,b:string)=>boolean} comparisonFunction - The function to use for the comparison.
+ * @returns {*} - The result of the comparison.
+ */
+export function compareIgnoreCaseAndAccents(a, b, comparisonFunction) {
+    if (!a || !b) return comparisonFunction(a, b); // Return the comparison result if either string is empty
+
+    // Normalize and remove diacritics, then convert to lower case
+    const normalizedA = a.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+    const normalizedB = b.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+
+    // Check if the normalized strings are equal
+    return comparisonFunction(normalizedA, normalizedB);
+}
+
+/**
  * Performs a case-insensitive and accent-insensitive substring search.
  * This function normalizes the strings to remove diacritical marks and converts them to lowercase to ensure the search is insensitive to case and accents.
  *
- * @param {string} text - The text in which to search for the substring.
- * @param {string} searchTerm - The substring to search for in the text.
- * @returns {boolean} - Returns true if the searchTerm is found within the text, otherwise returns false.
+ * @param {string} text - The text in which to search for the substring
+ * @param {string} searchTerm - The substring to search for in the text
+ * @returns {boolean} true if the searchTerm is found within the text, otherwise returns false
  */
 export function includesIgnoreCaseAndAccents(text, searchTerm) {
-    if (!text || !searchTerm) return false; // Return false if either string is empty
+    return compareIgnoreCaseAndAccents(text, searchTerm, (a, b) => a?.includes(b) === true);
+}
 
-    // Normalize and remove diacritics, then convert to lower case
-    const normalizedText = text.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
-    const normalizedSearchTerm = searchTerm.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
-
-    // Check if the normalized text includes the normalized search term
-    return normalizedText.includes(normalizedSearchTerm);
+/**
+ * Performs a case-insensitive and accent-insensitive equality check.
+ * This function normalizes the strings to remove diacritical marks and converts them to lowercase to ensure the search is insensitive to case and accents.
+ *
+ * @param {string} a - The first string to compare
+ * @param {string} b - The second string to compare
+ * @returns {boolean} true if the strings are equal, otherwise returns false
+ */
+export function equalsIgnoreCaseAndAccents(a, b) {
+    return compareIgnoreCaseAndAccents(a, b, (a, b) => a === b);
 }
 
 /**

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2631,7 +2631,9 @@ async function createNewWorldInfo(worldName, { interactive = false } = {}) {
         return false;
     }
 
-    const allowed = await checkOverwriteExistingData('World Info', world_names, worldName, { interactive: interactive, actionName: 'Create', deleteAction: (existingName) => deleteWorldInfo(existingName) });
+    const sanitizedWorldName = await getSanitizedFilename(worldName);
+
+    const allowed = await checkOverwriteExistingData('World Info', world_names, sanitizedWorldName, { interactive: interactive, actionName: 'Create', deleteAction: (existingName) => deleteWorldInfo(existingName) });
     if (!allowed) {
         return false;
     }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1,5 +1,5 @@
 import { saveSettings, callPopup, substituteParams, getRequestHeaders, chat_metadata, this_chid, characters, saveCharacterDebounced, menu_type, eventSource, event_types, getExtensionPromptByName, saveMetadata, getCurrentChatId, extension_prompt_roles } from '../script.js';
-import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean } from './utils.js';
+import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, equalsIgnoreCaseAndAccents } from './utils.js';
 import { extension_settings, getContext } from './extensions.js';
 import { NOTE_MODULE_NAME, metadata_keys, shouldWIAddPrompt } from './authors-note.js';
 import { isMobile } from './RossAscends-mods.js';
@@ -50,6 +50,7 @@ const WI_ENTRY_EDIT_TEMPLATE = $('#entry_edit_template .world_entry');
 
 let world_info = {};
 let selected_world_info = [];
+/** @type {string[]} */
 let world_names;
 let world_info_depth = 2;
 let world_info_min_activations = 0; // if > 0, will continue seeking chat until minimum world infos are activated
@@ -2544,9 +2545,15 @@ async function renameWorldInfo(name, data) {
     }
 }
 
+/**
+ * Deletes a world info with the given name
+ *
+ * @param {string} worldInfoName - The name of the world info to delete
+ * @returns {Promise<boolean>} A promise that resolves to true if the world info was successfully deleted, false otherwise
+ */
 async function deleteWorldInfo(worldInfoName) {
     if (!world_names.includes(worldInfoName)) {
-        return;
+        return false;
     }
 
     const response = await fetch('/api/worldinfo/delete', {
@@ -2555,24 +2562,28 @@ async function deleteWorldInfo(worldInfoName) {
         body: JSON.stringify({ name: worldInfoName }),
     });
 
-    if (response.ok) {
-        const existingWorldIndex = selected_world_info.findIndex((e) => e === worldInfoName);
-        if (existingWorldIndex !== -1) {
-            selected_world_info.splice(existingWorldIndex, 1);
-            saveSettingsDebounced();
-        }
+    if (!response.ok) {
+        return false;
+    }
 
-        await updateWorldInfoList();
-        $('#world_editor_select').trigger('change');
+    const existingWorldIndex = selected_world_info.findIndex((e) => e === worldInfoName);
+    if (existingWorldIndex !== -1) {
+        selected_world_info.splice(existingWorldIndex, 1);
+        saveSettingsDebounced();
+    }
 
-        if ($('#character_world').val() === worldInfoName) {
-            $('#character_world').val('').trigger('change');
-            setWorldInfoButtonClass(undefined, false);
-            if (menu_type != 'create') {
-                saveCharacterDebounced();
-            }
+    await updateWorldInfoList();
+    $('#world_editor_select').trigger('change');
+
+    if ($('#character_world').val() === worldInfoName) {
+        $('#character_world').val('').trigger('change');
+        setWorldInfoButtonClass(undefined, false);
+        if (menu_type != 'create') {
+            saveCharacterDebounced();
         }
     }
+
+    return true;
 }
 
 function getFreeWorldEntryUid(data) {
@@ -2604,11 +2615,35 @@ function getFreeWorldName() {
     return undefined;
 }
 
-async function createNewWorldInfo(worldInfoName) {
+/**
+ * Creates a new world info/lorebook with the given name.
+ * Checks if a world with the same name already exists, providing a warning or optionally a user confirmation dialog.
+ *
+ * @param {string} worldInfoName - The name of the new world info
+ * @param {Object} options - Optional parameters
+ * @param {boolean} [options.interactive=false] - Whether to show a confirmation dialog when overwriting an existing world
+ * @returns {Promise<boolean>} - True if the world info was successfully created, false otherwise
+ */
+async function createNewWorldInfo(worldInfoName, { interactive = false } = {}) {
     const worldInfoTemplate = { entries: {} };
 
     if (!worldInfoName) {
-        return;
+        return false;
+    }
+
+    const existingWorld = world_names.find(x => equalsIgnoreCaseAndAccents(x, worldInfoName));
+    if (existingWorld) {
+        const overwrite = interactive ? await callPopup(`<h3>Creating New World Info</h3><p>A world with the same name already exists:<br />${existingWorld}</p>Do you want to overwrite it?`, 'confirm') : false;
+
+        if (!overwrite) {
+            toastr.warning(`World creation cancelled. A world with the same name already exists:<br />${existingWorld}`, 'Creating New World Info', { escapeHtml: false });
+            return false;
+        }
+
+        toastr.info(`Overwriting Existing World Info:<br />${existingWorld}`, 'Creating New World Info', { escapeHtml: false });
+
+        // Manually delete, as we want to overwrite. The name might be slightly different so file name would not be the same.
+        await deleteWorldInfo(existingWorld);
     }
 
     await saveWorldInfo(worldInfoName, worldInfoTemplate, true);
@@ -2620,6 +2655,8 @@ async function createNewWorldInfo(worldInfoName) {
     } else {
         hideWorldEditor();
     }
+
+    return true;
 }
 
 async function getCharacterLore() {
@@ -3644,7 +3681,7 @@ jQuery(() => {
         const finalName = await callPopup('<h3>Create a new World Info?</h3>Enter a name for the new file:', 'input', tempName);
 
         if (finalName) {
-            await createNewWorldInfo(finalName);
+            await createNewWorldInfo(finalName, { interactive: true });
         }
     });
 

--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -2,10 +2,27 @@ const path = require('path');
 const fs = require('fs');
 const writeFileSyncAtomic = require('write-file-atomic').sync;
 const express = require('express');
+const sanitize = require('sanitize-filename');
 const router = express.Router();
 const { validateAssetFileName } = require('./assets');
 const { jsonParser } = require('../express-common');
 const { clientRelativePath } = require('../util');
+
+router.post('/sanitize-filename', jsonParser, async (request, response) => {
+    try {
+        const fileName = String(request.body.fileName);
+        if (!fileName) {
+            return response.status(400).send('No fileName specified');
+        }
+
+        const sanitizedFilename = sanitize(fileName);
+        console.debug(`Sanitized fileName: ${fileName} -> ${sanitizedFilename}`);
+        return response.send({ fileName: sanitizedFilename });
+    } catch (error) {
+        console.log(error);
+        return response.sendStatus(500);
+    }
+});
 
 router.post('/upload', jsonParser, async (request, response) => {
     try {

--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -16,7 +16,6 @@ router.post('/sanitize-filename', jsonParser, async (request, response) => {
         }
 
         const sanitizedFilename = sanitize(fileName);
-        console.debug(`Sanitized fileName: ${fileName} -> ${sanitizedFilename}`);
         return response.send({ fileName: sanitizedFilename });
     } catch (error) {
         console.log(error);


### PR DESCRIPTION
- Fixes #2297
- Added another utils function for string comparison

The button for new world uses an interactive dialog where you can overwrite the world if you want to. All other calls (like slash command world creation) will just show a warning and cancel.