### PR TITLE
Inline image enlarge rework

### DIFF
--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -135,9 +135,14 @@ dialog {
     position: absolute;
     top: -8px;
     right: -8px;
-    width: 20px;
-    height: 20px;
-    font-size: 19px;
+    width: 21px;
+    height: 21px;
+    font-size: 18px;
+    padding: 2px 3px 3px 2px;
+
     filter: brightness(0.4);
+
+    /* Fix weird animation issue with font-scaling during popup open */
+    backface-visibility: hidden;
 }
 

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -133,16 +133,15 @@ dialog {
 
 .popup .popup-button-close {
     position: absolute;
-    top: -8px;
-    right: -8px;
-    width: 21px;
-    height: 21px;
-    font-size: 18px;
+    top: -6px;
+    right: -6px;
+    width: 24px;
+    height: 24px;
+    font-size: 20px;
     padding: 2px 3px 3px 2px;
 
-    filter: brightness(0.4);
+    filter: brightness(0.8);
 
     /* Fix weird animation issue with font-scaling during popup open */
     backface-visibility: hidden;
 }
-

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -109,7 +109,6 @@ dialog {
 
 .menu_button.popup-button-ok {
     background-color: var(--crimson70a);
-    cursor: pointer;
 }
 
 .menu_button.popup-button-ok:hover {
@@ -130,5 +129,15 @@ dialog {
 
 .popup-controls .menu_button:hover:focus-visible {
     filter: brightness(1.3) saturate(1.3);
+}
+
+.popup .popup-button-close {
+    position: absolute;
+    top: -8px;
+    right: -8px;
+    width: 20px;
+    height: 20px;
+    font-size: 19px;
+    filter: brightness(0.4);
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -4855,10 +4855,11 @@
                 </div>
                 <textarea class="popup-input text_pole result-control" rows="1" data-result="1"></textarea>
                 <div class="popup-controls">
-                    <div class="popup-button-ok menu_button result-control" data-i18n="Delete" data-result="1" tabindex="0">Delete</div>
-                    <div class="popup-button-cancel menu_button result-control" data-i18n="Cancel" data-result="0" tabindex="0">Cancel</div>
+                    <div class="popup-button-ok menu_button result-control" data-result="1" data-i18n="Delete">Delete</div>
+                    <div class="popup-button-cancel menu_button result-control" data-result="0" data-i18n="Cancel">Cancel</div>
                 </div>
             </div>
+            <div class="popup-button-close right_menu_button fa-solid fa-circle-xmark" data-result="0" title="Close popup" data-i18n="[title]Close popup"></div>
         </dialog>
     </template>
     <div id="shadow_popup">

--- a/public/script.js
+++ b/public/script.js
@@ -2122,7 +2122,7 @@ export function addCopyToCodeBlocks(messageElement) {
         hljs.highlightElement(codeBlocks.get(i));
         if (navigator.clipboard !== undefined) {
             const copyButton = document.createElement('i');
-            copyButton.classList.add('fa-solid', 'fa-copy', 'code-copy');
+            copyButton.classList.add('fa-solid', 'fa-copy', 'code-copy', 'interactable');
             copyButton.title = 'Copy code';
             codeBlocks.get(i).appendChild(copyButton);
             copyButton.addEventListener('pointerup', function (event) {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -587,7 +587,7 @@ function enlargeMessageImage() {
     const titleEmpty = !title || title.trim().length === 0;
     imgContainer.find('pre').toggle(!titleEmpty);
     addCopyToCodeBlocks(imgContainer);
-    callGenericPopup(imgContainer, POPUP_TYPE.TEXT, '', { wide: true, large: true });
+    callGenericPopup(imgContainer, POPUP_TYPE.DISPLAY, '', { large: true });
 }
 
 async function deleteMessageImage() {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -35,7 +35,7 @@ import {
     extractTextFromOffice,
 } from './utils.js';
 import { extension_settings, renderExtensionTemplateAsync, saveMetadataDebounced } from './extensions.js';
-import { POPUP_RESULT, POPUP_TYPE, callGenericPopup } from './popup.js';
+import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { ScraperManager } from './scrapers.js';
 import { DragAndDropHandler } from './dragdrop.js';
 
@@ -566,7 +566,7 @@ export function isExternalMediaAllowed() {
     return !power_user.forbid_external_media;
 }
 
-function enlargeMessageImage() {
+async function enlargeMessageImage() {
     const mesBlock = $(this).closest('.mes');
     const mesId = mesBlock.attr('mesid');
     const message = chat[mesId];
@@ -580,14 +580,28 @@ function enlargeMessageImage() {
     const img = document.createElement('img');
     img.classList.add('img_enlarged');
     img.src = imgSrc;
+    const imgHolder = document.createElement('div');
+    imgHolder.classList.add('img_enlarged_holder');
+    imgHolder.append(img);
     const imgContainer = $('<div><pre><code></code></pre></div>');
-    imgContainer.prepend(img);
+    imgContainer.prepend(imgHolder);
     imgContainer.addClass('img_enlarged_container');
     imgContainer.find('code').addClass('txt').text(title);
     const titleEmpty = !title || title.trim().length === 0;
     imgContainer.find('pre').toggle(!titleEmpty);
     addCopyToCodeBlocks(imgContainer);
-    callGenericPopup(imgContainer, POPUP_TYPE.DISPLAY, '', { large: true });
+
+    const popup = new Popup(imgContainer, POPUP_TYPE.DISPLAY, '', { large: true, transparent: true });
+
+    popup.dlg.style.width = 'unset';
+    popup.dlg.style.height = 'unset';
+
+    img.addEventListener('click', () => {
+        const shouldZoom = !img.classList.contains('zoomed');
+        img.classList.toggle('zoomed', shouldZoom);
+    });
+
+    await popup.show();
 }
 
 async function deleteMessageImage() {

--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -23,18 +23,19 @@ export const POPUP_RESULT = {
 
 /**
  * @typedef {object} PopupOptions
- * @property {string|boolean?} [okButton] - Custom text for the OK button, or `true` to use the default (If set, the button will always be displayed, no matter the type of popup)
- * @property {string|boolean?} [cancelButton] - Custom text for the Cancel button, or `true` to use the default (If set, the button will always be displayed, no matter the type of popup)
- * @property {number?} [rows] - The number of rows for the input field
- * @property {boolean?} [wide] - Whether to display the popup in wide mode (wide screen, 1/1 aspect ratio)
- * @property {boolean?} [wider] - Whether to display the popup in wider mode (just wider, no height scaling)
- * @property {boolean?} [large] - Whether to display the popup in large mode (90% of screen)
- * @property {boolean?} [allowHorizontalScrolling] - Whether to allow horizontal scrolling in the popup
- * @property {boolean?} [allowVerticalScrolling] - Whether to allow vertical scrolling in the popup
- * @property {POPUP_RESULT|number?} [defaultResult] - The default result of this popup when Enter is pressed. Can be changed from `POPUP_RESULT.AFFIRMATIVE`.
- * @property {CustomPopupButton[]|string[]?} [customButtons] - Custom buttons to add to the popup. If only strings are provided, the buttons will be added with default options, and their result will be in order from `2` onward.
- * @property {(popup: Popup) => boolean?} [onClosing] - Handler called before the popup closes, return `false` to cancel the close
- * @property {(popup: Popup) => void?} [onClose] - Handler called after the popup closes, but before the DOM is cleaned up
+ * @property {string|boolean?} [okButton=null] - Custom text for the OK button, or `true` to use the default (If set, the button will always be displayed, no matter the type of popup)
+ * @property {string|boolean?} [cancelButton=null] - Custom text for the Cancel button, or `true` to use the default (If set, the button will always be displayed, no matter the type of popup)
+ * @property {number?} [rows=1] - The number of rows for the input field
+ * @property {boolean?} [wide=false] - Whether to display the popup in wide mode (wide screen, 1/1 aspect ratio)
+ * @property {boolean?} [wider=false] - Whether to display the popup in wider mode (just wider, no height scaling)
+ * @property {boolean?} [large=false] - Whether to display the popup in large mode (90% of screen)
+ * @property {boolean?} [transparent=false] - Whether to display the popup in transparent mode (no background, border, shadow or anything, only its content)
+ * @property {boolean?} [allowHorizontalScrolling=false] - Whether to allow horizontal scrolling in the popup
+ * @property {boolean?} [allowVerticalScrolling=false] - Whether to allow vertical scrolling in the popup
+ * @property {POPUP_RESULT|number?} [defaultResult=POPUP_RESULT.AFFIRMATIVE] - The default result of this popup when Enter is pressed. Can be changed from `POPUP_RESULT.AFFIRMATIVE`.
+ * @property {CustomPopupButton[]|string[]?} [customButtons=null] - Custom buttons to add to the popup. If only strings are provided, the buttons will be added with default options, and their result will be in order from `2` onward.
+ * @property {(popup: Popup) => boolean?} [onClosing=null] - Handler called before the popup closes, return `false` to cancel the close
+ * @property {(popup: Popup) => void?} [onClose=null] - Handler called after the popup closes, but before the DOM is cleaned up
  */
 
 /**
@@ -105,7 +106,7 @@ export class Popup {
      * @param {string} [inputValue=''] - The initial value of the input field
      * @param {PopupOptions} [options={}] - Additional options for the popup
      */
-    constructor(content, type, inputValue = '', { okButton = null, cancelButton = null, rows = 1, wide = false, wider = false, large = false, allowHorizontalScrolling = false, allowVerticalScrolling = false, defaultResult = POPUP_RESULT.AFFIRMATIVE, customButtons = null, onClosing = null, onClose = null } = {}) {
+    constructor(content, type, inputValue = '', { okButton = null, cancelButton = null, rows = 1, wide = false, wider = false, large = false, transparent = false, allowHorizontalScrolling = false, allowVerticalScrolling = false, defaultResult = POPUP_RESULT.AFFIRMATIVE, customButtons = null, onClosing = null, onClose = null } = {}) {
         Popup.util.popups.push(this);
 
         // Make this popup uniquely identifiable
@@ -132,6 +133,7 @@ export class Popup {
         if (wide) this.dlg.classList.add('wide_dialogue_popup');
         if (wider) this.dlg.classList.add('wider_dialogue_popup');
         if (large) this.dlg.classList.add('large_dialogue_popup');
+        if (transparent) this.dlg.classList.add('transparent_dialogue_popup');
         if (allowHorizontalScrolling) this.dlg.classList.add('horizontal_scrolling_dialogue_popup');
         if (allowVerticalScrolling) this.dlg.classList.add('vertical_scrolling_dialogue_popup');
 

--- a/public/style.css
+++ b/public/style.css
@@ -4457,26 +4457,36 @@ a {
 
 .mes_img_controls {
     position: absolute;
-    top: 0.5em;
+    top: 0.1em;
     left: 0;
     width: 100%;
-    display: none;
+    display: flex;
+    opacity: 0;
     flex-direction: row;
     justify-content: space-between;
     padding: 1em;
 }
 
 .mes_img_controls .right_menu_button {
-    padding: 0;
     filter: brightness(80%);
+    padding: 1px;
+    height: 1.25em;
+    width: 1.25em;
+}
+
+.mes_img_controls .right_menu_button::before {
+    /* Fix weird alignment with this font-awesome icons on focus */
+    position: relative;
+    top: 0.6125em;
 }
 
 .mes_img_controls .right_menu_button:hover {
     filter: brightness(150%);
 }
 
-.mes_img_container:hover .mes_img_controls {
-    display: flex;
+.mes_img_container:hover .mes_img_controls,
+.mes_img_container:focus-within .mes_img_controls {
+    opacity: 1;
 }
 
 .mes .mes_img_container.img_extra {

--- a/public/style.css
+++ b/public/style.css
@@ -366,16 +366,6 @@ input[type='checkbox']:focus-visible {
     font-weight: bold;
 }
 
-.img_enlarged_container {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    padding: 10px;
-    height: 100%;
-    width: 100%;
-}
-
-.img_enlarged_container pre code,
 .mes_text pre code {
     position: relative;
     display: block;
@@ -3144,6 +3134,12 @@ grammarly-extension {
     min-width: 750px;
 }
 
+.transparent_dialogue_popup {
+    background-color: transparent;
+    box-shadow: none;
+    border: none;
+}
+
 #dialogue_popup .horizontal_scrolling_dialogue_popup {
     overflow-x: unset !important;
 }
@@ -4493,10 +4489,47 @@ a {
     display: flex;
 }
 
-.img_enlarged {
-    object-fit: contain;
+.img_enlarged_holder {
     /* Scaling via flex-grow and object-fit only works if we have some kind of base-height set */
     min-height: 120px;
+}
+
+.img_enlarged_holder:has(.zoomed) {
+    overflow: auto;
+}
+
+.img_enlarged {
+    object-fit: contain;
+    width: 100%;
+    height: 100%;
+    cursor: zoom-in
+}
+
+.img_enlarged.zoomed {
+    object-fit: cover;
+    width: auto;
+    height: auto;
+    cursor: zoom-out;
+}
+
+.img_enlarged_container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 10px;
+    height: 100%;
+    width: 100%;
+}
+
+.img_enlarged_holder::-webkit-scrollbar-corner {
+    background-color: transparent;
+}
+
+.img_enlarged_container pre code {
+    position: relative;
+    display: block;
+    overflow-x: auto;
+    padding: 1em;
 }
 
 .cropper-container {

--- a/public/style.css
+++ b/public/style.css
@@ -3140,6 +3140,10 @@ grammarly-extension {
     border: none;
 }
 
+.transparent_dialogue_popup:focus-visible {
+    outline: none;
+}
+
 #dialogue_popup .horizontal_scrolling_dialogue_popup {
     overflow-x: unset !important;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -4494,11 +4494,9 @@ a {
 }
 
 .img_enlarged {
-    max-width: 100%;
-    max-height: 100%;
-    border-radius: 2px;
-    border: 1px solid transparent;
     object-fit: contain;
+    /* Scaling via flex-grow and object-fit only works if we have some kind of base-height set */
+    min-height: 120px;
 }
 
 .cropper-container {

--- a/public/style.css
+++ b/public/style.css
@@ -4536,6 +4536,29 @@ a {
     padding: 1em;
 }
 
+.popup:has(.img_enlarged.zoomed).large_dialogue_popup {
+    height: 100vh !important;
+    height: 100svh !important;
+    max-height: 100vh !important;
+    max-height: 100svh !important;
+    max-width: 100vw !important;
+    max-width: 100svw !important;
+    padding: 0;
+}
+
+.popup:has(.img_enlarged.zoomed).large_dialogue_popup .popup-content {
+    margin: 0;
+    padding: 0;
+}
+
+.popup:has(.img_enlarged.zoomed).large_dialogue_popup .img_enlarged_container pre {
+    display: none;
+}
+
+.popup:has(.img_enlarged.zoomed).large_dialogue_popup .popup-button-close {
+    display: none !important;
+}
+
 .cropper-container {
     max-width: 100% !important;
 }


### PR DESCRIPTION
### Popup type "DISPLAY" & image enlarge changes
- New popup type "DISPLAY", for showing content with an X in the corner, without buttons
- Rework popup result controls to automatically support click (or other) events to close complete the popup
- Fix inline image icons/actions being keyboard interactable
- Switch inline image enlarge popup to new DISPLAY type
- Make enlarge inline image popup zoomable
- Add optional popup class for transparent popups

Important bits, to show.
![st_image_enlaaaarge3](https://github.com/SillyTavern/SillyTavern/assets/9962104/77e63cf7-99c4-44cd-933b-ec7b7e461907)
