### PR TITLE
Loader overlay improvements & Popup.complete async

### DIFF
--- a/public/css/loader.css
+++ b/public/css/loader.css
@@ -1,4 +1,4 @@
-#loader, #preloader {
+#preloader {
     position: fixed;
     margin: 0;
     padding: 0;

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -27,8 +27,17 @@ dialog {
     backface-visibility: hidden;
     transform: translateZ(0);
     -webkit-font-smoothing: subpixel-antialiased;
+
+    /* Variables setup */
+    --popup-animation-speed: var(--animation-duration-slow);
 }
 
+/** Popup styles applied to the main popup */
+.popup--animation-fast { --popup-animation-speed: var(--animation-duration); }
+.popup--animation-slow { --popup-animation-speed: var(--animation-duration-slow); }
+.popup--animation-none { --popup-animation-speed: 0ms; }
+
+/* Styling of main popup elements */
 .popup .popup-body {
     display: flex;
     flex-direction: column;
@@ -60,11 +69,11 @@ dialog {
 
 /* Opening animation */
 .popup[opening] {
-    animation: pop-in var(--animation-duration-slow) ease-in-out;
+    animation: pop-in var(--popup-animation-speed) ease-in-out;
 }
 
 .popup[opening]::backdrop {
-    animation: fade-in var(--animation-duration-slow) ease-in-out;
+    animation: fade-in var(--popup-animation-speed) ease-in-out;
 }
 
 /* Open state of the dialog */
@@ -85,11 +94,11 @@ body.no-blur .popup[open]::backdrop {
 
 /* Closing animation */
 .popup[closing] {
-    animation: pop-out var(--animation-duration-slow) ease-in-out;
+    animation: pop-out var(--popup-animation-speed) ease-in-out;
 }
 
 .popup[closing]::backdrop {
-    animation: fade-out var(--animation-duration-slow) ease-in-out;
+    animation: fade-out var(--popup-animation-speed) ease-in-out;
 }
 
 .popup #toast-container {

--- a/public/script.js
+++ b/public/script.js
@@ -43,7 +43,6 @@ import {
     saveGroupChat,
     getGroups,
     generateGroupWrapper,
-    deleteGroup,
     is_group_generating,
     resetSelectedGroup,
     select_group_chats,
@@ -228,7 +227,7 @@ import { appendFileContent, hasPendingFileAttachment, populateFileAttachment, de
 import { initPresetManager } from './scripts/preset-manager.js';
 import { MacrosParser, evaluateMacros } from './scripts/macros.js';
 import { currentUser, setUserControls } from './scripts/user.js';
-import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup, fixToastrForDialogs } from './scripts/popup.js';
+import { POPUP_TYPE, Popup, callGenericPopup, fixToastrForDialogs } from './scripts/popup.js';
 import { renderTemplate, renderTemplateAsync } from './scripts/templates.js';
 import { ScraperManager } from './scripts/scrapers.js';
 import { SlashCommandParser } from './scripts/slash-commands/SlashCommandParser.js';
@@ -266,8 +265,6 @@ await new Promise((resolve) => {
 });
 
 showLoader();
-// Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
-document.getElementById('preloader').remove();
 
 // Configure toast library:
 toastr.options.escapeHtml = true; // Prevent raw HTML inserts

--- a/public/script.js
+++ b/public/script.js
@@ -7829,6 +7829,8 @@ window['SillyTavern'].getContext = function () {
         registerDataBankScraper: ScraperManager.registerDataBankScraper,
         callPopup: callPopup,
         callGenericPopup: callGenericPopup,
+        showLoader: showLoader,
+        hideLoader: hideLoader,
         mainApi: main_api,
         extensionSettings: extension_settings,
         ModuleWorkerWrapper: ModuleWorkerWrapper,

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -641,14 +641,14 @@ async function showExtensionsDetails() {
             action: async () => {
                 requiresReload = true;
                 await autoUpdateExtensions(true);
-                popup.complete(POPUP_RESULT.AFFIRMATIVE);
+                await popup.complete(POPUP_RESULT.AFFIRMATIVE);
             },
         };
 
         // If we are updating an extension, the "old" popup is still active. We should close that.
         const oldPopup = Popup.util.popups.find(popup => popup.content.querySelector('.extensions_info'));
         if (oldPopup) {
-            oldPopup.complete(POPUP_RESULT.CANCELLED);
+            await oldPopup.complete(POPUP_RESULT.CANCELLED);
         }
 
         const popup = new Popup(`<div class="extensions_info">${html}</div>`, POPUP_TYPE.TEXT, '', { okButton: 'Close', wide: true, large: true, customButtons: [updateAllButton], allowVerticalScrolling: true });

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -644,6 +644,13 @@ async function showExtensionsDetails() {
                 popup.complete(POPUP_RESULT.AFFIRMATIVE);
             },
         };
+
+        // If we are updating an extension, the "old" popup is still active. We should close that.
+        const oldPopup = Popup.util.popups.find(popup => popup.content.querySelector('.extensions_info'));
+        if (oldPopup) {
+            oldPopup.complete(POPUP_RESULT.CANCELLED);
+        }
+
         const popup = new Popup(`<div class="extensions_info">${html}</div>`, POPUP_TYPE.TEXT, '', { okButton: 'Close', wide: true, large: true, customButtons: [updateAllButton], allowVerticalScrolling: true });
         popupPromise = popup.show();
     } catch (error) {

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -12,7 +12,7 @@ export function showLoader() {
     loaderPopup = new Popup(`
         <div id="loader">
             <div id="load-spinner" class="fa-solid fa-gear fa-spin fa-3x"></div>
-        </div>`, POPUP_TYPE.DISPLAY, null, { transparent: true });
+        </div>`, POPUP_TYPE.DISPLAY, null, { transparent: true, animation: 'fast' });
 
     // No close button, loaders are not closable
     loaderPopup.closeButton.style.display = 'none';

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -5,6 +5,8 @@ const ELEMENT_ID = 'loader';
 /** @type {Popup} */
 let loaderPopup;
 
+let preloaderYoinked = false;
+
 export function showLoader() {
     // Two loaders don't make sense. Don't await, we can overlay the old loader while it closes
     if (loaderPopup) loaderPopup.complete(POPUP_RESULT.CANCELLED);
@@ -21,6 +23,10 @@ export function showLoader() {
 }
 
 export async function hideLoader() {
+    // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
+    // If it's present, we remove it once and then it's gone.
+    yoinkPreloader();
+
     if (!loaderPopup) {
         console.warn('There is no loader showing to hide');
         return Promise.resolve();
@@ -48,3 +54,8 @@ export async function hideLoader() {
     });
 }
 
+function yoinkPreloader() {
+    if (preloaderYoinked) return;
+    document.getElementById('preloader').remove();
+    preloaderYoinked = true;
+}

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -23,26 +23,23 @@ export function showLoader() {
 }
 
 export async function hideLoader() {
+    // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
+    // If it's present, we remove it once and then it's gone.
+    yoinkPreloader();
+
     if (!loaderPopup) {
         console.warn('There is no loader showing to hide');
         return Promise.resolve();
     }
 
     return new Promise((resolve) => {
-        //Sets up a 2-step animation. Spinner blurs/fades out, and then the loader shadow does the same.
+        //Sets up a 2-step animation. Spinner blurs/fades out, and then the loader shadow does the same  (by utilizing the popup closing transition)
         $('#load-spinner').on('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function () {
-            $(`#${ELEMENT_ID}`)
-                //only fade out the spinner and replace with login screen
-                .animate({ opacity: 0 }, 300, function () {
-                    // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
-                    // If it's present, we remove it once and then it's gone.
-                    yoinkPreloader();
-                    $(`#${ELEMENT_ID}`).remove();
-                    loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE).then(() => {
-                        loaderPopup = null;
-                        resolve();
-                    });
-                });
+            $(`#${ELEMENT_ID}`).remove();
+            loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE).then(() => {
+                loaderPopup = null;
+                resolve();
+            });
         });
 
         $('#load-spinner')

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -23,10 +23,6 @@ export function showLoader() {
 }
 
 export async function hideLoader() {
-    // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
-    // If it's present, we remove it once and then it's gone.
-    yoinkPreloader();
-
     if (!loaderPopup) {
         console.warn('There is no loader showing to hide');
         return Promise.resolve();
@@ -38,6 +34,9 @@ export async function hideLoader() {
             $(`#${ELEMENT_ID}`)
                 //only fade out the spinner and replace with login screen
                 .animate({ opacity: 0 }, 300, function () {
+                    // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
+                    // If it's present, we remove it once and then it's gone.
+                    yoinkPreloader();
                     $(`#${ELEMENT_ID}`).remove();
                     loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE).then(() => {
                         loaderPopup = null;

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -1,19 +1,39 @@
+import { POPUP_RESULT, POPUP_TYPE, Popup } from './popup.js';
+
 const ELEMENT_ID = 'loader';
 
+/** @type {Popup} */
+let loaderPopup;
+
 export function showLoader() {
-    const container = $('<div></div>').attr('id', ELEMENT_ID);
-    const loader = $('<div></div>').attr('id', 'load-spinner').addClass('fa-solid fa-gear fa-spin fa-3x');
-    container.append(loader);
-    $('body').append(container);
+    // Two loaders don't make sense
+    if (loaderPopup) loaderPopup.complete(POPUP_RESULT.CANCELLED);
+
+    loaderPopup = new Popup(`
+        <div id="loader">
+            <div id="load-spinner" class="fa-solid fa-gear fa-spin fa-3x"></div>
+        </div>`, POPUP_TYPE.DISPLAY, null, { transparent: true });
+
+    // No close button, loaders are not closable
+    loaderPopup.closeButton.style.display = 'none';
+
+    loaderPopup.show();
 }
 
 export async function hideLoader() {
+    if (!loaderPopup) {
+        console.warn('There is no loader showing to hide');
+        return;
+    }
+
     //Sets up a 2-step animation. Spinner blurs/fades out, and then the loader shadow does the same.
     $('#load-spinner').on('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function () {
         $(`#${ELEMENT_ID}`)
             //only fade out the spinner and replace with login screen
             .animate({ opacity: 0 }, 300, function () {
                 $(`#${ELEMENT_ID}`).remove();
+                loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE);
+                loaderPopup = null;
             });
     });
 
@@ -22,4 +42,5 @@ export async function hideLoader() {
             'filter': 'blur(15px)',
             'opacity': '0',
         });
+
 }

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -14,7 +14,7 @@ export function showLoader() {
     loaderPopup = new Popup(`
         <div id="loader">
             <div id="load-spinner" class="fa-solid fa-gear fa-spin fa-3x"></div>
-        </div>`, POPUP_TYPE.DISPLAY, null, { transparent: true, animation: 'fast' });
+        </div>`, POPUP_TYPE.DISPLAY, null, { transparent: true, animation: 'none' });
 
     // No close button, loaders are not closable
     loaderPopup.closeButton.style.display = 'none';
@@ -23,19 +23,19 @@ export function showLoader() {
 }
 
 export async function hideLoader() {
-    // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
-    // If it's present, we remove it once and then it's gone.
-    yoinkPreloader();
-
     if (!loaderPopup) {
         console.warn('There is no loader showing to hide');
         return Promise.resolve();
     }
 
     return new Promise((resolve) => {
-        //Sets up a 2-step animation. Spinner blurs/fades out, and then the loader shadow does the same  (by utilizing the popup closing transition)
+        // Spinner blurs/fades out
         $('#load-spinner').on('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function () {
             $(`#${ELEMENT_ID}`).remove();
+            // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
+            // If it's present, we remove it once and then it's gone.
+            yoinkPreloader();
+
             loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE).then(() => {
                 loaderPopup = null;
                 resolve();

--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -35,6 +35,7 @@ export const POPUP_RESULT = {
  * @property {boolean?} [transparent=false] - Whether to display the popup in transparent mode (no background, border, shadow or anything, only its content)
  * @property {boolean?} [allowHorizontalScrolling=false] - Whether to allow horizontal scrolling in the popup
  * @property {boolean?} [allowVerticalScrolling=false] - Whether to allow vertical scrolling in the popup
+ * @property {'slow'|'fast'|'none'?} [animation='slow'] - Animation speed for the popup (opening, closing, ...)
  * @property {POPUP_RESULT|number?} [defaultResult=POPUP_RESULT.AFFIRMATIVE] - The default result of this popup when Enter is pressed. Can be changed from `POPUP_RESULT.AFFIRMATIVE`.
  * @property {CustomPopupButton[]|string[]?} [customButtons=null] - Custom buttons to add to the popup. If only strings are provided, the buttons will be added with default options, and their result will be in order from `2` onward.
  * @property {CustomPopupInput[]?} [customInputs=null] - Custom inputs to add to the popup. The display below the content and the input box, one by one.
@@ -142,7 +143,7 @@ export class Popup {
      * @param {string} [inputValue=''] - The initial value of the input field
      * @param {PopupOptions} [options={}] - Additional options for the popup
      */
-    constructor(content, type, inputValue = '', { okButton = null, cancelButton = null, rows = 1, wide = false, wider = false, large = false, transparent = false, allowHorizontalScrolling = false, allowVerticalScrolling = false, defaultResult = POPUP_RESULT.AFFIRMATIVE, customButtons = null, customInputs = null, onClosing = null, onClose = null, cropAspect = null, cropImage = null } = {}) {
+    constructor(content, type, inputValue = '', { okButton = null, cancelButton = null, rows = 1, wide = false, wider = false, large = false, transparent = false, allowHorizontalScrolling = false, allowVerticalScrolling = false, animation = 'slow', defaultResult = POPUP_RESULT.AFFIRMATIVE, customButtons = null, customInputs = null, onClosing = null, onClose = null, cropAspect = null, cropImage = null } = {}) {
         Popup.util.popups.push(this);
 
         // Make this popup uniquely identifiable
@@ -175,6 +176,7 @@ export class Popup {
         if (transparent) this.dlg.classList.add('transparent_dialogue_popup');
         if (allowHorizontalScrolling) this.dlg.classList.add('horizontal_scrolling_dialogue_popup');
         if (allowVerticalScrolling) this.dlg.classList.add('vertical_scrolling_dialogue_popup');
+        if (animation) this.dlg.classList.add('popup--animation-' + animation);
 
         // If custom button captions are provided, we set them beforehand
         this.okButton.textContent = typeof okButton === 'string' ? okButton : 'OK';

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1653,8 +1653,8 @@ async function buttonsCallback(args, text) {
                 const buttonElement = document.createElement('div');
                 buttonElement.classList.add('menu_button', 'result-control', 'wide100p');
                 buttonElement.dataset.result = String(result);
-                buttonElement.addEventListener('click', () => {
-                    popup?.complete(result);
+                buttonElement.addEventListener('click', async () => {
+                    await popup.complete(result);
                 });
                 buttonElement.innerText = button;
                 buttonContainer.appendChild(buttonElement);


### PR DESCRIPTION
The loader was inserted into the base DOM body, which didn't work with the new popups.
I changed it to use an actual modal overlay with the new popup dialogs. Which is also **really** blocking now, preventing keyboard navigation, etc.

## All stuff done here
- Changed Loader to use modal overlay
- Refactored `Popup.complete` to be async, so the closing of the popup can be awaited if needed
- Define animation speed for popups as a style variable, and make popup style argument to set it when opening the popup
- Add `showLoader` and `hideLoader` to the `SillyTavern.getContext()` object

ℹ️ Info: This PR also includes #2448, as this was kind of a follow-up of that one.

## Checklist:

- [x] I have read the [Contributting guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
