### PR TITLE
validate group that all members exist

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -178,8 +178,37 @@ async function loadGroupChat(chatId) {
     return [];
 }
 
+async function validateGroup(group) {
+    if (!group) return;
+
+    // Validate that all members exist as characters
+    let dirty = false;
+    group.members = group.members.filter(member => {
+        const character = characters.find(x => x.avatar === member || x.name === member);
+        if (!character) {
+            const msg = `Warning: Listed member ${member} does not exist as a character. It will be removed from the group.`;
+            toastr.warning(msg, 'Group Validation');
+            console.warn(msg);
+            dirty = true;
+        }
+        return character;
+    });
+
+    if (dirty) {
+        await editGroup(group.id, true, false);
+    }
+}
+
 export async function getGroupChat(groupId, reload = false) {
     const group = groups.find((x) => x.id === groupId);
+    if (!group) {
+        console.warn(`Group not found`, groupId);
+        return;
+    }
+
+    // Run validation before any loading
+    validateGroup(group);
+
     const chat_id = group.chat_id;
     const data = await loadGroupChat(chat_id);
     let freshChat = false;
@@ -197,7 +226,6 @@ export async function getGroupChat(groupId, reload = false) {
         if (group && Array.isArray(group.members)) {
             for (let member of group.members) {
                 const character = characters.find(x => x.avatar === member || x.name === member);
-
                 if (!character) {
                     continue;
                 }
@@ -219,10 +247,8 @@ export async function getGroupChat(groupId, reload = false) {
         freshChat = true;
     }
 
-    if (group) {
-        let metadata = group.chat_metadata ?? {};
-        updateChatMetadata(metadata, true);
-    }
+    let metadata = group.chat_metadata ?? {};
+    updateChatMetadata(metadata, true);
 
     if (reload) {
         select_group_chats(groupId, true);

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -202,7 +202,7 @@ async function validateGroup(group) {
 export async function getGroupChat(groupId, reload = false) {
     const group = groups.find((x) => x.id === groupId);
     if (!group) {
-        console.warn(`Group not found`, groupId);
+        console.warn('Group not found', groupId);
         return;
     }
 


### PR DESCRIPTION
As suggested by @Cohee1207, we can check and clean up group members that do not exist as characters.
*Most* errors following that should be hidden, but we should still make sure.

There are two big scenarios where this could easily appear, this handling makes sense:
1. "Importing" a group by copying the group JSON file.
2. Deleting a character from the list, without first removing it from existing groups.

Not in the scope of this PR, but *should* likely also be done:
- When deleting a character, all groups where it was a member of should be iterated, the member removed and also saved.

## Checklist:

- [X] I have read [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
