### PR TITLE
/theme allows returning current theme & fix /theme and /bg doc

### DIFF
--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -2968,7 +2968,13 @@ function setAvgBG() {
     return '';
 }
 
-async function setThemeCallback(_, text) {
+async function setThemeCallback(_, themeName) {
+    if (!themeName) {
+        // allow reporting of the theme name if called without args
+        // for use in ST Scripts via pipe
+        return power_user.theme;
+    }
+
     // @ts-ignore
     const fuse = new Fuse(themes, {
         keys: [
@@ -2976,12 +2982,12 @@ async function setThemeCallback(_, text) {
         ],
     });
 
-    const results = fuse.search(text);
-    console.debug('Theme fuzzy search results for ' + text, results);
+    const results = fuse.search(themeName);
+    console.debug('Theme fuzzy search results for ' + themeName, results);
     const theme = results[0]?.item;
 
     if (!theme) {
-        toastr.warning(`Could not find theme with name: ${text}`);
+        toastr.warning(`Could not find theme with name: ${themeName}`);
         return;
     }
 
@@ -4056,13 +4062,30 @@ $(document).ready(() => {
         callback: setThemeCallback,
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
-                description: 'name',
+                description: 'theme name',
                 typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
                 enumProvider: () => themes.map(theme => new SlashCommandEnumValue(theme.name)),
             }),
         ],
-        helpString: 'sets a UI theme by name',
+        helpString: `
+        <div>
+            Sets a UI theme by name.
+        </div>
+        <div>
+            If no theme name is is provided, this will return the currently active theme.
+        </div>
+        <div>
+            <strong>Example:</strong>
+            <ul>
+                <li>
+                    <pre><code>/theme Cappuccino</code></pre>
+                </li>
+                <li>
+                    <pre><code>/theme</code></pre>
+                </li>
+            </ul>
+        </div>
+    `,
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'movingui',

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -139,9 +139,8 @@ export function initDefaultSlashCommands() {
         returns: 'the current background',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
-                description: 'filename',
+                description: 'background filename',
                 typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
                 enumProvider: () => [...document.querySelectorAll('.bg_example')]
                     .map(it => new SlashCommandEnumValue(it.getAttribute('bgfile')))
                     .filter(it => it.value?.length),
@@ -152,10 +151,16 @@ export function initDefaultSlashCommands() {
             Sets a background according to the provided filename. Partial names allowed.
         </div>
         <div>
+            If no background is provided, this will return the currently selected background.
+        </div>
+        <div>
             <strong>Example:</strong>
             <ul>
                 <li>
                     <pre><code>/bg beach.jpg</code></pre>
+                </li>
+                <li>
+                    <pre><code>/bg</code></pre>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
### Minor changes
- Allow `/theme` to return the current theme. (works similar to other commands, like `/bg`)
- Expand documentation for `/theme`
- Update documentation for `/bg` to match what it does. (mentioning the empty args return, and fix arg not being required)

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
