### PR TITLE
Preserve neutral chat on reloading with commands

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -8949,15 +8949,12 @@ export async function deleteCharacter(characterKey, { deleteChats = true } = {})
  * It also ensures to save the settings after all the operations.
  */
 async function removeCharacterFromUI() {
+    preserveNeutralChat();
     await clearChat();
-    $('#character_cross').click();
-    this_chid = undefined;
-    characters.length = 0;
-    name2 = systemUserName;
-    chat.splice(0, chat.length, ...SAFETY_CHAT);
-    chat_metadata = {};
+    $('#character_cross').trigger('click');
+    resetChatState();
     $(document.getElementById('rm_button_selected_ch')).children('h2').text('');
-    this_chid = undefined;
+    restoreNeutralChat();
     await getCharacters();
     await printMessages();
     saveSettingsDebounced();

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -19,6 +19,8 @@ import {
     this_chid,
     saveChatConditional,
     chat_metadata,
+    neutralCharacterName,
+    updateChatMetadata,
 } from '../script.js';
 import { selected_group } from './group-chats.js';
 import { power_user } from './power-user.js';
@@ -1350,6 +1352,32 @@ async function verifyAttachmentsForSource(source) {
     } catch (error) {
         console.error('Attachment verification failed', error);
     }
+}
+
+const NEUTRAL_CHAT_KEY = 'neutralChat';
+
+export function preserveNeutralChat() {
+    if (this_chid !== undefined || selected_group || name2 !== neutralCharacterName) {
+        return;
+    }
+
+    sessionStorage.setItem(NEUTRAL_CHAT_KEY, JSON.stringify({ chat, chat_metadata }));
+}
+
+export function restoreNeutralChat() {
+    if (this_chid !== undefined || selected_group || name2 !== neutralCharacterName) {
+        return;
+    }
+
+    const neutralChat = sessionStorage.getItem(NEUTRAL_CHAT_KEY);
+    if (!neutralChat) {
+        return;
+    }
+
+    const { chat: neutralChatData, chat_metadata: neutralChatMetadata } = JSON.parse(neutralChat);
+    chat.splice(0, chat.length, ...neutralChatData);
+    updateChatMetadata(neutralChatMetadata, true);
+    sessionStorage.removeItem(NEUTRAL_CHAT_KEY);
 }
 
 /**


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Prevents no-char Assistant chat vanishing on using certain commands that reload the chat.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
