### PR TITLE
Apply theme on startup from fresh browser session

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -84,6 +84,7 @@ import {
     context_presets,
     resetMovableStyles,
     forceCharacterEditorTokenize,
+    initTheme,
 } from './scripts/power-user.js';
 
 import {
@@ -870,6 +871,7 @@ async function firstLoadInit() {
     await getSystemMessages();
     sendSystemMessage(system_message_types.WELCOME);
     await getSettings();
+    initTheme();
     initTags();
     await getUserAvatars(true, user_avatar);
     await getCharacters();

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -3009,6 +3009,15 @@ export function forceCharacterEditorTokenize() {
     $('#character_popup').trigger('input');
 }
 
+export function initTheme()
+{
+    if (power_user.theme !== undefined)
+    {
+        applyTheme(power_user.theme);
+        saveSettingsDebounced();
+    }
+}
+
 $(document).ready(() => {
     const adjustAutocompleteDebounced = debounce(() => {
         $('.ui-autocomplete-input').each(function () {


### PR DESCRIPTION
When using a clean browser (cache, cookies and local storage cleaned) accessing Silly Tavern again will not correctly apply the selected theme. The theme will be loaded from user settings as it should, but will not be applied. Not only will the, presumably desired theme not be applied, to apply it, you'd have to swap off of the theme, then swap back on it.

This PR simply adds a call `applyTheme(string)` from `script.js` after the settings have been loaded, to load the theme last used by the user. This causes the theme currently selected to actually be loaded on startup, saving 3 additional mouse clicks when starting up.

Potentially unwanted side effect. Less tech savvy users may "brick" their instance by applying a theme/custom CSS that prevents them from seeing the theme select option, and may not know to edit the settings file, assuming it's available to them.