### PR TITLE
Fix single-line text inputs and checkboxes becoming squished by `resetScrollHeight`

### DIFF
--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -100,7 +100,7 @@ export async function loadInstructMode(data) {
 
         $element.on('input', async function () {
             power_user.instruct[control.property] = control.isCheckbox ? !!$(this).prop('checked') : $(this).val();
-            if (!CSS.supports('field-sizing', 'content')) {
+            if (!CSS.supports('field-sizing', 'content') && $(this).is('textarea')) {
                 await resetScrollHeight($(this));
             }
             saveSettingsDebounced();


### PR DESCRIPTION
Follow-up to #2786 which reverts the use of contenteditable divs for autosizing text inputs and goes back to using textareas while using `field-sizing` on supported browsers.

On Firefox, when an instruct mode's `input` event was triggered, `resetScrollHeight` was called on it that sets an inline height style.  However this was happening even when the target was a single-line textarea or checkbox, causing them to look squished. This change just omits non-textareas from that dynamic height adjustment.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
