### PR TITLE
Fix "hidden" block in char list messing up scroll

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2412,7 +2412,6 @@ input[type="file"] {
 }
 
 #rm_print_characters_block .text_block {
-    height: 100%;
     width: 100%;
     opacity: 0.5;
     margin: 0 auto 1px auto;


### PR DESCRIPTION
Didn't really happen with the normal char list, but if "grid view" was chosen, the "hidden characters" block that shows characters if any are filtered out, was wrongly sized.
This led to a scroll bar far longer than it needed to be.
And then, if one was searching or selecting a tag, the refresh didn't jump to the correct position.

This fixes it by using implicit height for the hidden characters block.

- Fixes #2743

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
