### PR TITLE
Fix non-ASCII name character voice setting

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -915,7 +915,7 @@ function getCharacters(unrestricted) {
 
 function sanitizeId(input) {
     // Remove any non-alphanumeric characters except underscore (_) and hyphen (-)
-    let sanitized = input.replace(/[^a-zA-Z0-9-_]/g, '');
+    let sanitized = encodeURIComponent(input).replace(/[^a-zA-Z0-9-_]/g, '');
 
     // Ensure first character is always a letter
     if (!/^[a-zA-Z]/.test(sanitized)) {


### PR DESCRIPTION
When the character's name consists exclusively of non-ASCII characters, sanitizedName will be 'element_'. Due to same IDs, additional characters with such names cannot be configured voice settings. URL encoding helps avoid duplication.

Before:
<img src="https://github.com/SillyTavern/SillyTavern/assets/91325858/4f1b15a8-9532-4c75-bd07-1dda365278f3" width="230px">

After:
<img src="https://github.com/SillyTavern/SillyTavern/assets/91325858/d3affa24-b45b-4154-8842-2e6bac425725" width="230px">