### PR TITLE
Augment Edit Box Input Enfasterment

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -154,6 +154,7 @@ import {
     ensureImageFormatSupported,
     flashHighlight,
     isTrueBoolean,
+    throttle,
 } from './scripts/utils.js';
 import { debounce_timeout } from './scripts/constants.js';
 
@@ -9169,24 +9170,16 @@ jQuery(async function () {
         chooseBogusFolder($(this), tagId);
     });
 
-    const editTextAreaInputThrottle = (func, limit) => {
-        let inThrottle;
-        return (...args) => {
-            if (!inThrottle) {
-                func(...args);
-                inThrottle = true;
-                setTimeout(() => inThrottle = false, limit);
-            }
-        };
-    };
-    const editTextAreaAdjustHeight = editTextAreaInputThrottle(e => {
-        scroll_holder = document.getElementById('chat').scrollTop;
+    const editTextAreaAdjustHeight = throttle(e => {
+        scroll_holder = chatElement[0].scrollTop;
         e.style.height = '0';
-        e.style.height = 4 + e.scrollHeight + 'px';
+        e.style.height = `${e.scrollHeight + 3}px`;
         is_use_scroll_holder = true;
-    }, 200);
+    }, debounce_timeout.standard);
     document.addEventListener('input', e => {
-        if (e.target.classList.contains('edit_textarea')) editTextAreaAdjustHeight(e.target);
+        if (e.target instanceof HTMLTextAreaElement && e.target.classList.contains('edit_textarea')) {
+            editTextAreaAdjustHeight(e.target);
+        }
     });
     document.getElementById('chat').addEventListener('scroll', function() {
         if (is_use_scroll_holder) {

--- a/public/script.js
+++ b/public/script.js
@@ -9169,14 +9169,28 @@ jQuery(async function () {
         chooseBogusFolder($(this), tagId);
     });
 
-    $(document).on('input', '.edit_textarea', function () {
-        scroll_holder = $('#chat').scrollTop();
-        $(this).height(0).height(this.scrollHeight);
+    const editTextAreaInputThrottle = (func, limit) => {
+        let inThrottle;
+        return (...args) => {
+            if (!inThrottle) {
+                func(...args);
+                inThrottle = true;
+                setTimeout(() => inThrottle = false, limit);
+            }
+        };
+    };
+    const editTextAreaAdjustHeight = editTextAreaInputThrottle(e => {
+        scroll_holder = document.getElementById('chat').scrollTop;
+        e.style.height = '0';
+        e.style.height = 4 + e.scrollHeight + 'px';
         is_use_scroll_holder = true;
+    }, 200);
+    document.addEventListener('input', e => {
+        if (e.target.classList.contains('edit_textarea')) editTextAreaAdjustHeight(e.target);
     });
-    $('#chat').on('scroll', function () {
+    document.getElementById('chat').addEventListener('scroll', function() {
         if (is_use_scroll_holder) {
-            $('#chat').scrollTop(scroll_holder);
+            this.scrollTop = scroll_holder;
             is_use_scroll_holder = false;
         }
     });

--- a/public/script.js
+++ b/public/script.js
@@ -154,7 +154,6 @@ import {
     ensureImageFormatSupported,
     flashHighlight,
     isTrueBoolean,
-    throttle,
 } from './scripts/utils.js';
 import { debounce_timeout } from './scripts/constants.js';
 
@@ -9170,18 +9169,24 @@ jQuery(async function () {
         chooseBogusFolder($(this), tagId);
     });
 
-    const editTextAreaAdjustHeight = throttle(e => {
+    /**
+     * Sets the scroll height of the edit textarea to fit the content.
+     * @param {HTMLTextAreaElement} e Textarea element to auto-fit
+     */
+    function autoFitEditTextArea(e) {
         scroll_holder = chatElement[0].scrollTop;
         e.style.height = '0';
-        e.style.height = `${e.scrollHeight + 3}px`;
+        e.style.height = `${e.scrollHeight + 4}px`;
         is_use_scroll_holder = true;
-    }, debounce_timeout.standard);
+    }
+    const autoFitEditTextAreaDebounced = debounce(autoFitEditTextArea, debounce_timeout.short);
     document.addEventListener('input', e => {
         if (e.target instanceof HTMLTextAreaElement && e.target.classList.contains('edit_textarea')) {
-            editTextAreaAdjustHeight(e.target);
+            const immediately = e.target.scrollHeight > e.target.offsetHeight || e.target.value === '';
+            immediately ? autoFitEditTextArea(e.target) : autoFitEditTextAreaDebounced(e.target);
         }
     });
-    document.getElementById('chat').addEventListener('scroll', function() {
+    document.getElementById('chat').addEventListener('scroll', function () {
         if (is_use_scroll_holder) {
             this.scrollTop = scroll_holder;
             is_use_scroll_holder = false;

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -5,6 +5,8 @@
 export const debounce_timeout = {
     /** [100 ms] For ultra-fast responses, typically for keypresses or executions that might happen multiple times in a loop or recursion. */
     quick: 100,
+    /** [200 ms] Slightly slower than quick, but still very responsive. */
+    short: 200,
     /** [300 ms] Default time for general use, good balance between responsiveness and performance. */
     standard: 300,
     /** [1.000 ms] For situations where the function triggers more intensive tasks. */


### PR DESCRIPTION
So I'd been wondering why input in the edit box was so laggy. Turns out, every time you press a key, it resizes the input box. I converted it from jQuery to JavaScript, but it was still a bit slow, so now there's a 200ms throttle as well. It was still a bit sluggish at 100ms.

Also, I had to add 4 to the number it feeds into style.height because apparently, jQuery makes some sort of adjustment to height or scrollHeight that pure JavaScript doesn't. +2 was the minimum I needed to not get a vertical scrollbar, so I went with +4.

Good Enough™

## Checklist:

- [✓] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
