### PR TITLE
ask user to confirm proxy connections

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -548,7 +548,7 @@ function setOpenAIMessages(chat) {
         switch (oai_settings.names_behavior) {
             case character_names_behavior.NONE:
                 if (selected_group || (chat[j].force_avatar && chat[j].name !== name1 && chat[j].extra?.type !== system_message_types.NARRATOR)) {
-                    // content = `${chat[j].name}: ${content}`;
+                    content = `${chat[j].name}: ${content}`;
                 }
                 break;
             case character_names_behavior.CONTENT:

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -73,7 +73,7 @@ import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument } from './slash-commands/SlashCommandArgument.js';
 import { renderTemplateAsync } from './templates.js';
 import { SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js';
-import { Popup, POPUP_RESULT, POPUP_TYPE, PopupUtils } from './popup.js';
+import { Popup, POPUP_RESULT } from './popup.js';
 
 export {
     openai_messages_count,
@@ -3525,10 +3525,9 @@ async function onPresetImportFileChange(e) {
     if (shouldConfirm) {
         const textHeader = 'The imported preset contains proxy and/or custom endpoint settings.';
         const textMessage = fields.join('<br>');
-        const cancelButton = { text: 'Cancel import', result: POPUP_RESULT.CANCELLED, appendAtEnd: true, action: () => popup.complete(POPUP_RESULT.CANCELLED) };
+        const cancelButton = { text: 'Cancel import', result: POPUP_RESULT.CANCELLED, appendAtEnd: true };
         const popupOptions = { customButtons: [cancelButton], okButton: 'Remove them', cancelButton: 'Import as-is' };
-        const popup = new Popup(PopupUtils.BuildTextWithHeader(textHeader, textMessage), POPUP_TYPE.CONFIRM, '', popupOptions);
-        const popupResult = await popup.show();
+        const popupResult = await Popup.show.confirm(textHeader, textMessage, popupOptions);
 
         if (popupResult === POPUP_RESULT.CANCELLED) {
             console.log('Import cancelled by user');
@@ -3590,10 +3589,9 @@ async function onExportPresetClick() {
     const shouldConfirm = fieldValues.length > 0;
     const textHeader = 'Your preset contains proxy and/or custom endpoint settings.';
     const textMessage = `<div>Do you want to remove these fields before exporting?</div><br>${DOMPurify.sanitize(fieldValues.join('<br>'))}`;
-    const cancelButton = { text: 'Cancel', result: POPUP_RESULT.CANCELLED, appendAtEnd: true, action: () => popup.complete(POPUP_RESULT.CANCELLED) };
+    const cancelButton = { text: 'Cancel', result: POPUP_RESULT.CANCELLED, appendAtEnd: true };
     const popupOptions = { customButtons: [cancelButton] };
-    const popup = new Popup(PopupUtils.BuildTextWithHeader(textHeader, textMessage), POPUP_TYPE.CONFIRM, '', popupOptions);
-    const popupResult = shouldConfirm && await popup.show();
+    const popupResult = await Popup.show.confirm(textHeader, textMessage, popupOptions);
 
     if (popupResult === POPUP_RESULT.CANCELLED) {
         console.log('Export cancelled by user');

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -416,21 +416,16 @@ async function validateReverseProxy() {
     const rememberKey = `Proxy_SkipConfirm_${getStringHash(oai_settings.reverse_proxy)}`;
     const skipConfirm = localStorage.getItem(rememberKey) === 'true';
 
-    const confirmation = skipConfirm || await Popup.show.confirm('Connecting To Proxy', `<span>Are you sure you want to connect to the following proxy URL?</span><var>${oai_settings.reverse_proxy}</var>`, {
-        customInputs: [{ id: 'proxy-remember', label: 'Don\'t ask again for this proxy URL' }],
-        onClose: popup => {
-            if (popup.result) {
-                const rememberValue = popup.inputResults.get('proxy-remember');
-                localStorage.setItem(rememberKey, String(rememberValue));
-            }
-        },
-    });
+    const confirmation = skipConfirm || await Popup.show.confirm('Connecting To Proxy', `<span>Are you sure you want to connect to the following proxy URL?</span><var>${DOMPurify.sanitize(oai_settings.reverse_proxy)}</var>`);
+
     if (!confirmation) {
         toastr.error('Update or remove your reverse proxy settings.');
         setOnlineStatus('no_connection');
         resultCheckStatus();
         throw new Error('Proxy connection denied.');
     }
+
+    localStorage.setItem(rememberKey, String(true));
 }
 
 /**

--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -565,7 +565,7 @@ export class Popup {
     };
 }
 
-export class PopupUtils {
+class PopupUtils {
     /**
      * Builds popup content with header and text below
      *

--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -560,7 +560,7 @@ export class Popup {
     };
 }
 
-class PopupUtils {
+export class PopupUtils {
     /**
      * Builds popup content with header and text below
      *


### PR DESCRIPTION
More or less a copy of the asset list extension's connect confirmation.
If denied by user, interrupts generation in the exact same way as invalid proxy URLs do, i.e., by throwing an exception. Then toasts user to change their proxy settings.
Makes `validateReverseProxy()` async, but it was only ever called in async functions anyways.

May have side effects. This is really just a demo based on a discord discussion.


## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
