### PR TITLE
Extensions & Assets UI updates - More info, tooltips & helpful guides

### DIFF
--- a/public/css/animations.css
+++ b/public/css/animations.css
@@ -55,16 +55,11 @@
 
 /* Flashing for highlighting animation */
 @keyframes flash {
-
-    20%,
-    60%,
-    100% {
+    0%, 50%, 100% {
         opacity: 1;
     }
 
-    0%,
-    40%,
-    80% {
+    25%, 75% {
         opacity: 0.2;
     }
 }

--- a/public/scripts/extensions/assets/confirm.html
+++ b/public/scripts/extensions/assets/confirm.html
@@ -1,9 +1,0 @@
-<div class="m-b-1">
-    Are you sure you want to connect to '{{url}}'?
-</div>
-<div class="flex-container justifyCenter">
-    <label class="checkbox_label" for="assets-remember">
-        <input type="checkbox" id="assets-remember">
-        Don't ask again for this URL
-    </label>
-</div>

--- a/public/scripts/extensions/assets/index.js
+++ b/public/scripts/extensions/assets/index.js
@@ -7,7 +7,7 @@ import { getRequestHeaders, callPopup, processDroppedFiles, eventSource, event_t
 import { deleteExtension, extensionNames, getContext, installExtension, renderExtensionTemplateAsync } from '../../extensions.js';
 import { POPUP_TYPE, callGenericPopup } from '../../popup.js';
 import { executeSlashCommands } from '../../slash-commands.js';
-import { getStringHash, isValidUrl } from '../../utils.js';
+import { flashHighlight, getStringHash, isValidUrl } from '../../utils.js';
 export { MODULE_NAME };
 
 const MODULE_NAME = 'assets';
@@ -403,6 +403,13 @@ jQuery(async () => {
     const charactersButton = windowHtml.find('#assets-characters-button');
     charactersButton.on('click', async function () {
         openCharacterBrowser(false);
+    });
+
+    const installHintButton = windowHtml.find('.assets-install-hint-link');
+    installHintButton.on('click', async function () {
+        const installButton = $('#third_party_extension_button');
+        flashHighlight(installButton, 5000);
+        toastr.info('Click the flashing button to the right of this to install extensions.', 'How to install extensions?');
     });
 
     const connectButton = windowHtml.find('#assets-connect-button');

--- a/public/scripts/extensions/assets/index.js
+++ b/public/scripts/extensions/assets/index.js
@@ -420,7 +420,7 @@ jQuery(async () => {
 
     const connectButton = windowHtml.find('#assets-connect-button');
     connectButton.on('click', async function () {
-        const url = String(assetsJsonUrl.val());
+        const url = DOMPurify.sanitize(String(assetsJsonUrl.val()));
         const rememberKey = `Assets_SkipConfirm_${getStringHash(url)}`;
         const skipConfirm = localStorage.getItem(rememberKey) === 'true';
 

--- a/public/scripts/extensions/assets/index.js
+++ b/public/scripts/extensions/assets/index.js
@@ -219,6 +219,12 @@ function downloadAssetsList(url) {
                 $('#assets_menu').show();
             })
             .catch((error) => {
+                // Info hint if the user maybe... likely accidently was trying to install an extension and we wanna help guide them? uwu :3
+                const installButton = $('#third_party_extension_button');
+                flashHighlight(installButton, 10_000);
+                toastr.info('If you are trying to install an extension, click the flashing button to the right of this.', 'Trying to install a custom extension?', { timeOut: 10_000 });
+
+                // Error logged after, to appear on top
                 console.error(error);
                 toastr.error('Problem with assets URL', DEBUG_PREFIX + 'Cannot get assets list');
                 $('#assets-connect-button').addClass('fa-plug-circle-exclamation');

--- a/public/scripts/extensions/assets/index.js
+++ b/public/scripts/extensions/assets/index.js
@@ -3,7 +3,7 @@ TODO:
 */
 //const DEBUG_TONY_SAMA_FORK_MODE = true
 
-import { getRequestHeaders, callPopup, processDroppedFiles, eventSource, event_types } from '../../../script.js';
+import { getRequestHeaders, processDroppedFiles, eventSource, event_types } from '../../../script.js';
 import { deleteExtension, extensionNames, getContext, installExtension, renderExtensionTemplateAsync } from '../../extensions.js';
 import { POPUP_TYPE, Popup, callGenericPopup } from '../../popup.js';
 import { executeSlashCommands } from '../../slash-commands.js';
@@ -222,7 +222,7 @@ function downloadAssetsList(url) {
                 // Info hint if the user maybe... likely accidently was trying to install an extension and we wanna help guide them? uwu :3
                 const installButton = $('#third_party_extension_button');
                 flashHighlight(installButton, 10_000);
-                toastr.info('If you are trying to install an extension, click the flashing button to the right of this.', 'Trying to install a custom extension?', { timeOut: 10_000 });
+                toastr.info('Click the flashing button at the top right corner of the menu.', 'Trying to install a custom extension?', { timeOut: 10_000 });
 
                 // Error logged after, to appear on top
                 console.error(error);
@@ -415,7 +415,7 @@ jQuery(async () => {
     installHintButton.on('click', async function () {
         const installButton = $('#third_party_extension_button');
         flashHighlight(installButton, 5000);
-        toastr.info('Click the flashing button to the right of this to install extensions.', 'How to install extensions?');
+        toastr.info('Click the flashing button to install extensions.', 'How to install extensions?');
     });
 
     const connectButton = windowHtml.find('#assets-connect-button');

--- a/public/scripts/extensions/assets/style.css
+++ b/public/scripts/extensions/assets/style.css
@@ -7,10 +7,14 @@
     margin-left: 5px;
 }
 
+.assets-url-block {
+    display: flex;
+    flex-direction: column;
+}
+
 .assets-connect-div {
     display: flex;
     flex-direction: row;
-    padding: 5px;
 }
 
 .assets-list-git {

--- a/public/scripts/extensions/assets/style.css
+++ b/public/scripts/extensions/assets/style.css
@@ -12,6 +12,10 @@
     flex-direction: column;
 }
 
+.assets-install-hint-link {
+    cursor: help;
+}
+
 .assets-connect-div {
     display: flex;
     flex-direction: row;

--- a/public/scripts/extensions/assets/window.html
+++ b/public/scripts/extensions/assets/window.html
@@ -5,10 +5,26 @@
             <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
         </div>
         <div class="inline-drawer-content">
-            <label for="assets-json-url-field" data-i18n="Assets URL">Assets URL</label>
-            <div class="assets-connect-div">
-                <input id="assets-json-url-field" class="text_pole widthUnset flex1">
-                <i id="assets-connect-button" class="menu_button fa-solid fa-plug-circle-exclamation fa-xl redOverlayGlow"></i>
+            <div>
+                <small data-i18n="To install 3rd party extensions, load a custom asset list or select &quot;Install&nbsp;Extension&quot;">
+                    To install 3rd party extensions, load a custom asset list or select "Install&nbsp;Extension"
+                </small>
+            </div>
+            <div class="assets-url-block m-b-1 m-t-1">
+                <label for="assets-json-url-field" data-i18n="Assets URL">Assets URL</label>
+                <small title="Load a list of extensions & assets based on an asset list file.
+
+The default Asset URL in this field points to the list of offical first party extensions and assets.
+If you have a custom asset list, you can insert it here.
+
+To install a single 3rd party extension, use the &quot;Install Extensions&quot; button on the top right.">
+                    <span>Load an asset list</span>
+                    <div class="fa-solid fa-circle-info opacity50p"></div>
+                </small>
+                <div class="assets-connect-div">
+                    <input id="assets-json-url-field" class="text_pole widthUnset flex1">
+                    <i id="assets-connect-button" class="menu_button fa-solid fa-plug-circle-exclamation fa-xl redOverlayGlow" title="Load Asset List" data-i18n="[title]Load Asset List"></i>
+                </div>
             </div>
             <div id="assets_filters" class="flex-container">
                 <select id="assets_type_select" class="text_pole flex1">

--- a/public/scripts/extensions/assets/window.html
+++ b/public/scripts/extensions/assets/window.html
@@ -5,11 +5,12 @@
             <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
         </div>
         <div class="inline-drawer-content">
-            <div>
-                <small data-i18n="To install 3rd party extensions, load a custom asset list or select &quot;Install&nbsp;Extension&quot;">
-                    To install 3rd party extensions, load a custom asset list or select "Install&nbsp;Extension"
-                </small>
-            </div>
+            <small>
+                <span data-i18n="To install 3rd party extensions, load a custom asset list or select">
+                    To install 3rd party extensions, load a custom asset list or select
+                </span>
+                <a class="assets-install-hint-link" data-i18n="Install&nbsp;Extension">Install&nbsp;Extension</a>
+            </small>
             <div class="assets-url-block m-b-1 m-t-1">
                 <label for="assets-json-url-field" data-i18n="Assets URL">Assets URL</label>
                 <small title="Load a list of extensions & assets based on an asset list file.

--- a/public/scripts/extensions/assets/window.html
+++ b/public/scripts/extensions/assets/window.html
@@ -6,10 +6,13 @@
         </div>
         <div class="inline-drawer-content">
             <small>
-                <span data-i18n="To install 3rd party extensions, load a custom asset list or select">
-                    To install 3rd party extensions, load a custom asset list or select
+                <span data-i18n="Load a custom asset list or select">
+                    Load a custom asset list or select
                 </span>
                 <a class="assets-install-hint-link" data-i18n="Install&nbsp;Extension">Install&nbsp;Extension</a>
+                <span data-i18n="to install 3rd party extensions.">
+                    to install 3rd party extensions.
+                </span>
             </small>
             <div class="assets-url-block m-b-1 m-t-1">
                 <label for="assets-json-url-field" data-i18n="Assets URL">Assets URL</label>

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1571,12 +1571,28 @@ export function setValueByPath(obj, path, value) {
 /**
  * Flashes the given HTML element via CSS flash animation for a defined period
  * @param {JQuery<HTMLElement>} element - The element to flash
- * @param {number} timespan - A numer in milliseconds how the flash should last
+ * @param {number} timespan - A number in milliseconds how the flash should last (default is 2000ms.  Multiples of 1000ms work best, as they end with the flash animation being at 100% opacity)
  */
 export function flashHighlight(element, timespan = 2000) {
+    const flashDuration = 2000; // Duration of a single flash cycle in milliseconds
+
     element.addClass('flash animated');
-    setTimeout(() => element.removeClass('flash animated'), timespan);
+    element.css('--animation-duration', `${flashDuration}ms`);
+
+    // Repeat the flash animation
+    const intervalId = setInterval(() => {
+        element.removeClass('flash animated');
+        void element[0].offsetWidth; // Trigger reflow to restart animation
+        element.addClass('flash animated');
+    }, flashDuration);
+
+    setTimeout(() => {
+        clearInterval(intervalId);
+        element.removeClass('flash animated');
+        element.css('--animation-duration', '');
+    }, timespan);
 }
+
 
 /**
  * Checks if the given control has an animation applied to it

--- a/public/style.css
+++ b/public/style.css
@@ -208,8 +208,8 @@ table.responsiveTable {
 }
 
 .animated {
-    -webkit-animation-duration: 3s !important;
-    animation-duration: 3s !important;
+    -webkit-animation-duration: var(--animation-duration, 3s) !important;
+    animation-duration: var(--animation-duration, 3s) !important;
     -webkit-animation-fill-mode: both !important;
     animation-fill-mode: both !important;
     box-shadow: inset 0 0 5px var(--SmartThemeQuoteColor);


### PR DESCRIPTION
Okay. I am opening a betting pool how many people will still accidently use the wrong field.

### Internal changes
- Fixed `flashHighlight` not really flashing for its full flash duration. It'll now set a css var for the chosen length. And restart the flash animation until the duration ends, so it will actually always flash in the same intervals.
- Also fixed the flash animation from being uneven, not ending in 100% opacity, which looked a bit weird.

### Updated info
- Added tooltip on the button to load the asset list
- Added subtitle to what "Asset URL does"
- Added tooltip explaining in more detail what an asset list is, and that you can paste custom asset lists there
- Added an **inline block** under the asset list extension window that to install custom extension, you need to click the button for it
- Added a hyperlink in that list that if clicked, **flashes** the button on the right that you should click
- Added another toast that pops up if you enter an extension repo into the asset url field and click load, which leads to an error
- This new toastr asks you if you are trying to install install an extension, and flashes the button ***for even longer***

Someone got any idea for "wtf, duh?" style hints and toasts?

![st_ass_ext_hints](https://github.com/SillyTavern/SillyTavern/assets/9962104/c2338eaa-b5e6-4559-8f28-6cea974c9ffd)

![st_ass_ext_hints2](https://github.com/SillyTavern/SillyTavern/assets/9962104/200e015b-0af7-4c09-9e0b-65d105f1c1ad)


## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
