### PR TITLE
Minor group chat timestamp fix

### DIFF
--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -14,7 +14,7 @@ import {
     saveChatConditional,
     saveItemizedPrompts,
 } from '../script.js';
-import { humanizedDateTime } from './RossAscends-mods.js';
+import { humanizedDateTime, getMessageTimeStamp } from './RossAscends-mods.js';
 import {
     getGroupPastChats,
     group_activation_strategy,
@@ -297,7 +297,7 @@ async function convertSoloToGroupChat() {
     if (groupChat.length === 0) {
         const newMessage = {
             ...system_messages[system_message_types.GROUP],
-            send_date: humanizedDateTime(),
+            send_date: getMessageTimeStamp(),
             extra: { type: system_message_types.GROUP },
         };
         groupChat.push(newMessage);


### PR DESCRIPTION
I was initially going to make this a part of my upcoming PR, but decided to separate this out.

send_date is supposed to have the meridiem-based timestamp that getMessageTimeStamp provides (e.g. `June 19, 2023 2:20pm`), but for some reason this particular instance was the odd one out.

Probably has extremely little consequence, but I saw it, so here's the fix.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
