### PR TITLE
Do not translate randomly in /api/speech/recognize

### DIFF
--- a/src/endpoints/speech.js
+++ b/src/endpoints/speech.js
@@ -40,7 +40,7 @@ router.post('/recognize', jsonParser, async (req, res) => {
         const pipe = await module.default.getPipeline(TASK, model);
         const wav = getWaveFile(audio);
         const start = performance.now();
-        const result = await pipe(wav, { language: lang || null });
+        const result = await pipe(wav, { language: lang || null, task: 'transcribe' });
         const end = performance.now();
         console.log(`Execution duration: ${(end - start) / 1000} seconds`);
         console.log('Transcribed audio:', result.text);


### PR DESCRIPTION
`/api/speech/recognize` doesn't explicitly specify the task when running the pipeline. (You can specify either `transcribe` or `translate` for the task.)
Because of this, the decoder_prompt doesn't include the task token, and in the case of multiple languages, it randomly translates to English.
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
