### PR TITLE
Image generation stop handling

### DIFF
--- a/public/scripts/extensions/stable-diffusion/button.html
+++ b/public/scripts/extensions/stable-diffusion/button.html
@@ -1,5 +1,5 @@
 <div id="sd_gen" class="list-group-item flex-container flexGap5">
-    <div class="fa-solid fa-paintbrush extensionsMenuExtensionButton" title="Trigger Stable Diffusion"  data-i18n="[title]Trigger Stable Diffusion" /></div>
+    <div class="fa-solid fa-paintbrush extensionsMenuExtensionButton" title="Trigger Stable Diffusion"  data-i18n="[title]Trigger Stable Diffusion"></div>
     <span>Generate Image</span>
 </div>
 <div id="sd_stop_gen" class="list-group-item flex-container flexGap5">

--- a/public/scripts/extensions/stable-diffusion/button.html
+++ b/public/scripts/extensions/stable-diffusion/button.html
@@ -1,4 +1,8 @@
 <div id="sd_gen" class="list-group-item flex-container flexGap5">
     <div class="fa-solid fa-paintbrush extensionsMenuExtensionButton" title="Trigger Stable Diffusion"  data-i18n="[title]Trigger Stable Diffusion" /></div>
-    Generate Image
+    <span>Generate Image</span>
+</div>
+<div id="sd_stop_gen" class="list-group-item flex-container flexGap5">
+    <div class="fa-solid fa-circle-stop extensionsMenuExtensionButton" title="Abort current image generation task" data-i18n="[title]Abort current image generation task"></div>
+    <span>Stop Image Generation</span>
 </div>

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -37,6 +37,7 @@ const MODULE_NAME = 'sd';
 const UPDATE_INTERVAL = 1000;
 // This is a 1x1 transparent PNG
 const PNG_PIXEL = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+const CUSTOM_STOP_EVENT = 'sd_stop_generation';
 
 const sources = {
     extras: 'extras',
@@ -2290,6 +2291,7 @@ async function generatePicture(initiator, args, trigger, message, callback) {
 
     const dimensions = setTypeSpecificDimensions(generationType);
     const abortController = new AbortController();
+    const stopButton = document.getElementById('sd_stop_gen');
     let negativePromptPrefix = args?.negative || '';
     let imagePath = '';
 
@@ -2300,9 +2302,8 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         const prompt = await getPrompt(generationType, message, trigger, quietPrompt, combineNegatives);
         console.log('Processed image prompt:', prompt);
 
-        eventSource.once(event_types.GENERATION_STOPPED, stopListener);
-        context.deactivateSendButtons();
-        hideSwipeButtons();
+        $(stopButton).show();
+        eventSource.once(CUSTOM_STOP_EVENT, stopListener);
 
         if (typeof args?._abortController?.addEventListener === 'function') {
             args._abortController.addEventListener('abort', stopListener);
@@ -2314,10 +2315,9 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         throw new Error('SD prompt text generation failed.');
     }
     finally {
+        $(stopButton).hide();
         restoreOriginalDimensions(dimensions);
-        eventSource.removeListener(event_types.GENERATION_STOPPED, stopListener);
-        context.activateSendButtons();
-        showSwipeButtons();
+        eventSource.removeListener(CUSTOM_STOP_EVENT, stopListener);
     }
 
     return imagePath;
@@ -3425,6 +3425,10 @@ async function addSDGenButtons() {
             generatePicture(initiators.wand, {}, param);
         }
     });
+
+    const stopGenButton = $('#sd_stop_gen');
+    stopGenButton.hide();
+    stopGenButton.on('click', () => eventSource.emit(CUSTOM_STOP_EVENT));
 }
 
 function isValidState() {

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2312,7 +2312,8 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         imagePath = await sendGenerationRequest(generationType, prompt, negativePromptPrefix, characterName, callback, initiator, abortController.signal);
     } catch (err) {
         console.trace(err);
-        throw new Error('SD prompt text generation failed.');
+        toastr.error('SD prompt text generation failed. Reason: ' + err, 'Image Generation');
+        throw new Error('SD prompt text generation failed. Reason: ' + err);
     }
     finally {
         $(stopButton).hide();

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -3396,7 +3396,7 @@ async function addSDGenButtons() {
     $(document).on('click touchend', function (e) {
         const target = $(e.target);
         if (target.is(dropdown) || target.closest(dropdown).length) return;
-        if (target.is(button) && !dropdown.is(':visible') && $('#send_but').is(':visible')) {
+        if ((target.is(button) || target.closest(button).length) && !dropdown.is(':visible') && $('#send_but').is(':visible')) {
             e.preventDefault();
 
             dropdown.fadeIn(animation_duration);

--- a/public/scripts/extensions/translate/buttons.html
+++ b/public/scripts/extensions/translate/buttons.html
@@ -1,8 +1,8 @@
 <div id="translate_chat" class="list-group-item flex-container flexGap5">
-    <div class="fa-solid fa-language extensionsMenuExtensionButton" /></div>
+    <div class="fa-solid fa-language extensionsMenuExtensionButton"></div>
     <span data-i18n="ext_translate_btn_chat">Translate Chat</span>
 </div>
 <div id="translate_input_message" class="list-group-item flex-container flexGap5">
-    <div class="fa-solid fa-keyboard extensionsMenuExtensionButton" /></div>
+    <div class="fa-solid fa-keyboard extensionsMenuExtensionButton"></div>
     <span data-i18n="ext_translate_btn_input">Translate Input</span>
 </div>


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Closes #2591 

* Image generation no longer shares a stop button with text generation.
* Adds a separate button to the wand menu.
* Appears only when the actual image generation is in progress.
* When the text prompt is generated, you can freely proceed to start text generation. It won't interrupt image gens.
* Triggered by the wand, slash command, or interactive mode. Paintbrush message action has a separate abort controller.
* I did not want to put it into the input area since it's already overcrowded with buttons.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
