### PR TITLE
WI update "Order" from custom sorting button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3630,7 +3630,8 @@
                             <div id="OpenAllWIEntries" class="menu_button fa-solid fa-expand" title="Open all Entries" data-i18n="[title]Open all Entries"></div>
                             <div id="CloseAllWIEntries" class="menu_button fa-solid fa-compress" title="Close all Entries" data-i18n="[title]Close all Entries"></div>
                             <div id="world_popup_new" class="menu_button fa-solid fa-plus" title="New Entry" data-i18n="[title]New Entry"></div>
-                            <div id="world_backfill_memos" class="menu_button fa-solid fa-notes-medical" title="Fill empty Memo/Titles with Keywords" data-i18n="[title]Fill empty Memo/Titles with Keywords"></div>
+                            <div id="world_backfill_memos" class="menu_button fa-solid fa-notes-medical" title="Fill empty Memo/Titles with Keywords" data-i18n="[title]Fill empty Memo/Titles with Keywords"></div><div id="world_apply_custom_sorting" class="menu_button fa-solid fa-solid fa-arrow-down-9-1"
+                                title="Apply custom sorting as Order" data-i18n="[title]Apply custom sorting as Order"></div>
                             <div id="world_import_button" class="menu_button fa-solid fa-file-import" title="Import World Info" data-i18n="[title]Import World Info"></div>
                             <div id="world_popup_export" class="menu_button fa-solid fa-file-export" title="Export World Info" data-i18n="[title]Export World Info"></div>
                             <div id="world_duplicate" class="menu_button fa-solid fa-paste" title="Duplicate World Info" data-i18n="[title]Duplicate World Info"></div>

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1937,10 +1937,10 @@ function displayWorldEntries(name, data, navigation = navigation_option.none, fl
 
         let content = '<span>Apply your custom sorting to the "Order" field. The Order values will go down from the chosen number.</span>';
         if (moreThan100) {
-            content += `<div class="m-t-1"><i class="fa-solid fa-triangle-exclamation" style="color: #FFD43B;"></i> More than 100 entries in this world. You have to choose a number higher than that to work.<br />(Usual default: 100)<br />Minimum: ${entryCount}</div>`;
+            content += `<div class="m-t-1"><i class="fa-solid fa-triangle-exclamation" style="color: #FFD43B;"></i> More than 100 entries in this world. If you don't choose a number higher than that, the lower entries will default to 0.<br />(Usual default: 100)<br />Minimum: ${entryCount}</div>`;
         }
 
-        const result = await Popup.show.input('Apply Custom Sorting', content, moreThan100 ? '' : '100', { okButton: 'Apply', cancelButton: 'Cancel' });
+        const result = await Popup.show.input('Apply Custom Sorting', content, '100', { okButton: 'Apply', cancelButton: 'Cancel' });
         if (!result) return;
 
         const start = Number(result);
@@ -1949,13 +1949,12 @@ function displayWorldEntries(name, data, navigation = navigation_option.none, fl
             return;
         }
         if (start < entryCount) {
-            toastr.warning('The number must be higher than the total entry count: ' + entryCount, 'Apply Custom Sorting');
-            return;
+            toastr.warning('A number lower than the entry count has been chosen. All entries below that will default to 0.', 'Apply Custom Sorting');
         }
 
         let counter = 0;
         for (const entry of Object.values(data.entries)) {
-            const newOrder = start - (entry.displayIndex ?? 0);
+            const newOrder = Math.max(start - (entry.displayIndex ?? 0), 0);
             if (entry.order === newOrder) continue;
 
             entry.order = newOrder;

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1931,6 +1931,47 @@ function displayWorldEntries(name, data, navigation = navigation_option.none, fl
         }
     });
 
+    $('#world_apply_custom_sorting').off('click').on('click', async () => {
+        const entryCount = Object.keys(data.entries).length;
+        const moreThan100 = entryCount > 100;
+
+        let content = '<span>Apply your custom sorting to the "Order" field. The Order values will go down from the chosen number.</span>';
+        if (moreThan100) {
+            content += `<div class="m-t-1"><i class="fa-solid fa-triangle-exclamation" style="color: #FFD43B;"></i> More than 100 entries in this world. You have to choose a number higher than that to work.<br />(Usual default: 100)<br />Minimum: ${entryCount}</div>`;
+        }
+
+        const result = await Popup.show.input('Apply Custom Sorting', content, moreThan100 ? '' : '100', { okButton: 'Apply', cancelButton: 'Cancel' });
+        if (!result) return;
+
+        const start = Number(result);
+        if (isNaN(start) || start < 0) {
+            toastr.error('Invalid number: ' + result, 'Apply Custom Sorting');
+            return;
+        }
+        if (start < entryCount) {
+            toastr.warning('The number must be higher than the total entry count: ' + entryCount, 'Apply Custom Sorting');
+            return;
+        }
+
+        let counter = 0;
+        for (const entry of Object.values(data.entries)) {
+            const newOrder = start - (entry.displayIndex ?? 0);
+            if (entry.order === newOrder) continue;
+
+            entry.order = newOrder;
+            setOriginalDataValue(data, entry.order, 'order', entry.order);
+            counter++;
+        }
+
+        if (counter > 0) {
+            toastr.info(`Updated ${counter} Order values`, 'Apply Custom Sorting');
+            await saveWorldInfo(name, data, true);
+            updateEditor(navigation_option.previous);
+        } else {
+            toastr.info('All values up to date', 'Apply Custom Sorting');
+        }
+    });
+
     $('#world_popup_export').off('click').on('click', () => {
         if (name && data) {
             const jsonValue = JSON.stringify(data);


### PR DESCRIPTION
### Use Case:
People who use custom sorting in WI might do that just for a specific display order. But most often, their sorting will also make sense for the actual sorting of the entries being inserted into the context.
To not break compatibility, I made a neat button, similar to the prefill for memo/title field, that will just update the "Order" value of all entries in the book, based on a a descending value of the inde


### Notes:
- Adds a button that automatically updates the "Order" values of entries based on the custom sorting order ("displayIndex")
- Shows popup to choose starting value, because it's descending (default: 100)
- shows warnings/errors if any issues appear with the value
- warning inside popup if more than 100 entries exist, and a higher value should be chosen
- Warns if number is below entry count, make rest of entries default to Order: 0
- Implements #2533

### Showcase:
![image](https://github.com/user-attachments/assets/42f7a834-a1db-4a6b-8b6f-3b7fa80a1db6)
![image](https://github.com/user-attachments/assets/77cfb834-a657-46ca-bdce-862fe43b54df)
![image](https://github.com/user-attachments/assets/3376bd5e-7a7b-417f-9845-3a094f0ae8f4)



## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
