### PR TITLE
Skip popup when making new chat from chat list

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9708,14 +9708,8 @@ jQuery(async function () {
     });
 
     $('#newChatFromManageScreenButton').on('click', function () {
-        setTimeout(() => {
-            $('#option_start_new_chat').trigger('click');
-        }, 1);
-        setTimeout(() => {
-            $('#dialogue_popup_ok').trigger('click');
-        }, 1);
+        doNewChat({ deleteCurrentChat: false });
         $('#select_chat_cross').trigger('click');
-
     });
 
     //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes the new chat popup no longer auto-skipping when opened from chat management.

Looks like `newChatFromManageScreenButton` was missed in #2427

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
