### PR TITLE
Fixed an issue where the text inside the buttons in the API connection menu became vertically long and difficult to read in a multi-byte character environment.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1983,8 +1983,8 @@
                                     KoboldCpp works better when you select the Text Completion API and then KoboldCpp as a type!
                                 </div>
                                 <div class="flex-container">
-                                    <div id="api_button" class="api_button menu_button" type="submit" data-i18n="Connect" data-server-connect="kobold">Connect</div>
-                                    <div class="api_loading menu_button" data-i18n="Cancel">Cancel</div>
+                                    <div id="api_button" class="api_button menu_button menu_button_icon" type="submit" data-i18n="Connect" data-server-connect="kobold">Connect</div>
+                                    <div class="api_loading menu_button menu_button_icon" data-i18n="Cancel">Cancel</div>
                                 </div>
                             </div>
                             <div class="online_status">
@@ -2023,8 +2023,8 @@
                                 <option value="kayra-v1">Kayra</option>
                             </select>
                             <div class="flex-container">
-                                <div id="api_button_novel" class="api_button menu_button" type="submit" data-i18n="Connect">Connect</div>
-                                <div class="api_loading menu_button" data-i18n="Cancel">Cancel</div>
+                                <div id="api_button_novel" class="api_button menu_button menu_button_icon" type="submit" data-i18n="Connect">Connect</div>
+                                <div class="api_loading menu_button menu_button_icon" data-i18n="Cancel">Cancel</div>
                             </div>
                         </form>
                         <div class="online_status">
@@ -2396,9 +2396,9 @@
                                 </div>
                             </div>
                             <div class="flex-container">
-                                <div id="api_button_textgenerationwebui" class="api_button menu_button" type="submit" data-i18n="Connect" data-server-connect="ooba_blocking,vllm,aphrodite,tabby,koboldcpp,ollama,llamacpp,huggingface">Connect</div>
+                                <div id="api_button_textgenerationwebui" class="api_button menu_button menu_button_icon" type="submit" data-i18n="Connect" data-server-connect="ooba_blocking,vllm,aphrodite,tabby,koboldcpp,ollama,llamacpp,huggingface">Connect</div>
                                 <div data-tg-type="openrouter" class="menu_button menu_button_icon openrouter_authorize" title="Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai" data-i18n="Authorize;[title]Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai">Authorize</div>
-                                <div class="api_loading menu_button" data-i18n="Cancel">Cancel</div>
+                                <div class="api_loading menu_button menu_button_icon" data-i18n="Cancel">Cancel</div>
                             </div>
                             <label data-tg-type="ooba,aphrodite" class="checkbox_label margin-bot-10px" for="legacy_api_textgenerationwebui">
                                 <input type="checkbox" id="legacy_api_textgenerationwebui" />
@@ -3033,7 +3033,7 @@
                         </div>
                         <div class="flex-container flex">
                             <div id="api_button_openai" class="api_button menu_button menu_button_icon" type="submit" data-i18n="Connect">Connect</div>
-                            <div class="api_loading menu_button" data-i18n="Cancel">Cancel</div>
+                            <div class="api_loading menu_button menu_button_icon" data-i18n="Cancel">Cancel</div>
                             <div data-source="custom" id="customize_additional_parameters" class="menu_button menu_button_icon" data-i18n="Additional Parameters">Additional Parameters</div>
                             <div data-source="openrouter" class="menu_button menu_button_icon openrouter_authorize" title="Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai" data-i18n="Authorize;[title]Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai">Authorize</div>
                             <div id="test_api_button" class="menu_button menu_button_icon" title="Verifies your API connection by sending a short test message. Be aware that you'll be credited for it!" data-i18n="[title]Verifies your API connection by sending a short test message. Be aware that you'll be credited for it!"><span data-i18n="Test Message">Test Message</span></div>


### PR DESCRIPTION

The issue occurred because, in environments where multi-byte characters (e.g., Japanese or Chinese) were used, the button text would wrap and display vertically, making it difficult to read and causing layout issues.

After the fix, the text now displays correctly without vertical stretching, and the UI layout remains consistent.

Additionally, I confirmed that this change does not introduce any new style issues across devices, including smartphones and PCs, or at different screen sizes.

**Before:**
![image](https://github.com/user-attachments/assets/282618c2-fe0a-49c2-b505-b8cdd73990dc)

**After:**
![image](https://github.com/user-attachments/assets/7e3327dc-db42-484a-a47d-56ac77468000)


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
