### PR TITLE
Make input popups respect "Enter to Send" setting

### DIFF
--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -1,3 +1,4 @@
+import { shouldSendOnEnter } from './RossAscends-mods.js';
 import { power_user } from './power-user.js';
 import { removeFromArray, runAfterAnimation, uuidv4 } from './utils.js';
 
@@ -344,9 +345,17 @@ export class Popup {
                     if (this.dlg != document.activeElement?.closest('.popup'))
                         return;
 
-                    // Check if the current focus is a result control. Only should we apply the compelete action
+                    // Check if the current focus is a result control. Only should we apply the complete action
                     const resultControl = document.activeElement?.closest('.result-control');
                     if (!resultControl)
+                        return;
+
+                    // Check if we are inside an input type text or a textarea field and send on enter is disabled
+                    const textarea = document.activeElement?.closest('textarea');
+                    if (textarea instanceof HTMLTextAreaElement && !shouldSendOnEnter())
+                        return;
+                    const input = document.activeElement?.closest('input[type="text"]');
+                    if (input instanceof HTMLInputElement && !shouldSendOnEnter())
                         return;
 
                     evt.preventDefault();


### PR DESCRIPTION
It's not *really* a "Send" action, but well.
Someone asked if we could make the popups with "Input" type that utilize a textarea to not automatically close on pressing Enter inside the textarea.
Figure it would make sense to tie it to the same setting. Especially helpful for commands like `/input` where you want to write multiline text.
If you have disabled Enter-functionality for the chat input field, chances are high you expect the same from the popup input field.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
