### PR TITLE
Improve Tag Backup Restore functionality

### DIFF
--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -101,6 +101,21 @@ const showPopupHelper = {
         if (typeof result === 'string' || typeof result === 'boolean') throw new Error(`Invalid popup result. CONFIRM popups only support numbers, or null. Result: ${result}`);
         return result;
     },
+    /**
+     * Asynchronously displays a text popup with the given header and text, returning the clicked result button value.
+     *
+     * @param {string?} header - The header text for the popup.
+     * @param {string?} text - The main text for the popup.
+     * @param {PopupOptions} [popupOptions={}] - Options for the popup.
+     * @return {Promise<POPUP_RESULT>} A Promise that resolves with the result of the user's interaction.
+     */
+    text: async (header, text, popupOptions = {}) => {
+        const content = PopupUtils.BuildTextWithHeader(header, text);
+        const popup = new Popup(content, POPUP_TYPE.TEXT, null, popupOptions);
+        const result = await popup.show();
+        if (typeof result === 'string' || typeof result === 'boolean') throw new Error(`Invalid popup result. TEXT popups only support numbers, or null. Result: ${result}`);
+        return result;
+    },
 };
 
 export class Popup {

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1450,8 +1450,8 @@ async function onTagRestoreFileSelect(e) {
     // Prompt user if they want to overwrite existing tags
     let overwrite = false;
     if (tags.length > 0) {
-        const result = await Popup.show.confirm('Tag Restore', 'You have existing tags. If the backup contains any of those tags, to you want the backup to overwrite your current tags?',
-            { okButton: 'Overwrite', cancelButton: 'Keep' });
+        const result = await Popup.show.confirm('Tag Restore', 'You have existing tags. If the backup contains any of those tags, do you want the backup to overwrite their settings (Name, color, folder state, etc)?',
+            { okButton: 'Overwrite', cancelButton: 'Keep Existing' });
         overwrite = result === POPUP_RESULT.AFFIRMATIVE;
     }
 

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1464,12 +1464,19 @@ async function onTagRestoreFileSelect(e) {
             continue;
         }
 
-        const existingTag = tags.find(x => x.id === tag.id);
+        // Check against both existing id (direct match) and tag with the same name, which is not allowed.
+        let existingTag = tags.find(x => x.id === tag.id);
+        if (existingTag && !overwrite) {
+            warnings.push(`Tag '${tag.name}' with id ${tag.id} already exists.`);
+            continue;
+        }
+        existingTag = getTag(tag.name);
+        if (existingTag && !overwrite) {
+            warnings.push(`Tag with name '${tag.name}' already exists.`);
+            continue;
+        }
+
         if (existingTag) {
-            if (!overwrite) {
-                warnings.push(`Tag with id ${tag.id} already exists.`);
-                continue;
-            }
             // On overwrite, we remove and re-add the tag
             removeFromArray(tags, existingTag);
         }
@@ -1491,7 +1498,7 @@ async function onTagRestoreFileSelect(e) {
         const groupExists = groups.some(x => String(x.id) === String(key));
 
         if (!characterExists && !groupExists) {
-            warnings.push(`Tag map key ${key} does not exist.`);
+            warnings.push(`Tag map key ${key} does not exist as character or group.`);
             continue;
         }
 

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1536,7 +1536,9 @@ async function onTagRestoreFileSelect(e) {
     printCharactersDebounced();
     saveSettingsDebounced();
 
-    await onViewTagsListClick();
+    // Reprint the tag management popup, without having it to be opened again
+    const tagContainer = $('#tag_view_list .tag_view_list_tags');
+    printViewTagList(tagContainer);
 }
 
 function onBackupRestoreClick() {

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1436,13 +1436,13 @@ async function onTagRestoreFileSelect(e) {
     const data = await parseJsonFile(file);
 
     if (!data) {
-        toastr.warning('Empty file data', 'Tag restore');
+        toastr.warning('Empty file data', 'Tag Restore');
         console.log('Tag restore: File data empty.');
         return;
     }
 
     if (!data.tags || !data.tag_map || !Array.isArray(data.tags) || typeof data.tag_map !== 'object') {
-        toastr.warning('Invalid file format', 'Tag restore');
+        toastr.warning('Invalid file format', 'Tag Restore');
         console.log('Tag restore: Invalid file format.');
         return;
     }
@@ -1450,7 +1450,8 @@ async function onTagRestoreFileSelect(e) {
     // Prompt user if they want to overwrite existing tags
     let overwrite = false;
     if (tags.length > 0) {
-        const result = await Popup.show.confirm('Tag Restore', 'You have existing tags. If the backup contains any of those tags, to you want the backup to overwrite your current tags?', { okButton: 'Overwrite', cancelButton: 'Keep' })
+        const result = await Popup.show.confirm('Tag Restore', 'You have existing tags. If the backup contains any of those tags, to you want the backup to overwrite your current tags?',
+            { okButton: 'Overwrite', cancelButton: 'Keep' });
         overwrite = result === POPUP_RESULT.AFFIRMATIVE;
     }
 
@@ -1463,13 +1464,14 @@ async function onTagRestoreFileSelect(e) {
             continue;
         }
 
-        if (tags.find(x => x.id === tag.id)) {
+        const existingTag = tags.find(x => x.id === tag.id);
+        if (existingTag) {
             if (!overwrite) {
                 warnings.push(`Tag with id ${tag.id} already exists.`);
                 continue;
             }
             // On overwrite, we remove and re-add the tag
-            removeFromArray(tags, tag);
+            removeFromArray(tags, existingTag);
         }
 
         tags.push(tag);
@@ -1502,10 +1504,13 @@ async function onTagRestoreFileSelect(e) {
     }
 
     if (warnings.length) {
-        toastr.success('Tags restored with warnings. Check console for details.', 'Tag restore');
+        toastr.warning('Tags restored with warnings. Check console or click on this message for details.', 'Tag Restore', {
+            timeOut: toastr.options.timeOut * 2, // Display double the time
+            onclick: () => Popup.show.text('Tag Restore Warnings', `<samp class="justifyLeft">${warnings.join('<br />')}<samp>`, { allowVerticalScrolling: true }),
+        });
         console.warn(`TAG RESTORE REPORT\n====================\n${warnings.join('\n')}`);
     } else {
-        toastr.success('Tags restored successfully.', 'Tag restore');
+        toastr.success('Tags restored successfully.', 'Tag Restore');
     }
 
     $('#tag_view_restore_input').val('');

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1525,7 +1525,7 @@ async function onTagRestoreFileSelect(e) {
     if (warnings.length) {
         toastr.warning('Tags restored with warnings. Check console or click on this message for details.', 'Tag Restore', {
             timeOut: toastr.options.timeOut * 2, // Display double the time
-            onclick: () => Popup.show.text('Tag Restore Warnings', `<samp class="justifyLeft">${warnings.join('<br />')}<samp>`, { allowVerticalScrolling: true }),
+            onclick: () => Popup.show.text('Tag Restore Warnings', `<samp class="justifyLeft">${DOMPurify.sanitize(warnings.join('\n'))}<samp>`, { allowVerticalScrolling: true }),
         });
         console.warn(`TAG RESTORE REPORT\n====================\n${warnings.join('\n')}`);
     } else {

--- a/public/style.css
+++ b/public/style.css
@@ -470,6 +470,13 @@ kbd {
     line-height: 1;
 }
 
+samp {
+    display: block;
+    font-family: var(--monoFontFamily);
+    white-space: pre-wrap;
+    text-align: start;
+    justify-content: left;
+}
 
 hr {
     background-image: linear-gradient(90deg, var(--transparent), var(--SmartThemeBodyColor), var(--transparent));


### PR DESCRIPTION
Multiple smaller changes to the tag backup restore functionality

### Tag Backup Restore
- If there are warnings on restore, the toast will be "warn", not "success", and be clickable. Opening a popup that shows the full log of warnings.
- Allow backup restore to overwrite existing tags (with user confirm popup), not simply skipping them. Providing a more true "restore" functionality.
- As tag names are supposed to be unique, additionally check on existing tag names, not just id, on import.
- Streamline and combine the tag map import to work when tags are either skipped or combined, so the actual resulting id is used for the mapping

### Additional Changes
- Added `Popup.show.text` utility method for easier calling of a simple text popup, with actual return value.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
