### PR TITLE
Append continuation message after prefill when using "Continue Prefill" with Claude

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1776,8 +1776,7 @@ async function sendOpenAIRequest(type, messages, signal) {
         generate_data['claude_use_sysprompt'] = oai_settings.claude_use_sysprompt;
         generate_data['stop'] = getCustomStoppingStrings(); // Claude shouldn't have limits on stop strings.
         generate_data['human_sysprompt_message'] = substituteParams(oai_settings.human_sysprompt_message);
-        // Don't add a prefill on quiet gens (summarization)
-        console.log(isContinue && oai_settings.continue_prefill);
+        // Don't add a prefill on quiet gens (summarization) and when using continue prefill.
         if (!isQuiet && !(isContinue && oai_settings.continue_prefill)) {
             generate_data['assistant_prefill'] = isImpersonate ? substituteParams(oai_settings.assistant_impersonation) : substituteParams(oai_settings.assistant_prefill);
         }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1777,7 +1777,8 @@ async function sendOpenAIRequest(type, messages, signal) {
         generate_data['stop'] = getCustomStoppingStrings(); // Claude shouldn't have limits on stop strings.
         generate_data['human_sysprompt_message'] = substituteParams(oai_settings.human_sysprompt_message);
         // Don't add a prefill on quiet gens (summarization)
-        if (!isQuiet && !isContinue) {
+        console.log(isContinue && oai_settings.continue_prefill);
+        if (!isQuiet && !(isContinue && oai_settings.continue_prefill)) {
             generate_data['assistant_prefill'] = isImpersonate ? substituteParams(oai_settings.assistant_impersonation) : substituteParams(oai_settings.assistant_prefill);
         }
     }

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -132,7 +132,9 @@ function convertClaudeMessages(messages, prefillString, useSysPrompt, humanMsgFi
     });
 
     // Shouldn't be conditional anymore, messages api expects the last role to be user unless we're explicitly prefilling
-    if (prefillString) {
+    if (messages[messages.length - 1].role == 'assistant' && prefillString) {
+        messages[messages.length - 1].content = prefillString.trimEnd() + messages[messages.length - 1].content;
+    } else if (prefillString) {
         messages.push({
             role: 'assistant',
             content: prefillString.trimEnd(),

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -132,9 +132,7 @@ function convertClaudeMessages(messages, prefillString, useSysPrompt, humanMsgFi
     });
 
     // Shouldn't be conditional anymore, messages api expects the last role to be user unless we're explicitly prefilling
-    if (messages[messages.length - 1].role == 'assistant' && prefillString) {
-        messages[messages.length - 1].content = prefillString + messages[messages.length - 1].content.trimEnd();
-    } else if (prefillString) {
+    if (prefillString) {
         messages.push({
             role: 'assistant',
             content: prefillString.trimEnd(),

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -133,7 +133,7 @@ function convertClaudeMessages(messages, prefillString, useSysPrompt, humanMsgFi
 
     // Shouldn't be conditional anymore, messages api expects the last role to be user unless we're explicitly prefilling
     if (messages[messages.length - 1].role == 'assistant' && prefillString) {
-        messages[messages.length - 1].content = prefillString.trimEnd() + messages[messages.length - 1].content;
+        messages[messages.length - 1].content = prefillString + messages[messages.length - 1].content.trimEnd();
     } else if (prefillString) {
         messages.push({
             role: 'assistant',


### PR DESCRIPTION
Currently when using "Continue Prefill" and having an "Assistant Prefill" set, continuing a message ends up with the request having the "Assistant Prefill" after the message that should be continued, resulting in the generation very rarely actually continuing from the last message.

This prepends the prefillString to the last message if its an assistant message rather than appending it as a new message to the chat.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
