### PR TITLE
Translation improvements

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -209,7 +209,7 @@ import {
     instruct_presets,
     selectContextPreset,
 } from './scripts/instruct-mode.js';
-import { initLocales } from './scripts/i18n.js';
+import { initLocales, t, translate } from './scripts/i18n.js';
 import { getFriendlyTokenizerName, getTokenCount, getTokenCountAsync, getTokenizerModel, initTokenizers, saveTokenCache } from './scripts/tokenizers.js';
 import {
     user_avatar,
@@ -7825,6 +7825,8 @@ window['SillyTavern'].getContext = function () {
         messageFormatting: messageFormatting,
         shouldSendOnEnter: shouldSendOnEnter,
         isMobile: isMobile,
+        t: t,
+        translate: translate,
         tags: tags,
         tagMap: tag_map,
         menuType: menu_type,

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -32,6 +32,49 @@ const observer = new MutationObserver(mutations => {
 });
 
 /**
+ * Translates a template string with named arguments
+ *
+ * Uses the template literal with all values replaced by index placeholder for translation key.
+ *
+ * @example
+ * ```js
+ * toastr.warn(t`Tag ${tagName} not found.`);
+ * ```
+ * Should be translated in the translation files as:
+ * ```
+ * Tag ${0} not found. -> Tag ${0} nicht gefunden.
+ * ```
+ *
+ * @param {TemplateStringsArray} strings - Template strings array
+ * @param  {...any} values - Values for placeholders in the template string
+ * @returns {string} Translated and formatted string
+ */
+export function t(strings, ...values) {
+    let str = strings.reduce((result, string, i) => result + string + (values[i] !== undefined ? `\${${i}}` : ''), '');
+    let translatedStr = translate(str);
+
+    // Replace indexed placeholders with actual values
+    return translatedStr.replace(/\$\{(\d+)\}/g, (match, index) => values[index]);
+}
+
+/**
+ * Translates a given key or text
+ *
+ * If the translation is based on a key, that one is used to find a possible translation in the translation file.
+ * The original text still has to be provided, as that is the default value being returned if no translation is found.
+ *
+ * For in-code text translation on a format string, using the template literal `t` is preferred.
+ *
+ * @param {string} text - The text to translate
+ * @param {string?} key - The key to use for translation. If not provided, text is used as the key.
+ * @returns {string} - The translated text
+ */
+export function translate(text, key = null) {
+    const translationKey = key || text;
+    return localeData?.[translationKey] || text;
+}
+
+/**
  * Fetches the locale data for the given language.
  * @param {string} language Language code
  * @returns {Promise<Record<string, string>>} Locale data


### PR DESCRIPTION
## Translation attributes
Added MutationObserver that checks dynamically for new elements with `i18n` attributes. Both if they get the attributes added later, or if the element gets added later.
This now allows stuff likely dynamically rendered popups to use translation tags in the template files, and those are getting translated after render once the popup is inserted into the DOM.

## Translation template literal function
This is a bit deeper magic. And I am not *sure* yet if I fully support it. That's why I am open for opinions. But there **is** an easy way to translate stuff in JS that is directly written and set in code, even with format strings.
It's **Template Literals**, especially with the [Tagged Templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) feature.

This would allow any dynamically or literal text to be translated, if the correct syntax is used. Especially useful for toasts, or those places where button/header labels are dynamically set. Even objects are dynamically built and its not feasible to insert the i18n attribute as well.

The functionality is easy.
In code, you just do something like this:
```js
toastr.warn(t`Tag ${tagName} not found.`);
```
And the translation file would be written like this:
```
Tag ${0} not found. -> Tag ${0} nicht gefunden.
```
Note that it works with zero-based indices, like old-school string formatting, for the translation part. There will be **no** dynamic property or code execution in the translations files. That's the reason.

![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/67ff18f2-069f-451d-b97b-a0cf244dbd55)


### What that means
I am not going to refactor all code to use those literals, Neither does it make sense really.
But this allows us to change key places where it makes sense for localization to be translatable. At requests of translators/users.

Also, those translation keys aren't automatically find-able at the moment. Same as the dynamically added i18n keys.
I think, in the future it would make sense do build some kind of "gathering" functionality that can be turned on in the debug settings or something that captures all translation keys, and then can output all of that to a file. So translators can just click through the UI, and automatically find the keys they need to translate, without having to manually inspect the DOM and write them by hand.


P.S.: This is my present for @steve02081504 

## Checklist:

- [x] I have read the [Contributing guidelinez](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).