### PR TITLE
Add /setpromptentry command to manipulate individual chat completion preset entries

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1224,7 +1224,7 @@ SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         ),
     ],
     unnamedArgumentList: [
-        SlashCommandArgument.fromProps({ description: 'Set entry/entries on or off',
+        SlashCommandArgument.fromProps({ description: 'Set entry/entries on, off or toggle current state',
             typeList: [ARGUMENT_TYPE.STRING],
             isRequired: true,
             acceptsMultiple: false,
@@ -1232,7 +1232,7 @@ SlashCommandParser.addCommandObject(SlashCommand.fromProps({
             enumList: ['on', 'off', 'toggle'],
         }),
     ],
-    helpString: 'Sets the model for the current API. Gets the current model name if no argument is provided.',
+    helpString: 'Sets or toggles individual chat completion prompt entries.',
 }));
 
 registerVariableCommands();

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1226,7 +1226,7 @@ SlashCommandParser.addCommandObject(SlashCommand.fromProps({
             enumList: ['on', 'off', 'toggle'],
         }),
     ],
-    helpString: 'Sets the model for the current API. Gets the current model name if no argument is provided.',
+    helpString: 'Sets the toggles for prompt entries. Toggle by default.',
 }));
 
 registerVariableCommands();


### PR DESCRIPTION
Should be pretty self-explanatory, this pr implements a command to manipulate the toggles for entries inside chat completion presets.
The default value for unnamedArgumentList is unused/not implemented, but I added it in case support gets added
