### PR TITLE
Gemini max context size corrections, option selector update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2808,10 +2808,10 @@
                                         <option value="gemini-1.0-pro">Gemini 1.0 Pro</option>
                                         <option value="gemini-pro">Gemini Pro (1.0)</option>
                                         <option value="gemini-pro-vision">Gemini Pro Vision (1.0)</option>
-                                        <option value="text-bison-001">PaLM 2 (Legacy)</option>
-                                        <option value="chat-bison-001">PaLM 2 Chat (Legacy)</option>
                                         <option value="gemini-ultra">Gemini Ultra (1.0)</option>
                                         <option value="gemini-1.0-ultra-latest">Gemini 1.0 Ultra</option>
+                                        <option value="text-bison-001">PaLM 2 (Legacy)</option>
+                                        <option value="chat-bison-001">PaLM 2 Chat (Legacy)</option>
                                     </optgroup>
                                     <optgroup label="Subversions">
                                         <option value="gemini-1.5-pro-exp-0801">Gemini 1.5 Pro Experiment 2024-08-01</option>

--- a/public/index.html
+++ b/public/index.html
@@ -2810,6 +2810,8 @@
                                         <option value="gemini-pro-vision">Gemini Pro Vision (1.0)</option>
                                         <option value="text-bison-001">PaLM 2 (Legacy)</option>
                                         <option value="chat-bison-001">PaLM 2 Chat (Legacy)</option>
+                                        <option value="gemini-ultra">Gemini Ultra (1.0)</option>
+                                        <option value="gemini-1.0-ultra-latest">Gemini 1.0 Ultra</option>
                                     </optgroup>
                                     <optgroup label="Subversions">
                                         <option value="gemini-1.5-pro-exp-0801">Gemini 1.5 Pro Experiment 2024-08-01</option>

--- a/public/index.html
+++ b/public/index.html
@@ -2802,23 +2802,24 @@
                             <div>
                                 <h4 data-i18n="Google Model">Google Model</h4>
                                 <select id="model_google_select">
-                                    <optgroup label="Latest">
-                                        <!-- Doesn't work without "latest". Maybe my key is scuffed? -->
-                                        <option value="gemini-1.5-flash-latest">Gemini 1.5 Flash</option>
-                                        <option value="gemini-1.5-pro-latest">Gemini 1.5 Pro</option>
-                                        <!-- Points to 1.0, no default 1.5 endpoint -->
-                                        <option value="gemini-pro">Gemini Pro</option>
-                                        <option value="gemini-pro-vision">Gemini Pro Vision</option>
-                                        <option value="gemini-ultra">Gemini Ultra</option>
-                                        <option value="text-bison-001">Bison Text</option>
-                                        <option value="chat-bison-001">Bison Chat</option>
+                                    <optgroup label="Primary">
+                                        <option value="gemini-1.5-pro">Gemini 1.5 Pro</option>
+                                        <option value="gemini-1.5-flash">Gemini 1.5 Flash</option>
+                                        <option value="gemini-1.0-pro">Gemini 1.0 Pro</option>
+                                        <option value="gemini-pro">Gemini Pro (1.0)</option>
+                                        <option value="gemini-pro-vision">Gemini Pro Vision (1.0)</option>
+                                        <option value="text-bison-001">PaLM 2 (Legacy)</option>
+                                        <option value="chat-bison-001">PaLM 2 Chat (Legacy)</option>
                                     </optgroup>
-                                    <optgroup label="Sub-versions">
+                                    <optgroup label="Subversions">
                                         <option value="gemini-1.5-pro-exp-0801">Gemini 1.5 Pro Experiment 2024-08-01</option>
-                                        <option value="gemini-1.5-pro-latest">Gemini 1.5 Pro</option>
-                                        <option value="gemini-1.0-pro-latest">Gemini 1.0 Pro</option>
-                                        <option value="gemini-1.0-pro-vision-latest">Gemini 1.0 Pro Vision</option>
-                                        <option value="gemini-1.0-ultra-latest">Gemini 1.0 Ultra</option>
+                                        <option value="gemini-1.5-pro-latest">Gemini 1.5 Pro [latest]</option>
+                                        <option value="gemini-1.5-pro-001">Gemini 1.5 Pro [001]</option>
+                                        <option value="gemini-1.5-flash-latest">Gemini 1.5 Flash [latest]</option>
+                                        <option value="gemini-1.5-flash-001">Gemini 1.5 Flash [001]</option>
+                                        <option value="gemini-1.0-pro-latest">Gemini 1.0 Pro [latest]</option>
+                                        <option value="gemini-1.0-pro-001">Gemini 1.0 Pro (Tuning) [001]</option>
+                                        <option value="gemini-1.0-pro-vision-latest">Gemini 1.0 Pro Vision [latest]</option>
                                     </optgroup>
                                 </select>
                             </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -341,7 +341,7 @@ const oai_settings = {
     personality_format: default_personality_format,
     openai_model: 'gpt-4-turbo',
     claude_model: 'claude-3-5-sonnet-20240620',
-    google_model: 'gemini-pro',
+    google_model: 'gemini-1.5-pro',
     ai21_model: 'j2-ultra',
     mistralai_model: 'mistral-large-latest',
     cohere_model: 'command-r-plus',

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4068,10 +4068,13 @@ async function onModelChange() {
             $('#openai_max_context').attr('max', max_32k);
         } else if (value === 'text-bison-001') {
             $('#openai_max_context').attr('max', max_8k);
+        // The ultra endpoints are possibly dead:
+        } else if (value.includes('gemini-1.0-ultra') || value === 'gemini-ultra') {
+            $('#openai_max_context').attr('max', max_32k);
         } else {
             $('#openai_max_context').attr('max', max_4k);
         }
-        let makersuite_max_temp = value.includes('vision') ? 1.0 : 2.0;
+        let makersuite_max_temp = (value.includes('vision') || value.includes('ultra')) ? 1.0 : 2.0;
         oai_settings.temp_openai = Math.min(makersuite_max_temp, oai_settings.temp_openai);
         $('#temp_openai').attr('max', makersuite_max_temp).val(oai_settings.temp_openai).trigger('input');
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -127,6 +127,7 @@ const max_128k = 128 * 1000;
 const max_200k = 200 * 1000;
 const max_256k = 256 * 1000;
 const max_1mil = 1000 * 1000;
+const max_2mil = 2000 * 1000;
 const scale_max = 8191;
 const claude_max = 9000; // We have a proper tokenizer, so theoretically could be larger (up to 9k)
 const claude_100k_max = 99000;
@@ -260,7 +261,7 @@ const default_settings = {
     personality_format: default_personality_format,
     openai_model: 'gpt-4-turbo',
     claude_model: 'claude-3-5-sonnet-20240620',
-    google_model: 'gemini-pro',
+    google_model: 'gemini-1.5-pro',
     ai21_model: 'j2-ultra',
     mistralai_model: 'mistral-large-latest',
     cohere_model: 'command-r-plus',
@@ -4056,17 +4057,21 @@ async function onModelChange() {
 
     if (oai_settings.chat_completion_source == chat_completion_sources.MAKERSUITE) {
         if (oai_settings.max_context_unlocked) {
+            $('#openai_max_context').attr('max', max_2mil);
+        } else if (value.includes('gemini-1.5-pro')) {
+            $('#openai_max_context').attr('max', max_2mil);
+        } else if (value.includes('gemini-1.5-flash')) {
             $('#openai_max_context').attr('max', max_1mil);
-        } else if (value === 'gemini-1.5-pro-latest' || value.includes('gemini-1.5-flash')) {
-            $('#openai_max_context').attr('max', max_1mil);
-        } else if (value === 'gemini-ultra' || value === 'gemini-1.0-pro-latest' || value === 'gemini-pro' || value === 'gemini-1.0-ultra-latest') {
-            $('#openai_max_context').attr('max', max_32k);
-        } else if (value === 'gemini-1.0-pro-vision-latest' || value === 'gemini-pro-vision') {
+        } else if (value.includes('gemini-1.0-pro-vision') || value === 'gemini-pro-vision') {
             $('#openai_max_context').attr('max', max_16k);
-        } else {
+        } else if (value.includes('gemini-1.0-pro') || value === 'gemini-pro') {
+            $('#openai_max_context').attr('max', max_32k);
+        } else if (value === 'text-bison-001') {
             $('#openai_max_context').attr('max', max_8k);
+        } else {
+            $('#openai_max_context').attr('max', max_4k);
         }
-        let makersuite_max_temp = (value.includes('vision') || value.includes('ultra')) ? 1.0 : 2.0;
+        let makersuite_max_temp = value.includes('vision') ? 1.0 : 2.0;
         oai_settings.temp_openai = Math.min(makersuite_max_temp, oai_settings.temp_openai);
         $('#temp_openai').attr('max', makersuite_max_temp).val(oai_settings.temp_openai).trigger('input');
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -271,7 +271,7 @@ async function sendMakerSuiteRequest(request, response) {
     };
 
     function getGeminiBody() {
-        const should_use_system_prompt = ['gemini-1.5-flash', 'gemini-1.5-pro'].includes(model) && request.body.use_makersuite_sysprompt;
+        const should_use_system_prompt = (model.includes('gemini-1.5-flash') || model.includes('gemini-1.5-pro')) && request.body.use_makersuite_sysprompt;
         const prompt = convertGooglePrompt(request.body.messages, model, should_use_system_prompt, request.body.char_name, request.body.user_name);
         let body = {
             contents: prompt.contents,


### PR DESCRIPTION
`gemini-ultra` no longer gets any response from the API, I think it's pretty much dead, so it's gone.

Max context size updates, this was supposed to be in my last commit but I did an oopsy-woopsy-fucky-wucky and it got left out.

Changed the dropdown to include all the endpoints and subversions and shit.

Also made the default model selection for MakerSuite be `gemini-1.5-pro` instead of `gemini-pro` since it doesn't look like Google is going to change the `gemini-pro` endpoint to 1.5 any time soon.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
