### PR TITLE
Update Advanced Formatting verbiage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3073,13 +3073,13 @@
                             </h4>
                             <div class="flex-container justifyCenter">
                                 <input type="file" hidden data-preset-manager-file="context" accept=".json, .settings">
-                                <i id="context_set_default" class="menu_button fa-solid fa-heart" title="Auto-select this preset for Instruct Mode." data-i18n="[title]Auto-select this preset for Instruct Mode"></i>
-                                <i data-preset-manager-update="context" class="menu_button fa-solid fa-save" title="Update current preset" data-i18n="[title]Update current preset"></i>
-                                <i data-preset-manager-new="context" class="menu_button fa-solid fa-file-circle-plus" title="Save preset as" data-i18n="[title]Save preset as"></i>
-                                <i data-preset-manager-import="context" class="menu_button fa-solid fa-file-import" title="Import preset" data-i18n="[title]Import preset"></i>
-                                <i data-preset-manager-export="context" class="menu_button fa-solid fa-file-export" title="Export preset" data-i18n="[title]Export preset"></i>
-                                <i data-preset-manager-restore="context" class="menu_button fa-solid fa-recycle" title="Restore current preset" data-i18n="[title]Restore current preset"></i>
-                                <i id="context_delete_preset" data-preset-manager-delete="context" class="menu_button fa-solid fa-trash-can" title="Delete the preset" data-i18n="[title]Delete the preset"></i>
+                                <i id="context_set_default" class="menu_button fa-solid fa-heart" title="Auto-select this template for Instruct Mode." data-i18n="[title]Auto-select this template for Instruct Mode"></i>
+                                <i data-preset-manager-update="context" class="menu_button fa-solid fa-save" title="Update current template" data-i18n="[title]Update current template"></i>
+                                <i data-preset-manager-new="context" class="menu_button fa-solid fa-file-circle-plus" title="Save template as" data-i18n="[title]Save template as"></i>
+                                <i data-preset-manager-import="context" class="menu_button fa-solid fa-file-import" title="Import template" data-i18n="[title]Import template"></i>
+                                <i data-preset-manager-export="context" class="menu_button fa-solid fa-file-export" title="Export template" data-i18n="[title]Export template"></i>
+                                <i data-preset-manager-restore="context" class="menu_button fa-solid fa-recycle" title="Restore current template" data-i18n="[title]Restore current template"></i>
+                                <i id="context_delete_preset" data-preset-manager-delete="context" class="menu_button fa-solid fa-trash-can" title="Delete the template" data-i18n="[title]Delete the template"></i>
                             </div>
                             <div class="flex-container">
                                 <select id="context_presets" data-preset-manager-for="context" class="flex1 text_pole"></select>
@@ -3196,7 +3196,7 @@
                         <div id="instructSettingsBlock">
                             <h4 class="standoutHeader title_restorable justifySpaceBetween">
                                 <div class="flex-container">
-                                    <span data-i18n="Instruct Mode">Instruct Mode</span>
+                                    <span data-i18n="Instruct Template">Instruct Template</span>
                                     <a href="https://docs.sillytavern.app/usage/core-concepts/instructmode/" class="notes-link" target="_blank">
                                         <span class="fa-solid fa-circle-question note-link-span"></span>
                                     </a>
@@ -3214,13 +3214,13 @@
                             </h4>
                             <div class="flex-container margin0 justifyCenter">
                                 <input type="file" hidden data-preset-manager-file="instruct" accept=".json, .settings">
-                                <i id="instruct_set_default" class="menu_button fa-solid fa-heart" title="Auto-select this preset on API connection." data-i18n="[title]Auto-select this preset on API connection"></i>
-                                <i data-preset-manager-update="instruct" class="menu_button fa-solid fa-save" title="Update current preset" data-i18n="[title]Update current preset"></i>
-                                <i data-preset-manager-new="instruct" class="menu_button fa-solid fa-file-circle-plus" title="Save preset as" data-i18n="[title]Save preset as"></i>
-                                <i data-preset-manager-import="instruct" class=" menu_button fa-solid fa-file-import" title="Import preset" data-i18n="[title]Import preset"></i>
-                                <i data-preset-manager-export="instruct" class=" menu_button fa-solid fa-file-export" title="Export preset" data-i18n="[title]Export preset"></i>
-                                <i data-preset-manager-restore="instruct" class=" menu_button fa-solid fa-recycle" title="Restore current preset" data-i18n="[title]Restore current preset"></i>
-                                <i data-preset-manager-delete="instruct" class=" menu_button fa-solid fa-trash-can" title="Delete the preset" data-i18n="[title]Delete the preset"></i>
+                                <i id="instruct_set_default" class="menu_button fa-solid fa-heart" title="Auto-select this template on API connection." data-i18n="[title]Auto-select this template on API connection"></i>
+                                <i data-preset-manager-update="instruct" class="menu_button fa-solid fa-save" title="Update current template" data-i18n="[title]Update current template"></i>
+                                <i data-preset-manager-new="instruct" class="menu_button fa-solid fa-file-circle-plus" title="Save template as" data-i18n="[title]Save template as"></i>
+                                <i data-preset-manager-import="instruct" class=" menu_button fa-solid fa-file-import" title="Import template" data-i18n="[title]Import template"></i>
+                                <i data-preset-manager-export="instruct" class=" menu_button fa-solid fa-file-export" title="Export template" data-i18n="[title]Export template"></i>
+                                <i data-preset-manager-restore="instruct" class=" menu_button fa-solid fa-recycle" title="Restore current template" data-i18n="[title]Restore current template"></i>
+                                <i data-preset-manager-delete="instruct" class=" menu_button fa-solid fa-trash-can" title="Delete template" data-i18n="[title]Delete template"></i>
                             </div>
 
                             <div class="flex-container">
@@ -3229,7 +3229,7 @@
                             <label>
                                 <small>
                                     <span data-i18n="Activation Regex">Activation Regex</span>
-                                    <span class="fa-solid fa-circle-question" title="When connecting to an API or choosing a model, automatically activate this Instruct Mode template if the model name matches the provided regular expression."></span>
+                                    <span class="fa-solid fa-circle-question" title="When connecting to an API or choosing a model, automatically activate this Instruct Template if the model name matches the provided regular expression."></span>
                                 </small>
                             </label>
                             <div>

--- a/public/index.html
+++ b/public/index.html
@@ -3081,7 +3081,7 @@
                                 <i data-preset-manager-restore="context" class="menu_button fa-solid fa-recycle" title="Restore current template" data-i18n="[title]Restore current template"></i>
                                 <i id="context_delete_preset" data-preset-manager-delete="context" class="menu_button fa-solid fa-trash-can" title="Delete the template" data-i18n="[title]Delete the template"></i>
                             </div>
-                            <div class="flex-container">
+                            <div class="flex-container" title="Select your current Context Template" data-i18n="[title]Select your current Context Template">
                                 <select id="context_presets" data-preset-manager-for="context" class="flex1 text_pole"></select>
                             </div>
                             <div>
@@ -3223,7 +3223,7 @@
                                 <i data-preset-manager-delete="instruct" class=" menu_button fa-solid fa-trash-can" title="Delete template" data-i18n="[title]Delete template"></i>
                             </div>
 
-                            <div class="flex-container">
+                            <div class="flex-container" title="Select your current Instruct Template" data-i18n="[title]Select your current Instruct Template">
                                 <select id="instruct_presets" data-preset-manager-for="instruct" class="flex1 text_pole"></select>
                             </div>
                             <label>

--- a/public/script.js
+++ b/public/script.js
@@ -8511,7 +8511,7 @@ async function selectContextCallback(_, name) {
     const result = fuse.search(name);
 
     if (result.length === 0) {
-        toastr.warning(`Context preset "${name}" not found`);
+        toastr.warning(`Context template "${name}" not found`);
         return '';
     }
 
@@ -8530,7 +8530,7 @@ async function selectInstructCallback(_, name) {
     const result = fuse.search(name);
 
     if (result.length === 0) {
-        toastr.warning(`Instruct preset "${name}" not found`);
+        toastr.warning(`Instruct template "${name}" not found`);
         return '';
     }
 
@@ -9054,8 +9054,8 @@ API: ${getSettingsContents.main_api}
 API Type: ${getSettingsContents[getSettingsContents.main_api + '_settings'].type}
 API server: ${getSettingsContents.api_server}
 Model: ${getContextContents.onlineStatus}
-Context Preset: ${power_user.context.preset}
-Instruct Preset: ${power_user.instruct.preset}
+Context Template: ${power_user.context.preset}
+Instruct Template: ${power_user.instruct.preset}
 API Settings: ${JSON.stringify(getSettingsContents[getSettingsContents.main_api + '_settings'], null, 2)}
 \`\`\`
     `;
@@ -9193,17 +9193,17 @@ jQuery(async function () {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'instruct',
         callback: selectInstructCallback,
-        returns: 'current preset',
+        returns: 'current template',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
-                description: 'instruct preset name',
+                description: 'instruct template name',
                 typeList: [ARGUMENT_TYPE.STRING],
                 enumProvider: () => instruct_presets.map(preset => new SlashCommandEnumValue(preset.name, null, enumTypes.enum, enumIcons.preset)),
             }),
         ],
         helpString: `
             <div>
-                Selects instruct mode preset by name. Gets the current instruct if no name is provided.
+                Selects instruct mode template by name. Gets the current instruct template if no name is provided.
             </div>
             <div>
                 <strong>Example:</strong>
@@ -9231,7 +9231,7 @@ jQuery(async function () {
         returns: 'template name',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
-                description: 'context preset name',
+                description: 'context template name',
                 typeList: [ARGUMENT_TYPE.STRING],
                 enumProvider: () => context_presets.map(preset => new SlashCommandEnumValue(preset.name, null, enumTypes.enum, enumIcons.preset)),
             }),

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -156,7 +156,7 @@ export function selectInstructPreset(preset) {
     // If instruct preset is not already selected, select it
     if (preset !== power_user.instruct.preset) {
         $('#instruct_presets').val(preset).trigger('change');
-        toastr.info(`Instruct Mode: preset "${preset}" auto-selected`);
+        toastr.info(`Instruct Mode: template "${preset}" auto-selected`);
     }
 
     // If instruct mode is disabled, enable it
@@ -596,11 +596,11 @@ jQuery(() => {
         if (power_user.instruct.preset === power_user.default_instruct) {
             power_user.default_instruct = null;
             $(this).removeClass('default');
-            toastr.info('Default instruct preset cleared');
+            toastr.info('Default instruct template cleared');
         } else {
             power_user.default_instruct = power_user.instruct.preset;
             $(this).addClass('default');
-            toastr.info(`Default instruct preset set to ${power_user.default_instruct}`);
+            toastr.info(`Default instruct template set to ${power_user.default_instruct}`);
         }
 
         saveSettingsDebounced();

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -160,20 +160,25 @@ class PresetManager {
 
         const name = selected.text();
         await this.savePreset(name);
-        toastr.success('Preset updated');
+
+        const successToast = !this.isAdvancedFormatting() ? 'Preset updated' : 'Template updated';
+        toastr.success(successToast);
     }
 
     async savePresetAs() {
         const inputValue = this.getSelectedPresetName();
-        const popupText = !this.isNonGenericApi() ? '<h4>Hint: Use a character/group name to bind preset to a specific chat.</h4>' : '';
-        const name = await Popup.show.input('Preset name:', popupText, inputValue);
+        const popupText = !this.isAdvancedFormatting() ? '<h4>Hint: Use a character/group name to bind preset to a specific chat.</h4>' : '';
+        const headerText = !this.isAdvancedFormatting() ? 'Preset name:' : 'Template name:';
+        const name = await Popup.show.input(headerText, popupText, inputValue);
         if (!name) {
             console.log('Preset name not provided');
             return;
         }
 
         await this.savePreset(name);
-        toastr.success('Preset saved');
+
+        const successToast = !this.isAdvancedFormatting() ? 'Preset saved' : 'Template saved';
+        toastr.success(successToast);
     }
 
     async savePreset(name, settings) {
@@ -234,7 +239,7 @@ class PresetManager {
         return this.apiId == 'textgenerationwebui' || this.apiId == 'context' || this.apiId == 'instruct';
     }
 
-    isNonGenericApi() {
+    isAdvancedFormatting() {
         return this.apiId == 'context' || this.apiId == 'instruct';
     }
 
@@ -342,7 +347,7 @@ class PresetManager {
             }
         }
 
-        if (!this.isNonGenericApi()) {
+        if (!this.isAdvancedFormatting()) {
             settings['genamt'] = amount_gen;
             settings['max_length'] = max_context;
         }
@@ -394,7 +399,8 @@ class PresetManager {
         });
 
         if (!response.ok) {
-            toastr.error('Failed to restore default preset');
+            const errorToast = !this.isAdvancedFormatting() ? 'Failed to restore default preset' : 'Failed to restore default template';
+            toastr.error(errorToast);
             return;
         }
 
@@ -580,7 +586,8 @@ export async function initPresetManager() {
         data['name'] = name;
 
         await presetManager.savePreset(name, data);
-        toastr.success('Preset imported');
+        const successToast = !presetManager.isAdvancedFormatting() ? 'Preset imported' : 'Template imported';
+        toastr.success(successToast);
         e.target.value = null;
     });
 
@@ -598,7 +605,8 @@ export async function initPresetManager() {
             return;
         }
 
-        const confirm = await Popup.show.confirm('Delete the preset?', 'This action is irreversible and your current settings will be overwritten.');
+        const headerText = !presetManager.isAdvancedFormatting() ? 'Delete this preset?' : 'Delete this template?';
+        const confirm = await Popup.show.confirm(headerText, 'This action is irreversible and your current settings will be overwritten.');
         if (!confirm) {
             return;
         }
@@ -606,9 +614,11 @@ export async function initPresetManager() {
         const result = await presetManager.deleteCurrentPreset();
 
         if (result) {
-            toastr.success('Preset deleted');
+            const successToast = !presetManager.isAdvancedFormatting() ? 'Preset deleted' : 'Template deleted';
+            toastr.success(successToast);
         } else {
-            toastr.warning('Preset was not deleted from server');
+            const warningToast = !presetManager.isAdvancedFormatting() ? 'Preset was not deleted from server' : 'Template was not deleted from server';
+            toastr.warning(warningToast);
         }
 
         saveSettingsDebounced();
@@ -637,11 +647,15 @@ export async function initPresetManager() {
 
         if (data.isDefault) {
             if (Object.keys(data.preset).length === 0) {
-                toastr.error('Default preset cannot be restored');
+                const errorToast = !presetManager.isAdvancedFormatting() ? 'Default preset cannot be restored' : 'Default template cannot be restored';
+                toastr.error(errorToast);
                 return;
             }
 
-            const confirm = await Popup.show.confirm('Are you sure?', 'Resetting a <b>default preset</b> will restore the default settings.');
+            const confirmText = !presetManager.isAdvancedFormatting()
+                ? 'Resetting a <b>default preset</b> will restore the default settings.'
+                : 'Resetting a <b>default template</b> will restore the default settings.';
+            const confirm = await Popup.show.confirm('Are you sure?', confirmText);
             if (!confirm) {
                 return;
             }
@@ -650,16 +664,21 @@ export async function initPresetManager() {
             await presetManager.savePreset(name, data.preset);
             const option = presetManager.findPreset(name);
             presetManager.selectPreset(option);
-            toastr.success('Default preset restored');
+            const successToast = !presetManager.isAdvancedFormatting() ? 'Default preset restored' : 'Default template restored';
+            toastr.success(successToast);
         } else {
-            const confirm = await Popup.show.confirm('Are you sure?', 'Resetting a <b>custom preset</b> will restore to the last saved state.');
+            const confirmText = !presetManager.isAdvancedFormatting()
+                ? 'Resetting a <b>custom preset</b> will restore to the last saved state.'
+                : 'Resetting a <b>custom template</b> will restore to the last saved state.';
+            const confirm = await Popup.show.confirm('Are you sure?', confirmText);
             if (!confirm) {
                 return;
             }
 
             const option = presetManager.findPreset(name);
             presetManager.selectPreset(option);
-            toastr.success('Preset restored');
+            const successToast = !presetManager.isAdvancedFormatting() ? 'Preset restored' : 'Template restored';
+            toastr.success(successToast);
         }
     });
 }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

In the Text Completion world, preset only refers to sampling settings. So we call the things under the Advanced Formatting only as:

1. Context Template
2. Instruct Template

Instruct Mode is a concept, not a concrete formatting rule, so the UI column have been renamed respectively.

I did not touch any code comments or setting fields that refer to them as "presets", but I did update STscript help tips.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
