### PR TITLE
/stop slash command to stop generation

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -227,7 +227,7 @@ import { appendFileContent, hasPendingFileAttachment, populateFileAttachment, de
 import { initPresetManager } from './scripts/preset-manager.js';
 import { MacrosParser, evaluateMacros } from './scripts/macros.js';
 import { currentUser, setUserControls } from './scripts/user.js';
-import { POPUP_TYPE, Popup, callGenericPopup, fixToastrForDialogs } from './scripts/popup.js';
+import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup, fixToastrForDialogs } from './scripts/popup.js';
 import { renderTemplate, renderTemplateAsync } from './scripts/templates.js';
 import { ScraperManager } from './scripts/scrapers.js';
 import { SlashCommandParser } from './scripts/slash-commands/SlashCommandParser.js';
@@ -7184,7 +7184,8 @@ function onScenarioOverrideRemoveClick() {
  * @param {string} inputValue - Value to set the input to.
  * @param {PopupOptions} options - Options for the popup.
  * @typedef {{okButton?: string, rows?: number, wide?: boolean, wider?: boolean, large?: boolean, allowHorizontalScrolling?: boolean, allowVerticalScrolling?: boolean, cropAspect?: number }} PopupOptions - Options for the popup.
- * @returns
+ * @returns {Promise<any>} A promise that resolves when the popup is closed.
+ * @deprecated Use `callGenericPopup` instead.
  */
 export function callPopup(text, type, inputValue = '', { okButton, rows, wide, wider, large, allowHorizontalScrolling, allowVerticalScrolling, cropAspect } = {}) {
     function getOkButtonText() {
@@ -7815,6 +7816,7 @@ window['SillyTavern'].getContext = function () {
         eventTypes: event_types,
         addOneMessage: addOneMessage,
         generate: Generate,
+        stopGeneration: stopGeneration,
         getTokenCount: getTokenCount,
         extensionPrompts: extension_prompts,
         setExtensionPrompt: setExtensionPrompt,
@@ -7870,6 +7872,8 @@ window['SillyTavern'].getContext = function () {
          * @deprecated Legacy snake-case naming, compatibility with old extensions
          */
         event_types: event_types,
+        POPUP_TYPE: POPUP_TYPE,
+        POPUP_RESULT: POPUP_RESULT,
     };
 };
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -33,6 +33,7 @@ import {
     setCharacterName,
     setExtensionPrompt,
     setUserName,
+    stopGeneration,
     substituteParams,
     system_avatar,
     system_message_types,
@@ -897,6 +898,24 @@ export function initDefaultSlashCommands() {
             ),
         ],
         helpString: 'Adds a swipe to the last chat message.',
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'stop',
+        callback: () => {
+            const stopped = stopGeneration();
+            return String(stopped);
+        },
+        returns: 'true/false, whether the generation was running and got stopped',
+        helpString: `
+            <div>
+                Stops the generation and any streaming if it is currently running.
+            </div>
+            <div>
+                Note: This command cannot be executed from the chat input, as sending any message or script from there is blocked during generation.
+                But it can be executed via automations or QR scripts/buttons.
+            </div>
+        `,
+        aliases: ['generate-stop'],
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'abort',


### PR DESCRIPTION
A new command, usable in QR buttons, that stops the current generation/streaming in the same way as the Stop button does.

![image](https://github.com/SillyTavern/SillyTavern/assets/9962104/3481db82-4f19-4956-88da-0df0cc38f586)

## Checklist:

- [x] I have read the [Cotributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
