### PR TITLE
fix: pass model parameter for aphrodite tokenizer

### DIFF
--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -838,6 +838,7 @@ function getTextgenAPITokenizationParams(str) {
         url: getTextGenServer(),
         legacy_api: textgen_settings.legacy_api && (textgen_settings.type === OOBA || textgen_settings.type === APHRODITE),
         vllm_model: textgen_settings.vllm_model,
+        aphrodite_model: textgen_settings.aphrodite_model,
     };
 }
 

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -812,6 +812,7 @@ router.post('/remote/textgenerationwebui/encode', jsonParser, async function (re
     const baseUrl = String(request.body.url);
     const legacyApi = Boolean(request.body.legacy_api);
     const vllmModel = String(request.body.vllm_model) || '';
+    const aphroditeModel = String(request.body.aphrodite_model) || '';
 
     try {
         const args = {
@@ -847,7 +848,7 @@ router.post('/remote/textgenerationwebui/encode', jsonParser, async function (re
                     break;
                 case TEXTGEN_TYPES.APHRODITE:
                     url += '/v1/tokenize';
-                    args.body = JSON.stringify({ 'prompt': text });
+                    args.body = JSON.stringify({ 'model': aphroditeModel, 'prompt': text });
                     break;
                 default:
                     url += '/v1/internal/encode';


### PR DESCRIPTION
As of PygmalionAI/aphrodite-engine#599, the `model` parameter needs to be passed to the  `/v1/tokenize` endpoint of Aphrodite. This PR is backwards compatible with older versions of aphrodite, as we won't throw an error for unexpected parameters.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
