### PR TITLE
Add ability to omit settings from Connection Profile

### DIFF
--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -149,10 +149,12 @@ body.no-blur .popup[open]::backdrop {
     box-shadow: 0 0 5px var(--white20a);
 }
 
+.menu_button.primary,
 .menu_button.popup-button-ok {
     background-color: var(--crimson70a);
 }
 
+.menu_button.primary:hover,
 .menu_button.popup-button-ok:hover {
     background-color: var(--crimson-hover);
 }

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -149,12 +149,10 @@ body.no-blur .popup[open]::backdrop {
     box-shadow: 0 0 5px var(--white20a);
 }
 
-.menu_button.primary,
 .menu_button.popup-button-ok {
     background-color: var(--crimson70a);
 }
 
-.menu_button.primary:hover,
 .menu_button.popup-button-ok:hover {
     background-color: var(--crimson-hover);
 }

--- a/public/scripts/extensions/connection-manager/edit.html
+++ b/public/scripts/extensions/connection-manager/edit.html
@@ -3,11 +3,7 @@
     <div class="justifyLeft flex-container flexFlowColumn flexNoGap">
         {{#each settings}}
         <label class="checkbox_label">
-            {{#if this}}
-                <input type="checkbox" value="{{@key}}" name="exclude" checked>
-            {{else}}
-                <input type="checkbox" value="{{@key}}" name="exclude">
-            {{/if}}
+            <input type="checkbox" value="{{@key}}" name="exclude"{{#if this}} checked{{/if}}>
             <span>{{@key}}</span>
         </label>
         {{/each}}

--- a/public/scripts/extensions/connection-manager/edit.html
+++ b/public/scripts/extensions/connection-manager/edit.html
@@ -1,0 +1,16 @@
+<div>
+    <h3>Included settings:</h3>
+    <div class="justifyLeft flex-container flexFlowColumn flexNoGap">
+        {{#each settings}}
+        <label class="checkbox_label">
+            {{#if this}}
+                <input type="checkbox" value="{{@key}}" name="exclude" checked>
+            {{else}}
+                <input type="checkbox" value="{{@key}}" name="exclude">
+            {{/if}}
+            <span>{{@key}}</span>
+        </label>
+        {{/each}}
+    </div>
+    <h3>Profile name:</h3>
+</div>

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -534,7 +534,7 @@ async function renderDetailsContent(detailsContent) {
         const newName = await callGenericPopup(template, POPUP_TYPE.INPUT, profile.name, {
             customButtons: [{
                 text: 'Save and Update',
-                classes: ['primary'],
+                classes: ['popup-button-ok'],
                 result: POPUP_RESULT.AFFIRMATIVE,
                 action: () => {
                     saveChanges = true;

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -241,7 +241,8 @@ async function createConnectionProfile(forceName = null) {
         if (excludeState) {
             profile.exclude.push(keyName);
         } else {
-            profile.exclude.splice(profile.exclude.indexOf(keyName), 1);
+            const index = profile.exclude.indexOf(keyName);
+            index !== -1 && profile.exclude.splice(index, 1);
         }
     });
     const isNameTaken = (n) => extension_settings.connectionManager.profiles.some(p => p.name === n);

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -135,6 +135,7 @@ const profilesProvider = () => [
  * @property {string} [context] Context Template
  * @property {string} [instruct-state] Instruct Mode
  * @property {string} [tokenizer] Tokenizer
+ * @property {string[]} [exclude] Commands to exclude
  */
 
 /**
@@ -171,8 +172,13 @@ function findProfileByName(value) {
 async function readProfileFromCommands(mode, profile, cleanUp = false) {
     const commands = mode === 'cc' ? CC_COMMANDS : TC_COMMANDS;
     const opposingCommands = mode === 'cc' ? TC_COMMANDS : CC_COMMANDS;
+    const excludeList = Array.isArray(profile.exclude) ? profile.exclude : [];
     for (const command of commands) {
         try {
+            if (excludeList.includes(command)) {
+                continue;
+            }
+
             const args = getNamedArguments();
             const result = await SlashCommandParser.commands[command].callback(args, '');
             if (result) {
@@ -208,15 +214,36 @@ async function readProfileFromCommands(mode, profile, cleanUp = false) {
 async function createConnectionProfile(forceName = null) {
     const mode = main_api === 'openai' ? 'cc' : 'tc';
     const id = uuidv4();
+    /** @type {ConnectionProfile} */
     const profile = {
         id,
         mode,
+        exclude: [],
     };
 
     await readProfileFromCommands(mode, profile);
 
     const profileForDisplay = makeFancyProfile(profile);
-    const template = await renderExtensionTemplateAsync(MODULE_NAME, 'profile', { profile: profileForDisplay });
+    const template = $(await renderExtensionTemplateAsync(MODULE_NAME, 'profile', { profile: profileForDisplay }));
+    template.find('input[name="exclude"]').on('input', function () {
+        const fancyName = String($(this).val());
+        const keyName = Object.entries(FANCY_NAMES).find(x => x[1] === fancyName)?.[0];
+        if (!keyName) {
+            console.warn('Key not found for fancy name:', fancyName);
+            return;
+        }
+
+        if (!Array.isArray(profile.exclude)) {
+            profile.exclude = [];
+        }
+
+        const excludeState = !$(this).prop('checked');
+        if (excludeState) {
+            profile.exclude.push(keyName);
+        } else {
+            profile.exclude.splice(profile.exclude.indexOf(keyName), 1);
+        }
+    });
     const isNameTaken = (n) => extension_settings.connectionManager.profiles.some(p => p.name === n);
     const suggestedName = getUniqueName(collapseSpaces(`${profile.api ?? ''} ${profile.model ?? ''} - ${profile.preset ?? ''}`), isNameTaken);
     const name = forceName ?? await callGenericPopup(template, POPUP_TYPE.INPUT, suggestedName, { rows: 2 });
@@ -230,7 +257,13 @@ async function createConnectionProfile(forceName = null) {
         return null;
     }
 
-    profile.name = name;
+    if (Array.isArray(profile.exclude)) {
+        for (const command of profile.exclude) {
+            delete profile[command];
+        }
+    }
+
+    profile.name = String(name);
     return profile;
 }
 
@@ -357,6 +390,9 @@ async function renderDetailsContent(detailsContent) {
     const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
     if (profile) {
         const profileForDisplay = makeFancyProfile(profile);
+        if (Array.isArray(profile.exclude) && profile.exclude.length > 0) {
+            profileForDisplay['Omitted Settings'] = profile.exclude.map(e => FANCY_NAMES[e]).join(', ');
+        }
         const template = await renderExtensionTemplateAsync(MODULE_NAME, 'view', { profile: profileForDisplay });
         detailsContent.innerHTML = template;
     } else {
@@ -472,8 +508,8 @@ async function renderDetailsContent(detailsContent) {
         await eventSource.emit(event_types.CONNECTION_PROFILE_LOADED, NONE);
     });
 
-    const renameButton = document.getElementById('rename_connection_profile');
-    renameButton.addEventListener('click', async () => {
+    const editButton = document.getElementById('edit_connection_profile');
+    editButton.addEventListener('click', async () => {
         const selectedProfile = extension_settings.connectionManager.selectedProfile;
         const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
         if (!profile) {
@@ -481,20 +517,48 @@ async function renderDetailsContent(detailsContent) {
             return;
         }
 
-        const newName = await Popup.show.input('Enter a new name', null, profile.name, { rows: 2 });
+        if (!Array.isArray(profile.exclude)) {
+            profile.exclude = [];
+        }
+
+        const commands = profile.mode === 'cc' ? CC_COMMANDS : TC_COMMANDS;
+        const settings = commands.reduce((acc, command) => {
+            const fancyName = FANCY_NAMES[command];
+            acc[fancyName] = !profile.exclude.includes(command);
+            return acc;
+        }, {});
+        const template = $(await renderExtensionTemplateAsync(MODULE_NAME, 'edit', { name: profile.name, settings }));
+        const newName = await callGenericPopup(template, POPUP_TYPE.INPUT, profile.name);
+
         if (!newName) {
             return;
         }
 
-        if (extension_settings.connectionManager.profiles.some(p => p.name === newName)) {
+        if (profile.name !== newName && extension_settings.connectionManager.profiles.some(p => p.name === newName)) {
             toastr.error('A profile with the same name already exists.');
             return;
         }
 
-        profile.name = newName;
+        const newExcludeList = template.find('input[name="exclude"]:not(:checked)').map(function () {
+            return Object.entries(FANCY_NAMES).find(x => x[1] === String($(this).val()))?.[0];
+        }).get();
+
+        if (newExcludeList.length !== profile.exclude.length || !newExcludeList.every(e => profile.exclude.includes(e))) {
+            profile.exclude = newExcludeList;
+            for (const command of newExcludeList) {
+                delete profile[command];
+            }
+            toastr.info('Press "Update" to record them into the profile.', 'Included settings list updated');
+        }
+
+        if (profile.name !== newName) {
+            toastr.success('Connection profile renamed.');
+            profile.name = String(newName);
+        }
+
         saveSettingsDebounced();
         renderConnectionProfiles(profiles);
-        toastr.success('Connection profile renamed', '', { timeOut: 1500 });
+        await renderDetailsContent(detailsContent);
     });
 
     /** @type {HTMLElement} */

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -390,10 +390,11 @@ async function renderDetailsContent(detailsContent) {
     const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
     if (profile) {
         const profileForDisplay = makeFancyProfile(profile);
+        const templateParams = { profile: profileForDisplay };
         if (Array.isArray(profile.exclude) && profile.exclude.length > 0) {
-            profileForDisplay['Omitted Settings'] = profile.exclude.map(e => FANCY_NAMES[e]).join(', ');
+            templateParams.omitted = profile.exclude.map(e => FANCY_NAMES[e]).join(', ');
         }
-        const template = await renderExtensionTemplateAsync(MODULE_NAME, 'view', { profile: profileForDisplay });
+        const template = await renderExtensionTemplateAsync(MODULE_NAME, 'view', templateParams);
         detailsContent.innerHTML = template;
     } else {
         detailsContent.textContent = 'No profile selected';

--- a/public/scripts/extensions/connection-manager/profile.html
+++ b/public/scripts/extensions/connection-manager/profile.html
@@ -10,10 +10,12 @@
         </label>
         {{/each}}
     </div>
-    <small>
-        <b>Hint:</b>
-        <i>Click on the setting name to omit it from the profile.</i>
-    </small>
+    <div class="marginTop5">
+        <small>
+            <b>Hint:</b>
+            <i>Click on the setting name to omit it from the profile.</i>
+        </small>
+    </div>
     <h3 data-i18n="Enter a name:">
         Enter a name:
     </h3>

--- a/public/scripts/extensions/connection-manager/profile.html
+++ b/public/scripts/extensions/connection-manager/profile.html
@@ -2,11 +2,18 @@
     <h2 data-i18n="Creating a Connection Profile">
         Creating a Connection Profile
     </h2>
-    <ul class="justifyLeft">
+    <div class="justifyLeft flex-container flexFlowColumn flexNoGap">
         {{#each profile}}
-        <li><strong data-i18n="{{@key}}">{{@key}}:</strong>&nbsp;{{this}}</li>
+        <label class="checkbox_label">
+            <input type="checkbox" value="{{@key}}" name="exclude" checked>
+            <span><strong data-i18n="{{@key}}">{{@key}}:</strong>&nbsp;{{this}}</span>
+        </label>
         {{/each}}
-    </ul>
+    </div>
+    <small>
+        <b>Hint:</b>
+        <i>Click on the setting name to omit it from the profile.</i>
+    </small>
     <h3 data-i18n="Enter a name:">
         Enter a name:
     </h3>

--- a/public/scripts/extensions/connection-manager/settings.html
+++ b/public/scripts/extensions/connection-manager/settings.html
@@ -13,7 +13,7 @@
         <i id="view_connection_profile" class="menu_button fa-solid fa-info-circle" title="View connection profile details" data-i18n="[title]View connection profile details"></i>
         <i id="create_connection_profile" class="menu_button fa-solid fa-file-circle-plus" title="Create a new connection profile" data-i18n="[title]Create a new connection profile"></i>
         <i id="update_connection_profile" class="menu_button fa-solid fa-save" title="Update a connection profile" data-i18n="[title]Update a connection profile"></i>
-        <i id="rename_connection_profile" class="menu_button fa-solid fa-pencil" title="Rename a connection profile" data-i18n="[title]Rename a connection profile"></i>
+        <i id="edit_connection_profile" class="menu_button fa-solid fa-pencil" title="Edit a connection profile" data-i18n="[title]Edit a connection profile"></i>
         <i id="reload_connection_profile" class="menu_button fa-solid fa-recycle" title="Reload a connection profile" data-i18n="[title]Reload a connection profile"></i>
         <i id="delete_connection_profile" class="menu_button fa-solid fa-trash-can" title="Delete a connection profile" data-i18n="[title]Delete a connection profile"></i>
     </div>

--- a/public/scripts/extensions/connection-manager/view.html
+++ b/public/scripts/extensions/connection-manager/view.html
@@ -3,3 +3,8 @@
     <li><strong data-i18n="{{@key}}">{{@key}}:</strong>&nbsp;{{this}}</li>
     {{/each}}
 </ul>
+{{#if omitted}}
+<div class="marginTop5">
+    <strong data-i18n="Omitted Settings:">Omitted Settings:</strong>&nbsp;<span>{{omitted}}</span>
+</div>
+{{/if}}

--- a/public/scripts/extensions/connection-manager/view.html
+++ b/public/scripts/extensions/connection-manager/view.html
@@ -4,7 +4,7 @@
     {{/each}}
 </ul>
 {{#if omitted}}
-<div class="marginTop5">
+<div class="margin5">
     <strong data-i18n="Omitted Settings:">Omitted Settings:</strong>&nbsp;<span>{{omitted}}</span>
 </div>
 {{/if}}


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

From the release feedback. 

Primarily useful when you want to switch Advanced Formatting settings without reconnecting to the API.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
