### PR TITLE
Tweaks to activateNaturalOrder

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1006,6 +1006,7 @@ function activateNaturalOrder(members, input, lastMessage, allowSelfResponses, i
         }
     }
 
+    let chattyMembers = [];
     // activation by talkativeness (in shuffled order, except banned)
     const shuffledMembers = shuffle([...members]);
     for (let member of shuffledMembers) {
@@ -1023,19 +1024,24 @@ function activateNaturalOrder(members, input, lastMessage, allowSelfResponses, i
         if (talkativeness >= rollValue) {
             activatedMembers.push(member);
         }
+        if (talkativeness > 0){
+            chattyMembers.push(member);
+        }
     }
 
     // pick 1 at random if no one was activated
     let retries = 0;
-    while (activatedMembers.length === 0 && ++retries <= members.length) {
-        const randomIndex = Math.floor(Math.random() * members.length);
-        const character = characters.find((x) => x.avatar === members[randomIndex]);
+    // try to limit the selected random character to those with talkativeness > 0
+    let randomPool = chattyMembers.length > 0? chattyMembers : members;
+    while (activatedMembers.length === 0 && ++retries <= randomPool.length) {
+        const randomIndex = Math.floor(Math.random() * randomPool.length);
+        const character = characters.find((x) => x.avatar === randomPool[randomIndex]);
 
         if (!character) {
             continue;
         }
 
-        activatedMembers.push(members[randomIndex]);
+        activatedMembers.push(randomPool[randomIndex]);
     }
 
     // de-duplicate array of character avatars


### PR DESCRIPTION
This is related to issue 232:  [FEATURE_REQUEST] Group Chat "Reply Only When Mentioned" Setting #232

Use case: Running with "Join Character Cards (exclude muted)" but want some characters to remain silent unless explicitly triggered (Narrator, NPC bot).

It was mentioned in the issue that setting talkativeness to 0 would accomplish the ask, but it won't.

activateNaturalOrder will go through the following until it finds someone to speak:
      1) look for mentioned characters
      2) perform a random roll for each character's talkativeness
      3) if nobody has been selected, choose a random character to speak
So if no member characters are mentioned, and all fail the roll in step 2, then they are all equally likely to speak.  

This change tries to take talkativeness into account in step 3, eliminating all characters with talkativeness of 0 unless all members have talkativeness of 0. This does mean that shy characters (talkativeness of 0) will only speak when mentioned or all members are also shy.   


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
