### PR TITLE
Filter inclusion groups by timed effects

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3945,7 +3945,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun) {
         let newContent = '';
         const textToScanTokens = await getTokenCountAsync(allActivatedText);
 
-        filterByInclusionGroups(newEntries, allActivatedEntries, buffer, scanState);
+        filterByInclusionGroups(newEntries, allActivatedEntries, buffer, scanState, timedEffects);
 
         console.debug('[WI] --- PROBABILITY CHECKS ---');
         for (const entry of newEntries) {
@@ -4168,13 +4168,54 @@ function filterGroupsByScoring(groups, buffer, removeEntry, scanState) {
 }
 
 /**
+ * Removes entries on cooldown and forces sticky entries as winners.
+ * @param {Record<string, WIScanEntry[]>} groups The groups to filter
+ * @param {WorldInfoTimedEffects} timedEffects The timed effects to use
+ * @param {(entry: WIScanEntry) => void} removeEntry The function to remove an entry
+ */
+function filterGroupsByTimedEffects(groups, timedEffects, removeEntry) {
+    for (const [key, group] of Object.entries(groups)) {
+        // If the group has any sticky entries, leave only the sticky entries
+        const stickyEntries = group.filter(x => timedEffects.isEffectActive('sticky', x));
+        if (stickyEntries.length) {
+            for (const entry of group) {
+                if (stickyEntries.includes(entry)) {
+                    continue;
+                }
+
+                console.debug(`[WI] Entry ${entry.uid}`, `removed as a non-sticky loser from inclusion group '${key}'`, entry);
+                removeEntry(entry);
+            }
+        }
+
+        // It should not be possible for an entry on cooldown/delay to event get into the grouping phase but @Wolfsblvt told me to leave it here.
+        const cooldownEntries = group.filter(x => timedEffects.isEffectActive('cooldown', x));
+        if (cooldownEntries.length) {
+            console.debug(`[WI] Inclusion group '${key}' has entries on cooldown. They will be removed.`, cooldownEntries);
+            for (const entry of cooldownEntries) {
+                removeEntry(entry);
+            }
+        }
+
+        const delayEntries = group.filter(x => timedEffects.isEffectActive('delay', x));
+        if (delayEntries.length) {
+            console.debug(`[WI] Inclusion group '${key}' has entries with delay. They will be removed.`, delayEntries);
+            for (const entry of delayEntries) {
+                removeEntry(entry);
+            }
+        }
+    }
+}
+
+/**
  * Filters entries by inclusion groups.
  * @param {object[]} newEntries Entries activated on current recursion level
  * @param {Set<object>} allActivatedEntries Set of all activated entries
  * @param {WorldInfoBuffer} buffer The buffer to use for scanning
  * @param {number} scanState The current scan state
+ * @param {WorldInfoTimedEffects} timedEffects The timed effects currently active
  */
-function filterByInclusionGroups(newEntries, allActivatedEntries, buffer, scanState) {
+function filterByInclusionGroups(newEntries, allActivatedEntries, buffer, scanState, timedEffects) {
     console.debug('[WI] --- INCLUSION GROUP CHECKS ---');
 
     const grouped = newEntries.filter(x => x.group).reduce((acc, item) => {
@@ -4204,10 +4245,18 @@ function filterByInclusionGroups(newEntries, allActivatedEntries, buffer, scanSt
         }
     }
 
+    filterGroupsByTimedEffects(grouped, timedEffects, removeEntry);
     filterGroupsByScoring(grouped, buffer, removeEntry, scanState);
 
     for (const [key, group] of Object.entries(grouped)) {
         console.debug(`[WI] Checking inclusion group '${key}' with ${group.length} entries`, group);
+
+        // If the group has any sticky entries, the rest are already removed by the timed effects filter
+        const hasAnySticky = group.some(x => timedEffects.isEffectActive('sticky', x));
+        if (hasAnySticky) {
+            console.debug(`[WI] Skipping inclusion group check, group '${key}' has sticky entries`);
+            continue;
+        }
 
         if (Array.from(allActivatedEntries).some(x => x.group === key)) {
             console.debug(`[WI] Skipping inclusion group check, group '${key}' was already activated`);


### PR DESCRIPTION
Entries with an active 'sticky' effect in inclusions groups always remove non-sticky entries as losers. Then the rest of checks (group weights and/or key match scores) are skipped.

Closes #2762

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
