### PR TITLE
Prefer stickied WI for budget-limited cases

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3940,8 +3940,16 @@ export async function checkWorldInfo(chat, maxContext, isDryRun) {
         }
 
         console.debug(`[WI] Search done. Found ${activatedNow.size} possible entries.`);
+
+        // Sort the entries for the probability and the budget limit checks
         const newEntries = [...activatedNow]
-            .sort((a, b) => sortedEntries.indexOf(a) - sortedEntries.indexOf(b));
+            .sort((a, b) => {
+                const isASticky = timedEffects.isEffectActive('sticky', a) ? 1 : 0;
+                const isBSticky = timedEffects.isEffectActive('sticky', b) ? 1 : 0;
+                return isBSticky - isASticky || sortedEntries.indexOf(a) - sortedEntries.indexOf(b);
+            });
+
+
         let newContent = '';
         const textToScanTokens = await getTokenCountAsync(allActivatedText);
 


### PR DESCRIPTION
- Instead of processing entries by default sorting (based on order and books (char first, etc)), sticky will now be the first to process. This will make sure that stickied entries will reach the prompt, even in budget-limited scenarios.

This should still preserve the actual insertion order of activated entries, as they get sorted **again** by order right before building the different prompt positions.
The only difference is for entries with the same order, the stickies will now come first. Which I think, is totally okay.

#### Reasoning:
If you had a specific lower budget set, and more entries as the budget were matched, stickied entries could still be thrown away, if enough other entries with higher *priority* are activated too.
This might be counter-intuitive, as sticky is documented to **always** be active for this many turns, once it was activated once. This is more in line with the expectation now.

Side note: If more entries are stickied than the budget, this will still cut off the last entries. This is intentional. Setting a budget should always be the highest limit you can supply - especially for chats where you have a very low context.

(I would call this neither Bug Fix nor Feature. It's somewhere in between, as it's changing the existing logic to a different processing.)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
