### PR TITLE
[APHRODITE] add dynatemp, XTC, and fix token bans

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1341,7 +1341,7 @@
                                         </div>
                                     </div>
 
-                                    <div data-tg-type="koboldcpp" id="xtc_block" class="wide100p">
+                                    <div data-tg-type="koboldcpp, aphrodite" id="xtc_block" class="wide100p">
                                         <h4 class="wide100p textAlignCenter">
                                             <label data-i18n="Exclude Top Choices (XTC)">Exclude Top Choices (XTC)</label>
                                             <a href="https://github.com/oobabooga/text-generation-webui/pull/6335" target="_blank">
@@ -1401,7 +1401,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div data-tg-type="ooba, mancer, koboldcpp, tabby, llamacpp" id="dynatemp_block_ooba" class="wide100p">
+                                    <div data-tg-type="ooba, mancer, koboldcpp, tabby, llamacpp, aphrodite" id="dynatemp_block_ooba" class="wide100p">
                                         <h4 class="wide100p textAlignCenter">
                                             <div class="flex-container alignitemscenter justifyCenter">
                                                 <div class="checkbox_label" for="dynatemp_textgenerationwebui">

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1228,9 +1228,7 @@ export function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, 
         'dynatemp_exponent': dynatemp ? settings.dynatemp_exponent : undefined,
         'xtc_threshold': settings.xtc_threshold,
         'xtc_probability': settings.xtc_probability,
-        'custom_token_bans': [APHRODITE, MANCER].includes(settings.type) ?
-            toIntArray(banned_tokens) :
-            banned_tokens,
+        'custom_token_bans': toIntArray(banned_tokens),
     };
 
     if (settings.type === OPENROUTER) {

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1203,7 +1203,7 @@ export function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, 
         'repetition_penalty': settings.rep_pen,
         'seed': settings.seed >= 0 ? settings.seed : undefined,
         'stop': getStoppingStrings(isImpersonate, isContinue),
-        'temperature': settings.temp,
+        'temperature': dynatemp ? (settings.min_temp + settings.max_temp) / 2 : settings.temp,
         'temperature_last': settings.temperature_last,
         'top_p': settings.top_p,
         'top_k': settings.top_k,
@@ -1223,6 +1223,14 @@ export function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, 
         'guided_json': settings.json_schema,
         'early_stopping': false, // hacks
         'include_stop_str_in_output': false,
+        'dynatemp_min': dynatemp ? settings.min_temp : undefined,
+        'dynatemp_max': dynatemp ? settings.max_temp : undefined,
+        'dynatemp_exponent': dynatemp ? settings.dynatemp_exponent : undefined,
+        'xtc_threshold': settings.xtc_threshold,
+        'xtc_probability': settings.xtc_probability,
+        'custom_token_bans': [APHRODITE, MANCER].includes(settings.type) ?
+            toIntArray(banned_tokens) :
+            banned_tokens,
     };
 
     if (settings.type === OPENROUTER) {


### PR DESCRIPTION
This PR enables the DynaTemp and XTC samplers for Aphrodite, and makes it so that token bans are actually passed to Aphrodite.

Reference PRs:
- PygmalionAI/aphrodite-engine#740
- PygmalionAI/aphrodite-engine#754

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
