### PR TITLE
Remove DOM queries and jQuery during streaming

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2797,6 +2797,10 @@ class StreamingProcessor {
     constructor(type, force_name2, timeStarted, messageAlreadyGenerated) {
         this.result = '';
         this.messageId = -1;
+        this.messageDom = null;
+        this.messageTextDom = null;
+        this.messageTimerDom = null;
+        this.sendTextarea = document.querySelector('#send_textarea');
         this.type = type;
         this.force_name2 = force_name2;
         this.isStopped = false;
@@ -2833,11 +2837,15 @@ class StreamingProcessor {
         let messageId = -1;
 
         if (this.type == 'impersonate') {
-            $('#send_textarea').val('')[0].dispatchEvent(new Event('input', { bubbles: true }));
+            this.sendTextarea.value = '';
+            this.sendTextarea.dispatchEvent(new Event('input', { bubbles: true }));
         }
         else {
             await saveReply(this.type, text, true);
             messageId = chat.length - 1;
+            this.messageDom = document.querySelector(`#chat .mes[mesid="${messageId}"]`);
+            this.messageTextDom = this.messageDom.querySelector('.mes_text');
+            this.messageTimerDom = this.messageDom.querySelector('.mes_timer');
             this.showMessageButtons(messageId);
         }
 
@@ -2869,7 +2877,8 @@ class StreamingProcessor {
         }
 
         if (isImpersonate) {
-            $('#send_textarea').val(processedText)[0].dispatchEvent(new Event('input', { bubbles: true }));
+            this.sendTextarea.value = processedText;
+            this.sendTextarea.dispatchEvent(new Event('input', { bubbles: true }));
         }
         else {
             let currentTime = new Date();
@@ -2902,9 +2911,9 @@ class StreamingProcessor {
                 chat[messageId].is_user,
                 messageId,
             );
-            const mesText = $(`#chat .mes[mesid="${messageId}"] .mes_text`);
-            mesText.html(formattedText);
-            $(`#chat .mes[mesid="${messageId}"] .mes_timer`).text(timePassed.timerValue).attr('title', timePassed.timerTitle);
+            this.messageTextDom.innerHTML = formattedText;
+            this.messageTimerDom.textContent = timePassed.timerValue;
+            this.messageTimerDom.title = timePassed.timerTitle;
             this.setFirstSwipe(messageId);
         }
 


### PR DESCRIPTION
`StreamingProcessor.onProgressStreaming()` used jQuery to query for all of the updated elements on every streaming tick.
Querying for them once in `onStartStreaming()` and using vanilla JS to apply the updates makes for a massive performance improvement. In my test cases bringing CPU utilization during streaming down from around 25% to single digits.

Just for fun I also checked if using morphdom would have any further impact but did not see a noticeable effect. Likely because A: chat message DOM is fairly simple and B: all changes are pretty much (not 100% but close enough) just appended at the end of the existing HTML.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
