### PR TITLE
Throttle chat backups

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -83,6 +83,8 @@ skipContentCheck: false
 disableChatBackup: false
 # Number of backups to keep for each chat and settings file
 numberOfBackups: 50
+# Interval in milliseconds to throttle chat backups per user
+chatBackupThrottleInterval: 10000
 # Allowed hosts for card downloads
 whitelistImportDomains:
   - localhost

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -43,8 +43,9 @@ const backupFunctions = new Map();
  * @returns {function(string, string, string): void} Backup function
  */
 function getBackupFunction(handle) {
+    const throttleInterval = getConfigValue('chatBackupThrottleInterval', 10_000);
     if (!backupFunctions.has(handle)) {
-        backupFunctions.set(handle, _.throttle(backupChat, 10_000, { leading: true, trailing: true }));
+        backupFunctions.set(handle, _.throttle(backupChat, throttleInterval, { leading: true, trailing: true }));
     }
     return backupFunctions.get(handle);
 }

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -4,6 +4,7 @@ const readline = require('readline');
 const express = require('express');
 const sanitize = require('sanitize-filename');
 const writeFileAtomicSync = require('write-file-atomic').sync;
+const _ = require('lodash');
 
 const { jsonParser, urlencodedParser } = require('../express-common');
 const { getConfigValue, humanizedISO8601DateTime, tryParse, generateTimestamp, removeOldBackups } = require('../util');
@@ -33,6 +34,26 @@ function backupChat(directory, name, chat) {
         console.log(`Could not backup chat for ${name}`, err);
     }
 }
+
+const backupFunctions = new Map();
+
+/**
+ * Gets a backup function for a user.
+ * @param {string} handle User handle
+ * @returns {function(string, string, string): void} Backup function
+ */
+function getBackupFunction(handle) {
+    if (!backupFunctions.has(handle)) {
+        backupFunctions.set(handle, _.throttle(backupChat, 10_000, { leading: true, trailing: true }));
+    }
+    return backupFunctions.get(handle);
+}
+
+process.on('exit', () => {
+    for (const func of backupFunctions.values()) {
+        func.flush();
+    }
+});
 
 /**
  * Imports a chat from Ooba's format.
@@ -147,7 +168,7 @@ router.post('/save', jsonParser, function (request, response) {
         const fileName = `${String(request.body.file_name)}.jsonl`;
         const filePath = path.join(request.user.directories.chats, directoryName, sanitize(fileName));
         writeFileAtomicSync(filePath, jsonlData, 'utf8');
-        backupChat(request.user.directories.backups, directoryName, jsonlData);
+        getBackupFunction(request.user.profile.handle)(request.user.directories.backups, directoryName, jsonlData);
         return response.send({ result: 'ok' });
     } catch (error) {
         response.send(error);
@@ -446,7 +467,7 @@ router.post('/group/save', jsonParser, (request, response) => {
     let chat_data = request.body.chat;
     let jsonlData = chat_data.map(JSON.stringify).join('\n');
     writeFileAtomicSync(pathToFile, jsonlData, 'utf8');
-    backupChat(request.user.directories.backups, String(id), jsonlData);
+    getBackupFunction(request.user.profile.handle)(request.user.directories.backups, String(id), jsonlData);
     return response.send({ ok: true });
 });
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Closes #2861

Don't call backup saves more than once per 10 seconds (number debatable) for every user. Exiting the process would write all pending backups.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
