### PR TITLE
Improved Russian Google Translate syntax

### DIFF
--- a/src/endpoints/translate.js
+++ b/src/endpoints/translate.js
@@ -78,17 +78,17 @@ router.post('/google', jsonParser, async (request, response) => {
         console.log('Input text:', text);
         //console.log('----------');
 
-        // Применяем форматирование только если язык перевода - русский
+        // Apply formatting only if the translation language is Russian
         if (lang === 'ru') {
-             // Заменяем кавычки и звездочки на специальные маркеры перед переводом с пробелами
+             // Replace quotation marks and asterisks with special markers before translating
             const openQuote = '__OPEN_QUOTE__ ';
             const closeQuote = ' __CLOSE_QUOTE__';
             const openStar = '__OPEN_STAR__ ';
             const closeStar = ' __CLOSE_STAR__';
-             // Очень редкий случай, вызванный правилами русской граматики
+             // A very rare case
             const very_rare_execption = '__OPEN_STAR__, ';
 
-            // Используем счетчики для чередования между открывающими и закрывающими маркерами
+            // Use counters to alternate between opening and closing markers
             let quoteCounter = 0;
             let starCounter = 0;
 
@@ -112,11 +112,11 @@ router.post('/google', jsonParser, async (request, response) => {
                 try {
                     let result;
                     if (lang === 'ru') {
-                        // Декодирование для русского языка
+                        // Decoding for Russian language
                         const decodedData = iconv.decode(Buffer.concat(data), 'utf-8');
                         result = normaliseResponse(JSON.parse(decodedData));
                     } else {
-                        // Для других языков используем данные как есть
+                        // For other languages, we use the data as is
                         result = normaliseResponse(JSON.parse(Buffer.concat(data).toString()));
                     }
 
@@ -125,7 +125,7 @@ router.post('/google', jsonParser, async (request, response) => {
 
                     let fixedText = result.text;
 
-                    // Восстанавливаем форматирование только если язык перевода - русский
+                    // Restore formatting only if the target language is Russian
                     if (lang === 'ru') {
                         fixedText = result.text
                             .replace(new RegExp('__OPEN_QUOTE__ ', 'g'), '"')

--- a/src/endpoints/translate.js
+++ b/src/endpoints/translate.js
@@ -4,6 +4,9 @@ const express = require('express');
 const { readSecret, SECRET_KEYS } = require('./secrets');
 const { getConfigValue, uuidv4 } = require('../util');
 const { jsonParser } = require('../express-common');
+const iconv = require('iconv-lite');
+const { generateRequestUrl, normaliseResponse } = require('google-translate-api-browser');
+const bodyParser = require('body-parser');
 
 const DEEPLX_URL_DEFAULT = 'http://127.0.0.1:1188/translate';
 const ONERING_URL_DEFAULT = 'http://127.0.0.1:4990/translate';
@@ -60,13 +63,6 @@ router.post('/libre', jsonParser, async (request, response) => {
         return response.sendStatus(500);
     }
 });
-
-
-
-
-const iconv = require('iconv-lite');
-const { generateRequestUrl, normaliseResponse } = require('google-translate-api-browser');
-const bodyParser = require('body-parser');
 
 
 router.post('/google', jsonParser, async (request, response) => {

--- a/src/endpoints/translate.js
+++ b/src/endpoints/translate.js
@@ -86,7 +86,11 @@ router.post('/google', jsonParser, async (request, response) => {
                 try {
                     const result = normaliseResponse(JSON.parse(data));
                     console.log('Translated text: ' + result.text);
-                    return response.send(result.text);
+
+                    // Заменяем кавычки «» на ""
+                    const fixedText = result.text.replace(/«/g, '"').replace(/»/g, '"');
+
+                    return response.send(fixedText);
                 } catch (error) {
                     console.log('Translation error', error);
                     return response.sendStatus(500);

--- a/src/endpoints/translate.js
+++ b/src/endpoints/translate.js
@@ -67,6 +67,7 @@ router.post('/libre', jsonParser, async (request, response) => {
 
 router.post('/google', jsonParser, async (request, response) => {
     try {
+        const { generateRequestUrl, normaliseResponse } = require('google-translate-api-browser');
         let text = request.body.text;
         const lang = request.body.lang;
 
@@ -77,19 +78,14 @@ router.post('/google', jsonParser, async (request, response) => {
         console.log('Input text:', text);
         console.log('----------');
 
-        let originalText = text;
-
         // Применяем форматирование только если язык перевода - русский
         if (lang === 'ru') {
-            // Заменяем кавычки и звездочки на специальные маркеры перед переводом
             const openQuote = '__OPEN_QUOTE__ ';
             const closeQuote = ' __CLOSE_QUOTE__';
             const openStar = '__OPEN_STAR__ ';
             const closeStar = ' __CLOSE_STAR__';
-            // Очень редкий случай, вызванный правилами русской граматики
             const very_rare_execption = '__OPEN_STAR__, ';
 
-            // Используем счетчики для чередования между открывающими и закрывающими маркерами
             let quoteCounter = 0;
             let starCounter = 0;
 
@@ -103,24 +99,15 @@ router.post('/google', jsonParser, async (request, response) => {
         const url = generateRequestUrl(text, { to: lang });
 
         https.get(url, (resp) => {
-            let data = [];
+            let data = '';
 
             resp.on('data', (chunk) => {
-                data.push(chunk);
+                data += chunk;
             });
 
             resp.on('end', () => {
                 try {
-                    let result;
-                    if (lang === 'ru') {
-                        // Декодирование и нормализация только для русского языка
-                        const decodedData = iconv.decode(Buffer.concat(data), 'utf-8');
-                        result = normaliseResponse(JSON.parse(decodedData));
-                    } else {
-                        // Для других языков используем данные как есть
-                        result = JSON.parse(Buffer.concat(data).toString());
-                    }
-
+                    const result = normaliseResponse(JSON.parse(data));
                     console.log('Pre-Translated text:', result.text);
                     console.log('----------');
 


### PR DESCRIPTION
# Problem №1 and Problem №2
##  №1
Problem when Google Translate  replace "" on «» during translation, what broke the syntax.

## №2
Google translator, when translating direct speech, for some reason adds an additional quotation mark, which breaks the syntax.
## Example of text before
![Before](https://github.com/user-attachments/assets/e5d2d78d-8e03-4c80-a7f9-13ffc0567b8d)


# Solving of problem №1 and №2
1. Before submitting text for translation, we replace all quotation marks with special markers (__OPEN_QUOTE__ and __CLOSE_QUOTE__). This ensures that quotes are not changed translation.
2. Similarly, we replace asterisks with markers (__OPEN_STAR__ and __CLOSE_STAR__).
3. After receiving the translated text, we replace all markers back to the corresponding characters.

## Example of text after
![After](https://github.com/user-attachments/assets/863b3d4f-b127-407b-938d-b0d96e95b23a)


# Problem №3
Problem with strange characters appearing during translation.
## Example
![Problem2](https://github.com/user-attachments/assets/7085da09-7303-405e-bb16-b5d2f1392fa1)

## Solving of problem №3
It is solved by decoding.

# Impact on other languages
These changes do not affect translation and output when using other languages.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
