### PR TITLE
Expand `/popup` command and refactor a bit

### DIFF
--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -92,7 +92,7 @@ const showPopupHelper = {
      * @param {string?} header - The header text for the popup.
      * @param {string?} text - The main text for the popup.
      * @param {PopupOptions} [popupOptions={}] - Options for the popup.
-     * @return {Promise<POPUP_RESULT>} A Promise that resolves with the result of the user's interaction.
+     * @return {Promise<POPUP_RESULT?>} A Promise that resolves with the result of the user's interaction.
      */
     confirm: async (header, text, popupOptions = {}) => {
         const content = PopupUtils.BuildTextWithHeader(header, text);
@@ -107,7 +107,7 @@ const showPopupHelper = {
      * @param {string?} header - The header text for the popup.
      * @param {string?} text - The main text for the popup.
      * @param {PopupOptions} [popupOptions={}] - Options for the popup.
-     * @return {Promise<POPUP_RESULT>} A Promise that resolves with the result of the user's interaction.
+     * @return {Promise<POPUP_RESULT?>} A Promise that resolves with the result of the user's interaction.
      */
     text: async (header, text, popupOptions = {}) => {
         const content = PopupUtils.BuildTextWithHeader(header, text);

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1272,24 +1272,28 @@ export function initDefaultSlashCommands() {
                 description: 'show large popup',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
                 enumList: commonEnumProviders.boolean('onOff')(),
+                defaultValue: 'off',
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'wide',
                 description: 'show wide popup',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
                 enumList: commonEnumProviders.boolean('onOff')(),
+                defaultValue: 'off',
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'wider',
                 description: 'show wider popup',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
                 enumList: commonEnumProviders.boolean('onOff')(),
+                defaultValue: 'off',
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'transparent',
                 description: 'show transparent popup',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
                 enumList: commonEnumProviders.boolean('onOff')(),
+                defaultValue: 'off',
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'okButton',
@@ -1301,6 +1305,13 @@ export function initDefaultSlashCommands() {
                 name: 'cancelButton',
                 description: 'text for the Cancel button',
                 typeList: [ARGUMENT_TYPE.STRING],
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'result',
+                description: 'if enabled, returns the popup result (as an integer) instead of the popup text. Resolves to 1 for OK and 0/null for cancel or exiting out.',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('onOff')(),
+                defaultValue: 'off',
             }),
         ],
         unnamedArgumentList: [
@@ -1910,6 +1921,7 @@ async function buttonsCallback(args, text) {
 async function popupCallback(args, value) {
     const safeBody = DOMPurify.sanitize(value || '');
     const safeHeader = args?.header && typeof args?.header === 'string' ? DOMPurify.sanitize(args.header) : null;
+    const requestedResult = isTrueBoolean(args?.result);
 
     /** @type {import('./popup.js').PopupOptions} */
     const popupOptions = {
@@ -1920,8 +1932,8 @@ async function popupCallback(args, value) {
         okButton: args?.okButton !== undefined && typeof args?.okButton === 'string' ? args.okButton : 'Ok',
         cancelButton: args?.cancelButton !== undefined && typeof args?.cancelButton === 'string' ? args.cancelButton : null,
     };
-    await Popup.show.text(safeHeader, safeBody, popupOptions);
-    return String(value);
+    const result = await Popup.show.text(safeHeader, safeBody, popupOptions);
+    return String(requestedResult ? result : value);
 }
 
 async function getMessagesCallback(args, value) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1271,29 +1271,29 @@ export function initDefaultSlashCommands() {
                 name: 'large',
                 description: 'show large popup',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
-                enumList: commonEnumProviders.boolean('onOff')(),
-                defaultValue: 'off',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+                defaultValue: 'false',
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'wide',
                 description: 'show wide popup',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
-                enumList: commonEnumProviders.boolean('onOff')(),
-                defaultValue: 'off',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+                defaultValue: 'false',
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'wider',
                 description: 'show wider popup',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
-                enumList: commonEnumProviders.boolean('onOff')(),
-                defaultValue: 'off',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+                defaultValue: 'false',
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'transparent',
                 description: 'show transparent popup',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
-                enumList: commonEnumProviders.boolean('onOff')(),
-                defaultValue: 'off',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+                defaultValue: 'false',
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'okButton',
@@ -1310,14 +1310,16 @@ export function initDefaultSlashCommands() {
                 name: 'result',
                 description: 'if enabled, returns the popup result (as an integer) instead of the popup text. Resolves to 1 for OK and 0/null for cancel or exiting out.',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
-                enumList: commonEnumProviders.boolean('onOff')(),
-                defaultValue: 'off',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+                defaultValue: 'false',
             }),
         ],
         unnamedArgumentList: [
-            new SlashCommandArgument(
-                'text', [ARGUMENT_TYPE.STRING], true,
-            ),
+            SlashCommandArgument.fromProps({
+                description: 'popup text',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+            }),
         ],
         helpString: `
         <div>
@@ -1329,6 +1331,9 @@ export function initDefaultSlashCommands() {
             <ul>
                 <li>
                     <pre><code>/popup large=on wide=on okButton="Confirm" Please confirm this action.</code></pre>
+                </li>
+                <li>
+                    <pre><code>/popup okButton="Left" cancelButton="Right" result=true Do you want to go left or right? | /echo 0 means right, 1 means left. Choice: {{pipe}}</code></pre>
                 </li>
             </ul>
         </div>

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1274,6 +1274,12 @@ export function initDefaultSlashCommands() {
                 'wide', 'show wide popup', [ARGUMENT_TYPE.BOOLEAN], false, false, null, commonEnumProviders.boolean('onOff')(),
             ),
             new SlashCommandNamedArgument(
+                'wider', 'show wider popup', [ARGUMENT_TYPE.BOOLEAN], false, false, null, commonEnumProviders.boolean('onOff')(),
+            ),
+            new SlashCommandNamedArgument(
+                'transparent', 'show transparent popup', [ARGUMENT_TYPE.BOOLEAN], false, false, null, commonEnumProviders.boolean('onOff')(),
+            ),
+            new SlashCommandNamedArgument(
                 'okButton', 'text for the OK button', [ARGUMENT_TYPE.STRING], false,
             ),
         ],
@@ -1883,9 +1889,12 @@ async function buttonsCallback(args, text) {
 
 async function popupCallback(args, value) {
     const safeValue = DOMPurify.sanitize(value || '');
+    /** @type {import('./popup.js').PopupOptions} */
     const popupOptions = {
         large: isTrueBoolean(args?.large),
         wide: isTrueBoolean(args?.wide),
+        wider: isTrueBoolean(args?.wider),
+        transparent: isTrueBoolean(args?.transparent),
         okButton: args?.okButton !== undefined && typeof args?.okButton === 'string' ? args.okButton : 'Ok',
     };
     await delay(1);

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1267,21 +1267,41 @@ export function initDefaultSlashCommands() {
         callback: popupCallback,
         returns: 'popup text',
         namedArgumentList: [
-            new SlashCommandNamedArgument(
-                'large', 'show large popup', [ARGUMENT_TYPE.BOOLEAN], false, false, null, commonEnumProviders.boolean('onOff')(),
-            ),
-            new SlashCommandNamedArgument(
-                'wide', 'show wide popup', [ARGUMENT_TYPE.BOOLEAN], false, false, null, commonEnumProviders.boolean('onOff')(),
-            ),
-            new SlashCommandNamedArgument(
-                'wider', 'show wider popup', [ARGUMENT_TYPE.BOOLEAN], false, false, null, commonEnumProviders.boolean('onOff')(),
-            ),
-            new SlashCommandNamedArgument(
-                'transparent', 'show transparent popup', [ARGUMENT_TYPE.BOOLEAN], false, false, null, commonEnumProviders.boolean('onOff')(),
-            ),
-            new SlashCommandNamedArgument(
-                'okButton', 'text for the OK button', [ARGUMENT_TYPE.STRING], false,
-            ),
+            SlashCommandNamedArgument.fromProps({
+                name: 'large',
+                description: 'show large popup',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('onOff')(),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'wide',
+                description: 'show wide popup',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('onOff')(),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'wider',
+                description: 'show wider popup',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('onOff')(),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'transparent',
+                description: 'show transparent popup',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('onOff')(),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'okButton',
+                description: 'text for the OK button',
+                typeList: [ARGUMENT_TYPE.STRING],
+                defaultValue: 'OK',
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'cancelButton',
+                description: 'text for the Cancel button',
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
         ],
         unnamedArgumentList: [
             new SlashCommandArgument(
@@ -1297,7 +1317,7 @@ export function initDefaultSlashCommands() {
             <strong>Example:</strong>
             <ul>
                 <li>
-                    <pre><code>/popup large=on wide=on okButton="Submit" Enter some text:</code></pre>
+                    <pre><code>/popup large=on wide=on okButton="Confirm" Please confirm this action.</code></pre>
                 </li>
             </ul>
         </div>
@@ -1896,10 +1916,9 @@ async function popupCallback(args, value) {
         wider: isTrueBoolean(args?.wider),
         transparent: isTrueBoolean(args?.transparent),
         okButton: args?.okButton !== undefined && typeof args?.okButton === 'string' ? args.okButton : 'Ok',
+        cancelButton: args?.cancelButton !== undefined && typeof args?.cancelButton === 'string' ? args.cancelButton : null,
     };
-    await delay(1);
     await callGenericPopup(safeValue, POPUP_TYPE.TEXT, '', popupOptions);
-    await delay(1);
     return String(value);
 }
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1308,7 +1308,7 @@ export function initDefaultSlashCommands() {
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'result',
-                description: 'if enabled, returns the popup result (as an integer) instead of the popup text. Resolves to 1 for OK and 0/null for cancel or exiting out.',
+                description: 'if enabled, returns the popup result (as an integer) instead of the popup text. Resolves to 1 for OK and 0 cancel button, empty string for exiting out.',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
                 enumList: commonEnumProviders.boolean('trueFalse')(),
                 defaultValue: 'false',
@@ -1938,7 +1938,7 @@ async function popupCallback(args, value) {
         cancelButton: args?.cancelButton !== undefined && typeof args?.cancelButton === 'string' ? args.cancelButton : null,
     };
     const result = await Popup.show.text(safeHeader, safeBody, popupOptions);
-    return String(requestedResult ? result : value);
+    return String(requestedResult ? result ?? '' : value);
 }
 
 async function getMessagesCallback(args, value) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1908,7 +1908,9 @@ async function buttonsCallback(args, text) {
 }
 
 async function popupCallback(args, value) {
-    const safeValue = DOMPurify.sanitize(value || '');
+    const safeBody = DOMPurify.sanitize(value || '');
+    const safeHeader = args?.header && typeof args?.header === 'string' ? DOMPurify.sanitize(args.header) : null;
+
     /** @type {import('./popup.js').PopupOptions} */
     const popupOptions = {
         large: isTrueBoolean(args?.large),
@@ -1918,7 +1920,7 @@ async function popupCallback(args, value) {
         okButton: args?.okButton !== undefined && typeof args?.okButton === 'string' ? args.okButton : 'Ok',
         cancelButton: args?.cancelButton !== undefined && typeof args?.cancelButton === 'string' ? args.cancelButton : null,
     };
-    await callGenericPopup(safeValue, POPUP_TYPE.TEXT, '', popupOptions);
+    await Popup.show.text(safeHeader, safeBody, popupOptions);
     return String(value);
 }
 


### PR DESCRIPTION
Not the nicest way, but the actual modal popup in JS supported the styles `wide`, `wider`, `large` and `transparent` . The command supports all those now too. We also support `transparent` now.

Also expanded the command with the optional head argument, that stops the need to write HTML yourself to add a simple header.
```
/popup header="Did you know?" I am so cool!
```
This is no possible, and easier as ever.

The original popup command returned the given string itself, which was kinda weird. To not break it, but still allow to **actually** check what kind of interaction on the popup was chosen, the new argument `result` was introduced. If toggled on, the integer for the popup result will be returned.
For the slash command, that currently means `1` for OK click or `null` for canceled. If a custom cancelButton is supplied (also new), then it can also be `0`.

I also refactored the arguments to default to true/false instead of off/on.
In my eyes, "off/on" is good for an actual toggle, settings and stuff like that. Even three-state things. For a simple boolean argument, even non-programmers should be more inclined to understand what true/false means.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
