### PR TITLE
Update MakerSuite temperature caps

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4066,8 +4066,9 @@ async function onModelChange() {
         } else {
             $('#openai_max_context').attr('max', max_8k);
         }
-        oai_settings.temp_openai = Math.min(claude_max_temp, oai_settings.temp_openai);
-        $('#temp_openai').attr('max', claude_max_temp).val(oai_settings.temp_openai).trigger('input');
+        let makersuite_max_temp = (value.includes('vision') || value.includes('ultra')) ? 1.0 : 2.0;
+        oai_settings.temp_openai = Math.min(makersuite_max_temp, oai_settings.temp_openai);
+        $('#temp_openai').attr('max', makersuite_max_temp).val(oai_settings.temp_openai).trigger('input');
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
     }


### PR DESCRIPTION
Temperature ranges via the official documentation: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig

Worth mentioning that `top_k` is only used by `gemini-pro-vision` now ... and possibly `gemini-ultra`, which Google wants us to forget ever existed (since ultra is not mentioned anywhere on the page). Someone else can handle tackling hiding top_k unless those models are selected if they want.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
