### PR TITLE
Timed Effects for World Info

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5390,26 +5390,6 @@
                             </div>
                         </div>
                         <div class="flex-container wide100p flexGap10">
-                            <div class="flex2 flex-container flexFlowColumn flexNoGap" data-i18n="[title]Sticky entries will stay active for N messages after being triggered." title="Sticky entries will stay active for N messages after being triggered.">
-                                <div class="flex-container justifySpaceBetween marginBot5">
-                                    <small for="sticky" data-i18n="Sticky">
-                                        Sticky
-                                    </small>
-                                </div>
-                                <div class="range-block-range">
-                                    <input class="text_pole margin0" name="sticky" type="number" placeholder="Non-sticky" min="1" max="999999">
-                                </div>
-                            </div>
-                            <div class="flex2 flex-container flexFlowColumn flexNoGap" data-i18n="[title]Entries with a cooldown can't be activated N messages after being triggered." title="Entries with a cooldown can't be activated N messages after being triggered.">
-                                <div class="flex-container justifySpaceBetween marginBot5">
-                                    <small for="cooldown" data-i18n="Cooldown">
-                                        Cooldown
-                                    </small>
-                                </div>
-                                <div class="range-block-range">
-                                    <input class="text_pole margin0" name="cooldown" type="number" placeholder="No cooldown" min="1" max="999999">
-                                </div>
-                            </div>
                             <div class="flex3 flex-container flexFlowColumn flexNoGap">
                                 <div class="flex-container justifySpaceBetween">
                                     <small for="group">
@@ -5440,6 +5420,26 @@
                                 </div>
                                 <div class="range-block-range">
                                     <input type="number" class="text_pole margin0" name="groupWeight" rows="1" placeholder="100" min="1" max="999999">
+                                </div>
+                            </div>
+                            <div class="flex2 flex-container flexFlowColumn flexNoGap" data-i18n="[title]Sticky entries will stay active for N messages after being triggered." title="Sticky entries will stay active for N messages after being triggered.">
+                                <div class="flex-container justifySpaceBetween marginBot5">
+                                    <small for="sticky" data-i18n="Sticky">
+                                        Sticky
+                                    </small>
+                                </div>
+                                <div class="range-block-range">
+                                    <input class="text_pole margin0" name="sticky" type="number" placeholder="Non-sticky" min="1" max="999999">
+                                </div>
+                            </div>
+                            <div class="flex2 flex-container flexFlowColumn flexNoGap" data-i18n="[title]Entries with a cooldown can't be activated N messages after being triggered." title="Entries with a cooldown can't be activated N messages after being triggered.">
+                                <div class="flex-container justifySpaceBetween marginBot5">
+                                    <small for="cooldown" data-i18n="Cooldown">
+                                        Cooldown
+                                    </small>
+                                </div>
+                                <div class="range-block-range">
+                                    <input class="text_pole margin0" name="cooldown" type="number" placeholder="No cooldown" min="1" max="999999">
                                 </div>
                             </div>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -5437,7 +5437,7 @@
                                     </small>
                                 </div>
                                 <div class="range-block-range">
-                                    <input class="text_pole margin0" name="sticky" type="number" placeholder="Non-sticky" min="1" max="999999">
+                                    <input class="text_pole margin0" name="sticky" type="number" placeholder="Non-sticky" min="0" max="999999">
                                 </div>
                             </div>
                             <div class="flex2 flex-container flexFlowColumn flexNoGap" data-i18n="[title]Entries with a cooldown can't be activated N messages after being triggered." title="Entries with a cooldown can't be activated N messages after being triggered.">
@@ -5450,7 +5450,7 @@
                                     </small>
                                 </div>
                                 <div class="range-block-range">
-                                    <input class="text_pole margin0" name="cooldown" type="number" placeholder="No cooldown" min="1" max="999999">
+                                    <input class="text_pole margin0" name="cooldown" type="number" placeholder="No cooldown" min="0" max="999999">
                                 </div>
                             </div>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -5424,8 +5424,11 @@
                             </div>
                             <div class="flex2 flex-container flexFlowColumn flexNoGap" data-i18n="[title]Sticky entries will stay active for N messages after being triggered." title="Sticky entries will stay active for N messages after being triggered.">
                                 <div class="flex-container justifySpaceBetween marginBot5">
-                                    <small for="sticky" data-i18n="Sticky">
-                                        Sticky
+                                    <small class="flex-container alignItemsBaseline" for="sticky" data-i18n="Sticky">
+                                        <span data-i18n="Sticky">
+                                            Sticky
+                                        </span>
+                                        <i class="fa-solid fa-comments fa-xs"></i>
                                     </small>
                                 </div>
                                 <div class="range-block-range">
@@ -5434,8 +5437,11 @@
                             </div>
                             <div class="flex2 flex-container flexFlowColumn flexNoGap" data-i18n="[title]Entries with a cooldown can't be activated N messages after being triggered." title="Entries with a cooldown can't be activated N messages after being triggered.">
                                 <div class="flex-container justifySpaceBetween marginBot5">
-                                    <small for="cooldown" data-i18n="Cooldown">
-                                        Cooldown
+                                    <small class="flex-container alignItemsBaseline" for="cooldown" data-i18n="Cooldown">
+                                        <span data-i18n="Cooldown">
+                                            Cooldown
+                                        </span>
+                                        <i class="fa-solid fa-comments fa-xs"></i>
                                     </small>
                                 </div>
                                 <div class="range-block-range">

--- a/public/index.html
+++ b/public/index.html
@@ -5390,24 +5390,24 @@
                             </div>
                         </div>
                         <div class="flex-container wide100p flexGap10">
-                            <div class="flex4 flex-container flexFlowColumn flexNoGap">
-                                <div class="flex-container justifySpaceBetween">
-                                    <small for="characterFilter" data-i18n="Filter to Character(s)">
-                                        Filter to Character(s)
+                            <div class="flex2 flex-container flexFlowColumn flexNoGap" data-i18n="[title]Sticky entries will stay active for N messages after being triggered." title="Sticky entries will stay active for N messages after being triggered.">
+                                <div class="flex-container justifySpaceBetween marginBot5">
+                                    <small for="sticky" data-i18n="Sticky">
+                                        Sticky
                                     </small>
-                                    <label class="checkbox_label flexNoGap margin-r5" for="character_exclusion">
-                                        <input type="checkbox" name="character_exclusion" />
-                                        <span>
-                                            <small data-i18n="Character Exclusion">Character Exclusion</small>
-                                        </span>
-                                    </label>
                                 </div>
                                 <div class="range-block-range">
-                                    <select name="characterFilter" class="select2_multi_sameline" multiple>
-                                        <option value="">
-                                            <span data-i18n="-- Characters not found --">-- Characters not found --</span>
-                                        </option>
-                                    </select>
+                                    <input class="text_pole margin0" name="sticky" type="number" placeholder="Non-sticky" min="1" max="999999">
+                                </div>
+                            </div>
+                            <div class="flex2 flex-container flexFlowColumn flexNoGap" data-i18n="[title]Entries with a cooldown can't be activated N messages after being triggered." title="Entries with a cooldown can't be activated N messages after being triggered.">
+                                <div class="flex-container justifySpaceBetween marginBot5">
+                                    <small for="cooldown" data-i18n="Cooldown">
+                                        Cooldown
+                                    </small>
+                                </div>
+                                <div class="range-block-range">
+                                    <input class="text_pole margin0" name="cooldown" type="number" placeholder="No cooldown" min="1" max="999999">
                                 </div>
                             </div>
                             <div class="flex3 flex-container flexFlowColumn flexNoGap">
@@ -5440,6 +5440,28 @@
                                 </div>
                                 <div class="range-block-range">
                                     <input type="number" class="text_pole margin0" name="groupWeight" rows="1" placeholder="100" min="1" max="999999">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="flex-container wide100p flexGap10">
+                            <div class="flex4 flex-container flexFlowColumn flexNoGap">
+                                <div class="flex-container justifySpaceBetween">
+                                    <small for="characterFilter" data-i18n="Filter to Character(s)">
+                                        Filter to Character(s)
+                                    </small>
+                                    <label class="checkbox_label flexNoGap margin-r5" for="character_exclusion">
+                                        <input type="checkbox" name="character_exclusion" />
+                                        <span>
+                                            <small data-i18n="Character Exclusion">Character Exclusion</small>
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="range-block-range">
+                                    <select name="characterFilter" class="select2_multi_sameline" multiple>
+                                        <option value="">
+                                            <span data-i18n="-- Characters not found --">-- Characters not found --</span>
+                                        </option>
+                                    </select>
                                 </div>
                             </div>
                         </div>

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1791,7 +1791,8 @@ function customTokenizer(input, _selection, callback) {
 
             // Now remove the token from the current input, and the comma too
             current = current.slice(i + 1);
-            insideRegex = false, regexClosed = false;
+            insideRegex = false;
+            regexClosed = false;
             i = 0;
         }
     }
@@ -2866,6 +2867,12 @@ const newEntryTemplate = Object.fromEntries(
     Object.entries(newEntryDefinition).map(([key, value]) => [key, value.default]),
 );
 
+/**
+ * Creates a new world info entry from template.
+ * @param {string} _name Name of the WI (unused)
+ * @param {any} data WI data
+ * @returns {object | undefined} New entry object or undefined if failed
+ */
 function createWorldInfoEntry(_name, data) {
     const newUid = getFreeWorldEntryUid(data);
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -348,22 +348,26 @@ class WorldInfoTimedEvents {
     #entryHashCache = new WeakMap();
 
     /**
-     * @type {string[]} Array of chat messages
+     * Array of chat messages
+     * @type {string[]}
      */
     #chat = [];
 
     /**
-     * @type {WIScanEntry[]} Array of entries
+     * Array of entries
+     * @type {WIScanEntry[]}
      */
     #entries = [];
 
     /**
-     * @type {WIScanEntry[]} Array of entries that need to be activated due to sticky
+     * Array of entries that need to be activated due to sticky
+     * @type {WIScanEntry[]}
      */
     #stickyActivations = [];
 
     /**
-     * @type {WIScanEntry[]} Array of entries that need to be suppressed due to cooldown
+     * Array of entries that need to be suppressed due to cooldown
+     * @type {WIScanEntry[]}
      */
     #cooldownSuppressions = [];
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3164,7 +3164,7 @@ async function checkWorldInfo(chat, maxContext, isDryRun) {
             const isCooldown = timedEvents.isOnCooldown(entry);
 
             if (isCooldown && !isSticky) {
-                console.debug(`WI entry ${entry.uid} suppressed by external suppression`);
+                console.debug(`WI entry ${entry.uid} suppressed by cooldown`);
                 continue;
             }
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -334,9 +334,9 @@ class WorldInfoBuffer {
 
 class WorldInfoTimedEvents {
     /**
-     * @type {Map<WIScanEntry, number>} Cache for entry hashes
+     * @type {WeakMap<WIScanEntry, number>} Cache for entry hashes
      */
-    static #entryHashCache = new Map();
+    static #entryHashCache = new WeakMap();
 
     /**
      * @type {string[]} Array of chat messages

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1012,8 +1012,8 @@ function registerWorldInfoSlashCommands() {
             throw new Error('This command can only be used in chat');
         }
 
-        const file = resolveVariable(args.file);
-        const uid = resolveVariable(value);
+        const file = args.file;
+        const uid = value;
         const effect = args.effect;
 
         const entries = await getEntriesFromFile(file);
@@ -1050,8 +1050,8 @@ function registerWorldInfoSlashCommands() {
             throw new Error('This command can only be used in chat');
         }
 
-        const file = resolveVariable(args.file);
-        const uid = resolveVariable(args.uid);
+        const file = args.file;
+        const uid = args.uid;
         const effect = args.effect;
 
         if (value === undefined) {

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -103,6 +103,11 @@ const MAX_SCAN_DEPTH = 1000;
  * @property {number} start The chat index where the event starts
  * @property {number} end The chat index where the event ends
  */
+
+/**
+ * @typedef TimedEventType Type of timed event
+ * @type {'sticky'|'cooldown'}
+ */
 // End typedef area
 
 /**
@@ -332,21 +337,25 @@ class WorldInfoBuffer {
     }
 }
 
+/**
+ * Represents a timed events manager for World Info.
+ */
 class WorldInfoTimedEvents {
     /**
-     * @type {WeakMap<WIScanEntry, number>} Cache for entry hashes
+     * Cache for entry hashes. Uses weak map to avoid memory leaks.
+     * @type {WeakMap<WIScanEntry, number>}
      */
-    static #entryHashCache = new WeakMap();
+    #entryHashCache = new WeakMap();
 
     /**
      * @type {string[]} Array of chat messages
      */
-    #chat;
+    #chat = [];
 
     /**
      * @type {WIScanEntry[]} Array of entries
      */
-    #entries;
+    #entries = [];
 
     /**
      * @type {WIScanEntry[]} Array of entries that need to be activated due to sticky
@@ -398,12 +407,12 @@ class WorldInfoTimedEvents {
     * @returns {number} String hash
     */
     #getEntryHash(entry) {
-        if (WorldInfoTimedEvents.#entryHashCache.has(entry)) {
-            return WorldInfoTimedEvents.#entryHashCache.get(entry);
+        if (this.#entryHashCache.has(entry)) {
+            return this.#entryHashCache.get(entry);
         }
 
         const hash = getStringHash(JSON.stringify(entry));
-        WorldInfoTimedEvents.#entryHashCache.set(entry, hash);
+        this.#entryHashCache.set(entry, hash);
         return hash;
     }
 
@@ -419,7 +428,7 @@ class WorldInfoTimedEvents {
     /**
      * Gets a timed event for a WI entry.
      * @param {WIScanEntry} entry WI entry
-     * @param {'sticky'|'cooldown'} type Type of timed event
+     * @param {TimedEventType} type Type of timed event
      * @returns {WITimedEvent} Timed event for the entry
      */
     #getEntryTimedEvent(entry, type) {
@@ -459,7 +468,7 @@ class WorldInfoTimedEvents {
 
     /**
      * Processes entries for a given type of timed event.
-     * @param {'sticky'|'cooldown'} type Identifier for the type of timed event
+     * @param {TimedEventType} type Identifier for the type of timed event
      * @param {WIScanEntry[]} buffer Buffer to store the entries
      * @param {(entry: WIScanEntry) => void} onEnded Callback for when a timed event ends
      */
@@ -516,7 +525,7 @@ class WorldInfoTimedEvents {
 
     /**
      * Sets a timed event for a WI entry.
-     * @param {'sticky'|'cooldown'} type Type of timed event
+     * @param {TimedEventType} type Type of timed event
      * @param {WIScanEntry} entry WI entry to check
      */
     #setTimedEventOfType(type, entry) {

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -278,7 +278,7 @@ class WorldInfoBuffer {
     }
 
     /**
-     * Clean-up the external effects for entries (activations and suppressions).
+     * Clean-up the external effects for entries.
      */
     resetExternalEffects() {
         WorldInfoBuffer.externalActivations.splice(0, WorldInfoBuffer.externalActivations.length);

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3260,9 +3260,12 @@ async function checkWorldInfo(chat, maxContext, isDryRun) {
             const rollValue = Math.random() * 100;
 
             if (entry.useProbability && rollValue > entry.probability) {
-                console.debug(`WI entry ${entry.uid} ${entry.key} failed probability check, skipping`);
-                failedProbabilityChecks.add(entry);
-                continue;
+                const isSticky = timedEvents.isStickyActivated(entry);
+                if (!isSticky) {
+                    console.debug(`WI entry ${entry.uid} ${entry.key} failed probability check, skipping`);
+                    failedProbabilityChecks.add(entry);
+                    continue;
+                }
             } else { console.debug(`uid:${entry.uid} passed probability check, inserting to prompt`); }
 
             // Substitute macros inline, for both this checking and also future processing

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -585,12 +585,6 @@ class WorldInfoTimedEffects {
             return;
         }
 
-        const currentState = this.isEffectActive(type, entry);
-
-        if (currentState === newState) {
-            return;
-        }
-
         const key = this.#getEntryKey(entry);
         delete chat_metadata.timedWorldInfo[type][key];
 
@@ -1106,7 +1100,7 @@ function registerWorldInfoSlashCommands() {
         }
 
         const getNewEffectState = () => {
-            const currentState = timedEffects.isEffectActive(effect, entry);
+            const currentState = !!timedEffects.getEffectMetadata(effect, entry);
 
             if (['toggle', 't', ''].includes(value.trim().toLowerCase())) {
                 return !currentState;
@@ -1123,12 +1117,10 @@ function registerWorldInfoSlashCommands() {
             return currentState;
         };
 
-        timedEffects.checkTimedEffects();
         const newEffectState = getNewEffectState();
         timedEffects.setTimedEffect(effect, entry, newEffectState);
 
         await saveMetadata();
-        timedEffects.cleanUp();
         toastr.success(`Timed effect "${effect}" for entry ${entry.uid} is now ${newEffectState ? 'active' : 'inactive'}`);
 
         return '';

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -483,6 +483,8 @@ function convertWorldInfoToCharacterBook(name, entries) {
                 automation_id: entry.automationId ?? '',
                 role: entry.role ?? 0,
                 vectorized: entry.vectorized ?? false,
+                sticky: entry.sticky ?? null,
+                cooldown: entry.cooldown ?? null,
             },
         };
 


### PR DESCRIPTION
## Summary
Adds two types of **stateful** World Info scanning options:

1. Sticky - the entry stays active for N messages (not pairs/exchanges!) after being activated. Stickied entries ignore probability checks on consequent scans until they expire.
2. Cooldown - the entry can't be activated for N messages after being activated. Can be used together with sticky: the entry goes on cooldown when the sticky duration ends.

Also has companion commands for getting/setting the entry effects:
* `/wi-get-timed-effect`
* `/wi-set-timed-effect`

## Notable info:
* Making any changes to the entry that is currently on timed effect will cause the effect to be forcibly removed. In nerdy: a hash of the entry should match for all the duration of the effect.
* Active timed effects are removed if the chat doesn't advance, e.g. the last message was swiped or deleted.
* ~~You can't currently see the active timed effect in the UI. Only by monitoring console logs.~~ There are slash commands.
* Sticky is roughly equivalent to keep_activate_after_match spec v3 decorator, but with configurable duration (instead of eternal).
* Cooldown - same to dont_activate_after_match, again with a configurable duration.