### PR TITLE
Preset manager popups

### DIFF
--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -369,7 +369,7 @@ class PresetManager {
         if (Object.keys(preset_names).length) {
             const nextPresetName = Object.keys(preset_names)[0];
             const newValue = preset_names[nextPresetName];
-            $(this.select).find(`option[value="${newValue}"]`).attr('selected', true);
+            $(this.select).find(`option[value="${newValue}"]`).attr('selected', 'true');
             $(this.select).trigger('change');
         }
 

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -166,7 +166,7 @@ class PresetManager {
     async savePresetAs() {
         const inputValue = this.getSelectedPresetName();
         const popupText = !this.isNonGenericApi() ? '<h4>Hint: Use a character/group name to bind preset to a specific chat.</h4>' : '';
-        const name = Popup.show.input('Preset name:', popupText, inputValue);
+        const name = await Popup.show.input('Preset name:', popupText, inputValue);
         if (!name) {
             console.log('Preset name not provided');
             return;

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -1,6 +1,5 @@
 import {
     amount_gen,
-    callPopup,
     characters,
     eventSource,
     event_types,
@@ -19,6 +18,7 @@ import {
 import { groups, selected_group } from './group-chats.js';
 import { instruct_presets } from './instruct-mode.js';
 import { kai_settings } from './kai-settings.js';
+import { Popup } from './popup.js';
 import { context_presets, getContextSettings, power_user } from './power-user.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument } from './slash-commands/SlashCommandArgument.js';
@@ -165,11 +165,8 @@ class PresetManager {
 
     async savePresetAs() {
         const inputValue = this.getSelectedPresetName();
-        const popupText = `
-            <h3>Preset name:</h3>
-            ${!this.isNonGenericApi() ? '<h4>Hint: Use a character/group name to bind preset to a specific chat.</h4>' : ''}`;
-        const name = await callPopup(popupText, 'input', inputValue);
-
+        const popupText = !this.isNonGenericApi() ? '<h4>Hint: Use a character/group name to bind preset to a specific chat.</h4>' : '';
+        const name = Popup.show.input('Preset name:', popupText, inputValue);
         if (!name) {
             console.log('Preset name not provided');
             return;
@@ -597,8 +594,7 @@ export async function initPresetManager() {
             return;
         }
 
-        const confirm = await callPopup('Delete the preset? This action is irreversible and your current settings will be overwritten.', 'confirm');
-
+        const confirm = await Popup.show.input('Delete the preset?', 'This action is irreversible and your current settings will be overwritten.');
         if (!confirm) {
             return;
         }
@@ -641,8 +637,7 @@ export async function initPresetManager() {
                 return;
             }
 
-            const confirm = await callPopup('<h3>Are you sure?</h3>Resetting a <b>default preset</b> will restore the default settings.', 'confirm');
-
+            const confirm = await Popup.show.confirm('Are you sure?', 'Resetting a <b>default preset</b> will restore the default settings.');
             if (!confirm) {
                 return;
             }
@@ -653,8 +648,7 @@ export async function initPresetManager() {
             presetManager.selectPreset(option);
             toastr.success('Default preset restored');
         } else {
-            const confirm = await callPopup('<h3>Are you sure?</h3>Resetting a <b>custom preset</b> will restore to the last saved state.', 'confirm');
-
+            const confirm = await Popup.show.confirm('Are you sure?', 'Resetting a <b>custom preset</b> will restore to the last saved state.');
             if (!confirm) {
                 return;
             }

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -594,7 +594,7 @@ export async function initPresetManager() {
             return;
         }
 
-        const confirm = await Popup.show.input('Delete the preset?', 'This action is irreversible and your current settings will be overwritten.');
+        const confirm = await Popup.show.confirm('Delete the preset?', 'This action is irreversible and your current settings will be overwritten.');
         if (!confirm) {
             return;
         }


### PR DESCRIPTION
Just noticed the preset manager popups (the one about resetting it to the default) weren't moved to the new popup yet.
Those were easy to do.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
