### PR TITLE
Hugging Face Inference API Image Generation

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -1242,7 +1242,16 @@ async function onModelChange() {
     extension_settings.sd.model = $('#sd_model').find(':selected').val();
     saveSettingsDebounced();
 
-    const cloudSources = [sources.horde, sources.novel, sources.openai, sources.togetherai, sources.pollinations, sources.stability, sources.blockentropy];
+    const cloudSources = [
+        sources.horde,
+        sources.novel,
+        sources.openai,
+        sources.togetherai,
+        sources.pollinations,
+        sources.stability,
+        sources.blockentropy,
+        sources.huggingface,
+    ];
 
     if (cloudSources.includes(extension_settings.sd.source)) {
         return;
@@ -1457,6 +1466,9 @@ async function loadSamplers() {
         case sources.blockentropy:
             samplers = ['N/A'];
             break;
+        case sources.huggingface:
+            samplers = ['N/A'];
+            break;
     }
 
     for (const sampler of samplers) {
@@ -1645,6 +1657,9 @@ async function loadModels() {
             break;
         case sources.blockentropy:
             models = await loadBlockEntropyModels();
+            break;
+        case sources.huggingface:
+            models = [{ value: '', text: '<Enter Model ID above>' }];
             break;
     }
 
@@ -1993,6 +2008,9 @@ async function loadSchedulers() {
         case sources.blockentropy:
             schedulers = ['N/A'];
             break;
+        case sources.huggingface:
+            schedulers = ['N/A'];
+            break;
     }
 
     for (const scheduler of schedulers) {
@@ -2070,6 +2088,9 @@ async function loadVaes() {
             vaes = ['N/A'];
             break;
         case sources.blockentropy:
+            vaes = ['N/A'];
+            break;
+        case sources.huggingface:
             vaes = ['N/A'];
             break;
     }

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -3547,7 +3547,7 @@ function isValidState() {
         case sources.blockentropy:
             return secret_state[SECRET_KEYS.BLOCKENTROPY];
         case sources.huggingface:
-            return true;
+            return secret_state[SECRET_KEYS.HUGGINGFACE];
     }
 }
 

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -49,6 +49,7 @@
                 <option value="auto">Stable Diffusion Web UI (AUTOMATIC1111)</option>
                 <option value="horde">Stable Horde</option>
                 <option value="togetherai">TogetherAI</option>
+                <option value="huggingface">HuggingFace (Image Inference Endpoint)</option>
             </select>
             <div data-sd-source="auto">
                 <label for="sd_auto_url">SD Web UI URL</label>
@@ -81,6 +82,11 @@
                 <input id="sd_drawthings_auth" type="text" class="text_pole"  data-i18n="[placeholder]Example: username:password" placeholder="Example: username:password" value="" />
                 <!-- (Original Text)<b>Important:</b> run DrawThings app with HTTP API switch enabled in the UI! The server must be accessible from the SillyTavern host machine. -->
                 <i><b data-i18n="Important:">Important:</b></i><i data-i18n="sd_drawthings_auth_txt"> run DrawThings app with HTTP API switch enabled in the UI! The server must be accessible from the SillyTavern host machine.</i>
+            </div>
+            <div data-sd-source="huggingface">
+                <i>Hint: Save an API key in the Hugging Face API settings to use it here.</i>
+                <label for="sd_huggingface_model_id" data-i18n="Model ID">Model ID</label>
+                <input id="sd_huggingface_model_id" type="text" class="text_pole"  data-i18n="[placeholder]black-forest-labs/FLUX.1-dev" placeholder="black-forest-labs/FLUX.1-dev" value="" />
             </div>
             <div data-sd-source="vlad">
                 <label for="sd_vlad_url">SD.Next API URL</label>

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -86,7 +86,7 @@
             <div data-sd-source="huggingface">
                 <i>Hint: Save an API key in the Hugging Face API settings to use it here.</i>
                 <label for="sd_huggingface_model_id" data-i18n="Model ID">Model ID</label>
-                <input id="sd_huggingface_model_id" type="text" class="text_pole"  data-i18n="[placeholder]black-forest-labs/FLUX.1-dev" placeholder="black-forest-labs/FLUX.1-dev" value="" />
+                <input id="sd_huggingface_model_id" type="text" class="text_pole"  data-i18n="[placeholder] e.g. black-forest-labs/FLUX.1-dev" placeholder="e.g. black-forest-labs/FLUX.1-dev" value="" />
             </div>
             <div data-sd-source="vlad">
                 <label for="sd_vlad_url">SD.Next API URL</label>

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -41,6 +41,7 @@
                 <option value="comfy">ComfyUI</option>
                 <option value="drawthings">DrawThings HTTP API</option>
                 <option value="extras">Extras API (local / remote)</option>
+                <option value="huggingface">HuggingFace Inference API (serverless)</option>
                 <option value="novel">NovelAI Diffusion</option>
                 <option value="openai">OpenAI (DALL-E)</option>
                 <option value="pollinations">Pollinations</option>
@@ -49,7 +50,6 @@
                 <option value="auto">Stable Diffusion Web UI (AUTOMATIC1111)</option>
                 <option value="horde">Stable Horde</option>
                 <option value="togetherai">TogetherAI</option>
-                <option value="huggingface">HuggingFace (Image Inference Endpoint)</option>
             </select>
             <div data-sd-source="auto">
                 <label for="sd_auto_url">SD Web UI URL</label>
@@ -84,9 +84,9 @@
                 <i><b data-i18n="Important:">Important:</b></i><i data-i18n="sd_drawthings_auth_txt"> run DrawThings app with HTTP API switch enabled in the UI! The server must be accessible from the SillyTavern host machine.</i>
             </div>
             <div data-sd-source="huggingface">
-                <i>Hint: Save an API key in the Hugging Face API settings to use it here.</i>
+                <i>Hint: Save an API key in the Hugging Face (Text Completion) API settings to use it here.</i>
                 <label for="sd_huggingface_model_id" data-i18n="Model ID">Model ID</label>
-                <input id="sd_huggingface_model_id" type="text" class="text_pole"  data-i18n="[placeholder] e.g. black-forest-labs/FLUX.1-dev" placeholder="e.g. black-forest-labs/FLUX.1-dev" value="" />
+                <input id="sd_huggingface_model_id" type="text" class="text_pole"  data-i18n="[placeholder]e.g. black-forest-labs/FLUX.1-dev" placeholder="e.g. black-forest-labs/FLUX.1-dev" value="" />
             </div>
             <div data-sd-source="vlad">
                 <label for="sd_vlad_url">SD.Next API URL</label>


### PR DESCRIPTION
* HF image inference API is a weird case. It's lacking the params that we expect of the other image sources. I couldn't find any example of that API being used with options like steps, negative prompts, styles, seed, etc
* In cases where an imagegen provider is also an LLM, it uses that existing server code instead (OpenAI, Horde, NovelAI). With a little guidance, I could try to mimick that for HF since we also have HF LLM abilities too. For now it lives in `src/endpoints/stable-diffusion.js`
* I'm reusing the token from HF text completion, but I think that refers to their dedicated API, not their serverless API. Needs an endpoint config as well for differentiating that. I imagine most would use serverless (free) API.
* Tested with [this](https://huggingface.co/black-forest-labs/FLUX.1-dev) model

Overall it works, but would need some love to get merged. This closes #2613.

