### PR TITLE
Add Automation ID to Regex scripts and QR auto-execution on regex match

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -462,6 +462,7 @@ export const event_types = {
     LLM_FUNCTION_TOOL_CALL: 'llm_function_tool_call',
     ONLINE_STATUS_CHANGED: 'online_status_changed',
     IMAGE_SWIPED: 'image_swiped',
+    REGEX_SCRIPT_MATCHED: 'regex_script_matched',
 };
 
 export const eventSource = new EventEmitter();

--- a/public/script.js
+++ b/public/script.js
@@ -158,6 +158,7 @@ import {
     flashHighlight,
     isTrueBoolean,
     toggleDrawer,
+    uuidv4,
 } from './scripts/utils.js';
 import { debounce_timeout } from './scripts/constants.js';
 
@@ -2858,6 +2859,7 @@ class StreamingProcessor {
      * @param {string} continueMessage Previous message if the type is 'continue'
      */
     constructor(type, forceName2, timeStarted, continueMessage) {
+        this.streamId = uuidv4();
         this.result = '';
         this.messageId = -1;
         this.messageDom = null;

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -266,3 +266,8 @@ const onNewChat = async () => {
     await autoExec.handleNewChat();
 };
 eventSource.on(event_types.CHAT_CREATED, (...args) => executeIfReadyElseQueue(onNewChat, args));
+
+const onRegexMatch = async (script) => {
+    await autoExec.handleRegexMatch(script);
+};
+eventSource.on(event_types.REGEX_SCRIPT_MATCHED, (...args) => executeIfReadyElseQueue(onRegexMatch, args));

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -112,11 +112,11 @@
                 </div>
                 <div class="flex-container wide100p marginTop5">
                     <div class="flex1 flex-container flexNoGap">
-                        <small data-i18n="[title]ext_regex_automation_id_desc" title="When the regex is matched, execute the Quick Reply that has this Automation ID attached. Matches and capturing groups will be passed as scoped variables, e.g. &lcub;lcub;var::match&rcub;&rcub;, &lcub;lcub;var::$1&rcub;&rcub;, etc.">
+                        <small data-i18n="[title]ext_regex_automation_id_desc" title="When the regex is matched, execute Quick Replies that have the same Automation ID. Arguments: &lcub;&lcub;arg::scriptName&rcub;&rcub;, &lcub;&lcub;arg::replacement&rcub;&rcub;, &lcub;&lcub;arg::match&rcub;&rcub;, &lcub;&lcub;arg::$1&rcub;&rcub;, etc.">
                             <span data-i18n="Automation ID">Automation ID</span>
                             <span class="fa-solid fa-circle-question note-link-span"></span>
                         </small>
-                        <input name="automation_id" class="text_pole textarea_compact" />
+                        <input name="automation_id" class="text_pole textarea_compact" placeholder="( None )" data-i18n="[placeholder]ext_regex_automation_id_placeholder" />
                     </div>
                 </div>
             </div>

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -110,6 +110,15 @@
                         <input name="max_depth" class="text_pole textarea_compact" type="number" min="0" max="999" data-i18n="[placeholder]ext_regex_min_depth_placeholder" placeholder="Unlimited" />
                     </div>
                 </div>
+                <div class="flex-container wide100p marginTop5">
+                    <div class="flex1 flex-container flexNoGap">
+                        <small data-i18n="[title]ext_regex_automation_id_desc" title="When the regex is matched, execute the Quick Reply that has this Automation ID attached. Matches and capturing groups will be passed as scoped variables, e.g. &lcub;lcub;var::match&rcub;&rcub;, &lcub;lcub;var::$1&rcub;&rcub;, etc.">
+                            <span data-i18n="Automation ID">Automation ID</span>
+                            <span class="fa-solid fa-circle-question note-link-span"></span>
+                        </small>
+                        <input name="automation_id" class="text_pole textarea_compact" />
+                    </div>
+                </div>
             </div>
             <div class="flex1 wi-enter-footer-text flex-container flexFlowColumn flexNoGap alignitemsstart">
                 <small data-i18n="ext_regex_other_options">Other Options</small>

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -112,7 +112,7 @@
                 </div>
                 <div class="flex-container wide100p marginTop5">
                     <div class="flex1 flex-container flexNoGap">
-                        <small data-i18n="[title]ext_regex_automation_id_desc" title="When the regex is matched, execute Quick Replies that have the same Automation ID. Arguments: &lcub;&lcub;arg::scriptName&rcub;&rcub;, &lcub;&lcub;arg::replacement&rcub;&rcub;, &lcub;&lcub;arg::match&rcub;&rcub;, &lcub;&lcub;arg::$1&rcub;&rcub;, etc.">
+                        <small data-i18n="[title]ext_regex_automation_id_desc" title="When the regex is matched, execute active Quick Replies that have the same Automation ID. When streaming, only the first match will cause auto-execution. Arguments: &lcub;&lcub;arg::scriptName&rcub;&rcub;, &lcub;&lcub;arg::replacement&rcub;&rcub;, &lcub;&lcub;arg::match&rcub;&rcub;, &lcub;&lcub;arg::$1&rcub;&rcub;, etc.">
                             <span data-i18n="Automation ID">Automation ID</span>
                             <span class="fa-solid fa-circle-question note-link-span"></span>
                         </small>

--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -132,17 +132,20 @@ function runRegexScript(regexScript, rawString, { characterOverride } = {}) {
             return filteredMatch;
         });
 
+        // Substitute parameters in the replacement string
+        const replacement = substituteParams(replaceWithGroups);
+
         // Emit the event
         if (regexScript.automationId) {
             eventSource.emitAndWait(event_types.REGEX_SCRIPT_MATCHED, {
                 scriptName: regexScript.scriptName,
                 automationId: regexScript.automationId,
                 matches: args,
+                replacement: replacement,
             });
         }
 
-        // Substitute at the end
-        return substituteParams(replaceWithGroups);
+        return replacement;
     });
 
     return newString;

--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -1,4 +1,4 @@
-import { characters, substituteParams, this_chid } from '../../../script.js';
+import { characters, event_types, eventSource, substituteParams, this_chid } from '../../../script.js';
 import { extension_settings } from '../../extensions.js';
 import { regexFromString } from '../../utils.js';
 export {
@@ -131,6 +131,15 @@ function runRegexScript(regexScript, rawString, { characterOverride } = {}) {
 
             return filteredMatch;
         });
+
+        // Emit the event
+        if (regexScript.automationId) {
+            eventSource.emitAndWait(event_types.REGEX_SCRIPT_MATCHED, {
+                scriptName: regexScript.scriptName,
+                automationId: regexScript.automationId,
+                matches: args,
+            });
+        }
 
         // Substitute at the end
         return substituteParams(replaceWithGroups);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Self-explanatory. Mimics auto-execution on WI match. Also works in Regex editor test mode.

**Important:** regex replacement doesn't wait for QR execution to finish. It's "fire and forget" for performance reasons.

Passes QR argument macros:

* `{{arg::automationId}}`
* `{{arg::scriptName}}`
* `{{arg::match}}`
* `{{arg::replacement}}`
* `{{arg::$1}}` ... `{{arg::$N}}`

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
