### PR TITLE
Allow setting role, position and depth for marker prompts

### DIFF
--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -316,3 +316,15 @@
         margin-left: 0.5em;
     }
 }
+
+.completion_prompt_manager_popup_entry_form_control:has(#completion_prompt_manager_popup_entry_form_prompt:disabled) > div:first-child::after {
+    content: 'The content of this prompt is pulled from elsewhere and cannot be edited here.';
+    display: block;
+    width: 100%;
+    font-weight: 600;
+    text-align: center;
+}
+
+.completion_prompt_manager_popup_entry_form_control #completion_prompt_manager_popup_entry_form_prompt:disabled {
+    visibility: hidden;
+}

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -427,12 +427,13 @@ class PromptManager {
 
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_name').value = prompt.name;
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_role').value = 'system';
-            document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_prompt').value = prompt.content;
+            document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_prompt').value = prompt.content ?? '';
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_injection_position').value = prompt.injection_position ?? 0;
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_injection_depth').value = prompt.injection_depth ?? DEFAULT_DEPTH;
             document.getElementById(this.configuration.prefix + 'prompt_manager_depth_block').style.visibility = prompt.injection_position === INJECTION_POSITION.ABSOLUTE ? 'visible' : 'hidden';
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_forbid_overrides').checked = prompt.forbid_overrides ?? false;
             document.getElementById(this.configuration.prefix + 'prompt_manager_forbid_overrides_block').style.visibility = this.overridablePrompts.includes(prompt.identifier) ? 'visible' : 'hidden';
+            document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_prompt').disabled = prompt.marker ?? false;
 
             if (!this.systemPrompts.includes(promptId)) {
                 document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_injection_position').removeAttribute('disabled');
@@ -920,7 +921,16 @@ class PromptManager {
      * @returns {boolean} True if the prompt can be edited, false otherwise.
      */
     isPromptEditAllowed(prompt) {
-        return !prompt.marker;
+        const forceEditPrompts = [
+            'charDescription',
+            'charPersonality',
+            'scenario',
+            'personaDescription',
+            'worldInfoBefore',
+            'worldInfoAfter',
+            'dialogueExamples',
+        ];
+        return forceEditPrompts.includes(prompt.identifier) || !prompt.marker;
     }
 
     /**
@@ -929,7 +939,17 @@ class PromptManager {
      * @returns {boolean} True if the prompt can be deleted, false otherwise.
      */
     isPromptToggleAllowed(prompt) {
-        const forceTogglePrompts = ['charDescription', 'charPersonality', 'scenario', 'personaDescription', 'worldInfoBefore', 'worldInfoAfter', 'main', 'chatHistory', 'dialogueExamples'];
+        const forceTogglePrompts = [
+            'charDescription',
+            'charPersonality',
+            'scenario',
+            'personaDescription',
+            'worldInfoBefore',
+            'worldInfoAfter',
+            'main',
+            'chatHistory',
+            'dialogueExamples',
+        ];
         return prompt.marker && !forceTogglePrompts.includes(prompt.identifier) ? false : !this.configuration.toggleDisabled.includes(prompt.identifier);
     }
 
@@ -1182,8 +1202,9 @@ class PromptManager {
         const forbidOverridesBlock = document.getElementById(this.configuration.prefix + 'prompt_manager_forbid_overrides_block');
 
         nameField.value = prompt.name ?? '';
-        roleField.value = prompt.role ?? '';
+        roleField.value = prompt.role ?? 'system';
         promptField.value = prompt.content ?? '';
+        promptField.disabled = prompt.marker ?? false;
         injectionPositionField.value = prompt.injection_position ?? INJECTION_POSITION.RELATIVE;
         injectionDepthField.value = prompt.injection_depth ?? DEFAULT_DEPTH;
         injectionDepthBlock.style.visibility = prompt.injection_position === INJECTION_POSITION.ABSOLUTE ? 'visible' : 'hidden';
@@ -1279,6 +1300,7 @@ class PromptManager {
         nameField.value = '';
         roleField.selectedIndex = 0;
         promptField.value = '';
+        promptField.disabled = false;
         injectionPositionField.selectedIndex = 0;
         injectionPositionField.removeAttribute('disabled');
         injectionDepthField.value = DEFAULT_DEPTH;

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -928,7 +928,6 @@ class PromptManager {
             'personaDescription',
             'worldInfoBefore',
             'worldInfoAfter',
-            'dialogueExamples',
         ];
         return forceEditPrompts.includes(prompt.identifier) || !prompt.marker;
     }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

> **"Trust me, I know how to handle such power."**

<img width="804" alt="image" src="https://github.com/user-attachments/assets/41a29584-8b02-4a4d-b000-6b085d8c9771">

Prompts that are getting pulled from somewhere can be set to absolute (in-chat) positions and be given any depth and role.

* Personality
* Scenario
* Description
* WI before/after
* Persona description

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
