### PR TITLE
Adding display of queued speakers in group chat windows.

### DIFF
--- a/public/css/rm-groups.css
+++ b/public/css/rm-groups.css
@@ -68,9 +68,9 @@
     margin-top: 0.25rem;
     margin-bottom: 0.5rem;
     border: 1px solid var(--SmartThemeBorderColor);
-    ;
     border-radius: 10px;
     background-color: var(--black30a);
+    padding: 2px;
 }
 
 #rm_group_buttons_expander {

--- a/public/index.html
+++ b/public/index.html
@@ -4141,6 +4141,10 @@
                                     <input id="request_token_probabilities" type="checkbox" />
                                     <small data-i18n="Request token probabilities">Request token probabilities</small>
                                 </label>
+                                <label data-newbie-hidden class="checkbox_label" for="show_group_chat_queue" title="In group chat, highlight the character(s) that are currently queued to generate responses and the order in which they will respond." data-i18n="[title]Requests logprobs from the API for the Token Probabilities feature">
+                                    <input id="show_group_chat_queue" type="checkbox" />
+                                    <small data-i18n="Request token probabilities">Show group chat queue</small>
+                                </label>
                                 <div data-newbie-hidden class="inline-drawer wide100p flexFlowColumn">
                                     <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable" title="Automatically reject and re-generate AI message based on configurable criteria." data-i18n="[title]Automatically reject and re-generate AI message based on configurable criteria">
                                         <b><span data-i18n="Auto-swipe">Auto-swipe</span></b>
@@ -5796,6 +5800,7 @@
                 <div class="tags tags_inline"></div>
             </div>
             <input class="ch_fav" value="" hidden />
+            <div class="queue_position"></div>
             <div class="group_member_icon">
                 <div title="Temporarily disable automatic replies from this character" data-action="disable" class="right_menu_button fa-solid fa-lg fa-comment-slash" data-i18n="[title]Temporarily disable automatic replies from this character"></div>
                 <div title="Enable automatic replies from this character" data-action="enable" class="right_menu_button fa-solid fa-lg fa-comment-slash" data-i18n="[title]Enable automatic replies from this character"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -4141,9 +4141,9 @@
                                     <input id="request_token_probabilities" type="checkbox" />
                                     <small data-i18n="Request token probabilities">Request token probabilities</small>
                                 </label>
-                                <label data-newbie-hidden class="checkbox_label" for="show_group_chat_queue" title="In group chat, highlight the character(s) that are currently queued to generate responses and the order in which they will respond." data-i18n="[title]Requests logprobs from the API for the Token Probabilities feature">
+                                <label data-newbie-hidden class="checkbox_label" for="show_group_chat_queue" title="In group chat, highlight the character(s) that are currently queued to generate responses and the order in which they will respond." data-i18n="[title]In group chat, highlight the character(s) that are currently queued to generate responses and the order in which they will respond.">
                                     <input id="show_group_chat_queue" type="checkbox" />
-                                    <small data-i18n="Request token probabilities">Show group chat queue</small>
+                                    <small data-i18n="Show group chat queue">Show group chat queue</small>
                                 </label>
                                 <div data-newbie-hidden class="inline-drawer wide100p flexFlowColumn">
                                     <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable" title="Automatically reject and re-generate AI message based on configurable criteria." data-i18n="[title]Automatically reject and re-generate AI message based on configurable criteria">

--- a/public/scripts/char-data.js
+++ b/public/scripts/char-data.js
@@ -112,6 +112,5 @@
  * @property {string} chat - name of the current chat file chat
  * @property {string} avatar - file name of the avatar image (acts as a unique identifier)
  * @property {string} json_data - the full raw JSON data of the character
- * @property {number} queueOrder - Characters position in the char queue. #1 is currently generating.
  */
 export default 0;// now this file is a module

--- a/public/scripts/char-data.js
+++ b/public/scripts/char-data.js
@@ -112,5 +112,6 @@
  * @property {string} chat - name of the current chat file chat
  * @property {string} avatar - file name of the avatar image (acts as a unique identifier)
  * @property {string} json_data - the full raw JSON data of the character
+ * @property {number} queueOrder - Characters position in the char queue. #1 is currently generating.
  */
 export default 0;// now this file is a module

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -787,7 +787,7 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
         sendSystemMessage(system_message_types.EMPTY, '', { isSmallSys: true });
         return Promise.resolve();
     }
-    
+
     try {
         throwIfAborted();
         hideSwipeButtons();
@@ -857,13 +857,13 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
             const bias = getBiasStrings(userInput, type);
             await sendMessageAsUser(userInput, bias.messageBias);
             await saveChatConditional();
-            $('#send_textarea').val('')[0].dispatchEvent(new Event('input', { bubbles:true }));
+            $('#send_textarea').val('')[0].dispatchEvent(new Event('input', { bubbles: true }));
         }
         groupChatQueueOrder = new Map();
 
-        if (power_user.show_group_chat_queue){
-            for (let i = 0; i < activatedMembers.length; ++i){
-                groupChatQueueOrder.set(characters[activatedMembers[i]].avatar, i+1);
+        if (power_user.show_group_chat_queue) {
+            for (let i = 0; i < activatedMembers.length; ++i) {
+                groupChatQueueOrder.set(characters[activatedMembers[i]].avatar, i + 1);
             }
         }
         // now the real generation begins: cycle through every activated character
@@ -873,7 +873,7 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
             const generateType = type == 'swipe' || type == 'impersonate' || type == 'quiet' || type == 'continue' ? type : 'group_chat';
             setCharacterId(chId);
             setCharacterName(characters[chId].name);
-            if (power_user.show_group_chat_queue){
+            if (power_user.show_group_chat_queue) {
                 printGroupMembers();
             }
             await eventSource.emit(event_types.GROUP_MEMBER_DRAFTED, chId);
@@ -896,9 +896,9 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
                     messageChunk = textResult?.messageChunk;
                 }
             }
-            if (power_user.show_group_chat_queue){
+            if (power_user.show_group_chat_queue) {
                 groupChatQueueOrder.delete(characters[chId].avatar);
-                groupChatQueueOrder.forEach((value, key, map) => map.set(key, value-1));
+                groupChatQueueOrder.forEach((value, key, map) => map.set(key, value - 1));
             }
         }
     } finally {
@@ -907,7 +907,7 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
         is_group_generating = false;
         setSendButtonState(false);
         setCharacterId(undefined);
-        if (power_user.show_group_chat_queue){
+        if (power_user.show_group_chat_queue) {
             groupChatQueueOrder = new Map();
             printGroupMembers();
         }
@@ -1328,12 +1328,12 @@ function getGroupCharacterBlock(character) {
     const isFav = character.fav || character.fav == 'true';
     template.data('id', character.avatar);
     template.find('.avatar img').attr({ 'src': avatar, 'title': character.avatar });
-    template.find('.ch_name').text(character.name + (character.queueOrder > 0?'   (#' + character.queueOrder + ')':''));    template.attr('chid', characters.indexOf(character));
+    template.find('.ch_name').text(character.name + (character.queueOrder > 0 ? '   (#' + character.queueOrder + ')' : '')); template.attr('chid', characters.indexOf(character));
     template.find('.ch_fav').val(isFav);
     template.toggleClass('is_fav', isFav);
-    
+
     let queuePosition = groupChatQueueOrder.get(character.avatar);
-    if (queuePosition){
+    if (queuePosition) {
         template.find('.queue_position').text(queuePosition);
         template.toggleClass('is_queued', queuePosition > 1);
         template.toggleClass('is_active', queuePosition === 1);

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -121,6 +121,7 @@ const DEFAULT_AUTO_MODE_DELAY = 5;
 export const groupCandidatesFilter = new FilterHelper(debounce(printGroupCandidates, debounce_timeout.quick));
 let autoModeWorker = null;
 const saveGroupDebounced = debounce(async (group, reload) => await _save(group, reload), debounce_timeout.relaxed);
+/** @type {Map<string, number>} */
 let groupChatQueueOrder = new Map();
 
 function setAutoModeWorker() {
@@ -1631,6 +1632,7 @@ export async function openGroupById(groupId) {
         select_group_chats(groupId);
 
         if (selected_group !== groupId) {
+            groupChatQueueOrder = new Map();
             await clearChat();
             cancelTtsPlay();
             selected_group = groupId;

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1329,7 +1329,8 @@ function getGroupCharacterBlock(character) {
     const isFav = character.fav || character.fav == 'true';
     template.data('id', character.avatar);
     template.find('.avatar img').attr({ 'src': avatar, 'title': character.avatar });
-    template.find('.ch_name').text(character.name + (character.queueOrder > 0 ? '   (#' + character.queueOrder + ')' : '')); template.attr('chid', characters.indexOf(character));
+    template.find('.ch_name').text(character.name);
+    template.attr('chid', characters.indexOf(character));
     template.find('.ch_fav').val(isFav);
     template.toggleClass('is_fav', isFav);
 

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -70,6 +70,7 @@ import {
     animation_duration,
     depth_prompt_role_default,
     shouldAutoContinue,
+    this_chid,
 } from '../script.js';
 import { printTagList, createTagMapFromList, applyTagsOnCharacterSelect, tag_map, applyTagsOnGroupSelect } from './tags.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
@@ -785,7 +786,8 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
         sendSystemMessage(system_message_types.EMPTY, '', { isSmallSys: true });
         return Promise.resolve();
     }
-
+    
+    const showChatQueue = (!(typingIndicator.length === 0 && !isStreamingEnabled()) && openGroupId);
     try {
         throwIfAborted();
         hideSwipeButtons();
@@ -857,7 +859,11 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
             await saveChatConditional();
             $('#send_textarea').val('')[0].dispatchEvent(new Event('input', { bubbles:true }));
         }
-
+        if (showChatQueue){
+            for (let i = 0; i < activatedMembers.length; ++i){
+                characters[activatedMembers[i]].queueOrder = (i+1);
+            }
+        }
         // now the real generation begins: cycle through every activated character
         for (const chId of activatedMembers) {
             throwIfAborted();
@@ -865,6 +871,9 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
             const generateType = type == 'swipe' || type == 'impersonate' || type == 'quiet' || type == 'continue' ? type : 'group_chat';
             setCharacterId(chId);
             setCharacterName(characters[chId].name);
+            if (showChatQueue){
+                printGroupMembers();
+            }
             await eventSource.emit(event_types.GROUP_MEMBER_DRAFTED, chId);
 
             if (type !== 'swipe' && type !== 'impersonate' && !isStreamingEnabled()) {
@@ -885,6 +894,10 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
                     messageChunk = textResult?.messageChunk;
                 }
             }
+            if (showChatQueue){
+                activatedMembers.filter(chidx => characters[chidx].queueOrder > 0)
+                                .forEach(chindex => characters[chindex].queueOrder -= 1);
+            }
         }
     } finally {
         typingIndicator.hide();
@@ -892,6 +905,14 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
         is_group_generating = false;
         setSendButtonState(false);
         setCharacterId(undefined);
+        
+        if (showChatQueue){
+            group.members.forEach(avatar => {
+                let character = characters.find(x => x.avatar === avatar || x.name === avatar);
+                character.queueOrder = undefined;
+            });
+            printGroupMembers();
+        }
         setCharacterName('');
         activateSendButtons();
         showSwipeButtons();
@@ -1309,11 +1330,13 @@ function getGroupCharacterBlock(character) {
     const isFav = character.fav || character.fav == 'true';
     template.data('id', character.avatar);
     template.find('.avatar img').attr({ 'src': avatar, 'title': character.avatar });
-    template.find('.ch_name').text(character.name);
-    template.attr('chid', characters.indexOf(character));
+    template.find('.ch_name').text(character.name + (character.queueOrder > 0?'   (#' + character.queueOrder + ')':''));    template.attr('chid', characters.indexOf(character));
     template.find('.ch_fav').val(isFav);
     template.toggleClass('is_fav', isFav);
+    template.toggleClass('is_active', character.queueOrder === 1);
+    template.toggleClass('is_queued', character.queueOrder > 1);
     template.toggleClass('disabled', isGroupMemberDisabled(character.avatar));
+    template.toggleClass('is_active', character.avatar === (this_chid && characters[this_chid] && characters[this_chid].avatar));
 
     // Display inline tags
     const tagsElement = template.find('.tags');

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -179,6 +179,7 @@ let power_user = {
     send_on_enter: send_on_enter_options.AUTO,
     console_log_prompts: false,
     request_token_probabilities: false,
+    show_group_chat_queue: false,
     render_formulas: false,
     allow_name1_display: false,
     allow_name2_display: false,
@@ -1601,6 +1602,7 @@ function loadPowerUserSettings(settings, data) {
 
     $('#console_log_prompts').prop('checked', power_user.console_log_prompts);
     $('#request_token_probabilities').prop('checked', power_user.request_token_probabilities);
+    $('#show_group_chat_queue').prop('checked', power_user.show_group_chat_queue);
     $('#auto_fix_generated_markdown').prop('checked', power_user.auto_fix_generated_markdown);
     $('#auto_scroll_chat_to_bottom').prop('checked', power_user.auto_scroll_chat_to_bottom);
     $('#bogus_folders').prop('checked', power_user.bogus_folders);
@@ -3564,6 +3566,11 @@ $(document).ready(() => {
 
     $('#request_token_probabilities').on('input', function () {
         power_user.request_token_probabilities = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#show_group_chat_queue').on('input', function () {
+        power_user.show_group_chat_queue = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -2927,7 +2927,8 @@ input[type=search]:focus::-webkit-search-cancel-button {
 }
 
 .group_member .queue_position {
-    margin-right: 1rem;
+    margin-right: 0.75rem;
+    font-size: calc(var(--mainFontSize) * 0.9);
 }
 
 .group_member.is_queued {

--- a/public/style.css
+++ b/public/style.css
@@ -2922,6 +2922,14 @@ input[type=search]:focus::-webkit-search-cancel-button {
     position: relative;
 }
 
+.group_member .queue_position:not(:empty)::before {  
+    content: "#";
+}
+
+.group_member .queue_position{
+    margin-right: 1rem;
+}
+
 .group_member.is_queued {
     border: 2px solid var(--golden);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -2922,20 +2922,20 @@ input[type=search]:focus::-webkit-search-cancel-button {
     position: relative;
 }
 
-.group_member .queue_position:not(:empty)::before {  
+.group_member .queue_position:not(:empty)::before {
     content: "#";
 }
 
-.group_member .queue_position{
+.group_member .queue_position {
     margin-right: 1rem;
 }
 
 .group_member.is_queued {
-    border: 2px solid var(--golden);
+    outline: 2px solid var(--golden);
 }
 
 .group_member.is_active {
-    border: 2px solid var(--active);
+    outline: 2px solid var(--active);
 }
 
 .character_select.is_fav .avatar,

--- a/public/style.css
+++ b/public/style.css
@@ -2922,6 +2922,14 @@ input[type=search]:focus::-webkit-search-cancel-button {
     position: relative;
 }
 
+.group_member.is_queued {
+    border: 2px solid var(--golden);
+}
+
+.group_member.is_active {
+    border: 2px solid var(--active);
+}
+
 .character_select.is_fav .avatar,
 .group_select.is_fav .avatar,
 .group_member.is_fav .avatar,


### PR DESCRIPTION
- Adding display of queued speakers in group chat windows.
 - all drafted characters are highlighted - current in --active, others in --golden
 - Position in queue displayed next to each drafted character's name 

![image](https://github.com/SillyTavern/SillyTavern/assets/12687033/f707b176-fd4f-4784-b3fc-47fb33aa51c7)


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
