### PR TITLE
Improve auto-scroll snapping

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9254,6 +9254,11 @@ jQuery(async function () {
     });
     const chatElementScroll = document.getElementById('chat');
     const chatScrollHandler = function () {
+        if (power_user.waifuMode) {
+            scrollLock = true;
+            return;
+        }
+
         const scrollIsAtBottom = Math.abs(chatElementScroll.scrollHeight - chatElementScroll.clientHeight - chatElementScroll.scrollTop) < 1;
 
         // Cancel autoscroll if the user scrolls up

--- a/public/script.js
+++ b/public/script.js
@@ -9253,12 +9253,21 @@ jQuery(async function () {
         }
     });
     const chatElementScroll = document.getElementById('chat');
-    chatElementScroll.addEventListener('wheel', function () {
-        scrollLock = true;
-    }, { passive: true });
-    chatElementScroll.addEventListener('touchstart', function () {
-        scrollLock = true;
-    }, { passive: true });
+    const chatScrollHandler = function () {
+        const scrollIsAtBottom = Math.abs(chatElementScroll.scrollHeight - chatElementScroll.clientHeight - chatElementScroll.scrollTop) < 1;
+
+        // Cancel autoscroll if the user scrolls up
+        if (scrollLock && scrollIsAtBottom) {
+            scrollLock = false;
+        }
+
+        // Resume autoscroll if the user scrolls to the bottom
+        if (!scrollLock && !scrollIsAtBottom) {
+            scrollLock = true;
+        }
+    };
+    chatElementScroll.addEventListener('wheel', chatScrollHandler, { passive: true });
+    chatElementScroll.addEventListener('touchmove', chatScrollHandler, { passive: true });
     chatElementScroll.addEventListener('scroll', function () {
         if (is_use_scroll_holder) {
             this.scrollTop = scroll_holder;

--- a/public/script.js
+++ b/public/script.js
@@ -9261,12 +9261,12 @@ jQuery(async function () {
 
         const scrollIsAtBottom = Math.abs(chatElementScroll.scrollHeight - chatElementScroll.clientHeight - chatElementScroll.scrollTop) < 1;
 
-        // Cancel autoscroll if the user scrolls up
+        // Resume autoscroll if the user scrolls to the bottom
         if (scrollLock && scrollIsAtBottom) {
             scrollLock = false;
         }
 
-        // Resume autoscroll if the user scrolls to the bottom
+        // Cancel autoscroll if the user scrolls up
         if (!scrollLock && !scrollIsAtBottom) {
             scrollLock = true;
         }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

> Only stop if you scroll away from the autoscrolling position. And resume when you manually scroll back to where autoscrolling would currently take you.

Autoscrolling position = bottom of the chat. We don't count weirdness like reverse order on chat with the CSS.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
