### PR TITLE
Adds "chatvar" aliases & "length" alias

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -95,6 +95,7 @@ export function initDefaultSlashCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'persona',
         callback: setNameCallback,
+        aliases: ['name'],
         namedArgumentList: [
             new SlashCommandNamedArgument(
                 'mode', 'The mode for persona selection. ("lookup" = search for existing persona, "temp" = create a temporary name, set a temporary name, "all" = allow both in the same command)',
@@ -110,7 +111,6 @@ export function initDefaultSlashCommands() {
             }),
         ],
         helpString: 'Selects the given persona with its name and avatar (by name or avatar url). If no matching persona exists, applies a temporary name.',
-        aliases: ['name'],
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'sync',

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -859,11 +859,13 @@ export function registerVariableCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'listvar',
         callback: listVariablesCallback,
+        aliases: ['listchatvar'],
         helpString: 'List registered chat variables.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'setvar',
         callback: (args, value) => String(setLocalVariable(args.key || args.name, value, args)),
+        aliases: ['setchatvar'],
         returns: 'the set variable value',
         namedArgumentList: [
             SlashCommandNamedArgument.fromProps({
@@ -900,6 +902,7 @@ export function registerVariableCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'getvar',
         callback: (args, value) => String(getLocalVariable(value, args)),
+        aliases: ['getchatvar'],
         returns: 'the variable value',
         namedArgumentList: [
             SlashCommandNamedArgument.fromProps({
@@ -943,6 +946,7 @@ export function registerVariableCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'addvar',
         callback: (args, value) => String(addLocalVariable(args.key || args.name, value)),
+        aliases: ['addchatvar'],
         returns: 'the new variable value',
         namedArgumentList: [
             SlashCommandNamedArgument.fromProps({
@@ -1087,6 +1091,7 @@ export function registerVariableCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'incvar',
         callback: (_, value) => String(incrementLocalVariable(value)),
+        aliases: ['incchatvar'],
         returns: 'the new variable value',
         unnamedArgumentList: [
             SlashCommandNamedArgument.fromProps({
@@ -1115,6 +1120,7 @@ export function registerVariableCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'decvar',
         callback: (_, value) => String(decrementLocalVariable(value)),
+        aliases: ['decchatvar'],
         returns: 'the new variable value',
         unnamedArgumentList: [
             SlashCommandNamedArgument.fromProps({
@@ -1401,6 +1407,7 @@ export function registerVariableCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'flushvar',
         callback: async (_, value) => deleteLocalVariable(value instanceof SlashCommandClosure ? (await value.execute())?.pipe : String(value)),
+        aliases: ['flushchatvar'],
         unnamedArgumentList: [
             SlashCommandNamedArgument.fromProps({
                 name: 'key',
@@ -1870,6 +1877,7 @@ export function registerVariableCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'len',
         callback: (_, value) => String(lenValuesCallback(value)),
+        aliases: ['length'],
         returns: 'length of the provided value',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({


### PR DESCRIPTION
I think the chatvar commands would be handy to have for disambiguation purposes.

The length one is something I threw in because I find myself trying to do `/length` a lot.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
