### PR TITLE
Expand `/echo` command with `cssClass`, `color`, `escapeHtml` and `onClick`

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2227,7 +2227,7 @@ async function echoCallback(args, value) {
     // Make sure that the value is a string
     value = String(value);
 
-    const title = args.title ? args.title : undefined;
+    let title = args.title ? args.title : undefined;
     const severity = args.severity ? args.severity : 'info';
 
     /** @type {ToastrOptions} */
@@ -2259,6 +2259,7 @@ async function echoCallback(args, value) {
 
     // If we allow HTML, we need to sanitize it to prevent security risks
     if (!options.escapeHtml) {
+        if (title) title = DOMPurify.sanitize(title, { FORBID_TAGS: ['style'] });
         value = DOMPurify.sanitize(value, { FORBID_TAGS: ['style'] });
     }
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -772,11 +772,6 @@ export function initDefaultSlashCommands() {
                 ],
             }),
             SlashCommandNamedArgument.fromProps({
-                name: 'cssClass',
-                description: 'additional css class to add to the toast message (e.g. for custom styling)',
-                typeList: [ARGUMENT_TYPE.STRING],
-            }),
-            SlashCommandNamedArgument.fromProps({
                 name: 'timeout',
                 description: 'time in milliseconds to display the toast message. Set this and \'extendedTimeout\' to 0 to show indefinitely until dismissed.',
                 typeList: [ARGUMENT_TYPE.NUMBER],
@@ -802,6 +797,15 @@ export function initDefaultSlashCommands() {
                 defaultValue: 'false',
                 enumList: commonEnumProviders.boolean('trueFalse')(),
             }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'cssClass',
+                description: 'additional css class to add to the toast message (e.g. for custom styling)',
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'color',
+                description: 'custom CSS color of the toast message. Accepts all valid CSS color values (e.g. \'red\', \'#FF0000\', \'rgb(255, 0, 0)\').<br />>Can be more customizable with the \'cssClass\' argument and custom classes.',
+            })
         ],
         unnamedArgumentList: [
             new SlashCommandArgument(
@@ -2186,7 +2190,7 @@ async function generateCallback(args, value) {
 
 /**
  *
- * @param {{title?: string, severity?: string, cssClass?: string, timeout?: string, extendedTimeout?: string, preventDuplicates?: string, awaitDismissal?: string}} args - named arguments from the slash command
+ * @param {{title?: string, severity?: string, timeout?: string, extendedTimeout?: string, preventDuplicates?: string, awaitDismissal?: string, cssClass?: string, color?: string}} args - named arguments from the slash command
  * @param {string} value - The string to echo (unnamed argument from the slash command)
  * @returns {Promise<string>} The text that was echoed
  */
@@ -2226,20 +2230,25 @@ async function echoCallback(args, value) {
         options.toastClass = args.cssClass;
     }
 
+    let toast;
     switch (severity) {
         case 'error':
-            toastr.error(value, title, options);
+            toast = toastr.error(value, title, options);
             break;
         case 'warning':
-            toastr.warning(value, title, options);
+            toast = toastr.warning(value, title, options);
             break;
         case 'success':
-            toastr.success(value, title, options);
+            toast = toastr.success(value, title, options);
             break;
         case 'info':
         default:
-            toastr.info(value, title, options);
+            toast = toastr.info(value, title, options);
             break;
+    }
+
+    if (args.color) {
+        toast.css('background-color', args.color);
     }
 
     if (awaitDismissal) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2251,6 +2251,11 @@ async function echoCallback(args, value) {
         }
     }
 
+    // If we allow HTML, we need to sanitize it to prevent security risks
+    if (!options.escapeHtml) {
+        value = DOMPurify.sanitize(value, { FORBID_TAGS: ['style'] });
+    }
+
     let toast;
     switch (severity) {
         case 'error':

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -799,7 +799,7 @@ export function initDefaultSlashCommands() {
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'cssClass',
-                description: 'additional css class to add to the toast message (e.g. for custom styling)',
+                description: 'additional CSS class to add to the toast message (e.g. for custom styling)',
                 typeList: [ARGUMENT_TYPE.STRING],
             }),
             SlashCommandNamedArgument.fromProps({

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2241,7 +2241,11 @@ async function echoCallback(args, value) {
     }
     if (args.onClick) {
         if (args.onClick instanceof SlashCommandClosure) {
-            options.onclick = () => args.onClick.execute();
+            options.onclick = async () => {
+                // Execute the slash command directly, with its internal scope and everything. Clear progress at the end if the main script is already done.
+                await args.onClick.execute();
+                await clearCommandProgress();
+            };
         } else {
             toastr.warning('Invalid onClick provided for /echo command. This is not a closure');
         }

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -813,6 +813,11 @@ export function initDefaultSlashCommands() {
                 defaultValue: 'true',
                 enumList: commonEnumProviders.boolean('trueFalse')(),
             }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'onClick',
+                description: 'a closure to call when the toast is clicked. This executed closure receives scope as provided in the script. Careful about possible side effects when manipulating variables and more.',
+                typeList: [ARGUMENT_TYPE.CLOSURE],
+            }),
         ],
         unnamedArgumentList: [
             new SlashCommandArgument(
@@ -2197,7 +2202,7 @@ async function generateCallback(args, value) {
 
 /**
  *
- * @param {{title?: string, severity?: string, timeout?: string, extendedTimeout?: string, preventDuplicates?: string, awaitDismissal?: string, cssClass?: string, color?: string, escapeHtml?: string}} args - named arguments from the slash command
+ * @param {{title?: string, severity?: string, timeout?: string, extendedTimeout?: string, preventDuplicates?: string, awaitDismissal?: string, cssClass?: string, color?: string, escapeHtml?: string, onClick?: SlashCommandClosure}} args - named arguments from the slash command
  * @param {string} value - The string to echo (unnamed argument from the slash command)
  * @returns {Promise<string>} The text that was echoed
  */
@@ -2233,6 +2238,9 @@ async function echoCallback(args, value) {
 
     if (awaitDismissal) {
         options.onHidden = () => resolveToastDismissal(value);
+    }
+    if (args.onClick) {
+        options.onclick = () => args.onClick.execute();
     }
 
     let toast;

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2242,9 +2242,9 @@ async function echoCallback(args, value) {
     if (args.onClick) {
         if (args.onClick instanceof SlashCommandClosure) {
             options.onclick = async () => {
-                // Execute the slash command directly, with its internal scope and everything. Clear progress at the end if the main script is already done.
+                // Execute the slash command directly, with its internal scope and everything. Clear progress handler so it doesn't interfere with command execution progress.
+                args.onClick.onProgress = null;
                 await args.onClick.execute();
-                await clearCommandProgress();
             };
         } else {
             toastr.warning('Invalid onClick provided for /echo command. This is not a closure');

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -826,19 +826,19 @@ export function initDefaultSlashCommands() {
         ],
         helpString: `
         <div>
-            Echoes the provided text to a toast message. Useful for pipes debugging.
+            Echoes the provided text to a toast message. Can be used to display informational messages or for pipes debugging.
         </div>
         <div>
             <strong>Example:</strong>
             <ul>
                 <li>
-                    <pre><code>/echo title="My Message" severity=info This is an info message</code></pre>
+                    <pre><code>/echo title="My Message" severity=warning This is a warning message</code></pre>
                 </li>
                 <li>
-                    <pre><code>/echo title="My Message" color=black This message is purple</code></pre>
+                    <pre><code>/echo color=purple This message is purple</code></pre>
                 </li>
                 <li>
-                    <pre><code>/echo onClick={: /echo escapeHtml=false color=transparent cssClass=wider_dialogue_popup <img src="/img/five.png" /> :} timeout=5000 Clicking on this message within 10 seconds will open the image.</code></pre>
+                    <pre><code>/echo onClick={: /echo escapeHtml=false color=transparent cssClass=wider_dialogue_popup &lt;img src="/img/five.png" /&gt; :} timeout=5000 Clicking on this message within 5 seconds will open the image.</code></pre>
                 </li>
             </ul>
         </div>

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -805,7 +805,14 @@ export function initDefaultSlashCommands() {
             SlashCommandNamedArgument.fromProps({
                 name: 'color',
                 description: 'custom CSS color of the toast message. Accepts all valid CSS color values (e.g. \'red\', \'#FF0000\', \'rgb(255, 0, 0)\').<br />>Can be more customizable with the \'cssClass\' argument and custom classes.',
-            })
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'escapeHtml',
+                description: 'whether to escape HTML in the toast message.',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'true',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
         ],
         unnamedArgumentList: [
             new SlashCommandArgument(
@@ -2190,7 +2197,7 @@ async function generateCallback(args, value) {
 
 /**
  *
- * @param {{title?: string, severity?: string, timeout?: string, extendedTimeout?: string, preventDuplicates?: string, awaitDismissal?: string, cssClass?: string, color?: string}} args - named arguments from the slash command
+ * @param {{title?: string, severity?: string, timeout?: string, extendedTimeout?: string, preventDuplicates?: string, awaitDismissal?: string, cssClass?: string, color?: string, escapeHtml?: string}} args - named arguments from the slash command
  * @param {string} value - The string to echo (unnamed argument from the slash command)
  * @returns {Promise<string>} The text that was echoed
  */
@@ -2217,6 +2224,8 @@ async function echoCallback(args, value) {
     if (args.timeout && !isNaN(parseInt(args.timeout))) options.timeOut = parseInt(args.timeout);
     if (args.extendedTimeout && !isNaN(parseInt(args.extendedTimeout))) options.extendedTimeOut = parseInt(args.extendedTimeout);
     if (isTrueBoolean(args.preventDuplicates)) options.preventDuplicates = true;
+    if (args.cssClass) options.toastClass = args.cssClass;
+    if (args.escapeHtml !== undefined) options.escapeHtml = isTrueBoolean(args.escapeHtml);
 
     // Prepare possible await handling
     let awaitDismissal = isTrueBoolean(args.awaitDismissal);
@@ -2224,10 +2233,6 @@ async function echoCallback(args, value) {
 
     if (awaitDismissal) {
         options.onHidden = () => resolveToastDismissal(value);
-    }
-
-    if (args.cssClass) {
-        options.toastClass = args.cssClass;
     }
 
     let toast;

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2240,7 +2240,11 @@ async function echoCallback(args, value) {
         options.onHidden = () => resolveToastDismissal(value);
     }
     if (args.onClick) {
-        options.onclick = () => args.onClick.execute();
+        if (args.onClick instanceof SlashCommandClosure) {
+            options.onclick = () => args.onClick.execute();
+        } else {
+            toastr.warning('Invalid onClick provided for /echo command. This is not a closure');
+        }
     }
 
     let toast;

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -772,6 +772,11 @@ export function initDefaultSlashCommands() {
                 ],
             }),
             SlashCommandNamedArgument.fromProps({
+                name: 'cssClass',
+                description: 'additional css class to add to the toast message (e.g. for custom styling)',
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
+            SlashCommandNamedArgument.fromProps({
                 name: 'timeout',
                 description: 'time in milliseconds to display the toast message. Set this and \'extendedTimeout\' to 0 to show indefinitely until dismissed.',
                 typeList: [ARGUMENT_TYPE.NUMBER],
@@ -2181,7 +2186,7 @@ async function generateCallback(args, value) {
 
 /**
  *
- * @param {{title?: string, severity?: string, timeout?: string, extendedTimeout?: string, preventDuplicates?: string, awaitDismissal?: string}} args - named arguments from the slash command
+ * @param {{title?: string, severity?: string, cssClass?: string, timeout?: string, extendedTimeout?: string, preventDuplicates?: string, awaitDismissal?: string}} args - named arguments from the slash command
  * @param {string} value - The string to echo (unnamed argument from the slash command)
  * @returns {Promise<string>} The text that was echoed
  */
@@ -2215,6 +2220,10 @@ async function echoCallback(args, value) {
 
     if (awaitDismissal) {
         options.onHidden = () => resolveToastDismissal(value);
+    }
+
+    if (args.cssClass) {
+        options.toastClass = args.cssClass;
     }
 
     switch (severity) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -834,6 +834,12 @@ export function initDefaultSlashCommands() {
                 <li>
                     <pre><code>/echo title="My Message" severity=info This is an info message</code></pre>
                 </li>
+                <li>
+                    <pre><code>/echo title="My Message" color=black This message is purple</code></pre>
+                </li>
+                <li>
+                    <pre><code>/echo onClick={: /echo escapeHtml=false color=transparent cssClass=wider_dialogue_popup <img src="/img/five.png" /> :} timeout=5000 Clicking on this message within 10 seconds will open the image.</code></pre>
+                </li>
             </ul>
         </div>
     `,


### PR DESCRIPTION
New arguments to the `/echo` slash command.
`toastr` has a lot of options and customizability. And for one of the most-used slash commands (I figure), it's likely a good idea to expose a lot of options.

#### 1. `cssClass` to add a CSS class to the toast div
By itself, this doesn't do anything. But it allows extensible styling of toasts to your liking, based on existing CSS classes or one you can define via Custom CSS.
Until now, toasts couldn't be specifically targeted for styling. Now you can give them groups, names, whatever. Change background color, change font. Replace the icon. Style the header bigger, whatever. The rest is just custom selector below the class.

#### 2. `color` argument to quickly change toast color
The four types of toasts (info, success, warning, error) have their respective color. You could change them via styling, but that'd apply for all. You could apply a `cssClass` now, but this is faster and in-line.
It basically just sets the provided string into the `background-color` CSS property of the toast. On the user to check for validity, but all color writing styles are supported. Even transparent and unset to make it funny.

#### 3. `escapeHtml` to allow HTML-formatted toasts
Pretty self-explanatory. ST sets this to `false` by default. We can specify true or false here manually, and you can render whatever big information or even images you deem needed.

#### 4. `onClick` allowing closure execution when you interact. This is async (unless `awaitDismissal` is set), so your script itself continues running.
You can write whatever closure you want, it receives the full scope of the place it was written. Even local variables can be accessed, and they keep their values and all. Amazing, right? Think about the possibilities!
Still a disclaimer, as this allows parallel execution and such, it's not trivial. But loops and more have the same issues, so.

I tested this with this:
```
/let key=clicked 0 |
/let key=callback {: /var key=clicked {: /add clicked 1 :}() | /echo onClick={: /var key=callback :}() YOU CLICKED ME; DEAR GOD. ALREADY {{var::clicked}} TIMES :} |
/echo onClick={{var::callback}} You wanna click me? 👉👈 ...
```

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
