### PR TITLE
Fix crasher in script.js:displayChats, add minimal support for importing chat histories in Chub format

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6923,15 +6923,13 @@ export async function displayPastChats() {
             }
             // Check whether `text` {string} includes all of the `fragments` {string[]}.
             function matchFragments(fragments, text) {
-                if (!text) {
-                    return false;
-                }
-                return fragments.every(item => text.includes(item));
+                if (!text || !text.toLowerCase) return false;
+                return fragments.every(item => text.toLowerCase().includes(item));
             }
             const fragments = makeQueryFragments(searchQuery);
             // At least one chat message must match *all* the fragments.
             // Currently, this doesn't match if the fragment matches are distributed across several chat messages.
-            return chatContent && Object.values(chatContent).some(message => matchFragments(fragments, message?.mes?.toLowerCase()));
+            return chatContent && Object.values(chatContent).some(message => matchFragments(fragments, message?.mes));
         });
 
         console.debug(filteredData);


### PR DESCRIPTION
Fix crasher in script.js:displayChats if user has directly put a Chub chat file into their user data
Minimal support for importing chat histories in Chub format
Let eslint tidy a few things

Symptom: Going to Manage Chat Files locks up UI with
Uncaught (in promise) TypeError: text.toLowerCase is not a function
    filteredData http://127.0.0.1:8000/script.js:6932
    filteredData http://127.0.0.1:8000/script.js:6932
    displayChats http://127.0.0.1:8000/script.js:6905
    displayPastChats http://127.0.0.1:8000/script.js:6970

I've tried to keep this change as low-profile as possible because Chub format compatibility is not high-importance, but a crasher is a crasher.

What is the reason for a change? fix crasher caused by user putting Chub chat hist into user data, allow user to import Chub data using chat importer
What did you do to achieve this? added check for whether mes is a string before trying to lowercase it, added rewriting fn in /chats/import route
How would a reviewer test the change? test importing of a wider range of ST jsonl chat histories than I have access to, test importing a Chub chat history and putting it directly into user-data if available. I was supplied with test data by the user but it's better for everyone if I don't include that here
