### PR TITLE
fix: LLM Classifier Defaulting to Last Spoken Character's Expression For All Characters in Group Chats

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2524,9 +2524,10 @@ export function getStoppingStrings(isImpersonate, isContinue) {
  * @param {string} quietImage Image to use for the quiet prompt
  * @param {string} quietName Name to use for the quiet prompt (defaults to "System:")
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
+ * @param {number} [character_id] (For Group Chats Only) The character associated with the request.
  * @returns
  */
-export async function generateQuietPrompt(quiet_prompt, quietToLoud, skipWIAN, quietImage = null, quietName = null, responseLength = null) {
+export async function generateQuietPrompt(quiet_prompt, quietToLoud, skipWIAN, quietImage = null, quietName = null, responseLength = null, character_id = null) {
     console.log('got into genQuietPrompt');
     const responseLengthCustomized = typeof responseLength === 'number' && responseLength > 0;
     let originalResponseLength = -1;
@@ -2539,6 +2540,7 @@ export async function generateQuietPrompt(quiet_prompt, quietToLoud, skipWIAN, q
             force_name2: true,
             quietImage: quietImage,
             quietName: quietName,
+            force_chid: character_id,   
         };
         originalResponseLength = responseLengthCustomized ? saveResponseLength(main_api, responseLength) : -1;
         const generateFinished = await Generate('quiet', options);

--- a/public/script.js
+++ b/public/script.js
@@ -2524,10 +2524,11 @@ export function getStoppingStrings(isImpersonate, isContinue) {
  * @param {string} quietImage Image to use for the quiet prompt
  * @param {string} quietName Name to use for the quiet prompt (defaults to "System:")
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
- * @param {number} [character_id] (For Group Chats Only) The character associated with the request.
+ * @param {number} [characterId] (For Group Chats Only) The character associated with the request.
+ * @param {boolean} [isClassification] Whether the request is for classification
  * @returns
  */
-export async function generateQuietPrompt(quiet_prompt, quietToLoud, skipWIAN, quietImage = null, quietName = null, responseLength = null, character_id = null) {
+export async function generateQuietPrompt(quiet_prompt, quietToLoud, skipWIAN, quietImage = null, quietName = null, responseLength = null, characterId = null, isClassification = false) {
     console.log('got into genQuietPrompt');
     const responseLengthCustomized = typeof responseLength === 'number' && responseLength > 0;
     let originalResponseLength = -1;
@@ -2540,7 +2541,8 @@ export async function generateQuietPrompt(quiet_prompt, quietToLoud, skipWIAN, q
             force_name2: true,
             quietImage: quietImage,
             quietName: quietName,
-            force_chid: character_id,   
+            force_chid: characterId,   
+            isClassification: isClassification,
         };
         originalResponseLength = responseLengthCustomized ? saveResponseLength(main_api, responseLength) : -1;
         const generateFinished = await Generate('quiet', options);
@@ -3260,9 +3262,9 @@ function removeLastMessage() {
  * @param {GenerateOptions} options Generation options
  * @param {boolean} dryRun Whether to actually generate a message or just assemble the prompt
  * @returns {Promise<any>} Returns a promise that resolves when the text is done generating.
- * @typedef {{automatic_trigger?: boolean, force_name2?: boolean, quiet_prompt?: string, quietToLoud?: boolean, skipWIAN?: boolean, force_chid?: number, signal?: AbortSignal, quietImage?: string, maxLoops?: number, quietName?: string }} GenerateOptions
+ * @typedef {{automatic_trigger?: boolean, force_name2?: boolean, quiet_prompt?: string, quietToLoud?: boolean, skipWIAN?: boolean, force_chid?: number, signal?: AbortSignal, quietImage?: string, maxLoops?: number, quietName?: string, isClassification?: boolean }} GenerateOptions
  */
-export async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, maxLoops, quietName } = {}, dryRun = false) {
+export async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, maxLoops, quietName, isClassification } = {}, dryRun = false) {
     console.log('Generate entered');
     eventSource.emit(event_types.GENERATION_STARTED, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, maxLoops }, dryRun);
     setGenerationProgress(0);
@@ -3328,7 +3330,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     if (selected_group && !is_group_generating) {
         if (!dryRun) {
             // Returns the promise that generateGroupWrapper returns; resolves when generation is done
-            return generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, maxLoops });
+            return generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, maxLoops, isClassification });
         }
 
         const characterIndexMap = new Map(characters.map((char, index) => [char.avatar, index]));
@@ -3467,9 +3469,21 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     }
 
     // Collect messages with usable content
-    let coreChat = chat.filter(x => !x.is_system);
-    if (type === 'swipe') {
-        coreChat.pop();
+    var coreChat;
+
+    if (isClassification) {
+        // Only grab the last message sent by the character
+        // This is done mainly so that the LLM classifies the last message
+        // similar to BERT classification.
+        let tempCoreChat = chat.filter(x => !x.is_system && !x.is_user);
+
+        const lastCharacterMessageIndex = tempCoreChat.findLastIndex(x => x.name === name2);
+        coreChat = tempCoreChat.slice(lastCharacterMessageIndex, lastCharacterMessageIndex + 1);
+    } else {
+        coreChat = chat.filter(x => !x.is_system);
+        if (type === 'swipe') {
+            coreChat.pop();
+        }
     }
 
     coreChat = await Promise.all(coreChat.map(async (chatItem, index) => {

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -114,8 +114,6 @@ async function updateVisualNovelMode(name, expression) {
     // calculate layer indices based on recent messages
     await visualNovelUpdateLayers(container);
 
-    await Promise.allSettled(setSpritePromises);
-
     // update again based on new sprites
     if (setSpritePromises.length > 0) {
         await visualNovelUpdateLayers(container);
@@ -216,7 +214,7 @@ async function visualNovelSetCharacterSprites(container, name, expression) {
     }
 
     await Promise.allSettled(createCharacterPromises);
-    return setSpritePromises;
+    return await Promise.all(setSpritePromises);
 }
 
 async function visualNovelUpdateLayers(container) {

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -208,10 +208,7 @@ async function visualNovelSetCharacterSprites(container, name, expression) {
                 template.fadeIn(250, () => resolve());
             });
             createCharacterPromises.push(fadeInPromise);
-
-            // LLM API requires character ID to be passed
-            const characterId = context.characters.findIndex(x => x == character);
-            const setSpritePromise = setLastMessageSprite(template.find('img'), avatar, labels, characterId)
+            const setSpritePromise = setLastMessageSprite(template.find('img'), avatar, labels)
             setSpritePromises.push(setSpritePromise);
         }
     }
@@ -306,7 +303,7 @@ async function visualNovelUpdateLayers(container) {
     await Promise.allSettled(setLayerIndicesPromises);
 }
 
-async function setLastMessageSprite(img, avatar, labels, characterId = null) {
+async function setLastMessageSprite(img, avatar, labels) {
     const context = getContext();
     const lastMessage = context.chat.slice().reverse().find(x => x.original_avatar == avatar || (x.force_avatar && x.force_avatar.includes(encodeURIComponent(avatar))));
 
@@ -314,7 +311,7 @@ async function setLastMessageSprite(img, avatar, labels, characterId = null) {
         const text = lastMessage.mes || '';
         const spriteFolderName = getSpriteFolderName(lastMessage, lastMessage.name);
         const sprites = spriteCache[spriteFolderName] || [];
-        const label = await getExpressionLabel(text, characterId);
+        const label = await getExpressionLabel(text);
         const path = labels.includes(label) ? sprites.find(x => x.label === label)?.path : '';
 
         if (path) {
@@ -1111,7 +1108,7 @@ function onTextGenSettingsReady(args) {
     }
 }
 
-async function getExpressionLabel(text, characterId = null) {
+async function getExpressionLabel(text) {
     // Return if text is undefined, saving a costly fetch request
     if ((!modules.includes('classify') && extension_settings.expressions.api == EXPRESSION_API.extras) || !text) {
         return getFallbackExpression();

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1,4 +1,4 @@
-import { callPopup, eventSource, event_types, generateQuietPrompt, generateRaw, getRequestHeaders, main_api, online_status, saveSettingsDebounced, substituteParams, substituteParamsExtended, system_message_types } from '../../../script.js';
+import { callPopup, eventSource, event_types, generateRaw, getRequestHeaders, main_api, online_status, saveSettingsDebounced, substituteParams, substituteParamsExtended, system_message_types } from '../../../script.js';
 import { dragElement, isMobile } from '../../RossAscends-mods.js';
 import { getContext, getApiUrl, modules, extension_settings, ModuleWorkerWrapper, doExtrasFetch, renderExtensionTemplateAsync } from '../../extensions.js';
 import { loadMovingUIState, power_user } from '../../power-user.js';

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -111,6 +111,8 @@ async function updateVisualNovelMode(name, expression) {
 
     const setSpritePromises = await visualNovelSetCharacterSprites(container, name, expression);
 
+    await Promise.allSettled(setSpritePromises);
+
     // calculate layer indices based on recent messages
     await visualNovelUpdateLayers(container);
 
@@ -208,7 +210,14 @@ async function visualNovelSetCharacterSprites(container, name, expression) {
             createCharacterPromises.push(fadeInPromise);
 
             const characterId = context.characters.findIndex(x => x == character);
-            const setSpritePromise = await await setLastMessageSprite(template.find('img'), avatar, labels, characterId)
+
+            var setSpritePromise;
+            // LLM API requires character ID and await for the promise to resolve
+            if (extension_settings.expressions.api == EXPRESSION_API.llm) {
+                setSpritePromise = await setLastMessageSprite(template.find('img'), avatar, labels, characterId);
+            } else {
+                setSpritePromise = setLastMessageSprite(template.find('img'), avatar, labels);
+            }
             setSpritePromises.push(setSpritePromise);
         }
     }

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -111,10 +111,10 @@ async function updateVisualNovelMode(name, expression) {
 
     const setSpritePromises = await visualNovelSetCharacterSprites(container, name, expression);
 
-    await Promise.allSettled(setSpritePromises);
-
     // calculate layer indices based on recent messages
     await visualNovelUpdateLayers(container);
+
+    await Promise.allSettled(setSpritePromises);
 
     // update again based on new sprites
     if (setSpritePromises.length > 0) {
@@ -208,7 +208,7 @@ async function visualNovelSetCharacterSprites(container, name, expression) {
                 template.fadeIn(250, () => resolve());
             });
             createCharacterPromises.push(fadeInPromise);
-            const setSpritePromise = setLastMessageSprite(template.find('img'), avatar, labels)
+            const setSpritePromise = setLastMessageSprite(template.find('img'), avatar, labels);
             setSpritePromises.push(setSpritePromise);
         }
     }
@@ -1156,7 +1156,7 @@ async function getExpressionLabel(text) {
 
                     functionResult = args?.arguments;
                 });
-                const emotionResponse = await generateRaw(text, main_api, false, false, prompt)
+                const emotionResponse = await generateRaw(text, main_api, false, false, prompt);
                 return parseLlmResponse(functionResult || emotionResponse, expressionsList);
             }
             // Extras

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -208,13 +208,13 @@ async function visualNovelSetCharacterSprites(container, name, expression) {
             createCharacterPromises.push(fadeInPromise);
 
             const characterId = context.characters.findIndex(x => x == character);
-            const setSpritePromise = await setLastMessageSprite(template.find('img'), avatar, labels, characterId)
+            const setSpritePromise = await await setLastMessageSprite(template.find('img'), avatar, labels, characterId)
             setSpritePromises.push(setSpritePromise);
         }
     }
 
     await Promise.allSettled(createCharacterPromises);
-    return await Promise.all(setSpritePromises);
+    return setSpritePromises;
 }
 
 async function visualNovelUpdateLayers(container) {
@@ -1108,7 +1108,7 @@ function onTextGenSettingsReady(args) {
     }
 }
 
-async function getExpressionLabel(text, character_id = null) {
+async function getExpressionLabel(text, characterId = null) {
     // Return if text is undefined, saving a costly fetch request
     if ((!modules.includes('classify') && extension_settings.expressions.api == EXPRESSION_API.extras) || !text) {
         return getFallbackExpression();
@@ -1156,7 +1156,7 @@ async function getExpressionLabel(text, character_id = null) {
 
                     functionResult = args?.arguments;
                 });
-                const emotionResponse = await generateQuietPrompt(prompt, false, false, null, null, null, character_id);
+                const emotionResponse = await generateQuietPrompt(prompt, false, false, null, null, null, characterId, true);
                 return parseLlmResponse(functionResult || emotionResponse, expressionsList);
             }
             // Extras

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1,4 +1,4 @@
-import { callPopup, eventSource, event_types, generateQuietPrompt, getRequestHeaders, online_status, saveSettingsDebounced, substituteParams, substituteParamsExtended, system_message_types } from '../../../script.js';
+import { callPopup, eventSource, event_types, generateQuietPrompt, generateRaw, getRequestHeaders, main_api, online_status, saveSettingsDebounced, substituteParams, substituteParamsExtended, system_message_types } from '../../../script.js';
 import { dragElement, isMobile } from '../../RossAscends-mods.js';
 import { getContext, getApiUrl, modules, extension_settings, ModuleWorkerWrapper, doExtrasFetch, renderExtensionTemplateAsync } from '../../extensions.js';
 import { loadMovingUIState, power_user } from '../../power-user.js';
@@ -209,15 +209,9 @@ async function visualNovelSetCharacterSprites(container, name, expression) {
             });
             createCharacterPromises.push(fadeInPromise);
 
+            // LLM API requires character ID to be passed
             const characterId = context.characters.findIndex(x => x == character);
-
-            var setSpritePromise;
-            // LLM API requires character ID and await for the promise to resolve
-            if (extension_settings.expressions.api == EXPRESSION_API.llm) {
-                setSpritePromise = await setLastMessageSprite(template.find('img'), avatar, labels, characterId);
-            } else {
-                setSpritePromise = setLastMessageSprite(template.find('img'), avatar, labels);
-            }
+            const setSpritePromise = setLastMessageSprite(template.find('img'), avatar, labels, characterId)
             setSpritePromises.push(setSpritePromise);
         }
     }
@@ -1165,7 +1159,7 @@ async function getExpressionLabel(text, characterId = null) {
 
                     functionResult = args?.arguments;
                 });
-                const emotionResponse = await generateQuietPrompt(prompt, false, false, null, null, null, characterId, true);
+                const emotionResponse = await generateRaw(text, main_api, false, false, prompt)
                 return parseLlmResponse(functionResult || emotionResponse, expressionsList);
             }
             // Extras


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Summary
This PR addresses a bug present in ST 1.12.4 in which character sprites in a Group Chat will default to the classify result of the last message in chat history.

## Cause
> When opening a new/existing chat and the LLM classifier sends its prompt, it will default to the last message sent by a character with no regard as to it being the actual character's message. This means that if the last character's message ends up being *angry*, everyone will be angry no matter what their other messages say. The below example shows every character being *angry* due to Serika's message being classified as such even though Furina's message is nowhere near *angry* based off her greeting.
![image](https://github.com/user-attachments/assets/11b80f09-61e3-41ab-8033-d00c9c08d3d7)

When looking at the console logs, it will show that, despite each classify targeting one character, it uses the information of the last character who has sent a message.
![image](https://github.com/user-attachments/assets/16c6d8b0-add3-45bb-9b67-5233ddb5954c)

## Fix
To address the bug, instead of using `generateQuietPrompt`, `generateRaw` is used as a simple instruction template with the last message of each character being sent to the API.

With said fixes applied, characters should now display proper emotions as per this dev example here:
![image](https://github.com/user-attachments/assets/7d7ddb34-531f-4bef-bf6e-2fd421307bb1)