### PR TITLE
Add first/last user messages prefixes for instruct mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3297,6 +3297,24 @@
                                         </div>
                                     </div>
                                     <div class="flex-container">
+                                        <div class="flex1" title="Inserted before the first User's message." data-i18n="[title]Inserted before the first User's message.">
+                                            <label for="instruct_first_input_sequence">
+                                                <small data-i18n="First User Prefix">First User Prefix</small>
+                                            </label>
+                                            <div>
+                                                <textarea id="instruct_first_input_sequence" class="text_pole textarea_compact autoSetHeight" maxlength="2000" placeholder="&mdash;" rows="1"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="flex1" title="Inserted before the last User's message." data-i18n="[title]instruct_last_input_sequence">
+                                            <label for="instruct_last_input_sequence">
+                                                <small data-i18n="Last User Prefix">Last User Prefix</small>
+                                            </label>
+                                            <div>
+                                                <textarea id="instruct_last_input_sequence" class="text_pole wide100p textarea_compact autoSetHeight" maxlength="2000" placeholder="&mdash;" rows="1"></textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="flex-container">
                                         <div class="flex1" title="Will be inserted as a last prompt line when using system/neutral generation." data-i18n="[title]Will be inserted as a last prompt line when using system/neutral generation.">
                                             <label for="instruct_last_system_sequence">
                                                 <small data-i18n="System Instruction Prefix">System Instruction Prefix</small>

--- a/public/script.js
+++ b/public/script.js
@@ -3611,6 +3611,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     let chat2 = [];
     let continue_mag = '';
     const userMessageIndices = [];
+    const lastUserMessageIndex = coreChat.findLastIndex(x => x.is_user);
 
     for (let i = coreChat.length - 1, j = 0; i >= 0; i--, j++) {
         if (main_api == 'openai') {
@@ -3627,6 +3628,11 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         if (j === 0 && isInstruct) {
             // Reformat with the first output sequence (if any)
             chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.FIRST);
+        }
+
+        if (lastUserMessageIndex >= 0 && j === lastUserMessageIndex && isInstruct) {
+            // Reformat with the last input sequence (if any)
+            chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.LAST);
         }
 
         // Do not suffix the message for continuation
@@ -3654,7 +3660,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             mes: power_user.instruct.user_alignment_message,
             is_user: true,
         };
-        userAlignmentMessage = formatMessageHistoryItem(alignmentMessage, isInstruct, false);
+        userAlignmentMessage = formatMessageHistoryItem(alignmentMessage, isInstruct, force_output_sequence.FIRST);
     }
 
     // Call combined AN into Generate

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -34,6 +34,8 @@ const controls = [
     { id: 'instruct_names_force_groups', property: 'names_force_groups', isCheckbox: true },
     { id: 'instruct_first_output_sequence', property: 'first_output_sequence', isCheckbox: false },
     { id: 'instruct_last_output_sequence', property: 'last_output_sequence', isCheckbox: false },
+    { id: 'instruct_first_input_sequence', property: 'first_input_sequence', isCheckbox: false },
+    { id: 'instruct_last_input_sequence', property: 'last_input_sequence', isCheckbox: false },
     { id: 'instruct_activation_regex', property: 'activation_regex', isCheckbox: false },
     { id: 'instruct_bind_to_context', property: 'bind_to_context', isCheckbox: true },
     { id: 'instruct_skip_examples', property: 'skip_examples', isCheckbox: true },
@@ -58,6 +60,8 @@ function migrateInstructModeSettings(settings) {
         system_suffix: '',
         user_alignment_message: '',
         last_system_sequence: '',
+        first_input_sequence: '',
+        last_input_sequence: '',
         names_force_groups: true,
         skip_examples: false,
         system_same_as_user: false,
@@ -253,7 +257,15 @@ export function getInstructStoppingSequences() {
         const system_sequence = power_user.instruct.system_sequence?.replace(/{{name}}/gi, 'System') || '';
         const last_system_sequence = power_user.instruct.last_system_sequence?.replace(/{{name}}/gi, 'System') || '';
 
-        const combined_sequence = `${stop_sequence}\n${input_sequence}\n${output_sequence}\n${first_output_sequence}\n${last_output_sequence}\n${system_sequence}\n${last_system_sequence}`;
+        const combined_sequence = [
+            stop_sequence,
+            input_sequence,
+            output_sequence,
+            first_output_sequence,
+            last_output_sequence,
+            system_sequence,
+            last_system_sequence,
+        ].join('\n');
 
         combined_sequence.split('\n').filter((line, index, self) => self.indexOf(line) === index).forEach(addInstructSequence);
     }
@@ -301,6 +313,14 @@ export function formatInstructModeChat(name, mes, isUser, isNarrator, forceAvata
         }
 
         if (isUser) {
+            if (forceOutputSequence === force_output_sequence.FIRST) {
+                return power_user.instruct.first_input_sequence || power_user.instruct.input_sequence;
+            }
+
+            if (forceOutputSequence === force_output_sequence.LAST) {
+                return power_user.instruct.last_input_sequence || power_user.instruct.input_sequence;
+            }
+
             return power_user.instruct.input_sequence;
         }
 
@@ -552,6 +572,8 @@ export function replaceInstructMacros(input, env) {
         'instructStop': power_user.instruct.stop_sequence,
         'instructUserFiller': power_user.instruct.user_alignment_message,
         'instructSystemInstructionPrefix': power_user.instruct.last_system_sequence,
+        'instructFirstInput|instructFirstUserPrefix': power_user.instruct.first_input_sequence || power_user.instruct.input_sequence,
+        'instructLastInput|instructLastUserPrefix': power_user.instruct.last_input_sequence || power_user.instruct.input_sequence,
     };
 
     for (const [placeholder, value] of Object.entries(instructMacros)) {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -2175,7 +2175,7 @@ function validateStoryString(storyString, params) {
     validateMissingField('personality');
     validateMissingField('persona');
     validateMissingField('scenario');
-    validateMissingField('system');
+    // validateMissingField('system');
     validateMissingField('wiBefore', 'loreBefore');
     validateMissingField('wiAfter', 'loreAfter');
 

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -72,6 +72,8 @@
     <li><tt>&lcub;&lcub;instructSystemInstructionPrefix&rcub;&rcub;</tt> – <span data-i18n="help_macros_56">instruct system instruction prefix</span></li>
     <li><tt>&lcub;&lcub;instructUserFiller&rcub;&rcub;</tt> – <span data-i18n="help_macros_57">instruct first user message filler</span></li>
     <li><tt>&lcub;&lcub;instructStop&rcub;&rcub;</tt> – <span data-i18n="help_macros_58">instruct stop sequence</span></li>
+    <li><tt>&lcub;&lcub;instructFirstUserPrefix&rcub;&rcub;</tt> – <span data-i18n="help_macros_first_user">instruct user first input sequence</span></li>
+    <li><tt>&lcub;&lcub;instructLastUserPrefix&rcub;&rcub;</tt> – <span data-i18n="help_macros_last_user">instruct user last input sequence</span></li>
 </ul>
 <div data-i18n="Chat variables Macros:">
     Chat variables Macros:


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Should help with very weird new Mistral formats.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
