### PR TITLE
Allow mobile swipes with open panels if focused

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -905,7 +905,7 @@ export function initRossMods() {
         if (Popup.util.isPopupOpen()) {
             return;
         }
-        if ($('.mes_edit_buttons, .drawer-content, #character_popup, #dialogue_popup, #WorldInfo, #right-nav-panel, #left-nav-panel, #select_chat_popup, #floatingPrompt').is(':visible')) {
+        if (!$('#sheld').is(':focus-within')) {
             return;
         }
         var SwipeButR = $('.swipe_right:last');
@@ -923,7 +923,7 @@ export function initRossMods() {
         if (Popup.util.isPopupOpen()) {
             return;
         }
-        if ($('.mes_edit_buttons, .drawer-content, #character_popup, #dialogue_popup, #WorldInfo, #right-nav-panel, #left-nav-panel, #select_chat_popup, #floatingPrompt').is(':visible')) {
+        if (!$('#sheld').is(':focus-within')) {
             return;
         }
         var SwipeButL = $('.swipe_left:last');

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -896,8 +896,7 @@ export function initRossMods() {
 
     restoreUserInput();
 
-    //Regenerate if user swipes on the last mesage in chat
-
+    // Swipe gestures (see: https://www.npmjs.com/package/swiped-events)
     document.addEventListener('swiped-left', function (e) {
         if (power_user.gestures === false) {
             return;
@@ -905,7 +904,7 @@ export function initRossMods() {
         if (Popup.util.isPopupOpen()) {
             return;
         }
-        if (!$('#sheld').is(':focus-within')) {
+        if (!$(e.target).closest('#sheld').length) {
             return;
         }
         var SwipeButR = $('.swipe_right:last');
@@ -923,7 +922,7 @@ export function initRossMods() {
         if (Popup.util.isPopupOpen()) {
             return;
         }
-        if (!$('#sheld').is(':focus-within')) {
+        if (!$(e.target).closest('#sheld').length) {
             return;
         }
         var SwipeButL = $('.swipe_left:last');


### PR DESCRIPTION
This is a bugfix in reference to #2753.
Before, swipe gestures were disabled when any relevant panel was open, any popup was open, or a floating prompt was open.
A few panels might be small enough, especially the floating prompts like Token Probabilities, so now swiping will work even with those open, as long as the focus is **inside** the sheld.

Note: If you just opened Token Probabilities and try to swipe, it doesn't work. Swipe gesture doesn't set focus, you have to *tap* inside the sheld at least once. That is exactly how I'd expect it though.

- Allow mobile swipe gestures when sheld is focused, ignoring open panels or floating prompts present now
- Fixes #2753

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
