### PR TITLE
Fix extension update opening popup twice

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -644,6 +644,13 @@ async function showExtensionsDetails() {
                 popup.complete(POPUP_RESULT.AFFIRMATIVE);
             },
         };
+
+        // If we are updating an extension, the "old" popup is still active. We should close that.
+        const oldPopup = Popup.util.popups.find(popup => popup.content.querySelector('.extensions_info'));
+        if (oldPopup) {
+            oldPopup.complete(POPUP_RESULT.CANCELLED);
+        }
+
         const popup = new Popup(`<div class="extensions_info">${html}</div>`, POPUP_TYPE.TEXT, '', { okButton: 'Close', wide: true, large: true, customButtons: [updateAllButton], allowVerticalScrolling: true });
         popupPromise = popup.show();
     } catch (error) {


### PR DESCRIPTION
Extension management popup had an issue when updating extensions.
Clicking the button would start a loader, update the extension and then open the popup again, but the "old" one was still stuck.

It now correctly closes the popup when the new one opens.

Note: It might look a bit weird still, and the loader is broken. That's a fix/change that is coming with a separate PR.

## Checklist:

- [x] I haue read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
