### PR TITLE
fix `\x01` display in modern WI editor

### DIFF
--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1908,13 +1908,13 @@ export function select2ChoiceClickSubscribe(control, action, { buttonStyle = fal
  * @returns {string} The html representation of the highlighted regex
  */
 export function highlightRegex(regexStr) {
-    // Function to escape HTML special characters for safety
-    const escapeHtml = (str) => str.replace(/[&<>"']/g, match => ({
-        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', '\'': '&#39;',
+    // Function to escape special characters for safety or readability
+    const escape = (str) => str.replace(/[&<>"'\x01]/g, match => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', '\'': '&#39;', '\x01': '\\x01',
     })[match]);
 
-    // Replace special characters with their HTML-escaped forms
-    regexStr = escapeHtml(regexStr);
+    // Replace special characters with their escaped forms
+    regexStr = escape(regexStr);
 
     // Patterns that we want to highlight only if they are not escaped
     function getPatterns() {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).


This PR change this:
![图片](https://github.com/user-attachments/assets/c1c63688-549b-488c-8806-25556eeec03d)
![图片](https://github.com/user-attachments/assets/4b678aab-d58d-42f3-b814-bcd8217444da)
to a better look
![图片](https://github.com/user-attachments/assets/52c151fd-e1d2-4df7-b56f-c074697974d9)
