### PR TITLE
Fix colors resetting on Tag Management dragging

### DIFF
--- a/public/css/tags.css
+++ b/public/css/tags.css
@@ -209,20 +209,20 @@
     opacity: 1;
 }
 
-.tag_as_folder {
+.tag_as_folder.right_menu_button {
     filter: brightness(75%) saturate(0.6);
 }
 
-.tag_as_folder:hover,
-.tag_as_folder.flash {
-    filter: brightness(150%) saturate(0.6) !important;
+.tag_as_folder.right_menu_button:hover,
+.tag_as_folder.right_menu_button.flash {
+    filter: brightness(150%) saturate(0.6);
 }
 
-.tag_as_folder.no_folder {
+.tag_as_folder.right_menu_button.no_folder {
     filter: brightness(25%) saturate(0.25);
 }
 
-.tag_as_folder .tag_folder_indicator {
+.tag_as_folder.right_menu_button .tag_folder_indicator {
     position: absolute;
     top: calc(var(--mainFontSize) * -0.5);
     right: calc(var(--mainFontSize) * -0.5);

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1367,27 +1367,8 @@ function makeTagListDraggable(tagContainer) {
             const id = $(tagElement).attr('id');
             const tag = tags.find(x => x.id === id);
 
-            // Fix the defined colors, because if there is no color set, they seem to get automatically set to black
-            // based on the color picker after drag&drop, even if there was no color chosen. We just set them back.
-            const color = $(tagElement).find('.tagColorPickerHolder .tag-color').attr('color');
-            const color2 = $(tagElement).find('.tagColorPicker2Holder .tag-color2').attr('color');
-            if (color === '' || color === undefined) {
-                tag.color = '';
-                fixColor('background-color', tag.color);
-            }
-            if (color2 === '' || color2 === undefined) {
-                tag.color2 = '';
-                fixColor('color', tag.color2);
-            }
-
             // Update the sort order
             tag.sort_order = i;
-
-            function fixColor(property, color) {
-                $(tagElement).find('.tag_view_name').css(property, color);
-                $(`.tag[id="${id}"]`).css(property, color);
-                $(`.bogus_folder_select[tagid="${id}"] .avatar`).css(property, color);
-            }
         });
 
         // If tags were dragged manually, we have to disable auto sorting


### PR DESCRIPTION
Fixed tag colors resetting when a tag was dragging in the tag management window.
Critical issue, was my oversight. me dum.
That workaround that was *resetting* the colors wasn't needed anymore anyway, since I changed how the colors work and added the theme color binding.

I also fixed the CSS selector that made the folder checkmark if it was chosen as a folder appear in greyscale, making it hard to see that it's actually a selected folder now.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
