### PR TITLE
Improve error handling of /genraw and /gen

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3265,7 +3265,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
         }
 
         if (data.error) {
-            throw new Error(data.error);
+            throw new Error(data.response);
         }
 
         const message = cleanUpMessage(extractMessageFromData(data), false, false, true);

--- a/public/script.js
+++ b/public/script.js
@@ -4415,7 +4415,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             if (data?.response) {
                 toastr.error(data.response, 'API Error');
             }
-            throw data?.response;
+            throw new Error(data?.response);
         }
 
         //const getData = await response.json();

--- a/public/script.js
+++ b/public/script.js
@@ -4413,7 +4413,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             generatedPromptCache = '';
 
             if (data?.response) {
-                toastr.error(data.response, 'API Error');
+                toastr.error(data.response, 'API Error', { preventDuplicates: true });
             }
             throw new Error(data?.response);
         }

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2261,7 +2261,7 @@ async function generateRawCallback(args, value) {
         const result = await generateRaw(value, '', isFalseBoolean(args?.instruct), quietToLoud, systemPrompt, length);
         return result;
     } catch (err) {
-        console.error('Error on /genraw generation', err);
+        console.error('Error on /gen generation', err);
         toastr.error(err.message, 'Error on Generate');
     } finally {
         if (lock) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2241,7 +2241,7 @@ function setEphemeralStopStrings(value) {
 async function generateRawCallback(args, value) {
     if (!value) {
         console.warn('WARN: No argument provided for /genraw command');
-        return;
+        return '';
     }
 
     // Prevent generate recursion
@@ -2260,12 +2260,16 @@ async function generateRawCallback(args, value) {
         setEphemeralStopStrings(resolveVariable(args?.stop));
         const result = await generateRaw(value, '', isFalseBoolean(args?.instruct), quietToLoud, systemPrompt, length);
         return result;
+    } catch (err) {
+        console.error('Error on /genraw generation', err);
+        toastr.error(err.message, 'Error on Generate');
     } finally {
         if (lock) {
             activateSendButtons();
         }
         flushEphemeralStoppingStrings();
     }
+    return '';
 }
 
 /**
@@ -2291,12 +2295,16 @@ async function generateCallback(args, value) {
         const name = args?.name;
         const result = await generateQuietPrompt(value, quietToLoud, false, '', name, length);
         return result;
+    } catch (err) {
+        console.error('Error on /genraw generation', err);
+        toastr.error(err.message, 'Error on Generate');
     } finally {
         if (lock) {
             activateSendButtons();
         }
         flushEphemeralStoppingStrings();
     }
+    return '';
 }
 
 /**

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2262,7 +2262,7 @@ async function generateRawCallback(args, value) {
         return result;
     } catch (err) {
         console.error('Error on /genraw generation', err);
-        toastr.error(err.message, 'Error on Generate');
+        toastr.error(err.message, 'API Error', { preventDuplicates: true });
     } finally {
         if (lock) {
             activateSendButtons();
@@ -2297,7 +2297,7 @@ async function generateCallback(args, value) {
         return result;
     } catch (err) {
         console.error('Error on /gen generation', err);
-        toastr.error(err.message, 'Error on Generate');
+        toastr.error(err.message, 'API Error', { preventDuplicates: true });
     } finally {
         if (lock) {
             activateSendButtons();

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2261,7 +2261,7 @@ async function generateRawCallback(args, value) {
         const result = await generateRaw(value, '', isFalseBoolean(args?.instruct), quietToLoud, systemPrompt, length);
         return result;
     } catch (err) {
-        console.error('Error on /gen generation', err);
+        console.error('Error on /genraw generation', err);
         toastr.error(err.message, 'Error on Generate');
     } finally {
         if (lock) {
@@ -2296,7 +2296,7 @@ async function generateCallback(args, value) {
         const result = await generateQuietPrompt(value, quietToLoud, false, '', name, length);
         return result;
     } catch (err) {
-        console.error('Error on /genraw generation', err);
+        console.error('Error on /gen generation', err);
         toastr.error(err.message, 'Error on Generate');
     } finally {
         if (lock) {

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -375,7 +375,9 @@ router.post('/generate', jsonParser, async function (request, response) {
             }
         }
     } catch (error) {
-        let value = { error: true, status: error?.status, response: error?.statusText };
+        const status = error?.status ?? error?.code ?? 'UNKNOWN';
+        const text = error?.error ?? error?.statusText ?? error?.message ?? 'Unknown error on /generate endpoint';
+        let value = { error: true, status: status, response: text };
         console.log('Endpoint error:', error);
 
         if (!response.headersSent) {


### PR DESCRIPTION
- /generate TC backend returns more status/error texts
- Fix /genraw and /gen returning null/undefined
- Logging errors on /genraw if backend throws an error
- Fixes #2836

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
