### PR TITLE
Fix incorrect JanitorAI/JannyAI import due to incorrect HTTP header

### DIFF
--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -434,7 +434,7 @@ async function downloadJannyCharacter(uuid) {
             const imageResult = await fetch(downloadResult.downloadUrl);
             const buffer = await imageResult.buffer();
             const fileName = `${sanitize(uuid)}.png`;
-            const fileType = result.headers.get('content-type');
+            const fileType = imageResult.headers.get('content-type');
 
             return { buffer, fileName, fileType };
         }


### PR DESCRIPTION
For JanitorAI characters, `/importURL` and `/importUUID` endpoints were setting the Content-Type header to `application/json` instead of `image/png`.

This fixes #1576. After further investigating, I found that this bug is avoided by a different commit in staging: https://github.com/SillyTavern/SillyTavern/commit/0c2df51e2cda68fb5f701e6593ed03a22eee1835

Still, a bug is a bug ☺️



<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
