### PR TITLE
Enable DRY for llamacpp

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1272,8 +1272,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <!-- Enable for llama.cpp when the PR is merged: https://github.com/ggerganov/llama.cpp/pull/6839 -->
-                                    <div data-newbie-hidden data-tg-type="ooba" id="dryBlock" class="wide100p">
+                                    <div data-newbie-hidden data-tg-type="ooba, llamacpp" id="dryBlock" class="wide100p">
                                         <h4 class="wide100p textAlignCenter" title="DRY penalizes tokens that would extend the end of the input into a sequence that has previously occurred in the input. Set multiplier to 0 to disable.">
                                             <label data-i18n="DRY Repetition Penalty">DRY Repetition Penalty</label>
                                             <a href="https://github.com/oobabooga/text-generation-webui/pull/5677" target="_blank">


### PR DESCRIPTION
Continuation of #2211. Enables DRY Repetition Penalty block for llamacpp.

To be merged after this: https://github.com/ggerganov/llama.cpp/pull/6839