### PR TITLE
Removes trimming of lastChatMessage in OpenAI continue nudge

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -783,7 +783,7 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
         const promptObject = {
             identifier: 'continueNudge',
             role: 'system',
-            content: substituteParamsExtended(oai_settings.continue_nudge_prompt, { lastChatMessage: String(cyclePrompt).trim() }),
+            content: substituteParamsExtended(oai_settings.continue_nudge_prompt, { lastChatMessage: String(cyclePrompt) }),
             system_prompt: true,
         };
         const continuePrompt = new Prompt(promptObject);


### PR DESCRIPTION
## Checklist:

- [✓] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md)

Might as well do this while it's on my mind. Just seems like it would get in the way when explicitly trying to get the AI to continue on a new line. I mean I guess you could make a temporary edit to the chat nudge prompt if you really needed to, but that's hardly convenient.

I thought it might be Claude-related, but that only fucks up when assistant role prompts end in newlines.