### PR TITLE
Fix `/sendas` to not always enforce avatar, if not needed in solo chats

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3130,7 +3130,7 @@ export async function sendMessageAs(args, text) {
     const character = characters.find(x => x.avatar === name) ?? characters.find(x => x.name === name);
     let force_avatar, original_avatar;
 
-    const chatCharacter = this_chid !== null ? characters[this_chid] : null;
+    const chatCharacter = this_chid !== undefined ? characters[this_chid] : null;
     const isNeutralCharacter = !chatCharacter && name2 === neutralCharacterName && name === neutralCharacterName;
 
     if (chatCharacter === character || isNeutralCharacter) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3129,7 +3129,7 @@ export async function sendMessageAs(args, text) {
     const character = characters.find(x => x.avatar === name) ?? characters.find(x => x.name === name);
     let force_avatar, original_avatar;
 
-    if (characters[this_chid] === character) {
+    if (this_chid !== undefined && characters[this_chid] === character) {
         // If the targeted character is the currently selected one in a solo chat, we don't need to force any avatars
     }
     else if (character && character.avatar !== 'none') {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -24,6 +24,7 @@ import {
     main_api,
     name1,
     name2,
+    neutralCharacterName,
     reloadCurrentChat,
     removeMacros,
     renameCharacter,
@@ -3129,7 +3130,10 @@ export async function sendMessageAs(args, text) {
     const character = characters.find(x => x.avatar === name) ?? characters.find(x => x.name === name);
     let force_avatar, original_avatar;
 
-    if (this_chid !== undefined && characters[this_chid] === character) {
+    const chatCharacter = this_chid !== null ? characters[this_chid] : null;
+    const isNeutralCharacter = !chatCharacter && name2 === neutralCharacterName;
+
+    if (chatCharacter === character || isNeutralCharacter) {
         // If the targeted character is the currently selected one in a solo chat, we don't need to force any avatars
     }
     else if (character && character.avatar !== 'none') {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3131,7 +3131,7 @@ export async function sendMessageAs(args, text) {
     let force_avatar, original_avatar;
 
     const chatCharacter = this_chid !== null ? characters[this_chid] : null;
-    const isNeutralCharacter = !chatCharacter && name2 === neutralCharacterName;
+    const isNeutralCharacter = !chatCharacter && name2 === neutralCharacterName && name === neutralCharacterName;
 
     if (chatCharacter === character || isNeutralCharacter) {
         // If the targeted character is the currently selected one in a solo chat, we don't need to force any avatars

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3129,7 +3129,10 @@ export async function sendMessageAs(args, text) {
     const character = characters.find(x => x.avatar === name) ?? characters.find(x => x.name === name);
     let force_avatar, original_avatar;
 
-    if (character && character.avatar !== 'none') {
+    if (characters[this_chid] === character) {
+        // If the targeted character is the currently selected one in a solo chat, we don't need to force any avatars
+    }
+    else if (character && character.avatar !== 'none') {
         force_avatar = getThumbnailUrl('avatar', character.avatar);
         original_avatar = character.avatar;
     }


### PR DESCRIPTION
The ages old `/sendas` slash command had a pretty easy logic finding the target character.
But set the avatar url via `force_avatar`. Which would be okay in itself, enforcing that specific image. But the same field gets used in some places to decide whether there was manual modification of the message.

For example Text Completion uses it to decide whether the name prefix is getting added, even if the general name prefix setting is turned off.
Makes sense for Text Completion in case you write a different character into your chat in a solo chat. But if you are in a solo chat, and add a message for that character, there is no need for the name prefix.

Instead of dabbling with Text Completion instruct formatting or deeper stuff like this, we simply can just not set the avatar if character to send as is the same as you are currently chatting with.

- Fixes #2820

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
