### PR TITLE
Tag import fixed, again. (accepts char avatar key)

### DIFF
--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -445,7 +445,11 @@ export function getTagKeyForEntity(entityOrKey) {
     }
 
     // Next lets check if its a valid character or character id, so we can swith it to its tag
-    const character = characters.indexOf(x) >= 0 ? x : characters[x];
+    let character;
+    if (!character && characters.indexOf(x) >= 0) character = x; // Check for char object
+    if (!character && typeof x === 'number') character = characters[x]; // check if its a char id
+    if (!character) character = characters.find(y => y.avatar === x); // check if its a char key
+
     if (character) {
         x = character.avatar;
     }


### PR DESCRIPTION
Don't know who or what broke it again. And I am too lazy to find out.

But fix was easy, now the `getTagKeyForEntity` **actually** works like I intended it to. You can pass in char objects, a charid and also the char key (avatar).
Avatar was somehow missing. And that one was what tag import used, so it was broken.

Easily testable with the tag import dialog.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
