### PR TITLE
Save uploaded data unchanged if Chub conversion fails for any reason

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1027,6 +1027,12 @@ router.post('/chats', jsonParser, async function (request, response) {
                 const stats = fs.statSync(pathToFile);
                 const fileSizeInKB = `${(stats.size / 1024).toFixed(2)}kb`;
 
+                if (stats.size === 0) {
+                    console.log(`Found an empty chat file: ${pathToFile}`);
+                    res({});
+                    return;
+                }
+
                 const rl = readline.createInterface({
                     input: fileStream,
                     crlfDelay: Infinity,

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -435,7 +435,7 @@ router.post('/import', urlencodedParser, function (request, response) {
 
             // Do a tiny bit of work to import Chub Chat data
             // Processing the entire file is so fast that it's not worth checking if it's a Chub chat first
-            let flattenedChat;
+            let flattenedChat = data;
             try {
                 // flattening is unlikely to break, but it's not worth failing to
                 // import normal chats in an attempt to import a Chub chat


### PR DESCRIPTION
Save uploaded data unchanged if Chub conversion fails for any reason
Avoid non-resolving promise in /characters/chats readline if chat file is empty


What is the reason for a change? theoretically if flattenChubChat fails, the trycatch will save an empty file instead of doing what it's supposed to do. Also during testing discovered that if you give readline an empty file it will stream from it forever, so I put in a lil pre-check for this
What did you do to achieve this? initialised var correctly, checked stats.size in /characters/chats jsonFilesPromise
How would a reviewer test the change? Throw an exception in flattenChubChat, see if ST-formatted chat is successfully imported anyways. Create a 0-byte chat history jsonl in user data, see if Manage chat files still opens. 
