### PR TITLE
Includes captioning error messages in toast

### DIFF
--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -333,7 +333,7 @@ async function getCaptionForFile(file, prompt, quiet) {
         return caption;
     }
     catch (error) {
-        toastr.error('Failed to caption image.');
+        toastr.error(`Failed to caption image. ${error}`);
         console.log(error);
         return '';
     }

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -333,8 +333,9 @@ async function getCaptionForFile(file, prompt, quiet) {
         return caption;
     }
     catch (error) {
-        toastr.error(`Failed to caption image. ${error}`);
-        console.log(error);
+        const errorMessage = error.message || 'Unknown error';
+        toastr.error(errorMessage, "Failed to caption image.");
+        console.error(error);
         return '';
     }
     finally {


### PR DESCRIPTION
Show captioning errors in the toast for end users, while it does go console, makes it easier for an end user to know the problem in cases like forgetting to set the api url for a given captioning endpoint.
(rather than just showing a generic "failed to caption" message in the toast)

## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
