### PR TITLE
join chatlog with `\x01`

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -217,15 +217,16 @@ class WorldInfoBuffer {
             depth = MAX_SCAN_DEPTH;
         }
 
-        let result = this.#depthBuffer.slice(this.#startDepth, depth).join('\n\x01');
+        const JOINER = '\n\x01';
+        let result = this.#depthBuffer.slice(this.#startDepth, depth).join(JOINER);
 
         if (this.#injectBuffer.length > 0) {
-            result += '\n\x01' + this.#injectBuffer.join('\n\x01');
+            result += JOINER + this.#injectBuffer.join(JOINER);
         }
 
         // Min activations should not include the recursion buffer
         if (this.#recurseBuffer.length > 0 && scanState !== scan_state.MIN_ACTIVATIONS) {
-            result += '\n\x01' + this.#recurseBuffer.join('\n\x01');
+            result += JOINER + this.#recurseBuffer.join(JOINER);
         }
 
         return result;

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -217,15 +217,15 @@ class WorldInfoBuffer {
             depth = MAX_SCAN_DEPTH;
         }
 
-        let result = this.#depthBuffer.slice(this.#startDepth, depth).join('\n');
+        let result = this.#depthBuffer.slice(this.#startDepth, depth).join('\n\x01');
 
         if (this.#injectBuffer.length > 0) {
-            result += '\n' + this.#injectBuffer.join('\n');
+            result += '\n\x01' + this.#injectBuffer.join('\n\x01');
         }
 
         // Min activations should not include the recursion buffer
         if (this.#recurseBuffer.length > 0 && scanState !== scan_state.MIN_ACTIVATIONS) {
-            result += '\n' + this.#recurseBuffer.join('\n');
+            result += '\n\x01' + this.#recurseBuffer.join('\n\x01');
         }
 
         return result;


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

See the chat history on discord, this will provide convenience for matching only one message.
Now we can use `\x01{{user}}:[^\x01]*key` to match content