### PR TITLE
Update language code for Chinese Traditional translations(zh-TW) on LibreTranslate endpoint.

### DIFF
--- a/src/endpoints/translate.js
+++ b/src/endpoints/translate.js
@@ -19,8 +19,12 @@ router.post('/libre', jsonParser, async (request, response) => {
         return response.sendStatus(400);
     }
 
-    if (request.body.lang === 'zh-CN' || request.body.lang === 'zh-TW') {
+    if (request.body.lang === 'zh-CN') {
         request.body.lang = 'zh';
+    }
+
+    if (request.body.lang === 'zh-TW') {
+        request.body.lang = 'zt';
     }
 
     const text = request.body.text;


### PR DESCRIPTION
The code changes in `translate.js` update the language code for Chinese Traditional translations. The `zh-TW` language code is changed to `zt`. 
This ensures consistency and compatibility with the translation system(https://libretranslate.com/languages).

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
