### PR TITLE
Fix /send not saving chat in all cases

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4698,6 +4698,7 @@ export async function sendMessageAsUser(messageText, messageBias, insertAt = nul
         await eventSource.emit(event_types.MESSAGE_SENT, chat_id);
         addOneMessage(message);
         await eventSource.emit(event_types.USER_MESSAGE_RENDERED, chat_id);
+        await saveChatConditional();
     }
 }
 


### PR DESCRIPTION
As title says. Opposite to `/sendas` or `/sys`, the `/send` didn't save the chat if it was added as the last message.

Normally, chat does save on all messages, and on user messages too. So this makes sense.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
