### PR TITLE
`STRICT_ESCAPING` & `REPLACE_GETVAR` enabled by default on new accounts

### DIFF
--- a/default/content/settings.json
+++ b/default/content/settings.json
@@ -196,7 +196,15 @@
         "enableLabMode": false,
         "enableZenSliders": false,
         "ui_mode": 1,
-        "forbid_external_media": true
+        "forbid_external_media": true,
+        "stscript": {
+            "parser": {
+                "flags": {
+                    "1": true,
+                    "2": true
+                }
+            }
+        }
     },
     "extension_settings": {
         "apiUrl": "http://localhost:5100",


### PR DESCRIPTION
It's unrealistic to ever expect this to become the new standard without also making it the new default. I think this is long overdue, especially given how important `STRICT_ESCAPING` is.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
