### PR TITLE
Group members as stopping strings only added if generating for a specific member or impersonating

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2496,8 +2496,8 @@ export function getStoppingStrings(isImpersonate, isContinue) {
             result.push(charString);
         }
 
-        // Add other group members as the stopping strings
-        if (selected_group) {
+        // Add group members as stopping strings if generating for a specific group member or user. (Allow slash commands to work around name stopping string restrictions)
+        if (selected_group && (name2 || isImpersonate)) {
             const group = groups.find(x => x.id === selected_group);
 
             if (group && Array.isArray(group.members)) {


### PR DESCRIPTION
- Only add group members as stopping strings if generating for a specific group member or user. (Allow slash commands to work around name stopping string restrictions)

I know we have the new toggle where you can disable all name usage as stopping strings. That works for *most* use-cases.
Not a group user myself, but I still thought this change makes sense.

If you don't think so, just close it. Was just a quick two-minutes change.

Idea was:
If you are in a group, and use slash commands like `/gen` or `/genraw`, you don't want to be forced out of having `Char3: xxxx` blocks there. Might be needed for summaries and such.


## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
