### PR TITLE
Added quick Regenerate and Impersonate buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4144,6 +4144,18 @@
                                         Quick "Continue" button
                                     </small>
                                 </label>
+                                <label class="checkbox_label" for="quick_regenerate" title="Show a button in the input area to ask the AI regenerate its last message." data-i18n="[title]Show a button in the input area to ask the AI regenerate its last message">
+                                    <input id="quick_regenerate" type="checkbox" />
+                                    <small data-i18n="Quick 'Regenerate' button">
+                                        Quick "Regenerate" button
+                                    </small>
+                                </label>
+                                <label class="checkbox_label" for="quick_impersonate" title="Show a button in the input area to ask the AI to impersonate your character for a single message." data-i18n="[title]Show a button in the input area to ask the AI to impersonate your character for a single message">
+                                    <input id="quick_impersonate" type="checkbox" />
+                                    <small data-i18n="Quick 'Impersonate' button">
+                                        Quick "Impersonate" button
+                                    </small>
+                                </label>
                                 <div class="checkbox-container flex-container">
                                     <label data-newbie-hidden class="checkbox_label" for="swipes-checkbox" title="Show arrow buttons on the last in-chat message to generate alternative AI responses. Both PC and mobile." data-i18n="[title]Show arrow buttons on the last in-chat message to generate alternative AI responses. Both PC and mobile">
                                         <input id="swipes-checkbox" type="checkbox" />
@@ -6342,6 +6354,8 @@
                         <div id="mes_stop" title="Abort request" class="mes_stop" data-i18n="[title]Abort request">
                             <i class="fa-solid fa-circle-stop"></i>
                         </div>
+                        <div id="mes_impersonate" class="fa-solid fa-user-secret interactable displayNone" title="Ask AI to write your message for you" data-i18n="[title]Ask AI to write your message for you" tabindex="0"></div>
+                        <div id="mes_regenerate" class="fa-solid fa-repeat interactable displayNone" title="Regenerate last message" data-i18n="[title]Regenerate last message" tabindex="0"></div>
                         <div id="mes_continue" class="fa-fw fa-solid fa-arrow-right interactable displayNone" title="Continue the last message" data-i18n="[title]Continue the last message"></div>
                         <div id="send_but" class="fa-solid fa-paper-plane interactable displayNone" title="Send a message" data-i18n="[title]Send a message"></div>
                     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -4144,12 +4144,6 @@
                                         Quick "Continue" button
                                     </small>
                                 </label>
-                                <label class="checkbox_label" for="quick_regenerate" title="Show a button in the input area to ask the AI regenerate its last message." data-i18n="[title]Show a button in the input area to ask the AI regenerate its last message">
-                                    <input id="quick_regenerate" type="checkbox" />
-                                    <small data-i18n="Quick 'Regenerate' button">
-                                        Quick "Regenerate" button
-                                    </small>
-                                </label>
                                 <label class="checkbox_label" for="quick_impersonate" title="Show a button in the input area to ask the AI to impersonate your character for a single message." data-i18n="[title]Show a button in the input area to ask the AI to impersonate your character for a single message">
                                     <input id="quick_impersonate" type="checkbox" />
                                     <small data-i18n="Quick 'Impersonate' button">
@@ -6355,7 +6349,6 @@
                             <i class="fa-solid fa-circle-stop"></i>
                         </div>
                         <div id="mes_impersonate" class="fa-solid fa-user-secret interactable displayNone" title="Ask AI to write your message for you" data-i18n="[title]Ask AI to write your message for you" tabindex="0"></div>
-                        <div id="mes_regenerate" class="fa-solid fa-repeat interactable displayNone" title="Regenerate last message" data-i18n="[title]Regenerate last message" tabindex="0"></div>
                         <div id="mes_continue" class="fa-fw fa-solid fa-arrow-right interactable displayNone" title="Continue the last message" data-i18n="[title]Continue the last message"></div>
                         <div id="send_but" class="fa-solid fa-paper-plane interactable displayNone" title="Send a message" data-i18n="[title]Send a message"></div>
                     </div>

--- a/public/script.js
+++ b/public/script.js
@@ -5610,7 +5610,6 @@ export function activateSendButtons() {
     is_send_press = false;
     $('#send_but').removeClass('displayNone');
     $('#mes_continue').removeClass('displayNone');
-    $('#mes_regenerate').removeClass('displayNone');
     $('#mes_impersonate').removeClass('displayNone');
     $('.mes_buttons:last').show();
     hideStopButton();
@@ -5619,7 +5618,6 @@ export function activateSendButtons() {
 export function deactivateSendButtons() {
     $('#send_but').addClass('displayNone');
     $('#mes_continue').addClass('displayNone');
-    $('#mes_regenerate').addClass('displayNone');
     $('#mes_impersonate').addClass('displayNone');
     showStopButton();
 }
@@ -9099,14 +9097,14 @@ jQuery(async function () {
     $('#send_textarea').on('focusin focus click', () => {
         S_TAPreviouslyFocused = true;
     });
-    $('#send_but, #option_regenerate, #option_continue, #mes_continue, #mes_regenerate, #mes_impersonate').on('click', () => {
+    $('#send_but, #option_regenerate, #option_continue, #mes_continue, #mes_impersonate').on('click', () => {
         if (S_TAPreviouslyFocused) {
             $('#send_textarea').focus();
         }
     });
     $(document).click(event => {
         if ($(':focus').attr('id') !== 'send_textarea') {
-            var validIDs = ['options_button', 'send_but', 'mes_regenerate', 'mes_impersonate', 'mes_continue', 'send_textarea', 'option_regenerate', 'option_continue'];
+            var validIDs = ['options_button', 'send_but', 'mes_impersonate', 'mes_continue', 'send_textarea', 'option_regenerate', 'option_continue'];
             if (!validIDs.includes($(event.target).attr('id'))) {
                 S_TAPreviouslyFocused = false;
             }
@@ -9140,11 +9138,6 @@ jQuery(async function () {
     $('#character_search_bar').on('input', function () {
         const searchQuery = String($(this).val());
         debouncedCharacterSearch(searchQuery);
-    });
-
-
-    $('#mes_regenerate').on('click', function () {
-        $('#option_regenerate').trigger('click');
     });
 
     $('#mes_impersonate').on('click', function () {

--- a/public/script.js
+++ b/public/script.js
@@ -5610,6 +5610,8 @@ export function activateSendButtons() {
     is_send_press = false;
     $('#send_but').removeClass('displayNone');
     $('#mes_continue').removeClass('displayNone');
+    $('#mes_regenerate').removeClass('displayNone');
+    $('#mes_impersonate').removeClass('displayNone');
     $('.mes_buttons:last').show();
     hideStopButton();
 }
@@ -5617,6 +5619,8 @@ export function activateSendButtons() {
 export function deactivateSendButtons() {
     $('#send_but').addClass('displayNone');
     $('#mes_continue').addClass('displayNone');
+    $('#mes_regenerate').addClass('displayNone');
+    $('#mes_impersonate').addClass('displayNone');
     showStopButton();
 }
 
@@ -9095,14 +9099,14 @@ jQuery(async function () {
     $('#send_textarea').on('focusin focus click', () => {
         S_TAPreviouslyFocused = true;
     });
-    $('#send_but, #option_regenerate, #option_continue, #mes_continue').on('click', () => {
+    $('#send_but, #option_regenerate, #option_continue, #mes_continue, #mes_regenerate, #mes_impersonate').on('click', () => {
         if (S_TAPreviouslyFocused) {
             $('#send_textarea').focus();
         }
     });
     $(document).click(event => {
         if ($(':focus').attr('id') !== 'send_textarea') {
-            var validIDs = ['options_button', 'send_but', 'mes_continue', 'send_textarea', 'option_regenerate', 'option_continue'];
+            var validIDs = ['options_button', 'send_but', 'mes_regenerate', 'mes_impersonate', 'mes_continue', 'send_textarea', 'option_regenerate', 'option_continue'];
             if (!validIDs.includes($(event.target).attr('id'))) {
                 S_TAPreviouslyFocused = false;
             }
@@ -9138,6 +9142,14 @@ jQuery(async function () {
         debouncedCharacterSearch(searchQuery);
     });
 
+
+    $('#mes_regenerate').on('click', function () {
+        $('#option_regenerate').trigger('click');
+    });
+
+    $('#mes_impersonate').on('click', function () {
+        $('#option_impersonate').trigger('click');
+    });
 
     $('#mes_continue').on('click', function () {
         $('#option_continue').trigger('click');

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -311,6 +311,8 @@ function RA_checkOnlineStatus() {
         $('#send_form').addClass('no-connection'); //entire input form area is red when not connected
         $('#send_but').addClass('displayNone'); //send button is hidden when not connected;
         $('#mes_continue').addClass('displayNone'); //continue button is hidden when not connected;
+        $('#mes_regenerate').addClass('displayNone'); //continue button is hidden when not connected;
+        $('#mes_impersonate').addClass('displayNone'); //continue button is hidden when not connected;
         $('#API-status-top').removeClass('fa-plug');
         $('#API-status-top').addClass('fa-plug-circle-exclamation redOverlayGlow');
         connection_made = false;
@@ -327,6 +329,8 @@ function RA_checkOnlineStatus() {
             if (!is_send_press && !(selected_group && is_group_generating)) {
                 $('#send_but').removeClass('displayNone'); //on connect, send button shows
                 $('#mes_continue').removeClass('displayNone'); //continue button is shown when connected
+                $('#mes_regenerate').removeClass('displayNone'); //continue button is shown when connected
+                $('#mes_impersonate').removeClass('displayNone'); //continue button is shown when connected
             }
         }
     }

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -311,7 +311,6 @@ function RA_checkOnlineStatus() {
         $('#send_form').addClass('no-connection'); //entire input form area is red when not connected
         $('#send_but').addClass('displayNone'); //send button is hidden when not connected;
         $('#mes_continue').addClass('displayNone'); //continue button is hidden when not connected;
-        $('#mes_regenerate').addClass('displayNone'); //continue button is hidden when not connected;
         $('#mes_impersonate').addClass('displayNone'); //continue button is hidden when not connected;
         $('#API-status-top').removeClass('fa-plug');
         $('#API-status-top').addClass('fa-plug-circle-exclamation redOverlayGlow');
@@ -329,7 +328,6 @@ function RA_checkOnlineStatus() {
             if (!is_send_press && !(selected_group && is_group_generating)) {
                 $('#send_but').removeClass('displayNone'); //on connect, send button shows
                 $('#mes_continue').removeClass('displayNone'); //continue button is shown when connected
-                $('#mes_regenerate').removeClass('displayNone'); //continue button is shown when connected
                 $('#mes_impersonate').removeClass('displayNone'); //continue button is shown when connected
             }
         }

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -197,7 +197,6 @@ let power_user = {
     prefer_character_prompt: true,
     prefer_character_jailbreak: true,
     quick_continue: false,
-    quick_regenerate: false,
     quick_impersonate: false,
     continue_on_send: false,
     trim_spaces: true,
@@ -1588,10 +1587,8 @@ function loadPowerUserSettings(settings, data) {
     $('#trim_spaces').prop('checked', power_user.trim_spaces);
     $('#continue_on_send').prop('checked', power_user.continue_on_send);
     $('#quick_continue').prop('checked', power_user.quick_continue);
-    $('#quick_regenerate').prop('checked', power_user.quick_continue);
     $('#quick_impersonate').prop('checked', power_user.quick_continue);
     $('#mes_continue').css('display', power_user.quick_continue ? '' : 'none');
-    $('#mes_regenerate').css('display', power_user.quick_regenerate? '' : 'none');
     $('#mes_impersonate').css('display', power_user.quick_impersonate ? '' : 'none');
     $('#gestures-checkbox').prop('checked', power_user.gestures);
     $('#auto_swipe').prop('checked', power_user.auto_swipe);
@@ -3735,13 +3732,6 @@ $(document).ready(() => {
         const value = !!$(this).prop('checked');
         power_user.quick_continue = value;
         $('#mes_continue').css('display', value ? '' : 'none');
-        saveSettingsDebounced();
-    });
-
-    $('#quick_regenerate').on('input', function () {
-        const value = !!$(this).prop('checked');
-        power_user.quick_regenerate = value;
-        $('#mes_regenerate').css('display', value ? '' : 'none');
         saveSettingsDebounced();
     });
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -197,6 +197,8 @@ let power_user = {
     prefer_character_prompt: true,
     prefer_character_jailbreak: true,
     quick_continue: false,
+    quick_regenerate: false,
+    quick_impersonate: false,
     continue_on_send: false,
     trim_spaces: true,
     relaxed_api_urls: false,
@@ -1586,7 +1588,11 @@ function loadPowerUserSettings(settings, data) {
     $('#trim_spaces').prop('checked', power_user.trim_spaces);
     $('#continue_on_send').prop('checked', power_user.continue_on_send);
     $('#quick_continue').prop('checked', power_user.quick_continue);
+    $('#quick_regenerate').prop('checked', power_user.quick_continue);
+    $('#quick_impersonate').prop('checked', power_user.quick_continue);
     $('#mes_continue').css('display', power_user.quick_continue ? '' : 'none');
+    $('#mes_regenerate').css('display', power_user.quick_regenerate? '' : 'none');
+    $('#mes_impersonate').css('display', power_user.quick_impersonate ? '' : 'none');
     $('#gestures-checkbox').prop('checked', power_user.gestures);
     $('#auto_swipe').prop('checked', power_user.auto_swipe);
     $('#auto_swipe_minimum_length').val(power_user.auto_swipe_minimum_length);
@@ -3729,6 +3735,20 @@ $(document).ready(() => {
         const value = !!$(this).prop('checked');
         power_user.quick_continue = value;
         $('#mes_continue').css('display', value ? '' : 'none');
+        saveSettingsDebounced();
+    });
+
+    $('#quick_regenerate').on('input', function () {
+        const value = !!$(this).prop('checked');
+        power_user.quick_regenerate = value;
+        $('#mes_regenerate').css('display', value ? '' : 'none');
+        saveSettingsDebounced();
+    });
+
+    $('#quick_impersonate').on('input', function () {
+        const value = !!$(this).prop('checked');
+        power_user.quick_impersonate = value;
+        $('#mes_impersonate').css('display', value ? '' : 'none');
         saveSettingsDebounced();
     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -716,10 +716,6 @@ body .panelControlBar {
     order: 1;
 }
 
-#mes_regenerate {
-    order: 1;
-}
-
 #mes_impersonate {
     order: 1;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -716,6 +716,14 @@ body .panelControlBar {
     order: 1;
 }
 
+#mes_regenerate {
+    order: 1;
+}
+
+#mes_impersonate {
+    order: 1;
+}
+
 #send_form .mes_stop {
     display: none;
     order: 2;


### PR DESCRIPTION
Additional buttons mimic the behavior of the continue button.

This will close:
[FEATURE_REQUEST] quick impersonate/regenerate and adding swipes to persona message [#2232](https://github.com/SillyTavern/SillyTavern/issues/2232)

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
