### PR TITLE
Open popups should block all default hotkeys

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -954,6 +954,11 @@ export function initRossMods() {
      * @param {KeyboardEvent} event
      */
     async function processHotkeys(event) {
+        // Default hotkeys and shortcuts shouldn't work if any popup is currently open
+        if (Popup.util.isPopupOpen()) {
+            return;
+        }
+
         //Enter to send when send_textarea in focus
         if (document.activeElement == hotkeyTargets['send_textarea']) {
             const sendOnEnter = shouldSendOnEnter();
@@ -1107,10 +1112,6 @@ export function initRossMods() {
         }
 
         if (event.key == 'Escape') { //closes various panels
-            // Do not close panels if we are currently inside a popup
-            if (Popup.util.isPopupOpen())
-                return;
-
             //dont override Escape hotkey functions from script.js
             //"close edit box" and "cancel stream generation".
             if ($('#curEditTextarea').is(':visible') || $('#mes_stop').is(':visible')) {


### PR DESCRIPTION
If any modal popup is open, the default ST popups should not be evaluated.
Most shouldn't work anyway, because they check for explicit focus, but now we make sure that this doesn't happen.

Can be tested with the "ArrowRight" hotkey, that would trigger a swipe if the last message is a char message.
This does not happen anymore if any of the modern modal popups is open in the foreground.

- Fixes #2570

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
