### PR TITLE
Includes a layman's explanation of REPLACE_GETVAR in its tooltip

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4259,7 +4259,7 @@
                                             <span class="fa-solid fa-circle-question note-link-span"></span>
                                         </a>
                                     </label>
-                                    <label class="checkbox_label" title="Replace all {{getvar::}} and {{getglobalvar::}} macros with scoped variables to avoid double macro substitution." data-i18n="[title]Replace all {{getvar::}} and {{getglobalvar::}} macros with scoped variables to avoid double macro substitution.">
+                                    <label class="checkbox_label" title="Prevents {{getvar::}} {{getglobalvar::}} macros from having literal macro-like values auto-evaluated.&NewLine;e.g. &quot;{{newline}}&quot; remains as literal string &quot;{{newline}}&quot;&NewLine;&NewLine;(This is done by internally replacing {{getvar::}} {{getglobalvar::}} macros with scoped variables.)" data-i18n="[title]Prevents {{getvar::}} {{getglobalvar::}} macros from having literal macro-like values auto-evaluated.&NewLine;e.g. &quot;{{newline}}&quot; remains as literal string &quot;{{newline}}&quot;&NewLine;&NewLine;(This is done by internally replacing {{getvar::}} {{getglobalvar::}} macros with scoped variables.)">
                                         <input id="stscript_parser_flag_replace_getvar" type="checkbox" />
                                         <span data-i18n="REPLACE_GETVAR"><small>REPLACE_GETVAR</small></span>
                                         <a href="https://docs.sillytavern.app/usage/st-script/#replace-variable-macros" target="_blank" class="notes-link">


### PR DESCRIPTION
The tooltip will render as:

```
Prevents {{getvar::}} {{getglobalvar::}} macros from having literal macro-like values auto-evaluated.
e.g. "{{newline}}" remains as literal string "{{newline}}"

(This is done by internally replacing {{getvar::}} {{getglobalvar::}} macros with scoped variables.)
```

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
