### PR TITLE
Improve Mistral prompt conversion

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -483,7 +483,7 @@ async function sendMistralAIRequest(request, response) {
     }
 
     try {
-        const messages = convertMistralMessages(request.body.messages, request.body.model, request.body.char_name, request.body.user_name);
+        const messages = convertMistralMessages(request.body.messages, request.body.char_name, request.body.user_name);
         const controller = new AbortController();
         request.socket.removeAllListeners('close');
         request.socket.on('close', function () {

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -364,64 +364,48 @@ function convertGooglePrompt(messages, model, useSysPrompt = false, charName = '
 /**
  * Convert a prompt from the ChatML objects to the format used by MistralAI.
  * @param {object[]} messages Array of messages
- * @param {string} model Model name
  * @param {string} charName Character name
  * @param {string} userName User name
  */
-function convertMistralMessages(messages, model, charName = '', userName = '') {
+function convertMistralMessages(messages, charName = '', userName = '') {
     if (!Array.isArray(messages)) {
         return [];
     }
 
-    //large seems to be throwing a 500 error if we don't make the first message a user role, most likely a bug since the other models won't do this
-    if (model.includes('large')) {
-        messages[0].role = 'user';
-    }
-
-    //must send a user role as last message
+    // Make the last assistant message a prefill
     const lastMsg = messages[messages.length - 1];
-    if (messages.length > 0 && lastMsg && (lastMsg.role === 'system' || lastMsg.role === 'assistant')) {
-        if (lastMsg.role === 'assistant' && lastMsg.name) {
-            lastMsg.content = lastMsg.name + ': ' + lastMsg.content;
-        } else if (lastMsg.role === 'system') {
-            lastMsg.content = '[INST] ' + lastMsg.content + ' [/INST]';
-        }
-        lastMsg.role = 'user';
+    if (messages.length > 0 && lastMsg && (lastMsg.role === 'assistant')) {
+        lastMsg.prefix = true;
     }
 
-    //system prompts can be stacked at the start, but any futher sys prompts after the first user/assistant message will break the model
-    let encounteredNonSystemMessage = false;
+    // Doesn't support completion names, so prepend if not already done by the frontend (e.g. for group chats).
     messages.forEach(msg => {
         if (msg.role === 'system' && msg.name === 'example_assistant') {
-            if (charName) {
+            if (charName && !msg.content.startsWith(`${charName}: `)) {
                 msg.content = `${charName}: ${msg.content}`;
             }
             delete msg.name;
         }
 
         if (msg.role === 'system' && msg.name === 'example_user') {
-            if (userName) {
+            if (userName && !msg.content.startsWith(`${userName}: `)) {
                 msg.content = `${userName}: ${msg.content}`;
             }
             delete msg.name;
         }
 
-        if (msg.name) {
+        if (msg.name && msg.role !== 'system' && !msg.content.startsWith(`${msg.name}: `)) {
             msg.content = `${msg.name}: ${msg.content}`;
             delete msg.name;
         }
-
-        if ((msg.role === 'user' || msg.role === 'assistant') && !encounteredNonSystemMessage) {
-            encounteredNonSystemMessage = true;
-        }
-
-        if (encounteredNonSystemMessage && msg.role === 'system') {
-            msg.role = 'user';
-            //unsure if the instruct version is what they've deployed on their endpoints and if this will make a difference or not.
-            //it should be better than just sending the message as a user role without context though
-            msg.content = '[INST] ' + msg.content + ' [/INST]';
-        }
     });
+
+    // If system role message immediately follows an assistant message, change its role to user
+    for (let i = 0; i < messages.length - 1; i++) {
+        if (messages[i].role === 'assistant' && messages[i + 1].role === 'system') {
+            messages[i + 1].role = 'user';
+        }
+    }
 
     return messages;
 }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Closes #2557 

## Changes:

* System messages after non-system messages are no longer converted to user messages unless a system message _immediately follows_ an assistant role. Otherwise, Mistral returns a Bad Request.
* Fixed potential duplication of names added to the message content if they were already added by the frontend.
* If the prompt ends with an assistant role message, it is marked as a prefix (i.e. a prefill). To accomplish this - make a relative post-history assistant injection in a prompt manager. The example is attached below.

<div style="display: flex">
<img src="https://github.com/user-attachments/assets/87efb5c8-83c5-4b19-ab6d-cc43ec627c75" height="400" />
<img src="https://github.com/user-attachments/assets/8a523c15-09b3-4b7b-ab36-c7e9c7e2dcaf" height="300" />
</div>

I did not aim to replicate Claude's special treatment of prefills. If you know that I don't like it, you know.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
