### PR TITLE
Add bulk tag import

### DIFF
--- a/public/css/character-group-overlay.css
+++ b/public/css/character-group-overlay.css
@@ -99,6 +99,6 @@
 }
 
 #bulk_tag_shadow_popup #bulk_tag_popup #dialogue_popup_controls .menu_button {
-    width: 100px;
+    width: unset;
     padding: 0.25em;
 }

--- a/public/script.js
+++ b/public/script.js
@@ -10738,7 +10738,7 @@ jQuery(async function () {
                 }
             } break;
             case 'import_tags': {
-                await importTags(characters[this_chid], { forceShow: true });
+                await importTags(characters[this_chid], { importSetting: tag_import_setting.ASK });
             } break;
             /*case 'delete_button':
                 popup_type = "del_ch";

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -197,7 +197,7 @@ class BulkTagPopupHandler {
     #getHtml = () => {
         const characterData = JSON.stringify({ characterIds: this.characterIds });
         return `<div id="bulk_tag_shadow_popup">
-            <div id="bulk_tag_popup">
+            <div id="bulk_tag_popup" class="wider_dialogue_popup">
                 <div id="bulk_tag_popup_holder">
                     <h3 class="marginBot5">Modify tags of ${this.characterIds.length} characters</h3>
                     <small class="bulk_tags_desc m-b-1">Add or remove the mutual tags of all selected characters. Import all or existing tags for all selected characters.</small>

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -18,7 +18,7 @@ import {
 import { favsToHotswap } from './RossAscends-mods.js';
 import { hideLoader, showLoader } from './loader.js';
 import { convertCharacterToPersona } from './personas.js';
-import { createTagInput, getTagKeyForEntity, getTagsList, printTagList, tag_map, compareTagsForSort, removeTagFromMap } from './tags.js';
+import { createTagInput, getTagKeyForEntity, getTagsList, printTagList, tag_map, compareTagsForSort, removeTagFromMap, importTags } from './tags.js';
 
 /**
  * Static object representing the actions of the
@@ -219,6 +219,9 @@ class BulkTagPopupHandler {
                             <i class="fa-solid fa-trash-can margin-right-10px"></i>
                             Mutual
                         </div>
+                        <div id="bulk_tag_popup_import_all_tags" class="menu_button" title="Import all tags from selected characters" data-i18n="[title]Import all tags from selected characters">
+                            Import All
+                        </div>
                         <div id="bulk_tag_popup_cancel" class="menu_button" data-i18n="Cancel">Close</div>
                     </div>
                 </div>
@@ -254,6 +257,18 @@ class BulkTagPopupHandler {
         document.querySelector('#bulk_tag_popup_reset').addEventListener('click', this.resetTags.bind(this));
         document.querySelector('#bulk_tag_popup_remove_mutual').addEventListener('click', this.removeMutual.bind(this));
         document.querySelector('#bulk_tag_popup_cancel').addEventListener('click', this.hide.bind(this));
+        document.querySelector('#bulk_tag_popup_import_all_tags').addEventListener('click', this.importAllTags.bind(this));
+    }
+
+    /**
+     * Import all tags for all selected characters
+     */
+    async importAllTags() {
+        for (const characterId of this.characterIds) {
+            await importTags(characters[characterId], { importAll: true });
+        }
+
+        $('#bulkTagList').empty();
     }
 
     /**
@@ -570,7 +585,7 @@ class BulkEditOverlay {
             this.container.removeEventListener('mouseup', cancelHold);
             this.container.removeEventListener('touchend', cancelHold);
         },
-        BulkEditOverlay.longPressDelay);
+            BulkEditOverlay.longPressDelay);
     };
 
     handleLongPressEnd = (event) => {

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -200,7 +200,7 @@ class BulkTagPopupHandler {
             <div id="bulk_tag_popup">
                 <div id="bulk_tag_popup_holder">
                     <h3 class="marginBot5">Modify tags of ${this.characterIds.length} characters</h3>
-                    <small class="bulk_tags_desc m-b-1">Add or remove the mutual tags of all selected characters.</small>
+                    <small class="bulk_tags_desc m-b-1">Add or remove the mutual tags of all selected characters. Import all or existing tags for all selected characters.</small>
                     <div id="bulk_tags_avatars_block" class="avatars_inline avatars_inline_small tags tags_inline"></div>
                     <br>
                     <div id="bulk_tags_div" class="marginBot5" data-characters='${characterData}'>
@@ -221,6 +221,9 @@ class BulkTagPopupHandler {
                         </div>
                         <div id="bulk_tag_popup_import_all_tags" class="menu_button" title="Import all tags from selected characters" data-i18n="[title]Import all tags from selected characters">
                             Import All
+                        </div>
+                        <div id="bulk_tag_popup_import_existing_tags" class="menu_button" title="Import existing tags from selected characters" data-i18n="[title]Import existing tags from selected characters">
+                            Import Existing
                         </div>
                         <div id="bulk_tag_popup_cancel" class="menu_button" data-i18n="Cancel">Close</div>
                     </div>
@@ -258,6 +261,18 @@ class BulkTagPopupHandler {
         document.querySelector('#bulk_tag_popup_remove_mutual').addEventListener('click', this.removeMutual.bind(this));
         document.querySelector('#bulk_tag_popup_cancel').addEventListener('click', this.hide.bind(this));
         document.querySelector('#bulk_tag_popup_import_all_tags').addEventListener('click', this.importAllTags.bind(this));
+        document.querySelector('#bulk_tag_popup_import_existing_tags').addEventListener('click', this.importExistingTags.bind(this));
+    }
+
+    /**
+     * Import existing tags for all selected characters
+     */
+    async importExistingTags() {
+        for (const characterId of this.characterIds) {
+            await importTags(characters[characterId], { importExisting: true });
+        }
+
+        $('#bulkTagList').empty();
     }
 
     /**

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -18,7 +18,7 @@ import {
 import { favsToHotswap } from './RossAscends-mods.js';
 import { hideLoader, showLoader } from './loader.js';
 import { convertCharacterToPersona } from './personas.js';
-import { createTagInput, getTagKeyForEntity, getTagsList, printTagList, tag_map, compareTagsForSort, removeTagFromMap, importTags } from './tags.js';
+import { createTagInput, getTagKeyForEntity, getTagsList, printTagList, tag_map, compareTagsForSort, removeTagFromMap, importTags, tag_import_setting } from './tags.js';
 
 /**
  * Static object representing the actions of the
@@ -269,7 +269,7 @@ class BulkTagPopupHandler {
      */
     async importExistingTags() {
         for (const characterId of this.characterIds) {
-            await importTags(characters[characterId], { importExisting: true });
+            await importTags(characters[characterId], { importSetting: tag_import_setting.ONLY_EXISTING });
         }
 
         $('#bulkTagList').empty();
@@ -280,7 +280,7 @@ class BulkTagPopupHandler {
      */
     async importAllTags() {
         for (const characterId of this.characterIds) {
-            await importTags(characters[characterId], { importAll: true });
+            await importTags(characters[characterId], { importSetting: tag_import_setting.ALL });
         }
 
         $('#bulkTagList').empty();

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -750,10 +750,16 @@ async function handleTagImport(character, { importAll = false, importExisting = 
     const folderTags = getOpenBogusFolders();
 
     // Choose the setting for this dialog. If from settings, verify the setting really exists, otherwise take "ASK".
-    const setting = forceShow ? tag_import_setting.ASK
-        : importAll ? tag_import_setting.ALL
-            : importExisting ? tag_import_setting.ONLY_EXISTING
-                : Object.values(tag_import_setting).find(setting => setting === power_user.tag_import_setting) ?? tag_import_setting.ASK;
+    let setting;
+    if (forceShow) {
+        setting = tag_import_setting.ASK;
+    } else if (importAll) {
+        setting = tag_import_setting.ALL;
+    } else if (importExisting) {
+        setting = tag_import_setting.ONLY_EXISTING;
+    } else {
+        setting = Object.values(tag_import_setting).find(setting => setting === power_user.tag_import_setting) ?? tag_import_setting.ASK;
+    }
 
     switch (setting) {
         case tag_import_setting.ALL:

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -708,12 +708,13 @@ const ANTI_TROLL_MAX_TAGS = 15;
  *
  * @param {Character} character - The character
  * @param {object} [options] - Options
+ * @param {boolean} [options.importAll=false] - Whether to import all tags without dialog
  * @param {boolean} [options.forceShow=false] - Whether to force showing the import dialog
  * @returns {Promise<boolean>} Boolean indicating whether any tag was imported
  */
-async function importTags(character, { forceShow = false } = {}) {
+async function importTags(character, { importAll = false, forceShow = false } = {}) {
     // Gather the tags to import based on the selected setting
-    const tagNamesToImport = await handleTagImport(character, { forceShow });
+    const tagNamesToImport = await handleTagImport(character, { importAll, forceShow });
     if (!tagNamesToImport?.length) {
         console.debug('No tags to import');
         return;
@@ -732,10 +733,11 @@ async function importTags(character, { forceShow = false } = {}) {
  *
  * @param {Character} character - The character
  * @param {object} [options] - Options
+ * @param {boolean} [options.importAll=false] - Whether to import all tags without dialog
  * @param {boolean} [options.forceShow=false] - Whether to force showing the import dialog
  * @returns {Promise<string[]>} Array of strings representing the tags to import
  */
-async function handleTagImport(character, { forceShow = false } = {}) {
+async function handleTagImport(character, { importAll = false, forceShow = false } = {}) {
     /** @type {string[]} */
     const importTags = character.tags.map(t => t.trim()).filter(t => t)
         .filter(t => !IMPORT_EXLCUDED_TAGS.includes(t))
@@ -747,7 +749,8 @@ async function handleTagImport(character, { forceShow = false } = {}) {
 
     // Choose the setting for this dialog. If from settings, verify the setting really exists, otherwise take "ASK".
     const setting = forceShow ? tag_import_setting.ASK
-        : Object.values(tag_import_setting).find(setting => setting === power_user.tag_import_setting) ?? tag_import_setting.ASK;
+        : importAll ? tag_import_setting.ALL
+            : Object.values(tag_import_setting).find(setting => setting === power_user.tag_import_setting) ?? tag_import_setting.ASK;
 
     switch (setting) {
         case tag_import_setting.ALL:

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -709,12 +709,13 @@ const ANTI_TROLL_MAX_TAGS = 15;
  * @param {Character} character - The character
  * @param {object} [options] - Options
  * @param {boolean} [options.importAll=false] - Whether to import all tags without dialog
+ * @param {boolean} [options.importExisting=false] - Whether to import existing tags without dialog
  * @param {boolean} [options.forceShow=false] - Whether to force showing the import dialog
  * @returns {Promise<boolean>} Boolean indicating whether any tag was imported
  */
-async function importTags(character, { importAll = false, forceShow = false } = {}) {
+async function importTags(character, { importAll = false, importExisting = false, forceShow = false } = {}) {
     // Gather the tags to import based on the selected setting
-    const tagNamesToImport = await handleTagImport(character, { importAll, forceShow });
+    const tagNamesToImport = await handleTagImport(character, { importAll, importExisting, forceShow });
     if (!tagNamesToImport?.length) {
         console.debug('No tags to import');
         return;
@@ -734,10 +735,11 @@ async function importTags(character, { importAll = false, forceShow = false } = 
  * @param {Character} character - The character
  * @param {object} [options] - Options
  * @param {boolean} [options.importAll=false] - Whether to import all tags without dialog
+ * @param {boolean} [options.importExisting=false] - Whether to import existing tags without dialog
  * @param {boolean} [options.forceShow=false] - Whether to force showing the import dialog
  * @returns {Promise<string[]>} Array of strings representing the tags to import
  */
-async function handleTagImport(character, { importAll = false, forceShow = false } = {}) {
+async function handleTagImport(character, { importAll = false, importExisting = false, forceShow = false } = {}) {
     /** @type {string[]} */
     const importTags = character.tags.map(t => t.trim()).filter(t => t)
         .filter(t => !IMPORT_EXLCUDED_TAGS.includes(t))
@@ -750,7 +752,8 @@ async function handleTagImport(character, { importAll = false, forceShow = false
     // Choose the setting for this dialog. If from settings, verify the setting really exists, otherwise take "ASK".
     const setting = forceShow ? tag_import_setting.ASK
         : importAll ? tag_import_setting.ALL
-            : Object.values(tag_import_setting).find(setting => setting === power_user.tag_import_setting) ?? tag_import_setting.ASK;
+            : importExisting ? tag_import_setting.ONLY_EXISTING
+                : Object.values(tag_import_setting).find(setting => setting === power_user.tag_import_setting) ?? tag_import_setting.ASK;
 
     switch (setting) {
         case tag_import_setting.ALL:

--- a/public/style.css
+++ b/public/style.css
@@ -3195,7 +3195,7 @@ grammarly-extension {
 
 #bulk_tag_popup,
 #dialogue_popup {
-    width: 750px;
+    width: 500px;
     max-width: 90vw;
     max-width: 90dvw;
     position: absolute;

--- a/public/style.css
+++ b/public/style.css
@@ -3195,7 +3195,7 @@ grammarly-extension {
 
 #bulk_tag_popup,
 #dialogue_popup {
-    width: 500px;
+    width: 750px;
     max-width: 90vw;
     max-width: 90dvw;
     position: absolute;


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->
This PR adds two buttons to allow bulk tag import.  They are located in the "Tag" menu in bulk edit mode. 
One is used to import all tags, while the other is used to import existing tags only, similarly to the "Import Tags" menu for a single character. 
The following picture shows the modified menu.

![Screenshot_new_buttons](https://github.com/user-attachments/assets/b09ad771-7463-44e4-8ca1-8f630afc40a4)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).



