### PR TITLE
Prevent concurrent execution of initVoiceMap

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -1037,7 +1037,6 @@ export async function initVoiceMap(unrestricted = false) {
  * @param {boolean} unrestricted - If true, will include all characters in voiceMapEntries, even if they are not in the current chat.
  */
 async function initVoiceMapInternal(unrestricted) {
-
     // Gate initialization if not enabled or TTS Provider not ready. Prevents error popups.
     const enabled = $('#tts_enabled').is(':checked');
     if (!enabled) {

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -1,4 +1,4 @@
-import { cancelTtsPlay, eventSource, event_types, isStreamingEnabled, name2, saveSettingsDebounced, substituteParams } from '../../../script.js';
+import { cancelTtsPlay, eventSource, event_types, getCurrentChatId, isStreamingEnabled, name2, saveSettingsDebounced, substituteParams } from '../../../script.js';
 import { ModuleWorkerWrapper, doExtrasFetch, extension_settings, getApiUrl, getContext, modules, renderExtensionTemplateAsync } from '../../extensions.js';
 import { delay, escapeRegex, getBase64Async, getStringHash, onlyUnique } from '../../utils.js';
 import { EdgeTtsProvider } from './edge.js';
@@ -1022,10 +1022,17 @@ export async function initVoiceMap(unrestricted = false) {
     }
 
     currentInitVoiceMapPromise = (async () => {
+        const initialChatId = getCurrentChatId();
         try {
             await initVoiceMapInternal(unrestricted);
         } finally {
             currentInitVoiceMapPromise = null;
+        }
+        const currentChatId = getCurrentChatId();
+
+        if (initialChatId !== currentChatId) {
+            // Chat changed during initialization, reinitialize
+            await initVoiceMap(unrestricted);
         }
     })();
 


### PR DESCRIPTION
When the "Auto-load Last Chat" is enabled, the TTS VoiceMap may duplicate as shown in the figure. This occurs because `initVoiceMap` is called simultaneously from both `onChatChanged` and `loadTtsProvider`, which may result in the list being added twice depending on the timing. By returning the Promise if `initVoiceMap` is already running, concurrent execution is prevented.

<img width="467" src="https://github.com/SillyTavern/SillyTavern/assets/91325858/e6d74e1d-af10-46fa-a8dd-8e6ca47dee9c">


## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
