### PR TITLE
Suspend macros in first messages

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1880,6 +1880,7 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId) {
 
     if (Number(messageId) === 0 && !isSystem && !isUser) {
         mes = substituteParams(mes, undefined, ch_name);
+        chat[messageId] && (chat[messageId].mes = mes);
     }
 
     mesForShowdownParse = mes;


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Macros in first messages are still evaluated lazily, but only once. This is to prevent disconnect between the internal state and display (most prominent example - {{random}}).
2. Swiping first messages back and forth will still re-evaluate macros as they intentionally are not evaluated in the swipes array.
3. Editing the first message in chat will not show the macros as they are already replaced with the text. I'm not sure if that's really an issue.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
