### PR TITLE
Add tooltip to Restore Previous button in Summarize plugin

### DIFF
--- a/public/locales/zh-cn.json
+++ b/public/locales/zh-cn.json
@@ -1305,6 +1305,7 @@
     "ext_sum_current_summary": "当前摘要：",
     "ext_sum_restore_previous": "恢复上一个",
     "ext_sum_memory_placeholder": "摘要将在这里生成...",
+    "ext_sum_restore_tip": "恢复先前的摘要；重复使用以清除此聊天的摘要状态",
     "ext_sum_force_tip": "立即触发摘要更新。",
     "ext_sum_force_text": "现在总结",
     "Disable automatic summary updates. While paused, the summary remains as-is. You can still force an update by pressing the Summarize now button (which is only available with the Main API).": "禁用自动摘要更新。暂停时，摘要保持原样。您仍然可以通过按“立即汇总”按钮（仅适用于主 API）强制更新。",

--- a/public/scripts/extensions/memory/settings.html
+++ b/public/scripts/extensions/memory/settings.html
@@ -18,7 +18,7 @@
 
                 <div class="flex-container justifyspacebetween alignitemscenter">
                     <span class="flex1" data-i18n="ext_sum_current_summary">Current summary:</span>
-                    <div id="memory_restore" class="menu_button flex1 margin0">
+                    <div id="memory_restore" class="menu_button flex1 margin0" data-i18n="[title]ext_sum_restore_tip" title="Restore a previous summary; use repeatedly to clear summarization state for this chat.">
                         <span data-i18n="ext_sum_restore_previous">Restore Previous</span>
                     </div>
                 </div>


### PR DESCRIPTION
## What is the reason for a change?

The `Restore Previous` button can be used repeatedly to "unwind" all summarization state saved in the chat file, though it's not hinted in the UI. Per by @Cohee1207's suggestion, here's a PR that hints that in a tooltip.

discussion: https://discord.com/channels/1100685673633153084/1137348375856029716/1273371372894031882

## What did you do to achieve this?

Added a tooltip plus a `zh-cn` translation (from Google Translate; I don't know Chinese at all).

## How would a reviewer test the change?

Mouse over the button and see this:

![screenshot](https://github.com/user-attachments/assets/619da6ec-5bdd-4c03-b296-74dd76883101)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
