### PR TITLE
Add slash command to set tokenizer

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -212,7 +212,7 @@ import {
     selectContextPreset,
 } from './scripts/instruct-mode.js';
 import { initLocales, t, translate } from './scripts/i18n.js';
-import { getFriendlyTokenizerName, getTokenCount, getTokenCountAsync, getTokenizerModel, initTokenizers, saveTokenCache } from './scripts/tokenizers.js';
+import { getFriendlyTokenizerName, getTokenCount, getTokenCountAsync, getTokenizerModel, initTokenizers, saveTokenCache, selectTokenizer, TOKENIZER_NAME_MAP, tokenizers } from './scripts/tokenizers.js';
 import {
     user_avatar,
     getUserAvatars,
@@ -8451,6 +8451,25 @@ async function selectInstructCallback(_, name) {
     return foundName;
 }
 
+async function selectTokenizerCallback(_, name) {
+    if (!name) {
+        return TOKENIZER_NAME_MAP[power_user.tokenizer];
+    }
+
+    const tokenizerNames = Object.values(TOKENIZER_NAME_MAP);
+    const fuse = new Fuse(tokenizerNames);
+    const result = fuse.search(name);
+
+    if (result.length === 0) {
+        toastr.warning(`Tokenizer "${name}" not found`);
+        return '';
+    }
+
+    const foundName = result[0].item;
+    selectTokenizer(tokenizers[foundName.toUpperCase()]);
+    return foundName;
+}
+
 async function enableInstructCallback() {
     $('#instruct_enabled').prop('checked', true).trigger('change');
     return '';
@@ -9094,6 +9113,28 @@ jQuery(async function () {
                 </ul>
             </div>
         `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'tokenizer',
+        callback: selectTokenizerCallback,
+        returns: 'current tokenizer',
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'tokenizer name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                enumList: Object.values(TOKENIZER_NAME_MAP).map(tokenizer =>
+                    new SlashCommandEnumValue(tokenizer, null, enumTypes.enum, enumIcons.default)),
+            }),
+        ],
+        helpString: `
+            <div>
+                Selects tokenizer by name. Gets the current tokenizer if no name is provided.
+            </div>
+            <div>
+                <strong>Available tokenizers:</strong>
+                <pre><code>${Object.values(TOKENIZER_NAME_MAP).join(', ')}</code></pre>
+            </div>
+        `
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'instruct-on',

--- a/public/script.js
+++ b/public/script.js
@@ -212,7 +212,7 @@ import {
     selectContextPreset,
 } from './scripts/instruct-mode.js';
 import { initLocales, t, translate } from './scripts/i18n.js';
-import { getAvailableTokenizers, getFriendlyTokenizerName, getTokenCount, getTokenCountAsync, getTokenizerModel, initTokenizers, saveTokenCache, selectTokenizer } from './scripts/tokenizers.js';
+import { getFriendlyTokenizerName, getTokenCount, getTokenCountAsync, getTokenizerModel, initTokenizers, saveTokenCache } from './scripts/tokenizers.js';
 import {
     user_avatar,
     getUserAvatars,
@@ -8451,27 +8451,6 @@ async function selectInstructCallback(_, name) {
     return foundName;
 }
 
-async function selectTokenizerCallback(_, name) {
-    if (!name) {
-        return getAvailableTokenizers().find(tokenizer => tokenizer.tokenizerId === power_user.tokenizer)?.tokenizerKey ?? '';
-    }
-
-    const tokenizers = getAvailableTokenizers();
-    const fuse = new Fuse(tokenizers, { keys: ['tokenizerKey', 'tokenizerName'] });
-    const result = fuse.search(name);
-
-    if (result.length === 0) {
-        toastr.warning(`Tokenizer "${name}" not found`);
-        return '';
-    }
-
-    /** @type {import('./scripts/tokenizers.js').Tokenizer} */
-    const foundTokenizer = result[0].item;
-    selectTokenizer(foundTokenizer.tokenizerId);
-
-    return foundTokenizer.tokenizerKey;
-}
-
 async function enableInstructCallback() {
     $('#instruct_enabled').prop('checked', true).trigger('change');
     return '';
@@ -9115,28 +9094,6 @@ jQuery(async function () {
                 </ul>
             </div>
         `,
-    }));
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'tokenizer',
-        callback: selectTokenizerCallback,
-        returns: 'current tokenizer',
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'tokenizer name',
-                typeList: [ARGUMENT_TYPE.STRING],
-                enumList: getAvailableTokenizers().map(tokenizer =>
-                    new SlashCommandEnumValue(tokenizer.tokenizerKey, tokenizer.tokenizerName, enumTypes.enum, enumIcons.default)),
-            }),
-        ],
-        helpString: `
-            <div>
-                Selects tokenizer by name. Gets the current tokenizer if no name is provided.
-            </div>
-            <div>
-                <strong>Available tokenizers:</strong>
-                <pre><code>${getAvailableTokenizers().map(t => t.tokenizerKey).join(', ')}</code></pre>
-            </div>
-        `
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'instruct-on',

--- a/public/script.js
+++ b/public/script.js
@@ -8453,11 +8453,11 @@ async function selectInstructCallback(_, name) {
 
 async function selectTokenizerCallback(_, name) {
     if (!name) {
-        return getFriendlyTokenizerName(main_api).tokenizerName;
+        return getAvailableTokenizers().find(tokenizer => tokenizer.tokenizerId === power_user.tokenizer)?.tokenizerKey ?? '';
     }
 
     const tokenizers = getAvailableTokenizers();
-    const fuse = new Fuse(tokenizers, { keys: ['tokenizerName'] });
+    const fuse = new Fuse(tokenizers, { keys: ['tokenizerKey', 'tokenizerName'] });
     const result = fuse.search(name);
 
     if (result.length === 0) {
@@ -8465,9 +8465,11 @@ async function selectTokenizerCallback(_, name) {
         return '';
     }
 
+    /** @type {import('./scripts/tokenizers.js').Tokenizer} */
     const foundTokenizer = result[0].item;
-    selectTokenizer(foundTokenizer.tokenizerName, foundTokenizer.tokenizerId);
-    return foundTokenizer.tokenizerName;
+    selectTokenizer(foundTokenizer.tokenizerId);
+
+    return foundTokenizer.tokenizerKey;
 }
 
 async function enableInstructCallback() {
@@ -9123,7 +9125,7 @@ jQuery(async function () {
                 description: 'tokenizer name',
                 typeList: [ARGUMENT_TYPE.STRING],
                 enumList: getAvailableTokenizers().map(tokenizer =>
-                    new SlashCommandEnumValue(tokenizer.tokenizerName, null, enumTypes.enum, enumIcons.default)),
+                    new SlashCommandEnumValue(tokenizer.tokenizerKey, tokenizer.tokenizerName, enumTypes.enum, enumIcons.default)),
             }),
         ],
         helpString: `
@@ -9132,7 +9134,7 @@ jQuery(async function () {
             </div>
             <div>
                 <strong>Available tokenizers:</strong>
-                <pre><code>${getAvailableTokenizers().map(t => t.tokenizerName).join(', ')}</code></pre>
+                <pre><code>${getAvailableTokenizers().map(t => t.tokenizerKey).join(', ')}</code></pre>
             </div>
         `
     }));

--- a/public/script.js
+++ b/public/script.js
@@ -212,7 +212,7 @@ import {
     selectContextPreset,
 } from './scripts/instruct-mode.js';
 import { initLocales, t, translate } from './scripts/i18n.js';
-import { getFriendlyTokenizerName, getTokenCount, getTokenCountAsync, getTokenizerModel, initTokenizers, saveTokenCache, selectTokenizer, TOKENIZER_NAME_MAP, tokenizers } from './scripts/tokenizers.js';
+import { getAvailableTokenizers, getFriendlyTokenizerName, getTokenCount, getTokenCountAsync, getTokenizerModel, initTokenizers, saveTokenCache, selectTokenizer } from './scripts/tokenizers.js';
 import {
     user_avatar,
     getUserAvatars,
@@ -8453,11 +8453,11 @@ async function selectInstructCallback(_, name) {
 
 async function selectTokenizerCallback(_, name) {
     if (!name) {
-        return TOKENIZER_NAME_MAP[power_user.tokenizer];
+        return getFriendlyTokenizerName(main_api).tokenizerName;
     }
 
-    const tokenizerNames = Object.values(TOKENIZER_NAME_MAP);
-    const fuse = new Fuse(tokenizerNames);
+    const tokenizers = getAvailableTokenizers();
+    const fuse = new Fuse(tokenizers, { keys: ['tokenizerName'] });
     const result = fuse.search(name);
 
     if (result.length === 0) {
@@ -8465,9 +8465,9 @@ async function selectTokenizerCallback(_, name) {
         return '';
     }
 
-    const foundName = result[0].item;
-    selectTokenizer(tokenizers[foundName.toUpperCase()]);
-    return foundName;
+    const foundTokenizer = result[0].item;
+    selectTokenizer(foundTokenizer.tokenizerName, foundTokenizer.tokenizerId);
+    return foundTokenizer;
 }
 
 async function enableInstructCallback() {
@@ -9122,8 +9122,8 @@ jQuery(async function () {
             SlashCommandArgument.fromProps({
                 description: 'tokenizer name',
                 typeList: [ARGUMENT_TYPE.STRING],
-                enumList: Object.values(TOKENIZER_NAME_MAP).map(tokenizer =>
-                    new SlashCommandEnumValue(tokenizer, null, enumTypes.enum, enumIcons.default)),
+                enumList: getAvailableTokenizers().map(tokenizer =>
+                    new SlashCommandEnumValue(tokenizer.tokenizerName, null, enumTypes.enum, enumIcons.default)),
             }),
         ],
         helpString: `
@@ -9132,7 +9132,7 @@ jQuery(async function () {
             </div>
             <div>
                 <strong>Available tokenizers:</strong>
-                <pre><code>${Object.values(TOKENIZER_NAME_MAP).join(', ')}</code></pre>
+                <pre><code>${getAvailableTokenizers().map(t => t.tokenizerName).join(', ')}</code></pre>
             </div>
         `
     }));

--- a/public/script.js
+++ b/public/script.js
@@ -8467,7 +8467,7 @@ async function selectTokenizerCallback(_, name) {
 
     const foundTokenizer = result[0].item;
     selectTokenizer(foundTokenizer.tokenizerName, foundTokenizer.tokenizerId);
-    return foundTokenizer;
+    return foundTokenizer.tokenizerName;
 }
 
 async function enableInstructCallback() {

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -148,33 +148,45 @@ async function resetTokenCache() {
 }
 
 /**
+ * @typedef {object} Tokenizer
+ * @property {number} tokenizerId - The id of the tokenizer option
+ * @property {string} tokenizerKey - Internal name/key of the tokenizer
+ * @property {string} tokenizerName - Human-readable detailed name of the tokenizer (as displayed in the UI)
+ */
+
+/**
  * Gets all tokenizers available to the user.
- * @returns { { tokenizerName: string, tokenizerId: number }[] } Tokenizer info.
+ * @returns {Tokenizer[]} Tokenizer info.
  */
 export function getAvailableTokenizers() {
     const tokenizerOptions = $('#tokenizer').find('option').toArray();
     return tokenizerOptions.map(tokenizerOption => ({
-        tokenizerName: tokenizerOption.text,
         tokenizerId: Number(tokenizerOption.value),
+        tokenizerKey: Object.entries(tokenizers).find(([_, value]) => value === Number(tokenizerOption.value))[0].toLocaleLowerCase(),
+        tokenizerName: tokenizerOption.text,
     }))
 }
 
 /**
  * Selects tokenizer if not already selected.
- * @param {string} tokenizerName Tokenizer name.
  * @param {number} tokenizerId Tokenizer ID.
  */
-export function selectTokenizer(tokenizerName, tokenizerId) {
+export function selectTokenizer(tokenizerId) {
     if (tokenizerId !== power_user.tokenizer) {
-        $('#tokenizer').val(tokenizerId).trigger('change');
-        toastr.info(`Tokenizer: "${tokenizerName}" selected`);
+        const tokenizer = getAvailableTokenizers().find(tokenizer => tokenizer.tokenizerId === tokenizerId);
+        if (!tokenizer) {
+            console.warn('Failed to find tokenizer with id', tokenizerId);
+            return;
+        }
+        $('#tokenizer').val(tokenizer.tokenizerId).trigger('change');
+        toastr.info(`Tokenizer: "${tokenizer.tokenizerName}" selected`);
     }
 }
 
 /**
  * Gets the friendly name of the current tokenizer.
  * @param {string} forApi API to get the tokenizer for. Defaults to the main API.
- * @returns { { tokenizerName: string, tokenizerId: number } } Tokenizer info
+ * @returns {Tokenizer} Tokenizer info
  */
 export function getFriendlyTokenizerName(forApi) {
     if (!forApi) {
@@ -209,7 +221,9 @@ export function getFriendlyTokenizerName(forApi) {
         ? tokenizers.OPENAI
         : tokenizerId;
 
-    return { tokenizerName, tokenizerId };
+    const tokenizerKey = Object.entries(tokenizers).find(([_, value]) => value === tokenizerId)[0].toLocaleLowerCase();
+
+    return { tokenizerName, tokenizerKey, tokenizerId };
 }
 
 /**

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -148,20 +148,26 @@ async function resetTokenCache() {
 }
 
 /**
- * Maps tokenizer IDs to their names.
- * @example { 0: 'none', 1: 'gpt2', ... }
+ * Gets all tokenizers available to the user.
+ * @returns { { tokenizerName: string, tokenizerId: number }[] } Tokenizer info.
  */
-export const TOKENIZER_NAME_MAP = Object.fromEntries(
-    Object.entries(tokenizers).map(([name, id]) => [id, name.toLowerCase()]));
+export function getAvailableTokenizers() {
+    const tokenizerOptions = $('#tokenizer').find('option').toArray();
+    return tokenizerOptions.map(tokenizerOption => ({
+        tokenizerName: tokenizerOption.text,
+        tokenizerId: Number(tokenizerOption.value),
+    }))
+}
 
 /**
  * Selects tokenizer if not already selected.
+ * @param {string} tokenizerName Tokenizer name.
  * @param {number} tokenizerId Tokenizer ID.
  */
-export function selectTokenizer(tokenizerId) {
+export function selectTokenizer(tokenizerName, tokenizerId) {
     if (tokenizerId !== power_user.tokenizer) {
         $('#tokenizer').val(tokenizerId).trigger('change');
-        toastr.info(`Tokenizer: "${TOKENIZER_NAME_MAP[tokenizerId]}" selected`);
+        toastr.info(`Tokenizer: "${tokenizerName}" selected`);
     }
 }
 

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -148,6 +148,24 @@ async function resetTokenCache() {
 }
 
 /**
+ * Maps tokenizer IDs to their names.
+ * @example { 0: 'none', 1: 'gpt2', ... }
+ */
+export const TOKENIZER_NAME_MAP = Object.fromEntries(
+    Object.entries(tokenizers).map(([name, id]) => [id, name.toLowerCase()]));
+
+/**
+ * Selects tokenizer if not already selected.
+ * @param {number} tokenizerId Tokenizer ID.
+ */
+export function selectTokenizer(tokenizerId) {
+    if (tokenizerId !== power_user.tokenizer) {
+        $('#tokenizer').val(tokenizerId).trigger('change');
+        toastr.info(`Tokenizer: "${TOKENIZER_NAME_MAP[tokenizerId]}" selected`);
+    }
+}
+
+/**
  * Gets the friendly name of the current tokenizer.
  * @param {string} forApi API to get the tokenizer for. Defaults to the main API.
  * @returns { { tokenizerName: string, tokenizerId: number } } Tokenizer info


### PR DESCRIPTION
This adds a `/tokenizer` slash command which can be used to set the tokenizer to any supported value (including 'best_match'). This is useful if you use quick replies for changing api/model/presets and want to set the tokenizer as well.

Implements #2575

<img width="658" alt="image" src="https://github.com/user-attachments/assets/3a3f74c6-184d-4651-a394-b4a98919de3c">

First contribution to ST so not very familiar with the codebase, please let me know if this could have been implemented in a better way.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
