### PR TITLE
Add `certs` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ public/css/user.css
 /data
 /default/scaffold
 public/scripts/extensions/third-party
+/certs


### PR DESCRIPTION
This is the default path, but it is not in `.gitignore`.

https://github.com/SillyTavern/SillyTavern/blob/648e70b8c6ae10052c2e28d164390ff50846777a/server.js#L131

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
