### PR TITLE
Add title to Backgrounds panel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4333,7 +4333,10 @@
             </div>
             <div id="Backgrounds" class="drawer-content closedDrawer">
                 <div class="flex-container">
-                    <div class="flex-container wide100p">
+                    <div class="flex-container alignItemsBaseline wide100p">
+                        <h3 class="margin0 flex2" data-i18n="Background Image">
+                            Background Image
+                        </h3>
                         <input id="bg-filter" data-i18n="[placeholder]Filter" placeholder="Filter" class="text_pole flex1" type="search" />
                         <div id="auto_background" class="menu_button menu_button_icon" data-i18n="[title]Automatically select a background based on the chat context" title="Automatically select a background based on the chat context.">
                             <i class="fa-solid fa-wand-magic"></i>


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

I noticed that Backgrounds were the only panel in the top menu that doesn't have a title in the top left corner. 

### 𝒞𝑜𝓃𝓈𝒾𝓈𝓉𝑒𝓃𝒸𝓎

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
