### PR TITLE
Don't replace underscore italics inside of code blocks

### DIFF
--- a/public/scripts/showdown-underscore.js
+++ b/public/scripts/showdown-underscore.js
@@ -8,10 +8,10 @@ export const markdownUnderscoreExt = () => {
 
         return [{
             type: 'lang',
-            regex: /(`{3,})\s*\n[\s\S]*?\n\1(?:\n|$)|(`{1,2}).*?\2|(?<!\S)_(?!_)([^_\n]+?)(?<!_)_(?!\w)/g,
-            replace: function(match, tripleBackticks, singleOrDoubleBackticks, italicContent) {
-                if (singleOrDoubleBackticks || tripleBackticks) {
-                    // If it's backticks, return unchanged
+            regex: /(`{3,})\s*\n[\s\S]*?\n\1(?:\n|$)|(`{1,2}).*?\2|(\n`\n[\s\S]*?\n`\n)|(?<!\S)_(?!_)([^_\n]+?)(?<!_)_(?!\w)/g,
+            replace: function(match, tripleBackticks, singleOrDoubleBackticks, singleBackticksWithLineBreaks, italicContent) {
+                if (singleOrDoubleBackticks || tripleBackticks || singleBackticksWithLineBreaks) {
+                    // If it's any type of backticks, return unchanged
                     return match;
                 } else if (italicContent) {
                     // If it's an italic group, apply the replacement

--- a/public/scripts/showdown-underscore.js
+++ b/public/scripts/showdown-underscore.js
@@ -8,16 +8,16 @@ export const markdownUnderscoreExt = () => {
 
         return [{
             type: 'lang',
-            regex: new RegExp('(`{3})[\\s\\S]*?\\1|(`{1,2}).*?\\2|\\b(?<!_)_(?!_)(.*?)(?<!_)_(?!_)\\b', 'g'),
+            regex: /(`{3,})\s*\n[\s\S]*?\n\1(?:\n|$)|(`{1,2}).*?\2|(?<!\S)_(?!_)([^_\n]+?)(?<!_)_(?!\w)/g,
             replace: function(match, tripleBackticks, singleOrDoubleBackticks, italicContent) {
-                if (tripleBackticks || singleOrDoubleBackticks) {
-                    // If it's any kind of code block, return it unchanged
+                if (singleOrDoubleBackticks || tripleBackticks) {
+                    // If it's backticks, return unchanged
                     return match;
                 } else if (italicContent) {
                     // If it's an italic group, apply the replacement
                     return '<em>' + italicContent + '</em>';
                 }
-                // If neither condition is met, return the original match
+                // If none of the conditions are met, return the original match
                 return match;
             },
         }];

--- a/public/scripts/showdown-underscore.js
+++ b/public/scripts/showdown-underscore.js
@@ -8,15 +8,17 @@ export const markdownUnderscoreExt = () => {
 
         return [{
             type: 'lang',
-            regex: new RegExp('(`{1,3}).*?\\1|\\b(?<!_)_(?!_)(.*?)(?<!_)_(?!_)\\b', 'gs'),
-            replace: function(match, codeBlock, italicContent) {
-                if (codeBlock) {
-                    // If it's a code block, return it unchanged
+            regex: new RegExp('(`{3})[\\s\\S]*?\\1|(`{1,2}).*?\\2|\\b(?<!_)_(?!_)(.*?)(?<!_)_(?!_)\\b', 'g'),
+            replace: function(match, tripleBackticks, singleOrDoubleBackticks, italicContent) {
+                if (tripleBackticks || singleOrDoubleBackticks) {
+                    // If it's any kind of code block, return it unchanged
                     return match;
-                } else {
+                } else if (italicContent) {
                     // If it's an italic group, apply the replacement
-                    return `<em>${italicContent}</em>`;
+                    return '<em>' + italicContent + '</em>';
                 }
+                // If neither condition is met, return the original match
+                return match;
             },
         }];
     } catch (e) {

--- a/public/scripts/showdown-underscore.js
+++ b/public/scripts/showdown-underscore.js
@@ -7,11 +7,11 @@ export const markdownUnderscoreExt = () => {
         }
 
         return [{
-            type: 'lang',
-            regex: /(`{3,})\s*\n[\s\S]*?\n\1(?:\n|$)|(`{1,2}).*?\2|(\n`\n[\s\S]*?\n`\n)|(?<!\S)_(?!_)([^_\n]+?)(?<!_)_(?!\w)/g,
-            replace: function(match, tripleBackticks, singleOrDoubleBackticks, singleBackticksWithLineBreaks, italicContent) {
-                if (singleOrDoubleBackticks || tripleBackticks || singleBackticksWithLineBreaks) {
-                    // If it's any type of backticks, return unchanged
+            type: 'output',
+            regex: new RegExp('(<code>[\\s\\S]*?<\\/code>)|(?<!\\S)_(?!_)([^_\\n]+?)(?<!_)_(?!\\w)', 'g'),
+            replace: function(match, codeContent, italicContent) {
+                if (codeContent) {
+                    // If it's inside <code> tags, return unchanged
                     return match;
                 } else if (italicContent) {
                     // If it's an italic group, apply the replacement

--- a/public/scripts/showdown-underscore.js
+++ b/public/scripts/showdown-underscore.js
@@ -8,8 +8,16 @@ export const markdownUnderscoreExt = () => {
 
         return [{
             type: 'lang',
-            regex: new RegExp('\\b(?<!_)_(?!_)(.*?)(?<!_)_(?!_)\\b', 'g'),
-            replace: '<em>$1</em>',
+            regex: new RegExp('(`{1,3}).*?\\1|\\b(?<!_)_(?!_)(.*?)(?<!_)_(?!_)\\b', 'gs'),
+            replace: function(match, codeBlock, italicContent) {
+                if (codeBlock) {
+                    // If it's a code block, return it unchanged
+                    return match;
+                } else {
+                    // If it's an italic group, apply the replacement
+                    return `<em>${italicContent}</em>`;
+                }
+            },
         }];
     } catch (e) {
         console.error('Error in Showdown-underscore extension:', e);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Test case

<pre><code>
```
Some _word_ surrounded with _underscores_
```

`Some _word_ surrounded with _underscores_`

Some _word_ surrounded with _underscores_.
</code></pre>

## Before

<img width="651" alt="image" src="https://github.com/user-attachments/assets/3b02b4a4-5a09-447b-8c2c-04fd0f8764f4">

## After

<img width="651" alt="image" src="https://github.com/user-attachments/assets/6fd89c13-9b48-42c0-b086-9f867461e89c">

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
