### PR TITLE
Split WI Entry 'disable' into separate toggle

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -181,6 +181,10 @@
     width: 7em;
 }
 
+.world_entry .killSwitch.fa-toggle-on {
+    color: var(--SmartThemeQuoteColor);
+}
+
 .wi-card-entry {
     border: 1px solid;
     border-color: var(--SmartThemeBorderColor);

--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -120,6 +120,14 @@
     flex-wrap: wrap;
 }
 
+.world_entry .inline-drawer-header {
+    cursor: initial;
+}
+
+.world_entry .killSwitch {
+    cursor: pointer;
+}
+
 .world_entry_form_control input[type=button] {
     cursor: pointer;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -5302,7 +5302,7 @@
                         <span class="drag-handle">&#9776;</span>
                         <div class="gap5px world_entry_thin_controls wide100p alignitemscenter">
                             <div class="inline-drawer-toggle fa-fw fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
-                            <div class="fa-solid fa-toggle-on killSwitch" name="entryKillSwitch"></div>
+                            <div class="fa-solid fa-toggle-on killSwitch" name="entryKillSwitch" title="Toggle entry's active state."></div>
                             <div class="flex-container alignitemscenter wide100p">
 
                                 <div class="WIEntryTitleAndStatus flex-container flex1 alignitemscenter">

--- a/public/index.html
+++ b/public/index.html
@@ -5298,12 +5298,15 @@
         <div class="world_entry">
             <form class="world_entry_form  wi-card-entry">
                 <div class="inline-drawer wide100p">
-                    <div class="inline-drawer-toggle inline-drawer-header gap5px padding0">
+                    <div class="inline-drawer-header gap5px padding0">
                         <span class="drag-handle">&#9776;</span>
                         <div class="gap5px world_entry_thin_controls wide100p alignitemscenter">
-                            <div class="fa-fw fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                            <div class="inline-drawer-toggle fa-fw fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                            <div class="fa-solid fa-toggle-on" name="entryKillSwitch"></div>
                             <div class="flex-container alignitemscenter wide100p">
+
                                 <div class="WIEntryTitleAndStatus flex-container flex1 alignitemscenter">
+
                                     <div class="flex-container flex1">
                                         <textarea class="text_pole" rows="1" name="comment" maxlength="5000" data-i18n="[placeholder]Entry Title/Memo" placeholder="Entry Title/Memo"></textarea>
                                     </div>
@@ -5312,7 +5315,7 @@
                                         <option value="constant" title="Constant" data-i18n="[title]WI_Entry_Status_Constant">🔵</option>
                                         <option value="normal" title="Normal" data-i18n="[title]WI_Entry_Status_Normal">🟢</option>
                                         <option value="vectorized" title="Vectorized" data-i18n="[title]WI_Entry_Status_Vectorized">🔗</option>
-                                        <option value="disabled" title="Disabled" data-i18n="[title]WI_Entry_Status_Disabled">❌</option>
+                                        <!--<option value="disabled" title="Disabled" data-i18n="[title]WI_Entry_Status_Disabled">❌</option>-->
                                     </select>
                                 </div>
                                 <div class="WIEnteryHeaderControls flex-container">

--- a/public/index.html
+++ b/public/index.html
@@ -5310,12 +5310,10 @@
                                     <div class="flex-container flex1">
                                         <textarea class="text_pole" rows="1" name="comment" maxlength="5000" data-i18n="[placeholder]Entry Title/Memo" placeholder="Entry Title/Memo"></textarea>
                                     </div>
-                                    <!-- <span class="world_entry_form_position_value"></span> -->
                                     <select data-i18n="[title]WI Entry Status:🔵 Constant🟢 Normal🔗 Vectorized❌ Disabled" title="WI Entry Status:&#13;🔵 Constant&#13;🟢 Normal&#13;🔗 Vectorized&#13;❌ Disabled" name="entryStateSelector" class="text_pole widthNatural margin0">
                                         <option value="constant" title="Constant" data-i18n="[title]WI_Entry_Status_Constant">🔵</option>
                                         <option value="normal" title="Normal" data-i18n="[title]WI_Entry_Status_Normal">🟢</option>
                                         <option value="vectorized" title="Vectorized" data-i18n="[title]WI_Entry_Status_Vectorized">🔗</option>
-                                        <!--<option value="disabled" title="Disabled" data-i18n="[title]WI_Entry_Status_Disabled">❌</option>-->
                                     </select>
                                 </div>
                                 <div class="WIEnteryHeaderControls flex-container">

--- a/public/index.html
+++ b/public/index.html
@@ -5302,7 +5302,7 @@
                         <span class="drag-handle">&#9776;</span>
                         <div class="gap5px world_entry_thin_controls wide100p alignitemscenter">
                             <div class="inline-drawer-toggle fa-fw fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
-                            <div class="fa-solid fa-toggle-on" name="entryKillSwitch"></div>
+                            <div class="fa-solid fa-toggle-on killSwitch" name="entryKillSwitch"></div>
                             <div class="flex-container alignitemscenter wide100p">
 
                                 <div class="WIEntryTitleAndStatus flex-container flex1 alignitemscenter">

--- a/public/scripts/templates/worldInfoKeywordHeaders.html
+++ b/public/scripts/templates/worldInfoKeywordHeaders.html
@@ -1,6 +1,6 @@
 <div id="WIEntryHeaderTitlesPC" class="flex-container wide100p spaceBetween justifyCenter textAlignCenter" style="padding:0 4.5em;">
     <small class="flex1" data-i18n="Title/Memo">Title/Memo</small>
-    <small style="width: calc(3.5em + 15px)" data-i18n="Status">Status</small>
+    <small style="width: calc(3.5em + 15px)" data-i18n="Strategy">Strategy</small>
     <small style="width: calc(3.5em + 30px)" data-i18n="Position">Position</small>
     <small style="width: calc(3.5em + 20px)" data-i18n="Depth">Depth</small>
     <small style="width: calc(3.5em + 20px)" data-i18n="Order">Order</small>

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2872,42 +2872,22 @@ async function getWorldEntry(name, data, entry) {
         switch (value) {
             case 'constant':
                 data.entries[uid].constant = true;
-                //data.entries[uid].disable = false;
                 data.entries[uid].vectorized = false;
-                setWIOriginalDataValue(data, uid, 'enabled', true);
                 setWIOriginalDataValue(data, uid, 'constant', true);
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
-                //template.removeClass('disabledWIEntry');
                 break;
             case 'normal':
                 data.entries[uid].constant = false;
-                //data.entries[uid].disable = false;
                 data.entries[uid].vectorized = false;
-                setWIOriginalDataValue(data, uid, 'enabled', true);
                 setWIOriginalDataValue(data, uid, 'constant', false);
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
-                //template.removeClass('disabledWIEntry');
                 break;
             case 'vectorized':
                 data.entries[uid].constant = false;
-                //data.entries[uid].disable = false;
                 data.entries[uid].vectorized = true;
-                setWIOriginalDataValue(data, uid, 'enabled', true);
                 setWIOriginalDataValue(data, uid, 'constant', false);
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', true);
-                //template.removeClass('disabledWIEntry');
                 break;
-            /*
-            case 'disabled':
-                data.entries[uid].constant = false;
-                data.entries[uid].disable = true;
-                data.entries[uid].vectorized = false;
-                setWIOriginalDataValue(data, uid, 'enabled', false);
-                setWIOriginalDataValue(data, uid, 'constant', false);
-                setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
-                template.addClass('disabledWIEntry');
-                break;
-                */
         }
         await saveWorldInfo(name, data);
 
@@ -2918,7 +2898,7 @@ async function getWorldEntry(name, data, entry) {
     entryKillSwitch.on('click', async function (event) {
         const uid = entry.uid;
         data.entries[uid].disable = !data.entries[uid].disable;
-        let isActive = !data.entries[uid].disable;
+        const isActive = !data.entries[uid].disable;
         setWIOriginalDataValue(data, uid, 'enabled', isActive);
         template.toggleClass('disabledWIEntry', !isActive);
         entryKillSwitch.toggleClass('fa-toggle-off', !isActive);
@@ -2928,9 +2908,6 @@ async function getWorldEntry(name, data, entry) {
     });
 
     const entryState = function () {
-        /*  if (entry.disable === true) {
-             return 'disabled';
-         } else  */
         if (entry.constant === true) {
             return 'constant';
         } else if (entry.vectorized === true) {

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2920,15 +2920,9 @@ async function getWorldEntry(name, data, entry) {
         data.entries[uid].disable = !data.entries[uid].disable;
         let isActive = !data.entries[uid].disable;
         setWIOriginalDataValue(data, uid, 'enabled', isActive);
-        if (isActive) {
-            template.removeClass('disabledWIEntry');
-            entryKillSwitch.removeClass('fa-toggle-off');
-            entryKillSwitch.addClass('fa-toggle-on');
-        } else {
-            template.addClass('disabledWIEntry');
-            entryKillSwitch.addClass('fa-toggle-off');
-            entryKillSwitch.removeClass('fa-toggle-on');
-        }
+        template.toggleClass('disabledWIEntry', !isActive);
+        entryKillSwitch.toggleClass('fa-toggle-off', !isActive);
+        entryKillSwitch.toggleClass('fa-toggle-on', isActive);
         await saveWorldInfo(name, data);
 
     });
@@ -2947,17 +2941,9 @@ async function getWorldEntry(name, data, entry) {
     };
 
     const isActive = !entry.disable;
-    if (isActive) {
-        console.warn(`${entry.uid} is active`);
-        template.removeClass('disabledWIEntry');
-        entryKillSwitch.removeClass('fa-toggle-off');
-        entryKillSwitch.addClass('fa-toggle-on');
-    } else {
-        console.warn(`${entry.uid} is not active`);
-        template.addClass('disabledWIEntry');
-        entryKillSwitch.addClass('fa-toggle-off');
-        entryKillSwitch.removeClass('fa-toggle-on');
-    }
+    template.toggleClass('disabledWIEntry', !isActive);
+    entryKillSwitch.toggleClass('fa-toggle-off', !isActive);
+    entryKillSwitch.toggleClass('fa-toggle-on', isActive);
 
     template
         .find(`select[name="entryStateSelector"] option[value=${entryState()}]`)

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2859,21 +2859,7 @@ async function getWorldEntry(name, data, entry) {
     //add UID above content box (less important doesn't need to be always visible)
     template.find('.world_entry_form_uid_value').text(`(UID: ${entry.uid})`);
 
-    // disable
-    /*
-    const disableInput = template.find('input[name="disable"]');
-    disableInput.data("uid", entry.uid);
-    disableInput.on("input", async function () {
-        const uid = $(this).data("uid");
-        const value = $(this).prop("checked");
-        data.entries[uid].disable = value;
-        setOriginalDataValue(data, uid, "enabled", !data.entries[uid].disable);
-        await saveWorldInfo(name, data);
-    });
-    disableInput.prop("checked", entry.disable).trigger("input");
-    */
-
-    //new tri-state selector for constant/normal/disabled
+    //new tri-state selector for constant/normal/vectorized
     const entryStateSelector = template.find('select[name="entryStateSelector"]');
     entryStateSelector.data('uid', entry.uid);
     entryStateSelector.on('click', function (event) {
@@ -2886,31 +2872,32 @@ async function getWorldEntry(name, data, entry) {
         switch (value) {
             case 'constant':
                 data.entries[uid].constant = true;
-                data.entries[uid].disable = false;
+                //data.entries[uid].disable = false;
                 data.entries[uid].vectorized = false;
                 setWIOriginalDataValue(data, uid, 'enabled', true);
                 setWIOriginalDataValue(data, uid, 'constant', true);
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
-                template.removeClass('disabledWIEntry');
+                //template.removeClass('disabledWIEntry');
                 break;
             case 'normal':
                 data.entries[uid].constant = false;
-                data.entries[uid].disable = false;
+                //data.entries[uid].disable = false;
                 data.entries[uid].vectorized = false;
                 setWIOriginalDataValue(data, uid, 'enabled', true);
                 setWIOriginalDataValue(data, uid, 'constant', false);
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
-                template.removeClass('disabledWIEntry');
+                //template.removeClass('disabledWIEntry');
                 break;
             case 'vectorized':
                 data.entries[uid].constant = false;
-                data.entries[uid].disable = false;
+                //data.entries[uid].disable = false;
                 data.entries[uid].vectorized = true;
                 setWIOriginalDataValue(data, uid, 'enabled', true);
                 setWIOriginalDataValue(data, uid, 'constant', false);
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', true);
-                template.removeClass('disabledWIEntry');
+                //template.removeClass('disabledWIEntry');
                 break;
+            /*
             case 'disabled':
                 data.entries[uid].constant = false;
                 data.entries[uid].disable = true;
@@ -2920,15 +2907,38 @@ async function getWorldEntry(name, data, entry) {
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
                 template.addClass('disabledWIEntry');
                 break;
+                */
+        }
+        await saveWorldInfo(name, data);
+
+    });
+
+    const entryKillSwitch = template.find('div[name="entryKillSwitch"]');
+    entryKillSwitch.data('uid', entry.uid);
+    entryKillSwitch.on('click', async function (event) {
+        event.stopPropagation();
+        const uid = entry.uid;
+        data.entries[uid].disable = !data.entries[uid].disable;
+        let isActive = data.entries[uid].disable;
+        setWIOriginalDataValue(data, uid, 'enabled', isActive);
+        if (isActive) {
+            template.removeClass('disabledWIEntry');
+            entryKillSwitch.removeClass('fa-toggle-off');
+            entryKillSwitch.addClass('fa-toggle-on');
+        } else {
+            template.addClass('disabledWIEntry');
+            entryKillSwitch.addClass('fa-toggle-off');
+            entryKillSwitch.removeClass('fa-toggle-on');
         }
         await saveWorldInfo(name, data);
 
     });
 
     const entryState = function () {
-        if (entry.disable === true) {
-            return 'disabled';
-        } else if (entry.constant === true) {
+        /*  if (entry.disable === true) {
+             return 'disabled';
+         } else  */
+        if (entry.constant === true) {
             return 'constant';
         } else if (entry.vectorized === true) {
             return 'vectorized';
@@ -2936,6 +2946,20 @@ async function getWorldEntry(name, data, entry) {
             return 'normal';
         }
     };
+
+    const isActive = !entry.disable;
+    if (isActive) {
+        console.warn(`${entry.uid} is active`);
+        template.removeClass('disabledWIEntry');
+        entryKillSwitch.removeClass('fa-toggle-off');
+        entryKillSwitch.addClass('fa-toggle-on');
+    } else {
+        console.warn(`${entry.uid} is not active`);
+        template.addClass('disabledWIEntry');
+        entryKillSwitch.addClass('fa-toggle-off');
+        entryKillSwitch.removeClass('fa-toggle-on');
+    }
+
     template
         .find(`select[name="entryStateSelector"] option[value=${entryState()}]`)
         .prop('selected', true)

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2916,10 +2916,9 @@ async function getWorldEntry(name, data, entry) {
     const entryKillSwitch = template.find('div[name="entryKillSwitch"]');
     entryKillSwitch.data('uid', entry.uid);
     entryKillSwitch.on('click', async function (event) {
-        event.stopPropagation();
         const uid = entry.uid;
         data.entries[uid].disable = !data.entries[uid].disable;
-        let isActive = data.entries[uid].disable;
+        let isActive = !data.entries[uid].disable;
         setWIOriginalDataValue(data, uid, 'enabled', isActive);
         if (isActive) {
             template.removeClass('disabledWIEntry');


### PR DESCRIPTION
benefits: 
- no longer need to tamper with trigger strategy in order turn off an entry

other small changes: 
- switched WI Entry collapsible header behavior to only expand when the chevron icon is clicked, so it does not expand when the slim spaces between inputs are clicked by accident, or easily fat-fingered on mobile