### PR TITLE
`/api-url` slash command to get/set the API server url for text gen and OpenAI Custom

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -20,8 +20,6 @@ import {
     validateTextGenUrl,
     parseTextgenLogprobs,
     parseTabbyLogprobs,
-    textgenerationwebui_settings,
-    SERVER_INPUTS,
 } from './scripts/textgen-settings.js';
 
 const { MANCER, TOGETHERAI, OOBA, VLLM, APHRODITE, TABBY, OLLAMA, INFERMATICAI, DREAMGEN, OPENROUTER, FEATHERLESS } = textgen_types;
@@ -244,7 +242,7 @@ import { DragAndDropHandler } from './scripts/dragdrop.js';
 import { INTERACTABLE_CONTROL_CLASS, initKeyboard } from './scripts/keyboard.js';
 import { initDynamicStyles } from './scripts/dynamic-styles.js';
 import { SlashCommandEnumValue, enumTypes } from './scripts/slash-commands/SlashCommandEnumValue.js';
-import { commonEnumProviders, enumIcons } from './scripts/slash-commands/SlashCommandCommonEnumsProvider.js';
+import { enumIcons } from './scripts/slash-commands/SlashCommandCommonEnumsProvider.js';
 
 //exporting functions and vars for mods
 export {
@@ -8522,77 +8520,6 @@ async function connectAPISlash(_, text) {
 }
 
 /**
- * Sets the API URL and triggers the text generation web UI button click.
- *
- * @param {object} args - named args
- * @param {string?} [args.api=null] - the API name to set/get the URL for
- * @param {string?} [args.connect=true] - whether to connect to the API after setting
- * @param {string} url - the API URL to set
- * @returns {Promise<string>}
- */
-async function setApiUrlCallback({ api = null, connect = 'true' }, url) {
-    // Special handling for Chat Completion Custom OpenAI compatible, that one can also support API url handling
-    const isCurrentlyCustomOpenai = main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.CUSTOM;
-    if (api === chat_completion_sources.CUSTOM || (!api && isCurrentlyCustomOpenai)) {
-        if (url && !isCurrentlyCustomOpenai) {
-            toastr.warning(`Custom OpenAI API is not the currently selected API, so we cannot do an auto-connect. Consider switching to it via /api beforehand.`);
-            return '';
-        }
-
-        if (!url) {
-            return oai_settings.custom_url ?? '';
-        }
-
-        $('#custom_api_url_text').val(url).trigger('input');
-
-        if (isTrueBoolean(connect)) {
-            $('#api_button_openai').trigger('click');
-        }
-
-        return url;
-    }
-
-    // Do some checks and get the api type we are targeting with this command
-    if (api && !Object.values(textgen_types).includes(api)) {
-        toastr.warning(`API '${api}' is not a valid text_gen API.`);
-        return '';
-    }
-    if (!api && !Object.values(textgen_types).includes(textgenerationwebui_settings.type)) {
-        toastr.warning(`API '${textgenerationwebui_settings.type}' is not a valid text_gen API.`);
-        return '';
-    }
-    if (api && url && isTrueBoolean(connect) && api !== textgenerationwebui_settings.type) {
-        toastr.warning(`API '${api}' is not the currently selected API, so we cannot do an auto-connect. Consider switching to it via /api beforehand.`);
-        return '';
-    }
-    const type = api || textgenerationwebui_settings.type;
-
-    const inputSelector = SERVER_INPUTS[type];
-    if (!inputSelector) {
-        toastr.warning(`API '${type}' does not have a server url input.`);
-        return '';
-    }
-
-    // If no url was provided, return the current one
-    if (!url) {
-        return textgenerationwebui_settings.server_urls[type] ?? '';
-    }
-
-    // else, we want to actually set the url
-    $(inputSelector).val(url).trigger('input');
-    // trigger blur debounced, so we hide the autocomplete menu
-    setTimeout(() => $(inputSelector).trigger('blur'), 1);
-
-    // Trigger the auto connect via connect button, if requested
-    if (isTrueBoolean(connect)) {
-        $('#api_button_textgenerationwebui').trigger('click');
-    }
-
-    // We still re-acquire the value, as it might have been modified by the validation on connect
-    return textgenerationwebui_settings.server_urls[type] ?? '';
-}
-
-/**
  * Imports supported files dropped into the app window.
  * @param {File[]} files Array of files to process
  * @param {Map<File, string>} [data] Extra data to pass to the import function
@@ -9067,49 +8994,6 @@ jQuery(async function () {
             <div>
                 <strong>Available APIs:</strong>
                 <pre><code>${Object.keys(CONNECT_API_MAP).join(', ')}</code></pre>
-            </div>
-        `,
-    }));
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'api-url',
-        callback: setApiUrlCallback,
-        returns: 'the current API url',
-        aliases: ['server'],
-        namedArgumentList: [
-            SlashCommandNamedArgument.fromProps({
-                name: 'api',
-                description: 'API to set/get the URL for - if not provided, current API is used',
-                typeList: [ARGUMENT_TYPE.STRING],
-                enumList: [
-                    new SlashCommandEnumValue('custom', 'custom openai compatible', enumTypes.getBasedOnIndex(uniqueAPIs.findIndex(x => x === 'openai')), 'O'),
-                    ...Object.values(textgen_types).map(api => new SlashCommandEnumValue(api, null, enumTypes.getBasedOnIndex(uniqueAPIs.findIndex(x => x === 'textgenerationwebui')), 'T')),
-                ],
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'connect',
-                description: 'Whether to auto-connect to the API after setting the URL',
-                typeList: [ARGUMENT_TYPE.BOOLEAN],
-                defaultValue: 'true',
-                enumList: commonEnumProviders.boolean('trueFalse')(),
-            }),
-        ],
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'API url to connect to',
-                typeList: [ARGUMENT_TYPE.STRING],
-            }),
-        ],
-        helpString: `
-            <div>
-                Set the API url / server url for the currently selected API, including the port. If no argument is provided, it will return the current API url.
-            </div>
-            <div>
-                If a manual API is provided to <b>set</b>the URL, make sure to set <code>connect=false</code>, as auto-connect only works for the currently selected API,
-                or consider switching to it with <code>/api</code> first.
-            </div>
-            <div>
-                This slash command works for most of the Text Completion sources, and also Custom OpenAI compatible for the Chat Completion sources. If unsure which APIs are supported,
-                check the auto-completion of the optional <code>api</code> argument of this command.
             </div>
         `,
     }));

--- a/public/script.js
+++ b/public/script.js
@@ -8392,6 +8392,9 @@ const CONNECT_API_MAP = {
     },
 };
 
+// Collect all unique API names in an array
+export const UNIQUE_APIS = [...new Set(Object.values(CONNECT_API_MAP).map(x => x.selected))];
+
 // Fill connections map from textgen_types and chat_completion_sources
 for (const textGenType of Object.values(textgen_types)) {
     if (CONNECT_API_MAP[textGenType]) continue;
@@ -8966,9 +8969,6 @@ jQuery(async function () {
         return '';
     }
 
-    // Collect all unique API names in an array
-    const uniqueAPIs = [...new Set(Object.values(CONNECT_API_MAP).map(x => x.selected))];
-
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'dupe',
         callback: duplicateCharacter,
@@ -8983,7 +8983,7 @@ jQuery(async function () {
                 description: 'API to connect to',
                 typeList: [ARGUMENT_TYPE.STRING],
                 enumList: Object.entries(CONNECT_API_MAP).map(([api, { selected }]) =>
-                    new SlashCommandEnumValue(api, selected, enumTypes.getBasedOnIndex(uniqueAPIs.findIndex(x => x === selected)),
+                    new SlashCommandEnumValue(api, selected, enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === selected)),
                         selected[0].toUpperCase() ?? enumIcons.default)),
             }),
         ],

--- a/public/script.js
+++ b/public/script.js
@@ -9107,6 +9107,10 @@ jQuery(async function () {
                 If a manual API is provided to <b>set</b>the URL, make sure to set <code>connect=false</code>, as auto-connect only works for the currently selected API,
                 or consider switching to it with <code>/api</code> first.
             </div>
+            <div>
+                This slash command works for most of the Text Completion sources, and also Custom OpenAI compatible for the Chat Completion sources. If unsure which APIs are supported,
+                check the auto-completion of the optional <code>api</code> argument of this command.
+            </div>
         `,
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -49,7 +49,7 @@ import { findGroupMemberId, groups, is_group_generating, openGroupById, resetSel
 import { chat_completion_sources, oai_settings, setupChatCompletionPromptManager } from './openai.js';
 import { autoSelectPersona, retriggerFirstMessageOnEmptyChat, setPersonaLockState, togglePersonaLock, user_avatar } from './personas.js';
 import { addEphemeralStoppingString, chat_styles, flushEphemeralStoppingStrings, power_user } from './power-user.js';
-import { textgen_types, textgenerationwebui_settings } from './textgen-settings.js';
+import { SERVER_INPUTS, textgen_types, textgenerationwebui_settings } from './textgen-settings.js';
 import { decodeTextTokens, getFriendlyTokenizerName, getTextTokens, getTokenCountAsync } from './tokenizers.js';
 import { debounce, delay, isFalseBoolean, isTrueBoolean, showFontAwesomePicker, stringToRange, trimToEndSentence, trimToStartSentence, waitUntilCondition } from './utils.js';
 import { registerVariableCommands, resolveVariable } from './variables.js';
@@ -1510,6 +1510,49 @@ export function initDefaultSlashCommands() {
                     </ul>
                 </div>
             `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'api-url',
+        callback: setApiUrlCallback,
+        returns: 'the current API url',
+        aliases: ['server'],
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'api',
+                description: 'API to set/get the URL for - if not provided, current API is used',
+                typeList: [ARGUMENT_TYPE.STRING],
+                enumList: [
+                    new SlashCommandEnumValue('custom', 'custom openai compatible', enumTypes.getBasedOnIndex(uniqueAPIs.findIndex(x => x === 'openai')), 'O'),
+                    ...Object.values(textgen_types).map(api => new SlashCommandEnumValue(api, null, enumTypes.getBasedOnIndex(uniqueAPIs.findIndex(x => x === 'textgenerationwebui')), 'T')),
+                ],
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'connect',
+                description: 'Whether to auto-connect to the API after setting the URL',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'true',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'API url to connect to',
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
+        ],
+        helpString: `
+            <div>
+                Set the API url / server url for the currently selected API, including the port. If no argument is provided, it will return the current API url.
+            </div>
+            <div>
+                If a manual API is provided to <b>set</b>the URL, make sure to set <code>connect=false</code>, as auto-connect only works for the currently selected API,
+                or consider switching to it with <code>/api</code> first.
+            </div>
+            <div>
+                This slash command works for most of the Text Completion sources, and also Custom OpenAI compatible for the Chat Completion sources. If unsure which APIs are supported,
+                check the auto-completion of the optional <code>api</code> argument of this command.
+            </div>
+        `,
     }));
 
     registerVariableCommands();
@@ -3416,6 +3459,77 @@ function setPromptEntryCallback(args, targetState) {
     promptManager.render();
     promptManager.saveServiceSettings();
     return '';
+}
+
+/**
+ * Sets the API URL and triggers the text generation web UI button click.
+ *
+ * @param {object} args - named args
+ * @param {string?} [args.api=null] - the API name to set/get the URL for
+ * @param {string?} [args.connect=true] - whether to connect to the API after setting
+ * @param {string} url - the API URL to set
+ * @returns {Promise<string>}
+ */
+async function setApiUrlCallback({ api = null, connect = 'true' }, url) {
+    // Special handling for Chat Completion Custom OpenAI compatible, that one can also support API url handling
+    const isCurrentlyCustomOpenai = main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.CUSTOM;
+    if (api === chat_completion_sources.CUSTOM || (!api && isCurrentlyCustomOpenai)) {
+        if (url && !isCurrentlyCustomOpenai) {
+            toastr.warning('Custom OpenAI API is not the currently selected API, so we cannot do an auto-connect. Consider switching to it via /api beforehand.');
+            return '';
+        }
+
+        if (!url) {
+            return oai_settings.custom_url ?? '';
+        }
+
+        $('#custom_api_url_text').val(url).trigger('input');
+
+        if (isTrueBoolean(connect)) {
+            $('#api_button_openai').trigger('click');
+        }
+
+        return url;
+    }
+
+    // Do some checks and get the api type we are targeting with this command
+    if (api && !Object.values(textgen_types).includes(api)) {
+        toastr.warning(`API '${api}' is not a valid text_gen API.`);
+        return '';
+    }
+    if (!api && !Object.values(textgen_types).includes(textgenerationwebui_settings.type)) {
+        toastr.warning(`API '${textgenerationwebui_settings.type}' is not a valid text_gen API.`);
+        return '';
+    }
+    if (api && url && isTrueBoolean(connect) && api !== textgenerationwebui_settings.type) {
+        toastr.warning(`API '${api}' is not the currently selected API, so we cannot do an auto-connect. Consider switching to it via /api beforehand.`);
+        return '';
+    }
+    const type = api || textgenerationwebui_settings.type;
+
+    const inputSelector = SERVER_INPUTS[type];
+    if (!inputSelector) {
+        toastr.warning(`API '${type}' does not have a server url input.`);
+        return '';
+    }
+
+    // If no url was provided, return the current one
+    if (!url) {
+        return textgenerationwebui_settings.server_urls[type] ?? '';
+    }
+
+    // else, we want to actually set the url
+    $(inputSelector).val(url).trigger('input');
+    // trigger blur debounced, so we hide the autocomplete menu
+    setTimeout(() => $(inputSelector).trigger('blur'), 1);
+
+    // Trigger the auto connect via connect button, if requested
+    if (isTrueBoolean(connect)) {
+        $('#api_button_textgenerationwebui').trigger('click');
+    }
+
+    // We still re-acquire the value, as it might have been modified by the validation on connect
+    return textgenerationwebui_settings.server_urls[type] ?? '';
 }
 
 export let isExecutingCommandsFromChatInput = false;

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -94,7 +94,7 @@ let DREAMGEN_SERVER = 'https://dreamgen.com';
 let OPENROUTER_SERVER = 'https://openrouter.ai/api';
 let FEATHERLESS_SERVER = 'https://api.featherless.ai/v1';
 
-const SERVER_INPUTS = {
+export const SERVER_INPUTS = {
     [textgen_types.OOBA]: '#textgenerationwebui_api_url_text',
     [textgen_types.VLLM]: '#vllm_api_url_text',
     [textgen_types.APHRODITE]: '#aphrodite_api_url_text',


### PR DESCRIPTION
Setting API and presets via `/api`, `/preset` and Co was possible. For text completion, you usually need a server backend URL though. Some people might host different backends at once, or have non-default ports.
So providing a built-in slash command to set the actual API url / server url made sense for me.

The slash command itself works very similar to the ones mentioned above. Providing the current URL if no unnamed arg is providing, or otherwise setting it.
There are two optional arguments supported.
- `connect` with default `=true` will auto-connect to the given backend, by clicking the connect button. There is sadly no exposed framework function for this. But we are already juggling with controls on mass here anyway, so clicking that button sounds reasonable. For me it made sense to auto connect by default if you set an URL.
- `api`, defaulting to the currently selected API, allows to specify an API that might not be the currently selected one. Edge case, but why not support it. I can be connected to KoboldCPP, and still read the current backend url for ooba, or even update it. If setting the URL, you have to make sure to set `connect=false` though, as the button only works for the currently selected API. That is mentioned in the help text though.

### Slash command documentation
![image](https://github.com/user-attachments/assets/ab24dc73-85ff-42e8-be93-aeea4c36a5d4)


### Supported APIs
The command itself works for all Text Gen APIs that have listed API url fields in `SERVER_INPUTS`. That should be the standard exposed list for this.  
In addition, there is a special handling for Chat Completion "OpenAI Compatible", which also supports setting backend URLs, so it made sense to include this here. Code is a bit more ugly because of that, but well.
![image](https://github.com/user-attachments/assets/574792a1-c956-45f6-966d-9f74d45843c1)



## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
