### PR TITLE
Implement downloadable tokenizers

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -95,6 +95,9 @@ requestOverrides: []
 enableExtensions: true
 # Automatically update extensions when a release version changes
 enableExtensionsAutoUpdate: true
+# Additional model tokenizers can be downloaded on demand.
+# Disabling will fallback to another locally available tokenizer.
+enableDownloadableTokenizers: true
 # Extension settings
 extras:
   # Disables automatic model download from HuggingFace

--- a/public/index.html
+++ b/public/index.html
@@ -3283,6 +3283,8 @@
                                     <option value="12">Llama 3</option>
                                     <option value="13">Gemma / Gemini</option>
                                     <option value="14">Jamba</option>
+                                    <option value="15">Qwen2</option>
+                                    <option value="16">Command-R</option>
                                     <option value="4">NerdStash (NovelAI Clio)</option>
                                     <option value="5">NerdStash v2 (NovelAI Kayra)</option>
                                     <option value="7">Mistral</option>

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -590,6 +590,9 @@ function calculateOpenRouterCost() {
 export function getCurrentOpenRouterModelTokenizer() {
     const modelId = textgen_settings.openrouter_model;
     const model = openRouterModels.find(x => x.id === modelId);
+    if (modelId?.includes('jamba')) {
+        return tokenizers.JAMBA;
+    }
     switch (model?.architecture?.tokenizer) {
         case 'Llama2':
             return tokenizers.LLAMA;
@@ -603,6 +606,10 @@ export function getCurrentOpenRouterModelTokenizer() {
             return tokenizers.GEMMA;
         case 'Claude':
             return tokenizers.CLAUDE;
+        case 'Cohere':
+            return tokenizers.COMMAND_R;
+        case 'Qwen':
+            return tokenizers.QWEN2;
         default:
             return tokenizers.OPENAI;
     }

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -28,6 +28,8 @@ export const tokenizers = {
     LLAMA3: 12,
     GEMMA: 13,
     JAMBA: 14,
+    QWEN2: 15,
+    COMMAND_R: 16,
     BEST_MATCH: 99,
 };
 
@@ -104,6 +106,16 @@ const TOKENIZER_URLS = {
         encode: '/api/tokenizers/jamba/encode',
         decode: '/api/tokenizers/jamba/decode',
         count: '/api/tokenizers/jamba/encode',
+    },
+    [tokenizers.QWEN2]: {
+        encode: '/api/tokenizers/qwen2/encode',
+        decode: '/api/tokenizers/qwen2/decode',
+        count: '/api/tokenizers/qwen2/encode',
+    },
+    [tokenizers.COMMAND_R]: {
+        encode: '/api/tokenizers/command-r/encode',
+        decode: '/api/tokenizers/command-r/decode',
+        count: '/api/tokenizers/command-r/encode',
     },
     [tokenizers.API_TEXTGENERATIONWEBUI]: {
         encode: '/api/tokenizers/remote/textgenerationwebui/encode',
@@ -292,6 +304,12 @@ export function getTokenizerBestMatch(forApi) {
             }
             if (model.includes('jamba')) {
                 return tokenizers.JAMBA;
+            }
+            if (model.includes('command-r')) {
+                return tokenizers.COMMAND_R;
+            }
+            if (model.includes('qwen2')) {
+                return tokenizers.QWEN2;
             }
         }
 
@@ -511,6 +529,8 @@ export function getTokenizerModel() {
     const yiTokenizer = 'yi';
     const gemmaTokenizer = 'gemma';
     const jambaTokenizer = 'jamba';
+    const qwen2Tokenizer = 'qwen2';
+    const commandRTokenizer = 'command-r';
 
     // Assuming no one would use it for different models.. right?
     if (oai_settings.chat_completion_source == chat_completion_sources.SCALE) {
@@ -558,6 +578,12 @@ export function getTokenizerModel() {
         else if (model?.architecture?.tokenizer === 'Gemini') {
             return gemmaTokenizer;
         }
+        else if (model?.architecture?.tokenizer === 'Qwen') {
+            return qwen2Tokenizer;
+        }
+        else if (model?.architecture?.tokenizer === 'Cohere') {
+            return commandRTokenizer;
+        }
         else if (oai_settings.openrouter_model.includes('gpt-4o')) {
             return gpt4oTokenizer;
         }
@@ -579,6 +605,10 @@ export function getTokenizerModel() {
         else if (oai_settings.openrouter_model.includes('jamba')) {
             return jambaTokenizer;
         }
+    }
+
+    if (oai_settings.chat_completion_source == chat_completion_sources.COHERE) {
+        return commandRTokenizer;
     }
 
     if (oai_settings.chat_completion_source == chat_completion_sources.MAKERSUITE) {

--- a/src/util.js
+++ b/src/util.js
@@ -647,6 +647,20 @@ function getSeparator(n) {
     return '='.repeat(n);
 }
 
+/**
+ * Checks if the string is a valid URL.
+ * @param {string} url String to check
+ * @returns {boolean} If the URL is valid
+ */
+function isValidUrl(url) {
+    try {
+        new URL(url);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
 module.exports = {
     getConfig,
     getConfigValue,
@@ -676,4 +690,5 @@ module.exports = {
     makeHttp2Request,
     removeColorFormatting,
     getSeparator,
+    isValidUrl,
 };


### PR DESCRIPTION
Closes #2574, #2754

We can now distribute tokenizers without polluting the repo with huge JSON blobs. I've created a separate repository for storing tokenizer assets: <https://github.com/SillyTavern/SillyTavern-Tokenizers>

There are now two tokenizers to be downloaded:

1. Qwen2
2. Command-R (used by Cohere CC source).

The opt-out option exists in config.yaml: `enableDownloadableTokenizers`. You can also download tokenizers manually and put them into your data directory. If model is not cached and the download is disabled, a fallback tokenizer will be used for counting (llama3 in this case).

_Documentation update pending._

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
