### PR TITLE
/messages callback refactored to async

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1888,10 +1888,10 @@ async function getMessagesCallback(args, value) {
         return includeNames ? `${msg.name}: ${msg.mes}` : msg.mes;
     };
 
-    const messagePromises = new Array(range.end - range.start + 1);
+    const messagePromises = [];
 
     for (let rInd = range.start; rInd <= range.end; ++rInd)
-        messagePromises[rInd - range.start] = processMessage(rInd);
+        messagePromises.push(processMessage(rInd));
 
     const messages = await Promise.all(messagePromises);
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1835,7 +1835,7 @@ async function popupCallback(args, value) {
     return String(value);
 }
 
-function getMessagesCallback(args, value) {
+async function getMessagesCallback(args, value) {
     const includeNames = !isFalseBoolean(args?.names);
     const includeHidden = isTrueBoolean(args?.hidden);
     const role = args?.role;
@@ -1868,30 +1868,36 @@ function getMessagesCallback(args, value) {
         throw new Error(`Invalid role provided. Expected one of: system, assistant, user. Got: ${role}`);
     };
 
-    const messages = [];
-
-    for (let messageId = range.start; messageId <= range.end; messageId++) {
-        const message = chat[messageId];
-        if (!message) {
-            console.warn(`WARN: No message found with ID ${messageId}`);
-            continue;
+    const processMessage = async (mesId) => {
+        const msg = chat[mesId];
+        if (!msg) {
+            console.warn(`WARN: No message found with ID ${mesId}`);
+            return null;
         }
 
-        if (role && !filterByRole(message)) {
-            console.debug(`/messages: Skipping message with ID ${messageId} due to role filter`);
-            continue;
+        if (role && !filterByRole(msg)) {
+            console.debug(`/messages: Skipping message with ID ${mesId} due to role filter`);
+            return null;
         }
 
-        if (!includeHidden && message.is_system) {
-            console.debug(`/messages: Skipping hidden message with ID ${messageId}`);
-            continue;
+        if (!includeHidden && msg.is_system) {
+            console.debug(`/messages: Skipping hidden message with ID ${mesId}`);
+            return null;
         }
 
-        if (includeNames) {
-            messages.push(`${message.name}: ${message.mes}`);
-        } else {
-            messages.push(message.mes);
-        }
+        return includeNames ? `${msg.name}: ${msg.mes}` : msg.mes;
+    };
+
+    const messagePromises = new Array(range.end - range.start + 1);
+
+    for (let rInd = range.start; rInd <= range.end; ++rInd)
+        messagePromises[rInd - range.start] = processMessage(rInd);
+
+    const messages = await Promise.all(messagePromises);
+
+    for (let i = 0; i < messages.length; /**/ ) {
+        if (messages[i] !== null) ++i;
+        else messages.splice(i, 1);
     }
 
     return messages.join('\n\n');

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1895,12 +1895,7 @@ async function getMessagesCallback(args, value) {
 
     const messages = await Promise.all(messagePromises);
 
-    for (let i = 0; i < messages.length; /**/ ) {
-        if (messages[i] !== null) ++i;
-        else messages.splice(i, 1);
-    }
-
-    return messages.join('\n\n');
+    return messages.filter(m => m !== null).join('\n\n');
 }
 
 async function runCallback(args, name) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Refactors to async, processing messages separately and inserting them into a fixed-size array that's the proper order. Once all promise are fulfilled, removes null elements in the array using a for-loop and the splice method, which I believe is faster than using filter since it does not create a new array.

This should significantly increase performance when dealing with large ranges of messages, **particularly** when `names=on`

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
