### PR TITLE
Use GPT-4o tokenizer for Gemini

### DIFF
--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -308,6 +308,10 @@ function getTokenizerModel(requestModel) {
         return 'yi';
     }
 
+    if (requestModel.includes('gemini')) {
+        return 'gpt-4o';
+    }
+
     // default
     return 'gpt-3.5-turbo';
 }


### PR DESCRIPTION
Use GPT-4o tokenizer for Gemini, as Gemini tokenizer is more similar to GPT-4o's.

For example, for Japanese Wikipedia Main Page:
![cl100k_base](https://github.com/SillyTavern/SillyTavern/assets/139055015/ae8f880f-7575-480c-ae52-a76ff1b0c791)
![o200k_base](https://github.com/SillyTavern/SillyTavern/assets/139055015/bd758f24-e114-49cb-a29e-66783b766122)
![image](https://github.com/SillyTavern/SillyTavern/assets/139055015/9ffadbbc-5ee0-4492-a72b-e66c4d1f97ba)
