### PR TITLE
Add support for relative path API endpoints in connectToApi for doExtrasFetch

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -412,7 +412,7 @@ async function connectToApi(baseUrl) {
     }
 
     const url = new URL(baseUrl);
-    url.pathname = '/api/modules';
+    url.pathname += '/api/modules';
 
     try {
         const getExtensionsResult = await doExtrasFetch(url);


### PR DESCRIPTION
Add support for relative path API endpoints in connectToApi for doExtrasFetch

This adds support for SillyTavern-Extra URLs like "https://host/relativepath" in addition to the more common "https://host" URLs.