### PR TITLE
Remove slash command var usages

### DIFF
--- a/public/scripts/extensions/memory/index.js
+++ b/public/scripts/extensions/memory/index.js
@@ -447,7 +447,7 @@ async function summarizeCallback(args, text) {
     }
 
     const source = args.source || extension_settings.memory.source;
-    const prompt = substituteParamsExtended((resolveVariable(args.prompt) || extension_settings.memory.prompt), { words: extension_settings.memory.promptWords });
+    const prompt = substituteParamsExtended((args.prompt || extension_settings.memory.prompt), { words: extension_settings.memory.promptWords });
 
     try {
         switch (source) {
@@ -923,10 +923,8 @@ jQuery(async function () {
             SlashCommandNamedArgument.fromProps({
                 name: 'prompt',
                 description: 'prompt to use for summarization',
-                typeList: [ARGUMENT_TYPE.STRING, ARGUMENT_TYPE.VARIABLE_NAME],
+                typeList: [ARGUMENT_TYPE.STRING],
                 defaultValue: '',
-                enumProvider: commonEnumProviders.variables('all'),
-                forceEnum: false,
             }),
         ],
         unnamedArgumentList: [

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -349,7 +349,7 @@ function migrateSettings() {
 
 /**
  * /regex slash command callback
- * @param {object} args Named arguments
+ * @param {{name: string}} args Named arguments
  * @param {string} value Unnamed argument
  * @returns {string} The regexed string
  */
@@ -359,11 +359,11 @@ function runRegexCallback(args, value) {
         return value;
     }
 
-    const scriptName = String(resolveVariable(args.name));
+    const scriptName = args.name;
     const scripts = getRegexScripts();
 
     for (const script of scripts) {
-        if (String(script.scriptName).toLowerCase() === String(scriptName).toLowerCase()) {
+        if (script.scriptName.toLowerCase() === scriptName.toLowerCase()) {
             if (script.disabled) {
                 toastr.warning(`Regex script "${scriptName}" is disabled.`);
                 return value;
@@ -588,7 +588,7 @@ jQuery(async () => {
             SlashCommandNamedArgument.fromProps({
                 name: 'name',
                 description: 'script name',
-                typeList: [ARGUMENT_TYPE.STRING, ARGUMENT_TYPE.VARIABLE_NAME],
+                typeList: [ARGUMENT_TYPE.STRING],
                 isRequired: true,
                 enumProvider: localEnumProviders.regexScripts,
             }),

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2206,7 +2206,7 @@ async function generatePicture(initiator, args, trigger, message, callback) {
     }
 
     const dimensions = setTypeSpecificDimensions(generationType);
-    let negativePromptPrefix = resolveVariable(args?.negative) || '';
+    let negativePromptPrefix = args?.negative || '';
     let imagePath = '';
 
     try {
@@ -3356,8 +3356,7 @@ jQuery(async () => {
             SlashCommandNamedArgument.fromProps({
                 name: 'negative',
                 description: 'negative prompt prefix',
-                typeList: [ARGUMENT_TYPE.STRING, ARGUMENT_TYPE.VARIABLE_NAME],
-                enumProvider: commonEnumProviders.variables('all'),
+                typeList: [ARGUMENT_TYPE.STRING],
             }),
         ],
         unnamedArgumentList: [

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1310,12 +1310,9 @@ SlashCommandParser.addCommandObject(SlashCommand.fromProps({
     unnamedArgumentList: [
         SlashCommandArgument.fromProps({
             description: 'injection ID or a variable name pointing to ID',
-            typeList: [ARGUMENT_TYPE.STRING, ARGUMENT_TYPE.VARIABLE_NAME],
+            typeList: [ARGUMENT_TYPE.STRING],
             defaultValue: '',
-            enumProvider: () => [
-                ...commonEnumProviders.injects(),
-                ...commonEnumProviders.variables('all')().map(x => { x.description = 'Variable'; return x; }),
-            ],
+            enumProvider: commonEnumProviders.injects,
         }),
     ],
     callback: flushInjectsCallback,
@@ -1486,16 +1483,16 @@ function listInjectsCallback() {
 
 /**
  * Flushes script injections for the current chat.
- * @param {import('./slash-commands/SlashCommand.js').NamedArguments} args Named arguments
+ * @param {import('./slash-commands/SlashCommand.js').NamedArguments} _ Named arguments
  * @param {string} value Unnamed argument
  * @returns {string} Empty string
  */
-function flushInjectsCallback(args, value) {
+function flushInjectsCallback(_, value) {
     if (!chat_metadata.script_injects) {
         return '';
     }
 
-    const idArgument = resolveVariable(value, args._scope);
+    const idArgument = value;
 
     for (const [id, inject] of Object.entries(chat_metadata.script_injects)) {
         if (idArgument && id !== idArgument) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -466,12 +466,9 @@ SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         SlashCommandNamedArgument.fromProps({
             name: 'name',
             description: 'display name',
-            typeList: [ARGUMENT_TYPE.STRING, ARGUMENT_TYPE.VARIABLE_NAME],
+            typeList: [ARGUMENT_TYPE.STRING],
             defaultValue: '{{user}}',
-            enumProvider: () => [
-                ...commonEnumProviders.characters('character')(),
-                ...commonEnumProviders.variables('all')().map(x => { x.description = 'Variable'; return x; }),
-            ],
+            enumProvider: commonEnumProviders.characters('character'),
         }),
     ],
     unnamedArgumentList: [
@@ -2437,7 +2434,7 @@ async function sendUserMessageCallback(args, text) {
     const insertAt = Number(resolveVariable(args?.at));
 
     if ('name' in args) {
-        const name = resolveVariable(args.name) || '';
+        const name = args.name || '';
         const avatar = findPersonaByName(name) || user_avatar;
         await sendMessageAsUser(text, bias, insertAt, compact, name, avatar);
     }

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1267,13 +1267,9 @@ SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         SlashCommandNamedArgument.fromProps({
             name: 'id',
             description: 'injection ID or variable name pointing to ID',
-            typeList: [ARGUMENT_TYPE.STRING, ARGUMENT_TYPE.VARIABLE_NAME],
+            typeList: [ARGUMENT_TYPE.STRING],
             isRequired: true,
-
-            enumProvider: () => [
-                ...commonEnumProviders.injects(),
-                ...commonEnumProviders.variables('all')().map(x => { x.description = 'Variable'; return x; }),
-            ],
+            enumProvider: commonEnumProviders.injects,
         }),
         new SlashCommandNamedArgument(
             'position', 'injection position', [ARGUMENT_TYPE.STRING], false, false, 'after', ['before', 'after', 'chat'],
@@ -1415,7 +1411,7 @@ function injectCallback(args, value) {
         'assistant': extension_prompt_roles.ASSISTANT,
     };
 
-    const id = resolveVariable(args?.id);
+    const id = args?.id;
     const ephemeral = isTrueBoolean(args?.ephemeral);
 
     if (!id) {


### PR DESCRIPTION
This are the most glaring arguments that used var where it didn't make sense.

Left now are only the four `at` arguments for the different send commands, and all the variable commands.
I would say the former should be removed too.  
Stuff like `/len`, `/add` and co can support variables, I think that is okay and makes sense.