### PR TITLE
Add ChromaDB and RVC Model Persistence to Collab

### DIFF
--- a/colab/GPU.ipynb
+++ b/colab/GPU.ipynb
@@ -1,9 +1,10 @@
 {
   "cells": [
     {
-      "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "Y182dvBSqWIO"
+      },
       "source": [
         "**Links**<br>\n",
         "Extensions API GitHub: https://github.com/SillyTavern/SillyTavern-extras/<br>\n",
@@ -13,7 +14,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "cts8XEySqWIR"
+      },
       "outputs": [],
       "source": [
         "#@title <-- Tap this if you run on Mobile { display-mode: \"form\" }\n",
@@ -68,6 +71,9 @@
         "extras_enable_edge_tts = True #@param {type:\"boolean\"}\n",
         "#@markdown Enables RVC module\n",
         "extras_enable_rvc = False #@param {type:\"boolean\"}\n",
+        "#@markdown Store and access RVC models via Google Drive\n",
+        "rvc_use_gdrive = False #@param {type:\"boolean\"}\n",
+        "gdrive_rvc_path = \"SillyTavern/rvc_models\" #@param {'type': 'string'}\n",
         "#@markdown ***\n",
         "#@markdown Enables Whisper speech recognition module\n",
         "extras_enable_whisper_stt = True #@param {type:\"boolean\"}\n",
@@ -87,9 +93,14 @@
         "#@markdown ***\n",
         "#@markdown Enables ChromaDB module\n",
         "extras_enable_chromadb = True #@param {type:\"boolean\"}\n",
+        "#@markdown Enables ChromaDB persistence using Google Drive\n",
+        "chromadb_use_gdrive = False #@param {type:\"boolean\"}\n",
+        "gdrive_chromadb_path = \"SillyTavern/chromadb\" #@param {'type': 'string'}\n",
         "\n",
+        "import os\n",
         "import subprocess\n",
         "import secrets\n",
+        "from google.colab import drive\n",
         "\n",
         "# ---\n",
         "# SillyTavern extras\n",
@@ -139,6 +150,15 @@
         "params.append(f'--sd-model={sd_model}')\n",
         "params.append(f'--enable-modules={\",\".join(modules)}')\n",
         "\n",
+        "# Connect to Drive early so the user doesn't forget while all the downloading is happening.\n",
+        "if chromadb_use_gdrive or rvc_use_gdrive:\n",
+        "  drive.mount('/content/drive')\n",
+        "\n",
+        "if chromadb_use_gdrive:\n",
+        "  path_chromadb = '/content/drive/MyDrive/' + gdrive_chromadb_path\n",
+        "  if not os.path.exists(path_chromadb):\n",
+        "    !mkdir -p {path_chromadb}\n",
+        "  params.append(f'--chroma-folder={path_chromadb}')\n",
         "\n",
         "%cd /\n",
         "!git clone https://github.com/SillyTavern/SillyTavern-extras\n",
@@ -152,6 +172,16 @@
         "if extras_enable_rvc:\n",
         "  print(\"Installing RVC requirements\")\n",
         "  %pip install -r requirements-rvc.txt\n",
+        "\n",
+        "if rvc_use_gdrive:\n",
+        "  path_rvc_base = '/SillyTavern-extras/data/models/rvc'\n",
+        "  path_rvc_gdrive = '/content/drive/MyDrive/' + gdrive_rvc_path\n",
+        "  if not os.path.exists(path_rvc_gdrive):\n",
+        "    !mkdir -p {path_rvc_gdrive}\n",
+        "  if os.path.exists(path_rvc_base) and not os.path.islink(path_rvc_base):\n",
+        "    !rm -r {path_rvc_base}\n",
+        "  if not os.path.exists(path_rvc_base):\n",
+        "    os.symlink(path_rvc_gdrive, path_rvc_base, True)\n",
         "\n",
         "# Generate a random API key\n",
         "api_key = secrets.token_hex(5)\n",


### PR DESCRIPTION
Adds persistence for ChromaDB and RVC models by connecting to Google Drive and storing the files there. This prevents the user from having to constantly export and import files from the UI at the tradeoff of cloud storage space.

Changes were made directly in Collab and saved to Github via the "Save a copy to Github" dialogue.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
