### PR TITLE
Add `debugging` field for WIs to log only few entries if needed.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5499,6 +5499,12 @@
                                                                 Delay until recursion (this entry can only be activated on recursive checking)
                                                             </span>
                                                         </label>
+                                                        <label class="checkbox flex-container alignitemscenter flexNoGap">
+                                                            <input type="checkbox" name="debugging" />
+                                                            <span data-i18n="Log this entry to the console when running WI check.">
+                                                                Log this entry to the console when running WI check.
+                                                            </span>
+                                                        </label>
                                                     </div>
                                                 </span>
                                             </small>

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -489,6 +489,7 @@ function convertWorldInfoToCharacterBook(name, entries) {
                 sticky: entry.sticky ?? null,
                 cooldown: entry.cooldown ?? null,
                 delay: entry.delay ?? null,
+                debugging: entry.debugging ?? true,
             },
         };
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

_____

My WI book has nearly 220 entries & 7300 keys. This was extremely difficult when I was debugging it.
I hope to add this function so that when writing complex WIbooks, only the required entries can be selected and entered into the log, thereby reducing the reading burden when reading the log for debugging needs.
![图片](https://github.com/user-attachments/assets/b30fbd9a-f1ff-4612-8696-73a0721e3515)
![图片](https://github.com/user-attachments/assets/b48da653-4f47-4934-bd30-ef5ceb6de258)