### PR TITLE
WI "Delay until recursion" levels to delay delayed entries until other delayed entries are fully matched

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -274,3 +274,7 @@ select.keyselect+span.select2-container .select2-selection--multiple {
     align-self: center;
     width: 100%;
 }
+
+.world_entry:has(input[name="delay_until_recursion"]:not(:checked)) .world_entry_form_control:has(input[name="delayUntilRecursionLevel"]) {
+    display: none;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -5489,6 +5489,13 @@
                                         <small class="textAlignCenter" data-i18n="Automation ID">Automation ID</small>
                                         <input class="text_pole margin0" name="automationId" type="text" placeholder="( None )" data-i18n="[placeholder]( None )">
                                     </div>
+                                    <div class="world_entry_form_control flex1" title="Defines delay levels for recursive scans.&#13;&#13;Initially, only the first level (smallest number) will match.&#13;Once no matches are found, the next level becomes eligible for matching.&#13;This repeats until all levels are checked.&#13;&#13;Tied to the &quot;Delay until recursion&quot; setting." data-i18n="[title]delay_until_recursion_level">
+                                        <small class="textAlignCenter">
+                                            <span data-i18n="Recursion Level">Recursion Level</span>
+                                            <div class="fa-solid fa-circle-info opacity50p"></div>
+                                        </small>
+                                        <input class="text_pole margin0" name="delayUntilRecursionLevel" type="text" placeholder="1">
+                                    </div>
                                 </div>
                                 <div name="contentAndCharFilterBlock" class="world_entry_thin_controls flex2">
                                     <div class="world_entry_form_control flex1">

--- a/public/index.html
+++ b/public/index.html
@@ -5464,23 +5464,23 @@
                                     <div class="world_entry_form_control flex1">
                                         <small class="textAlignCenter" data-i18n="Case-Sensitive">Case-Sensitive</small>
                                         <select name="caseSensitive" class="text_pole widthNatural margin0">
-                                            <option value="null" data-i18n="Use global setting">Use global setting</option>
+                                            <option value="null" data-i18n="Use global">Use global</option>
                                             <option value="true" data-i18n="Yes">Yes</option>
                                             <option value="false" data-i18n="No">No</option>
                                         </select>
                                     </div>
                                     <div class="world_entry_form_control flex1">
-                                        <small class="textAlignCenter" data-i18n="Match Whole Words">Match Whole Words</small>
+                                        <small class="textAlignCenter" data-i18n="Whole Words">Whole Words</small>
                                         <select name="matchWholeWords" class="text_pole widthNatural margin0">
-                                            <option value="null" data-i18n="Use global setting">Use global setting</option>
+                                            <option value="null" data-i18n="Use global">Use global</option>
                                             <option value="true" data-i18n="Yes">Yes</option>
                                             <option value="false" data-i18n="No">No</option>
                                         </select>
                                     </div>
                                     <div class="world_entry_form_control flex1">
-                                        <small class="textAlignCenter" data-i18n="Use Group Scoring">Use Group Scoring</small>
+                                        <small class="textAlignCenter" data-i18n="Group Scoring">Group Scoring</small>
                                         <select name="useGroupScoring" class="text_pole widthNatural margin0">
-                                            <option value="null" data-i18n="Use global setting">Use global setting</option>
+                                            <option value="null" data-i18n="Use global">Use global</option>
                                             <option value="true" data-i18n="Yes">Yes</option>
                                             <option value="false" data-i18n="No">No</option>
                                         </select>
@@ -5512,20 +5512,20 @@
                                                     <div>
                                                         <label class="checkbox flex-container alignitemscenter flexNoGap">
                                                             <input type="checkbox" name="exclude_recursion" />
-                                                            <span data-i18n="Exclude from recursion">
-                                                                Non-recursable (this entry will not be activated by another)
+                                                            <span data-i18n="Non-recursable (will not be activated by another)">
+                                                                Non-recursable (will not be activated by another)
                                                             </span>
                                                         </label>
                                                         <label class="checkbox flex-container alignitemscenter flexNoGap">
                                                             <input type="checkbox" name="prevent_recursion" />
                                                             <span data-i18n="Prevent further recursion (this entry will not activate others)">
-                                                                Prevent further recursion (this entry will not activate others)
+                                                                Prevent further recursion (will not activate others)
                                                             </span>
                                                         </label>
                                                         <label class="checkbox flex-container alignitemscenter flexNoGap">
                                                             <input type="checkbox" name="delay_until_recursion" />
-                                                            <span data-i18n="Delay until recursion (this entry can only be activated on recursive checking)">
-                                                                Delay until recursion (this entry can only be activated on recursive checking)
+                                                            <span data-i18n="Delay until recursion (can only be activated on recursive checking)">
+                                                                Delay until recursion (can only be activated on recursive checking)
                                                             </span>
                                                         </label>
                                                     </div>

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2949,8 +2949,11 @@ async function getWorldEntry(name, data, entry) {
     preventRecursionInput.prop('checked', entry.preventRecursion).trigger('input');
 
     // delay until recursion
+    // delay until recursion level
     const delayUntilRecursionInput = template.find('input[name="delay_until_recursion"]');
     delayUntilRecursionInput.data('uid', entry.uid);
+    const delayUntilRecursionLevelInput = template.find('input[name="delayUntilRecursionLevel"]');
+    delayUntilRecursionLevelInput.data('uid', entry.uid);
     delayUntilRecursionInput.on('input', async function () {
         const uid = $(this).data('uid');
         const toggled = $(this).prop('checked');
@@ -2958,15 +2961,13 @@ async function getWorldEntry(name, data, entry) {
         // If the value contains a number, we'll take that one (set by the level input), otherwise we can use true/false switch
         const value = toggled ? data.entries[uid].delayUntilRecursion || true : false;
 
+        if (!toggled) delayUntilRecursionLevelInput.val('');
+
         data.entries[uid].delayUntilRecursion = value;
         setWIOriginalDataValue(data, uid, 'extensions.delay_until_recursion', data.entries[uid].delayUntilRecursion);
         await saveWorldInfo(name, data);
     });
     delayUntilRecursionInput.prop('checked', entry.delayUntilRecursion).trigger('input');
-
-    // delay until recursion level
-    const delayUntilRecursionLevelInput = template.find('input[name="delayUntilRecursionLevel"]');
-    delayUntilRecursionLevelInput.data('uid', entry.uid);
     delayUntilRecursionLevelInput.on('input', async function () {
         const uid = $(this).data('uid');
         const content = $(this).val();
@@ -3746,7 +3747,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun) {
     /** @type {number[]} Represents the delay levels for entries that are delayed until recursion */
     const availableRecursionDelayLevels = [...new Set(sortedEntries
         .filter(entry => entry.delayUntilRecursion)
-        .map(entry => entry.delayUntilRecursion === true ? 1 : entry.delayUntilRecursion)
+        .map(entry => entry.delayUntilRecursion === true ? 1 : entry.delayUntilRecursion),
     )].sort((a, b) => a - b);
     // Already preset with the first level
     let currentRecursionDelayLevel = availableRecursionDelayLevels.shift() ?? 0;
@@ -3767,7 +3768,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun) {
         count++;
 
         console.debug(`[WI] --- LOOP #${count} START ---`);
-        console.debug(`[WI] Scan state`, Object.entries(scan_state).find(x => x[1] === scanState));
+        console.debug('[WI] Scan state', Object.entries(scan_state).find(x => x[1] === scanState));
 
         // Until decided otherwise, we set the loop to stop scanning after this
         let nextScanState = scan_state.NONE;

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2953,12 +2953,34 @@ async function getWorldEntry(name, data, entry) {
     delayUntilRecursionInput.data('uid', entry.uid);
     delayUntilRecursionInput.on('input', async function () {
         const uid = $(this).data('uid');
-        const value = $(this).prop('checked');
+        const toggled = $(this).prop('checked');
+
+        // If the value contains a number, we'll take that one (set by the level input), otherwise we can use true/false switch
+        const value = toggled ? data.entries[uid].delayUntilRecursion || true : false;
+
         data.entries[uid].delayUntilRecursion = value;
         setWIOriginalDataValue(data, uid, 'extensions.delay_until_recursion', data.entries[uid].delayUntilRecursion);
         await saveWorldInfo(name, data);
     });
     delayUntilRecursionInput.prop('checked', entry.delayUntilRecursion).trigger('input');
+
+    // delay until recursion level
+    const delayUntilRecursionLevelInput = template.find('input[name="delayUntilRecursionLevel"]');
+    delayUntilRecursionLevelInput.data('uid', entry.uid);
+    delayUntilRecursionLevelInput.on('input', async function () {
+        const uid = $(this).data('uid');
+        const content = $(this).val();
+        const value = content === '' ? (typeof data.entries[uid].delayUntilRecursion === 'boolean' ? data.entries[uid].delayUntilRecursion : true)
+            : content === 1 ? true
+                : !isNaN(Number(content)) ? Number(content)
+                    : false;
+
+        data.entries[uid].delayUntilRecursion = value;
+        setWIOriginalDataValue(data, uid, 'extensions.delay_until_recursion', data.entries[uid].delayUntilRecursion);
+        await saveWorldInfo(name, data);
+    });
+    // No need to retrigger inpout event, we'll just set the curret current value. It was edited/saved above already
+    delayUntilRecursionLevelInput.val(['number', 'string'].includes(typeof entry.delayUntilRecursion) ? entry.delayUntilRecursion : '').trigger('input');
 
     // duplicate button
     const duplicateButton = template.find('.duplicate_entry_button');
@@ -3257,7 +3279,7 @@ export const newWorldInfoEntryDefinition = {
     disable: { default: false, type: 'boolean' },
     excludeRecursion: { default: false, type: 'boolean' },
     preventRecursion: { default: false, type: 'boolean' },
-    delayUntilRecursion: { default: false, type: 'boolean' },
+    delayUntilRecursion: { default: 0, type: 'number' },
     probability: { default: 100, type: 'number' },
     useProbability: { default: true, type: 'boolean' },
     depth: { default: DEFAULT_DEPTH, type: 'number' },

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -217,8 +217,9 @@ class WorldInfoBuffer {
             depth = MAX_SCAN_DEPTH;
         }
 
-        const JOINER = '\n\x01';
-        let result = this.#depthBuffer.slice(this.#startDepth, depth).join(JOINER);
+        const MATCHER = '\x01';
+        const JOINER = '\n' + MATCHER;
+        let result = MATCHER + this.#depthBuffer.slice(this.#startDepth, depth).join(JOINER);
 
         if (this.#injectBuffer.length > 0) {
             result += JOINER + this.#injectBuffer.join(JOINER);

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4055,6 +4055,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun) {
 
         // If the scan is done, but we still have open "delay until recursion" levels, we should continue with the next one
         if (nextScanState === scan_state.NONE && availableRecursionDelayLevels.length) {
+            nextScanState = scan_state.RECURSION;
             currentRecursionDelayLevel = availableRecursionDelayLevels.shift();
         }
 


### PR DESCRIPTION
Enhancing the "Delay until recursion" feature by optionally allowing to define delay recursion levels.

My take on #2853, implementing #2213, inspired and requested by @steve02081504.

All delayed entries will be *grouped* by level integer, ascending.
Original values `true`/`false` will persist, and true will be treated as level `1`, while `false` means off.

This allows a finer granularity and control in how recursive scans operate, when inclusion groups and NOT key values are not enough.

#### Technical Changes
- New input for "Delay Until Recursion" Levels
  - Input only appears when the main toggle for it is toggled on
  - The input sets the existing value on the WI entry to a numerical value
  - If no level provided, defaults to `true`/`false` as before - meaning if turned on the first level is `1`
  - Tooltip explaining it
- New delay until recursion matching logic
  - Recursive sweeps will only allow recursive entries of the "current level" to match
  - First sweep will automatically start with the first level
  - Then in descending order, new levels will **only** be allowed until the complete WI processing is done and it would stop otherwise
  - On the next level, all recursive entries up to that level are allowed again
  - The recursive loops can still trigger original entries and all before still, as there might be new matches cause of added context
- Updated Logging of WI with even more headers and better explanation of state changes

Docs will follow if the PR is good to go.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
