### PR TITLE
Fix the fix (fix fancy click target)

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2334,7 +2334,7 @@ async function getWorldEntry(name, data, entry) {
             input.on('select2:unselect', /** @type {function(*):void} */ event => updateWorldEntryKeyOptionsCache([event.params.data], { remove: true }));
 
             select2ChoiceClickSubscribe(input, target => {
-                const key = $(target.closest('.regex-highlight')).text();
+                const key = $(target.closest('.regex-highlight, .item')).text();
                 console.debug('Editing WI key', key);
 
                 // Remove the current key from the actual selection


### PR DESCRIPTION
The `.closest()` needs to look for both `.regex-highlight` and `.item` to handle both regex and plaintext keys.

## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
