### PR TITLE
Fix deleting of swipe being inconsistent via button, matching the `delswipe` slash command now

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -10323,19 +10323,12 @@ jQuery(async function () {
         if (deleteOnlySwipe) {
             const message = chat[this_edit_mes_id];
             const swipe_id = message.swipe_id;
-            message.swipes.splice(swipe_id, 1);
-            if (Array.isArray(message.swipe_info) && message.swipe_info.length) {
-                message.swipe_info.splice(swipe_id, 1);
-            }
-            if (swipe_id > 0) {
-                $('.swipe_left:last').click();
-            } else {
-                $('.swipe_right:last').click();
-            }
-        } else {
-            chat.splice(this_edit_mes_id, 1);
-            messageElement.remove();
+            await deleteSwipe(swipe_id);
+            return;
         }
+
+        chat.splice(this_edit_mes_id, 1);
+        messageElement.remove();
 
         let startFromZero = Number(this_edit_mes_id) === 0;
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -11,6 +11,7 @@ import {
     comment_avatar,
     deactivateSendButtons,
     default_avatar,
+    deleteSwipe,
     eventSource,
     event_types,
     extension_prompt_roles,
@@ -2309,37 +2310,10 @@ async function addSwipeCallback(args, value) {
 }
 
 async function deleteSwipeCallback(_, arg) {
-    const lastMessage = chat[chat.length - 1];
+    // Take the provided argument. Null if none provided, which will target the current swipe.
+    const swipeId = arg && !isNaN(Number(arg)) ? (Number(arg) - 1) : null;
 
-    if (!lastMessage || !Array.isArray(lastMessage.swipes) || !lastMessage.swipes.length) {
-        toastr.warning('No messages to delete swipes from.');
-        return '';
-    }
-
-    if (lastMessage.swipes.length <= 1) {
-        toastr.warning('Can\'t delete the last swipe.');
-        return '';
-    }
-
-    const swipeId = arg && !isNaN(Number(arg)) ? (Number(arg) - 1) : lastMessage.swipe_id;
-
-    if (swipeId < 0 || swipeId >= lastMessage.swipes.length) {
-        toastr.warning(`Invalid swipe ID: ${swipeId + 1}`);
-        return '';
-    }
-
-    lastMessage.swipes.splice(swipeId, 1);
-
-    if (Array.isArray(lastMessage.swipe_info) && lastMessage.swipe_info.length) {
-        lastMessage.swipe_info.splice(swipeId, 1);
-    }
-
-    const newSwipeId = Math.min(swipeId, lastMessage.swipes.length - 1);
-    lastMessage.swipe_id = newSwipeId;
-    lastMessage.mes = lastMessage.swipes[newSwipeId];
-
-    await saveChatConditional();
-    await reloadCurrentChat();
+    const newSwipeId = await deleteSwipe(swipeId);
 
     return String(newSwipeId);
 }


### PR DESCRIPTION
See #2749 for more info on what didn't work.

The fix I did now is refactoring the slash command callback into a new re-usable `deleteSwipe` function, and calling that inside the delete button now, so both will act exactly the same.

This also fixes a possible issue with extensions, where the `MESSAGE_DELETED` was fired, even though it was just a swipe that got deleted.

- Fixes #2749

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
