### PR TITLE
Fix /hide not targeting not visible messages

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -135,10 +135,11 @@ export async function hideChatMessageRange(start, end, unhide) {
         const message = chat[messageId];
         if (!message) continue;
 
+        message.is_system = hide;
+
+        // Also toggle "hidden" state for all visible messages
         const messageBlock = $(`.mes[mesid="${messageId}"]`);
         if (!messageBlock.length) continue;
-
-        message.is_system = hide;
         messageBlock.attr('is_system', String(hide));
     }
 


### PR DESCRIPTION
For whatever reason, the `/hide` slash command exited out if the messages targeted aren't visible.
That's not really needed.

Now, it'll hide all targeted messages, and only for those visible it'll also toggle the hidden state on the UI.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
