### PR TITLE
Change interactive widget to resizes content.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <title>SillyTavern</title>
     <base href="/">
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="darkreader-lock">
     <meta name="robots" content="noindex, nofollow" />


### PR DESCRIPTION
The default behaviour for chrome on android when the virtualy keyboard is enabled is to scroll the entire screen up, this makes the ui very finicky to use.

This prevents chrome on android from sliding up the entire view port and instead resizes viewport, keeping all content on screen. 

| Before | AFter |
|--------|--------|
| ![Screenshot_20240829-194357](https://github.com/user-attachments/assets/0e9115a9-9879-4ca1-b24f-795825a920db)| ![Screenshot_20240829-194258](https://github.com/user-attachments/assets/d65b94db-c687-421b-a104-4d7aaa9fb918)|




<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
