### PR TITLE
Calculate entry hash before replacing macros

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -108,6 +108,7 @@ const KNOWN_DECORATORS = ['@@activate', '@@dont_activate'];
  * @property {number} [cooldown] The cooldown of the entry
  * @property {number} [delay] The delay of the entry
  * @property {string[]} [decorators] Array of decorators for the entry
+ * @property {number} [hash] The hash of the entry
  */
 
 /**
@@ -383,12 +384,6 @@ class WorldInfoBuffer {
  */
 class WorldInfoTimedEffects {
     /**
-     * Cache for entry hashes. Uses weak map to avoid memory leaks.
-     * @type {WeakMap<WIScanEntry, number>}
-     */
-    #entryHashCache = new WeakMap();
-
-    /**
      * Array of chat messages.
      * @type {string[]}
      */
@@ -485,13 +480,7 @@ class WorldInfoTimedEffects {
     * @returns {number} String hash
     */
     #getEntryHash(entry) {
-        if (this.#entryHashCache.has(entry)) {
-            return this.#entryHashCache.get(entry);
-        }
-
-        const hash = getStringHash(JSON.stringify(entry));
-        this.#entryHashCache.set(entry, hash);
-        return hash;
+        return entry.hash;
     }
 
     /**
@@ -3603,10 +3592,11 @@ export async function getSortedEntries() {
         // Chat lore always goes first
         entries = [...chatLore.sort(sortFn), ...entries];
 
-        // Parse decorators
+        // Calculate hash and parse decorators
         entries = entries.map((entry) => {
+            const hash = getStringHash(JSON.stringify(entry));
             const [decorators, content] = parseDecorators(entry.content || '');
-            return { ...entry, decorators, content };
+            return { ...entry, decorators, content, hash };
         });
 
         console.debug(`[WI] Found ${entries.length} world lore entries. Sorted by strategy`, Object.entries(world_info_insertion_strategy).find((x) => x[1] === world_info_character_strategy));

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3592,11 +3592,13 @@ export async function getSortedEntries() {
         // Chat lore always goes first
         entries = [...chatLore.sort(sortFn), ...entries];
 
-        // Calculate hash and parse decorators
+        // Calculate hash and parse decorators. Split maps to preserve old hashes.
         entries = entries.map((entry) => {
-            const hash = getStringHash(JSON.stringify(entry));
             const [decorators, content] = parseDecorators(entry.content || '');
-            return { ...entry, decorators, content, hash };
+            return { ...entry, decorators, content };
+        }).map((entry) => {
+            const hash = getStringHash(JSON.stringify(entry));
+            return { ...entry, hash };
         });
 
         console.debug(`[WI] Found ${entries.length} world lore entries. Sorted by strategy`, Object.entries(world_info_insertion_strategy).find((x) => x[1] === world_info_character_strategy));


### PR DESCRIPTION
Fixes #2762

Hash is used by timed effect, so calculating hash after replacing macros can lead to inconsistent entry sticking.

`#getEntryHash` class function is left to minimize diff.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
