### PR TITLE
Expanded classify slash commands (add Classifier API to `/classify` and allow prompt override, new `classify-expressions`)

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -2122,7 +2122,26 @@ function migrateSettings() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'classify-expressions',
         aliases: ['expressions'],
-        callback: async () => (await getExpressionsList()).join(', '),
+        callback: async (args) => {
+            const list = await getExpressionsList();
+            switch (String(args.format).toLowerCase()) {
+                case 'json':
+                    return JSON.stringify(list);
+                default:
+                    return list.join(', ');
+            }
+        },
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'format',
+                description: 'The format to return the list in: comma-separated plain text or JSON array. Default is plain text.',
+                typeList: [ARGUMENT_TYPE.STRING],
+                enumList: [
+                    new SlashCommandEnumValue('plain', null, enumTypes.enum, ', '),
+                    new SlashCommandEnumValue('json', null, enumTypes.enum, '[]'),
+                ],
+            }),
+        ],
         returns: 'The comma-separated list of available expressions, including custom expressions.',
         helpString: 'Returns a list of available expressions, including custom expressions.',
     }));

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -938,7 +938,7 @@ async function classifyCallback(/** @type {{api: string?, prompt: string?}} */ {
         return '';
     }
 
-    const label = getExpressionLabel(text, expressionApi, { customPrompt: prompt });
+    const label = await getExpressionLabel(text, expressionApi, { customPrompt: prompt });
     console.debug(`Classification result for "${text}": ${label}`);
     return label;
 }

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1354,7 +1354,7 @@ function getCachedExpressions() {
     return [...expressionsList, ...extension_settings.expressions.custom].filter(onlyUnique);
 }
 
-async function getExpressionsList() {
+export async function getExpressionsList() {
     // Return cached list if available
     if (Array.isArray(expressionsList)) {
         return getCachedExpressions();
@@ -2085,7 +2085,7 @@ function migrateSettings() {
             }),
         ],
         helpString: 'Force sets the sprite for the current character.',
-        returns: 'label',
+        returns: 'the currently set sprite label after setting it.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'spriteoverride',
@@ -2101,7 +2101,7 @@ function migrateSettings() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'lastsprite',
         callback: (_, value) => lastExpression[String(value).trim()] ?? '',
-        returns: 'sprite',
+        returns: 'the last set sprite / expression for the named character.',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: 'character name',
@@ -2117,7 +2117,14 @@ function migrateSettings() {
         callback: toggleTalkingHeadCommand,
         aliases: ['talkinghead'],
         helpString: 'Character Expressions: toggles <i>Image Type - talkinghead (extras)</i> on/off.',
-        returns: ARGUMENT_TYPE.BOOLEAN,
+        returns: 'the current state of the <i>Image Type - talkinghead (extras)</i> on/off.',
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'classify-expressions',
+        aliases: ['expressions'],
+        callback: async () => (await getExpressionsList()).join(', '),
+        returns: 'The comma-separated list of available expressions, including custom expressions.',
+        helpString: 'Returns a list of available expressions, including custom expressions.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'classify',

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1161,7 +1161,7 @@ export async function getExpressionLabel(text, expressionsApi = extension_settin
                 }
 
                 const expressionsList = await getExpressionsList();
-                const prompt = customPrompt || await getLlmPrompt(expressionsList);
+                const prompt = substituteParamsExtended(String(customPrompt), { labels: expressionsList }) || await getLlmPrompt(expressionsList);
                 let functionResult = null;
                 eventSource.once(event_types.TEXT_COMPLETION_SETTINGS_READY, onTextGenSettingsReady);
                 eventSource.once(event_types.LLM_FUNCTION_TOOL_REGISTER, onFunctionToolRegister);


### PR DESCRIPTION
A few small improvements to the classify slash commands.

- Added `api` argument to `/classify`, to allow setting the Classifier API manually.
  Reasoning: If using LLM mode, you might still want to classify stuff via local model, or have the local classifier run on streaming, but use a QR to query the LLM at the end.
- Added `prompt` argument to `/classify` to allow overriding the default prompt specified in the extension settings.
  Reasoning: If we already have a prompt, and a slash command, why not give the option.
- Added `/classify-expressions` slash command to retrieve a comma-separated list of all expressions.
  Reasoning: Might want to use that in that custom prompt, in other `/genraw` calls, or whatever.

Allows shenanigans like this:
```
/classify api=llm {{lastCharMessage}} | /emote
```

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
