### PR TITLE
Update index.html - Fixed claude system prompt character limit

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1823,7 +1823,7 @@
                                                     <div class="fa-solid fa-clock-rotate-left"></div>
                                                 </div>
                                             </div>
-                                            <textarea id="claude_human_sysprompt_textarea" class="text_pole textarea_compact" rows="4" maxlength="10000" data-i18n="[placeholder]Human message" placeholder="Human message, instruction, etc.&#10;Adds nothing when empty, i.e. requires a new prompt with the role 'user'."></textarea>
+                                            <textarea id="claude_human_sysprompt_textarea" class="text_pole textarea_compact" rows="4" data-i18n="[placeholder]Human message" placeholder="Human message, instruction, etc.&#10;Adds nothing when empty, i.e. requires a new prompt with the role 'user'."></textarea>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Removed the maxlength property for the textarea.

Fix to Issue #2725.
The issue was that the system prompt for claude could not surpass 10000 character. The fix was to remove the maxlength="10000" from index.html claude_human_sysprompt_textarea.

To test this change, switch to chat completions -> Claude -> Enable system prompt -> Then enter a prompt greater than 10000 char.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Note: This is my first pull request ever, I have very little idea what I'm doing, sorry if I do anything wrong! I've read the contributing guidelines. 
