### PR TITLE
Emit event on streaming tick

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -454,7 +454,9 @@ export const event_types = {
     // TODO: Naming convention is inconsistent with other events
     CHARACTER_DELETED: 'characterDeleted',
     CHARACTER_DUPLICATED: 'character_duplicated',
-    SMOOTH_STREAM_TOKEN_RECEIVED: 'smooth_stream_token_received',
+    /** @deprecated The event is aliased to STREAM_TOKEN_RECEIVED. */
+    SMOOTH_STREAM_TOKEN_RECEIVED: 'stream_token_received',
+    STREAM_TOKEN_RECEIVED: 'stream_token_received',
     FILE_ATTACHMENT_DELETED: 'file_attachment_deleted',
     WORLDINFO_FORCE_ACTIVATE: 'worldinfo_force_activate',
     OPEN_CHARACTER_LIBRARY: 'open_character_library',
@@ -3122,6 +3124,7 @@ class StreamingProcessor {
                 if (logprobs) {
                     this.messageLogprobs.push(...(Array.isArray(logprobs) ? logprobs : [logprobs]));
                 }
+                await eventSource.emit(event_types.STREAM_TOKEN_RECEIVED, text);
                 await sw.tick(() => this.onProgressStreaming(this.messageId, this.continueMessage + text));
             }
             const seconds = (timestamps[timestamps.length - 1] - timestamps[0]) / 1000;

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -1,4 +1,3 @@
-import { eventSource, event_types } from '../script.js';
 import { power_user } from './power-user.js';
 import { delay } from './utils.js';
 
@@ -268,7 +267,6 @@ export class SmoothEventSourceStream extends EventSourceStream {
                         hasFocus && await delay(getDelay(lastStr));
                         controller.enqueue(new MessageEvent(event.type, { data: JSON.stringify(parsed.data) }));
                         lastStr = parsed.chunk;
-                        hasFocus && await eventSource.emit(event_types.SMOOTH_STREAM_TOKEN_RECEIVED, parsed.chunk);
                     }
                 } catch (error) {
                     console.debug('Smooth Streaming parsing error', error);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Adds a `STREAM_TOKEN_RECEIVED` event. Triggers when a StreamingProcessor receives a chunk of text, but before it is passed to be displayed. 
2. Deprecates `SMOOTH_STREAM_TOKEN_RECEIVED` event. The only known user is Blip extension, which was updated respectively: https://github.com/SillyTavern/Extension-Blip/commit/dfe2fa51a0909873b32a82638c5f4253a4900f72

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
