### PR TITLE
Makes `Continue prefill` use the continue nudge prompt + Removes trimming of lastChatMessage with non-prefill continue nudge

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -783,7 +783,7 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
         const promptObject = {
             identifier: 'continueNudge',
             role: 'system',
-            content: substituteParamsExtended(oai_settings.continue_nudge_prompt, { lastChatMessage: String(cyclePrompt).trim() }),
+            content: substituteParamsExtended(oai_settings.continue_nudge_prompt, { lastChatMessage: String(cyclePrompt) }),
             system_prompt: true,
         };
         const continuePrompt = new Prompt(promptObject);


### PR DESCRIPTION
## Checklist:

- [✓] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Continue prefill is currently more or less broken, as the current implementation is like this:

```
(previous message)
(assistant prefill prompt)
```

There's also really no way to format the assistant prefill prompt to account for this.

This makes it so that the continue nudge prompt is used instead of the assistant prefill. I see no need to try to account for this by adding a new continue prefill box like I did with assistant impersonation – assistant impersonation did work _sometimes_, but the current continue nudge never works.

Also, I don't know why trimming of the last chat message was done by default before, it just seems like something that would get in the way when you're explicitly trying to get the AI to continue on a new line.

However, continue prefill will trim the end of the continue nudge because Claude will throw a fit otherwise.