### PR TITLE
Gemini-related updates; adds gemini-1.5-pro-exp-0801

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2805,6 +2805,7 @@
                                     <optgroup label="Latest">
                                         <!-- Doesn't work without "latest". Maybe my key is scuffed? -->
                                         <option value="gemini-1.5-flash-latest">Gemini 1.5 Flash</option>
+                                        <option value="gemini-1.5-pro-latest">Gemini 1.5 Pro</option>
                                         <!-- Points to 1.0, no default 1.5 endpoint -->
                                         <option value="gemini-pro">Gemini Pro</option>
                                         <option value="gemini-pro-vision">Gemini Pro Vision</option>
@@ -2813,6 +2814,7 @@
                                         <option value="chat-bison-001">Bison Chat</option>
                                     </optgroup>
                                     <optgroup label="Sub-versions">
+                                        <option value="gemini-1.5-pro-exp-0801">Gemini 1.5 Pro Experiment 2024-08-01</option>
                                         <option value="gemini-1.5-pro-latest">Gemini 1.5 Pro</option>
                                         <option value="gemini-1.0-pro-latest">Gemini 1.0 Pro</option>
                                         <option value="gemini-1.0-pro-vision-latest">Gemini 1.0 Pro Vision</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -42,6 +42,8 @@
                         <option data-type="anthropic" value="claude-3-haiku-20240307">claude-3-haiku-20240307</option>
                         <option data-type="google" value="gemini-pro-vision">gemini-pro-vision</option>
                         <option data-type="google" value="gemini-1.5-flash-latest">gemini-1.5-flash-latest</option>
+                        <option data-type="google" value="gemini-1.5-pro-latest">gemini-1.5-pro-latest</option>
+                        <option data-type="google" value="gemini-1.5-pro-exp-0801">gemini-1.5-pro-exp-0801</option>
                         <option data-type="openrouter" value="openai/gpt-4-vision-preview">openai/gpt-4-vision-preview</option>
                         <option data-type="openrouter" value="openai/gpt-4o">openai/gpt-4o</option>
                         <option data-type="openrouter" value="openai/gpt-4-turbo">openai/gpt-4-turbo</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4649,10 +4649,14 @@ export function isImageInliningSupported() {
     // gultra just isn't being offered as multimodal, thanks google.
     const visionSupportedModels = [
         'gpt-4-vision',
-        'gemini-1.5-flash-latest',
         'gemini-1.5-flash',
+        'gemini-1.5-flash-latest',
+        'gemini-1.5-flash-001',
         'gemini-1.0-pro-vision-latest',
+        'gemini-1.5-pro',
         'gemini-1.5-pro-latest',
+        'gemini-1.5-pro-001',
+        'gemini-1.5-pro-exp-0801',
         'gemini-pro-vision',
         'claude-3',
         'claude-3-5',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -271,7 +271,7 @@ async function sendMakerSuiteRequest(request, response) {
     };
 
     function getGeminiBody() {
-        const should_use_system_prompt = ['gemini-1.5-flash-latest', 'gemini-1.5-pro-latest'].includes(model) && request.body.use_makersuite_sysprompt;
+        const should_use_system_prompt = ['gemini-1.5-flash', 'gemini-1.5-pro'].includes(model) && request.body.use_makersuite_sysprompt;
         const prompt = convertGooglePrompt(request.body.messages, model, should_use_system_prompt, request.body.char_name, request.body.user_name);
         let body = {
             contents: prompt.contents,

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -263,8 +263,13 @@ function convertGooglePrompt(messages, model, useSysPrompt = false, charName = '
     const PNG_PIXEL = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 
     const visionSupportedModels = [
+        'gemini-1.5-flash',
         'gemini-1.5-flash-latest',
+        'gemini-1.5-flash-001',
+        'gemini-1.5-pro',
         'gemini-1.5-pro-latest',
+        'gemini-1.5-pro-001',
+        'gemini-1.5-pro-exp-0801',
         'gemini-1.0-pro-vision-latest',
         'gemini-pro-vision',
     ];


### PR DESCRIPTION
Supersedes #2595

1. Adds "Gemini 1.5 Pro Experiment 2024-08-01" (`gemini-1.5-pro-exp-0801`) as a selection
1. Adds "Gemini 1.5 Pro" as a non-subversion selection
1. Updates the gemini-1.5-pro models to use a context of 2 million rather than 1 million (this info comes straight from the `/v1beta/models` endpoint for listing models and their info)
1. Fixes `should_use_system_prompt` to check for all pro 1.5 & flash 1.5 models, not just "latest"
1. Adds all the Vision supported models to `prompt-converters.js`'s & `openai.js`'s `visionSupportedModels` variable (including the `-001` ones which is what "latest" is uses)
1. Adds "Gemini 1.5 Pro" & "Gemini 1.5 Pro Experiment 2024-08-01" as selections in the caption extension

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).