### PR TITLE
fix WI fancy key click target

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2334,7 +2334,7 @@ async function getWorldEntry(name, data, entry) {
             input.on('select2:unselect', /** @type {function(*):void} */ event => updateWorldEntryKeyOptionsCache([event.params.data], { remove: true }));
 
             select2ChoiceClickSubscribe(input, target => {
-                const key = $(target).text();
+                const key = $(target.closest('.regex-highlight')).text();
                 console.debug('Editing WI key', key);
 
                 // Remove the current key from the actual selection


### PR DESCRIPTION
Clicking on a fancy regex in WI keys currently uses the targeted element to extract the text to edit, which can be a synax-highlighted sub-part of the regex instead of the whole thing.

This just adds a `.closest(.regex-highlight)` to the target to walk up the tree to get the whole regex.

## Checklist:

- [ x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
