### PR TITLE
Fix trim macro breaking on CRLF

### DIFF
--- a/public/scripts/macros.js
+++ b/public/scripts/macros.js
@@ -437,7 +437,7 @@ export function evaluateMacros(content, env) {
     content = replaceInstructMacros(content, env);
     content = replaceVariableMacros(content);
     content = content.replace(/{{newline}}/gi, '\n');
-    content = content.replace(/\n*{{trim}}\n*/gi, '');
+    content = content.replace(/(?:\r?\n)*{{trim}}(?:\r?\n)*/gi, '');
     content = content.replace(/{{noop}}/gi, '');
     content = content.replace(/{{input}}/gi, () => String($('#send_textarea').val()));
 


### PR DESCRIPTION
`{{trim}}` macro had issues if somehow windows linefeeds (`\r\n` (CRLF)) go into the text fields.

Either from the JSON files of the presets themselves, if they were edited manually I figure, or maybe copy&paste.
No matter if we only want to have `\n` alone, we should work around the edge case if carriage returns are present.

## Checklist:

- [x] I have read [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
