### PR TITLE
Fix WI sticky possibly not sticking with delay until recursion when inclusion group is set too

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3813,12 +3813,12 @@ export async function checkWorldInfo(chat, maxContext, isDryRun) {
             }
 
             // Only use checks for recursion flags if the scan step was activated by recursion
-            if (scanState !== scan_state.RECURSION && entry.delayUntilRecursion) {
+            if (scanState !== scan_state.RECURSION && entry.delayUntilRecursion && !isSticky) {
                 log('suppressed by delay until recursion');
                 continue;
             }
 
-            if (scanState === scan_state.RECURSION && world_info_recursive && entry.excludeRecursion) {
+            if (scanState === scan_state.RECURSION && world_info_recursive && entry.excludeRecursion && !isSticky) {
                 log('suppressed by exclude recursion');
                 continue;
             }


### PR DESCRIPTION
- When a WI entry has sticky, and inclusion group and "delay until recursion" set, another entry from the same group might prevent the sticky from activating. This is fixed here.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
