### PR TITLE
Fix: Properly handle text responses when character name is not provided in sendas cmd

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2847,7 +2847,6 @@ export async function sendMessageAs(args, text) {
 
     if (args.name) {
         name = args.name.trim();
-        mesText = text.trim();
 
         if (!name && !text) {
             toastr.warning('You must specify a name and text to send as');
@@ -2860,7 +2859,13 @@ export async function sendMessageAs(args, text) {
             localStorage.setItem(namelessWarningKey, 'true');
         }
         name = name2;
+        if (!text) {
+            toastr.warning('You must specify text to send as');
+            return '';
+        }
     }
+
+    mesText = text.trim();
 
     // Requires a regex check after the slash command is pushed to output
     mesText = getRegexedString(mesText, regex_placement.SLASH_COMMAND, { characterOverride: name });


### PR DESCRIPTION
# Issue:

There seems to be a bug in the following QR script that leads to {{char}} name not being used in `sendas` cmd.

Feel free to add this as a QR button to test the fix.
```
/setvar key=userQuery {{input}} |
/if left={{getvar::userQuery}} right="" rule=eq
    else={: 
    /send (OOC: {{getvar::userQuery}}) |
    /setvar key=completeOOC {{pipe}} ||
    /setinput {{noop}} |
    /pass | :}
{: /buttons labels=["I understand"] The message was blank! Type something first! | 
    /abort 
:} |

/let "demarc" {{newline}}{{newline}}---{{newline}}{{newline}} |

/if left={{getvar::UpdateTracker}} right="" rule=eq {: 
	/setvar key=UpdateTracker # World Tracker {{newline}}{{newline}}**Current Time/Date:** HH:MM:SS; <MM/DD/YYYY> (<insert name of day, i.e. Saturday, without arrows>){{newline}}**Current Location:** {{newline}}**Current Weather:** {{var::demarc}}# <insert Character Name>{{newline}}{{newline}}**Wearing:** {{newline}}{{newline}}- clothingitem1{{newline}}- clothingitem2{{newline}}{{newline}}**Current Position:** |
:} |

/gen lock=on name={{char}} (OOC: Pause the adventure/chat and do not continue it, only answer the OOC message: ``{{getvar::completeOOC}}``. If {{user}} points out you made a mistake, explain yourself fully on why you made the mistake. Use this template for replying: (OOC: [your message here without brackets])) |
/sendas name={{char}} {{pipe}} |

/flushvar userQuery |
/flushvar completeOOC |
```

This results in the following error:
```
engine.js:52 getRegexedString: rawString is not a string. Returning empty string.
getRegexedString @ engine.js:52
sendMessageAs @ slash-commands.js:2871
executeDirect @ SlashCommandClosure.js:251
eventemitter.js:101 Event emitted: message_received
eventemitter.js:101 Event emitted: character_message_rendered
index.js:18 [QR2] calling {args: Array(1), functionToCall: ƒ}
eventemitter.js:101 Event emitted: message_added
log.js:3 [STCDX2] QUEUE MESSAGE AND CYCLE [4]
log.js:3 [STCDX2] QUEUE MESSAGE [4]
index.js:1400 entered setExpressions
index.js:1407 checking for expression images to show..
index.js:1409 setting expression from character images folder
log.js:3 [STCDX2] PROCESS QUEUE [4]
log.js:3 [STCDX2] UPDATE MESSAGE <div class=​"mes_text">​</div>​
log.js:3 [STCDX2] ADD CODEX LINKS 
log.js:3 [STCDX2] MATCHER.checkNodes
log.js:3 [STCDX2] /MATCHER.checkNodes []
log.js:3 [STCDX2] /ADD CODEX LINKS
log.js:3 [STCDX2] /UPDATE MESSAGE <div class=​"mes_text">​</div>​
log.js:3 [STCDX2] /PROCESS QUEUE
index.js:10 [MFC] CHARACTER_MESSAGE_RENDERED [4]
tokenizers.js:125 Chat Completions: saving token cache
extensions.js:31 Clearing save metadata timeout
extensions.js:31 Clearing save metadata timeout
index.js:280 Vectors: Found 2 new items. Processing 5...
index.js:807 
        
        
       POST http://127.0.0.1:8000/api/vector/insert 500 (Internal Server Error)
insertVectorItems @ index.js:807
synchronizeChat @ index.js:281
await in synchronizeChat (async)
update @ extensions.js:97
(anonymous) @ index.js:637
(anonymous) @ utils.js:290
setTimeout (async)
fn @ utils.js:290
EventEmitter.emit @ eventemitter.js:112
await in EventEmitter.emit (async)
sendMessageAs @ slash-commands.js:2938
executeDirect @ SlashCommandClosure.js:251
index.js:311 Vectors: Failed to synchronize chat Error: Failed to insert vector items for collection Seraphina - 2024-07-27@21h34m52s
    at insertVectorItems (index.js:818:15)
    at async ModuleWorkerWrapper.synchronizeChat [as callback] (index.js:281:13)
    at async ModuleWorkerWrapper.update (extensions.js:97:13)
    at async index.js:637:42
synchronizeChat @ index.js:311
await in synchronizeChat (async)
update @ extensions.js:97
(anonymous) @ index.js:637
(anonymous) @ utils.js:290
setTimeout (async)
fn @ utils.js:290
EventEmitter.emit @ eventemitter.js:112
await in EventEmitter.emit (async)
sendMessageAs @ slash-commands.js:2938
executeDirect @ SlashCommandClosure.js:251

```
Resulting in an empty reply and vectorization error (due to empty reply):
![image](https://github.com/user-attachments/assets/536410f8-6d13-4c14-a573-b65de57d8091)



# Solution:

The root cause of the QR issue is not identified but the code needs to simply account for msgText being set if the sendas character is being defaulted.

This results in a proper response no error/warning in console logs.
![image](https://github.com/user-attachments/assets/cbd01c5a-7a04-415a-97ba-d0449b4d7119)


## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
