### PR TITLE
Fix to BR #2811 - Renaming character in Group Chat does not select the right character and renames the wrong character

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3412,7 +3412,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             .filter((index) => index !== undefined && index !== null);
 
         if (memberIds.length > 0) {
-            setCharacterId(memberIds[0]);
+            if (menu_type != 'character_edit') setCharacterId(memberIds[0]);
             setCharacterName('');
         } else {
             console.log('No enabled members found');


### PR DESCRIPTION
From #2811 - more debug detail is in the bug report.

### Describe the problem:
When going to a group chat for the first time and then clicking on Character A and then going back and clicking Character B then pressing rename on Character B shows the name from Character A.

I thought this error was just maybe just a glitch but when I ran it (rename), it ended up renaming character A and screwing up most of my saves for that character. Fortunately I had a few day old back of the saves.

I have tried to reproduce the effect and I was successful, the way I got it to happen again is going to a group chat, then selecting character A in the group, going back to the group main view, the pressing character A, doing this again for 2/3 times. Then I go to character B and press rename and the name of character A is character B's rename.

### Solution:
There were two calls to SetCharacterID being made when I was in the Character Edit menu in a group chat. The first one is supposed to run when the main group chat menu is open however because of a delay sometimes it runs after opening a character edit menu. The delayed one set's the this_chid to the first enabled character which would override the this_chid by entering the character edit menu.

So to fix this the following solution was applied:

``` js
        if (memberIds.length > 0) {
            if (menu_type != 'character_edit') setCharacterId(memberIds[0]);
            setCharacterName('');
        } else {
            console.log('No enabled members found');
            unblockGeneration(type);
            return Promise.resolve();
        }
```

Where I added the check `if (menu_type != 'character_edit')` to make sure this does not set the wrong this_chid when the character_edit menu is open.


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
