### PR TITLE
Slash commands to manage Extensions

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -244,7 +244,7 @@ import { commonEnumProviders, enumIcons } from './scripts/slash-commands/SlashCo
 import { initInputMarkdown } from './scripts/input-md-formatting.js';
 import { AbortReason } from './scripts/util/AbortReason.js';
 import { initSystemPrompts } from './scripts/sysprompt.js';
-import { registerExtensionSlashCommands } from './scripts/extensions-slashcommands.js';
+import { registerExtensionSlashCommands as initExtensionSlashCommands } from './scripts/extensions-slashcommands.js';
 
 //exporting functions and vars for mods
 export {
@@ -958,7 +958,7 @@ async function firstLoadInit() {
     initLogprobs();
     initInputMarkdown();
     initExtensions();
-    registerExtensionSlashCommands();
+    initExtensionSlashCommands();
     doDailyExtensionUpdatesCheck();
     await hideLoader();
     await fixViewport();

--- a/public/script.js
+++ b/public/script.js
@@ -244,6 +244,7 @@ import { commonEnumProviders, enumIcons } from './scripts/slash-commands/SlashCo
 import { initInputMarkdown } from './scripts/input-md-formatting.js';
 import { AbortReason } from './scripts/util/AbortReason.js';
 import { initSystemPrompts } from './scripts/sysprompt.js';
+import { registerExtensionSlashCommands } from './scripts/extensions-slashcommands.js';
 
 //exporting functions and vars for mods
 export {
@@ -957,6 +958,7 @@ async function firstLoadInit() {
     initLogprobs();
     initInputMarkdown();
     initExtensions();
+    registerExtensionSlashCommands();
     doDailyExtensionUpdatesCheck();
     await hideLoader();
     await fixViewport();

--- a/public/script.js
+++ b/public/script.js
@@ -158,7 +158,7 @@ import {
 } from './scripts/utils.js';
 import { debounce_timeout } from './scripts/constants.js';
 
-import { ModuleWorkerWrapper, doDailyExtensionUpdatesCheck, extension_settings, getContext, loadExtensionSettings, renderExtensionTemplate, renderExtensionTemplateAsync, runGenerationInterceptors, saveMetadataDebounced, writeExtensionField } from './scripts/extensions.js';
+import { ModuleWorkerWrapper, doDailyExtensionUpdatesCheck, extension_settings, getContext, initExtensions, loadExtensionSettings, renderExtensionTemplate, renderExtensionTemplateAsync, runGenerationInterceptors, saveMetadataDebounced, writeExtensionField } from './scripts/extensions.js';
 import { COMMENT_NAME_DEFAULT, executeSlashCommands, executeSlashCommandsOnChatInput, executeSlashCommandsWithOptions, getSlashCommandsHelp, initDefaultSlashCommands, isExecutingCommandsFromChatInput, pauseScriptExecution, processChatSlashCommands, registerSlashCommand, stopScriptExecution } from './scripts/slash-commands.js';
 import {
     tag_map,
@@ -956,6 +956,7 @@ async function firstLoadInit() {
     initCfg();
     initLogprobs();
     initInputMarkdown();
+    initExtensions();
     doDailyExtensionUpdatesCheck();
     await hideLoader();
     await fixViewport();

--- a/public/scripts/extensions-slashcommands.js
+++ b/public/scripts/extensions-slashcommands.js
@@ -284,7 +284,7 @@ export function registerExtensionSlashCommands() {
             const exists = findExtension(extensionName) !== undefined;
             return exists ? 'true' : 'false';
         },
-        returns: '<code>true</code>/<code>false</code> - Whether the extension exists and is installed.',
+        returns: 'Whether the extension exists and is installed.',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: 'Extension name',

--- a/public/scripts/extensions-slashcommands.js
+++ b/public/scripts/extensions-slashcommands.js
@@ -252,7 +252,7 @@ export function registerExtensionSlashCommands() {
             const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
             return String(isEnabled);
         },
-        returns: '<code>true</code>/<code>false</code> - The state of the extension, whether it is enabled.',
+        returns: 'The state of the extension, whether it is enabled.',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: 'Extension name',

--- a/public/scripts/extensions-slashcommands.js
+++ b/public/scripts/extensions-slashcommands.js
@@ -1,0 +1,276 @@
+import { disableExtension, enableExtension, extension_settings, extensionNames } from './extensions.js';
+import { SlashCommand } from './slash-commands/SlashCommand.js';
+import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
+import { SlashCommandClosure } from './slash-commands/SlashCommandClosure.js';
+import { commonEnumProviders } from './slash-commands/SlashCommandCommonEnumsProvider.js';
+import { SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js';
+import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
+import { equalsIgnoreCaseAndAccents, isFalseBoolean, isTrueBoolean } from './utils.js';
+
+/**
+ * @param {'enable' | 'disable' | 'toggle'} action - The action to perform on the extension
+ * @returns {(args: {[key: string]: string | SlashCommandClosure}, extensionName: string | SlashCommandClosure) => Promise<string>}
+ */
+function getExtensionActionCallback(action) {
+    return async (args, extensionName) => {
+        if (args?.reload instanceof SlashCommandClosure) throw new Error('\'reload\' argument cannot be a closure.');
+        if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
+        if (!extensionName) {
+            toastr.warning(`Extension name must be provided as an argument to ${action} this extension.`);
+            return '';
+        }
+
+        const reload = isTrueBoolean(args?.reload);
+        const internalExtensionName = extensionNames.find(x => equalsIgnoreCaseAndAccents(x, extensionName));
+        if (!internalExtensionName) {
+            toastr.warning(`Extension ${extensionName} does not exist.`);
+            return '';
+        }
+
+        const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
+
+        if (action === 'enable' && isEnabled) {
+            toastr.info(`Extension ${extensionName} is already enabled.`);
+            return internalExtensionName;
+        }
+
+        if (action === 'disable' && !isEnabled) {
+            toastr.info(`Extension ${extensionName} is already disabled.`);
+            return internalExtensionName;
+        }
+
+        if (action === 'toggle') {
+            action = isEnabled ? 'disable' : 'enable';
+        }
+
+        reload && toastr.info(`${action.charAt(0).toUpperCase() + action.slice(1)}ing extension ${extensionName} and reloading...`);
+
+        if (action === 'enable') {
+            await enableExtension(internalExtensionName, reload);
+        } else {
+            await disableExtension(internalExtensionName, reload);
+        }
+
+        toastr.success(`Extension ${extensionName} ${action}d.`);
+
+        return internalExtensionName;
+    };
+}
+
+export function registerExtensionSlashCommands() {
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'extension-enable',
+        callback: getExtensionActionCallback('enable'),
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'reload',
+                description: 'Whether to reload the page after enabling the extension',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'true',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Extension name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
+                forceEnum: true,
+            }),
+        ],
+        helpString: `
+            <div>
+                Enables a specified extension.
+            </div>
+            <div>
+                By default, the page will be reloaded automatically, stopping any further commands.<br />
+                If <code>reload=false</code> named argument is passed, the page will not be reloaded, and the extension will stay disabled until refreshed.
+                The page either needs to be refreshed, or <code>/reload-page</code> has to be called.
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <ul>
+                    <li>
+                        <pre><code class="language-stscript">/extension-enable Summarize</code></pre>
+                    </li>
+                </ul>
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'extension-disable',
+        callback: getExtensionActionCallback('enable'),
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'reload',
+                description: 'Whether to reload the page after disabling the extension',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'true',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Extension name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
+                forceEnum: true,
+            }),
+        ],
+        helpString: `
+            <div>
+                Disables a specified extension.
+            </div>
+            <div>
+                By default, the page will be reloaded automatically, stopping any further commands.<br />
+                If <code>reload=false</code> named argument is passed, the page will not be reloaded, and the extension will stay enabled until refreshed.
+                The page either needs to be refreshed, or <code>/reload-page</code> has to be called.
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <ul>
+                    <li>
+                        <pre><code class="language-stscript">/extension-disable Summarize</code></pre>
+                    </li>
+                </ul>
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'extension-toggle',
+        callback: async (args, extensionName) => {
+            if (args?.state instanceof SlashCommandClosure) throw new Error('\'state\' argument cannot be a closure.');
+            if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
+
+            const action = isTrueBoolean(args?.state) ? 'enable' :
+                isFalseBoolean(args?.state) ? 'disable' :
+                    'toggle';
+
+            return await getExtensionActionCallback(action)(args, extensionName);
+        },
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'reload',
+                description: 'Whether to reload the page after toggling the extension',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'true',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'state',
+                description: 'Explicitly set the state of the extension (true to enable, false to disable). If not provided, the state will be toggled to the opposite of the current state.',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Extension name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
+                forceEnum: true,
+            }),
+        ],
+        helpString: `
+            <div>
+                Toggles the state of a specified extension.
+            </div>
+            <div>
+                By default, the page will be reloaded automatically, stopping any further commands.<br />
+                If <code>reload=false</code> named argument is passed, the page will not be reloaded, and the extension will stay in its current state until refreshed.
+                The page either needs to be refreshed, or <code>/reload-page</code> has to be called.
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <ul>
+                    <li>
+                        <pre><code class="language-stscript">/extension-toggle Summarize</code></pre>
+                    </li>
+                    <li>
+                        <pre><code class="language-stscript">/extension-toggle Summarize state=true</code></pre>
+                    </li>
+                </ul>
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'extension-state',
+        callback: async (_, extensionName) => {
+            if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
+            const internalExtensionName = extensionNames.find(x => equalsIgnoreCaseAndAccents(x, extensionName));
+            if (!internalExtensionName) {
+                toastr.warning(`Extension ${extensionName} does not exist.`);
+                return '';
+            }
+
+            const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
+            return String(isEnabled);
+        },
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Extension name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
+                forceEnum: true,
+            }),
+        ],
+        helpString: `
+            <div>
+                Returns the state of a specified extension (true if enabled, false if disabled).
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <ul>
+                    <li>
+                        <pre><code class="language-stscript">/extension-state Summarize</code></pre>
+                    </li>
+                </ul>
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'extension-exists',
+        aliases: ['extension-installed'],
+        callback: async (_, extensionName) => {
+            if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
+            const exists = extensionNames.find(x => equalsIgnoreCaseAndAccents(x, extensionName)) !== undefined;
+            return exists ? 'true' : 'false';
+        },
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Extension name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
+                forceEnum: true,
+            }),
+        ],
+        helpString: `
+            <div>
+                Checks if a specified extension exists.
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <ul>
+                    <li>
+                        <pre><code class="language-stscript">/extension-exists LALib</code></pre>
+                    </li>
+                </ul>
+            </div>
+        `,
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'reload-page',
+        callback: async () => {
+            toastr.info('Reloading the page...');
+            location.reload();
+            return '';
+        },
+        helpString: 'Reloads the current page. All further commands will not be processed.',
+    }));
+}

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1056,7 +1056,7 @@ export async function openThirdPartyExtensionMenu(suggestUrl = '') {
 function getExtensionActionCallback(action) {
     return async (args, extensionName) => {
         if (args?.reload instanceof SlashCommandClosure) throw new Error('\'reload\' argument cannot be a closure.');
-        if (typeof extensionName !== 'string') throw new Error('Extension name does only support string. Closures or arrays are not allowed.');
+        if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
         if (!extensionName) {
             toastr.warning(`Extension name must be provided as an argument to ${action} this extension.`);
             return '';
@@ -1184,7 +1184,7 @@ function registerExtensionSlashCommands() {
         name: 'extension-toggle',
         callback: async (args, extensionName) => {
             if (args?.state instanceof SlashCommandClosure) throw new Error('\'state\' argument cannot be a closure.');
-            if (typeof extensionName !== 'string') throw new Error('Extension name does only support string. Closures or arrays are not allowed.');
+            if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
 
             const action = isTrueBoolean(args?.state) ? 'enable' :
                 isFalseBoolean(args?.state) ? 'disable' :
@@ -1233,6 +1233,73 @@ function registerExtensionSlashCommands() {
                     </li>
                     <li>
                         <pre><code class="language-stscript">/extension-toggle Summarize state=true</code></pre>
+                    </li>
+                </ul>
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'extension-state',
+        callback: async (_, extensionName) => {
+            if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
+            const internalExtensionName = extensionNames.find(x => equalsIgnoreCaseAndAccents(x, extensionName));
+            if (!internalExtensionName) {
+                toastr.warning(`Extension ${extensionName} does not exist.`);
+                return '';
+            }
+
+            const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
+            return String(isEnabled);
+        },
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Extension name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
+                forceEnum: true,
+            }),
+        ],
+        helpString: `
+            <div>
+                Returns the state of a specified extension (true if enabled, false if disabled).
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <ul>
+                    <li>
+                        <pre><code class="language-stscript">/extension-state Summarize</code></pre>
+                    </li>
+                </ul>
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'extension-exists',
+        aliases: ['extension-installed'],
+        callback: async (_, extensionName) => {
+            if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
+            const exists = extensionNames.find(x => equalsIgnoreCaseAndAccents(x, extensionName)) !== undefined;
+            return exists ? 'true' : 'false';
+        },
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Extension name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
+                forceEnum: true,
+            }),
+        ],
+        helpString: `
+            <div>
+                Checks if a specified extension exists.
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <ul>
+                    <li>
+                        <pre><code class="language-stscript">/extension-exists LALib</code></pre>
                     </li>
                 </ul>
             </div>

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1,14 +1,8 @@
 import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration } from '../script.js';
 import { showLoader } from './loader.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
-import { SlashCommand } from './slash-commands/SlashCommand.js';
-import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
-import { SlashCommandClosure } from './slash-commands/SlashCommandClosure.js';
-import { commonEnumProviders, enumIcons } from './slash-commands/SlashCommandCommonEnumsProvider.js';
-import { enumTypes, SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js';
-import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
-import { equalsIgnoreCaseAndAccents, isFalseBoolean, isSubsetOf, isTrueBoolean, setValueByPath } from './utils.js';
+import { isSubsetOf, setValueByPath } from './utils.js';
 export {
     getContext,
     getApiUrl,
@@ -249,7 +243,7 @@ function onEnableExtensionClick() {
     enableExtension(name, false);
 }
 
-async function enableExtension(name, reload = true) {
+export async function enableExtension(name, reload = true) {
     extension_settings.disabledExtensions = extension_settings.disabledExtensions.filter(x => x !== name);
     stateChanged = true;
     await saveSettings();
@@ -260,7 +254,7 @@ async function enableExtension(name, reload = true) {
     }
 }
 
-async function disableExtension(name, reload = true) {
+export async function disableExtension(name, reload = true) {
     extension_settings.disabledExtensions.push(name);
     stateChanged = true;
     await saveSettings();
@@ -1049,277 +1043,9 @@ export async function openThirdPartyExtensionMenu(suggestUrl = '') {
     await installExtension(url);
 }
 
-/**
- * @param {'enable' | 'disable' | 'toggle'} action - The action to perform on the extension
- * @returns {(args: {[key: string]: string | SlashCommandClosure}, extensionName: string | SlashCommandClosure) => Promise<string>}
- */
-function getExtensionActionCallback(action) {
-    return async (args, extensionName) => {
-        if (args?.reload instanceof SlashCommandClosure) throw new Error('\'reload\' argument cannot be a closure.');
-        if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
-        if (!extensionName) {
-            toastr.warning(`Extension name must be provided as an argument to ${action} this extension.`);
-            return '';
-        }
 
-        const reload = isTrueBoolean(args?.reload);
-        const internalExtensionName = extensionNames.find(x => equalsIgnoreCaseAndAccents(x, extensionName));
-        if (!internalExtensionName) {
-            toastr.warning(`Extension ${extensionName} does not exist.`);
-            return '';
-        }
-
-        const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
-
-        if (action === 'enable' && isEnabled) {
-            toastr.info(`Extension ${extensionName} is already enabled.`);
-            return internalExtensionName;
-        }
-
-        if (action === 'disable' && !isEnabled) {
-            toastr.info(`Extension ${extensionName} is already disabled.`);
-            return internalExtensionName;
-        }
-
-        if (action === 'toggle') {
-            action = isEnabled ? 'disable' : 'enable';
-        }
-
-        reload && toastr.info(`${action.charAt(0).toUpperCase() + action.slice(1)}ing extension ${extensionName} and reloading...`);
-
-        if (action === 'enable') {
-            await enableExtension(internalExtensionName, reload);
-        } else {
-            await disableExtension(internalExtensionName, reload);
-        }
-
-        toastr.success(`Extension ${extensionName} ${action}d.`);
-
-        return internalExtensionName;
-    };
-}
-
-function registerExtensionSlashCommands() {
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'extension-enable',
-        callback: getExtensionActionCallback('enable'),
-        namedArgumentList: [
-            SlashCommandNamedArgument.fromProps({
-                name: 'reload',
-                description: 'Whether to reload the page after enabling the extension',
-                typeList: [ARGUMENT_TYPE.BOOLEAN],
-                defaultValue: 'true',
-                enumList: commonEnumProviders.boolean('trueFalse')(),
-            }),
-        ],
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'Extension name',
-                typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
-                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
-                forceEnum: true,
-            }),
-        ],
-        helpString: `
-            <div>
-                Enables a specified extension.
-            </div>
-            <div>
-                By default, the page will be reloaded automatically, stopping any further commands.<br />
-                If <code>reload=false</code> named argument is passed, the page will not be reloaded, and the extension will stay disabled until refreshed.
-                The page either needs to be refreshed, or <code>/reload-page</code> has to be called.
-            </div>
-            <div>
-                <strong>Example:</strong>
-                <ul>
-                    <li>
-                        <pre><code class="language-stscript">/extension-enable Summarize</code></pre>
-                    </li>
-                </ul>
-            </div>
-        `,
-    }));
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'extension-disable',
-        callback: getExtensionActionCallback('enable'),
-        namedArgumentList: [
-            SlashCommandNamedArgument.fromProps({
-                name: 'reload',
-                description: 'Whether to reload the page after disabling the extension',
-                typeList: [ARGUMENT_TYPE.BOOLEAN],
-                defaultValue: 'true',
-                enumList: commonEnumProviders.boolean('trueFalse')(),
-            }),
-        ],
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'Extension name',
-                typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
-                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
-                forceEnum: true,
-            }),
-        ],
-        helpString: `
-            <div>
-                Disables a specified extension.
-            </div>
-            <div>
-                By default, the page will be reloaded automatically, stopping any further commands.<br />
-                If <code>reload=false</code> named argument is passed, the page will not be reloaded, and the extension will stay enabled until refreshed.
-                The page either needs to be refreshed, or <code>/reload-page</code> has to be called.
-            </div>
-            <div>
-                <strong>Example:</strong>
-                <ul>
-                    <li>
-                        <pre><code class="language-stscript">/extension-disable Summarize</code></pre>
-                    </li>
-                </ul>
-            </div>
-        `,
-    }));
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'extension-toggle',
-        callback: async (args, extensionName) => {
-            if (args?.state instanceof SlashCommandClosure) throw new Error('\'state\' argument cannot be a closure.');
-            if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
-
-            const action = isTrueBoolean(args?.state) ? 'enable' :
-                isFalseBoolean(args?.state) ? 'disable' :
-                    'toggle';
-
-            return await getExtensionActionCallback(action)(args, extensionName);
-        },
-        namedArgumentList: [
-            SlashCommandNamedArgument.fromProps({
-                name: 'reload',
-                description: 'Whether to reload the page after toggling the extension',
-                typeList: [ARGUMENT_TYPE.BOOLEAN],
-                defaultValue: 'true',
-                enumList: commonEnumProviders.boolean('trueFalse')(),
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'state',
-                description: 'Explicitly set the state of the extension (true to enable, false to disable). If not provided, the state will be toggled to the opposite of the current state.',
-                typeList: [ARGUMENT_TYPE.BOOLEAN],
-                enumList: commonEnumProviders.boolean('trueFalse')(),
-            }),
-        ],
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'Extension name',
-                typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
-                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
-                forceEnum: true,
-            }),
-        ],
-        helpString: `
-            <div>
-                Toggles the state of a specified extension.
-            </div>
-            <div>
-                By default, the page will be reloaded automatically, stopping any further commands.<br />
-                If <code>reload=false</code> named argument is passed, the page will not be reloaded, and the extension will stay in its current state until refreshed.
-                The page either needs to be refreshed, or <code>/reload-page</code> has to be called.
-            </div>
-            <div>
-                <strong>Example:</strong>
-                <ul>
-                    <li>
-                        <pre><code class="language-stscript">/extension-toggle Summarize</code></pre>
-                    </li>
-                    <li>
-                        <pre><code class="language-stscript">/extension-toggle Summarize state=true</code></pre>
-                    </li>
-                </ul>
-            </div>
-        `,
-    }));
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'extension-state',
-        callback: async (_, extensionName) => {
-            if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
-            const internalExtensionName = extensionNames.find(x => equalsIgnoreCaseAndAccents(x, extensionName));
-            if (!internalExtensionName) {
-                toastr.warning(`Extension ${extensionName} does not exist.`);
-                return '';
-            }
-
-            const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
-            return String(isEnabled);
-        },
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'Extension name',
-                typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
-                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
-                forceEnum: true,
-            }),
-        ],
-        helpString: `
-            <div>
-                Returns the state of a specified extension (true if enabled, false if disabled).
-            </div>
-            <div>
-                <strong>Example:</strong>
-                <ul>
-                    <li>
-                        <pre><code class="language-stscript">/extension-state Summarize</code></pre>
-                    </li>
-                </ul>
-            </div>
-        `,
-    }));
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'extension-exists',
-        aliases: ['extension-installed'],
-        callback: async (_, extensionName) => {
-            if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
-            const exists = extensionNames.find(x => equalsIgnoreCaseAndAccents(x, extensionName)) !== undefined;
-            return exists ? 'true' : 'false';
-        },
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'Extension name',
-                typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
-                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
-                forceEnum: true,
-            }),
-        ],
-        helpString: `
-            <div>
-                Checks if a specified extension exists.
-            </div>
-            <div>
-                <strong>Example:</strong>
-                <ul>
-                    <li>
-                        <pre><code class="language-stscript">/extension-exists LALib</code></pre>
-                    </li>
-                </ul>
-            </div>
-        `,
-    }));
-
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'reload-page',
-        callback: async () => {
-            toastr.info('Reloading the page...');
-            location.reload();
-            return '';
-        },
-        helpString: 'Reloads the current page. All further commands will not be processed.',
-    }));
-}
 
 export async function initExtensions() {
-    registerExtensionSlashCommands();
-
     await addExtensionsButtonAndMenu();
     $('#extensionsMenuButton').css('display', 'flex');
 

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -8,7 +8,7 @@ import { commonEnumProviders, enumIcons } from './slash-commands/SlashCommandCom
 import { enumTypes, SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
-import { equalsIgnoreCaseAndAccents, isSubsetOf, isTrueBoolean, setValueByPath } from './utils.js';
+import { equalsIgnoreCaseAndAccents, isFalseBoolean, isSubsetOf, isTrueBoolean, setValueByPath } from './utils.js';
 export {
     getContext,
     getApiUrl,
@@ -1050,33 +1050,50 @@ export async function openThirdPartyExtensionMenu(suggestUrl = '') {
 }
 
 /**
- * @param {boolean} enable - Whether to enable or disable the extension
+ * @param {'enable' | 'disable' | 'toggle'} action - The action to perform on the extension
  * @returns {(args: {[key: string]: string | SlashCommandClosure}, extensionName: string | SlashCommandClosure) => Promise<string>}
  */
-function getExtensionToggleCallback(enable) {
+function getExtensionActionCallback(action) {
     return async (args, extensionName) => {
         if (args?.reload instanceof SlashCommandClosure) throw new Error('\'reload\' argument cannot be a closure.');
         if (typeof extensionName !== 'string') throw new Error('Extension name does only support string. Closures or arrays are not allowed.');
         if (!extensionName) {
-            toastr.warning(`Extension name must be provided as an argument to ${enable ? 'enable' : 'disable'} this extension.`);
+            toastr.warning(`Extension name must be provided as an argument to ${action} this extension.`);
             return '';
         }
 
         const reload = isTrueBoolean(args?.reload);
-
         const internalExtensionName = extensionNames.find(x => equalsIgnoreCaseAndAccents(x, extensionName));
         if (!internalExtensionName) {
             toastr.warning(`Extension ${extensionName} does not exist.`);
             return '';
         }
-        if (enable === !extension_settings.disabledExtensions.includes(internalExtensionName)) {
-            toastr.info(`Extension ${extensionName} is already ${enable ? 'enabled' : 'disabled'}.`);
+
+        const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
+
+        if (action === 'enable' && isEnabled) {
+            toastr.info(`Extension ${extensionName} is already enabled.`);
             return internalExtensionName;
         }
 
-        reload && toastr.info(`${enable ? 'Enabling' : 'Disabling'} extension ${extensionName} and reloading...`);
-        await enableExtension(internalExtensionName, reload);
-        toastr.success(`Extension ${extensionName} ${enable ? 'enabled' : 'disabled'}.`);
+        if (action === 'disable' && !isEnabled) {
+            toastr.info(`Extension ${extensionName} is already disabled.`);
+            return internalExtensionName;
+        }
+
+        if (action === 'toggle') {
+            action = isEnabled ? 'disable' : 'enable';
+        }
+
+        reload && toastr.info(`${action.charAt(0).toUpperCase() + action.slice(1)}ing extension ${extensionName} and reloading...`);
+
+        if (action === 'enable') {
+            await enableExtension(internalExtensionName, reload);
+        } else {
+            await disableExtension(internalExtensionName, reload);
+        }
+
+        toastr.success(`Extension ${extensionName} ${action}d.`);
 
         return internalExtensionName;
     };
@@ -1085,7 +1102,7 @@ function getExtensionToggleCallback(enable) {
 function registerExtensionSlashCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'extension-enable',
-        callback: getExtensionToggleCallback(true),
+        callback: getExtensionActionCallback('enable'),
         namedArgumentList: [
             SlashCommandNamedArgument.fromProps({
                 name: 'reload',
@@ -1125,7 +1142,7 @@ function registerExtensionSlashCommands() {
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'extension-disable',
-        callback: getExtensionToggleCallback(false),
+        callback: getExtensionActionCallback('enable'),
         namedArgumentList: [
             SlashCommandNamedArgument.fromProps({
                 name: 'reload',
@@ -1158,6 +1175,64 @@ function registerExtensionSlashCommands() {
                 <ul>
                     <li>
                         <pre><code class="language-stscript">/extension-disable Summarize</code></pre>
+                    </li>
+                </ul>
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'extension-toggle',
+        callback: async (args, extensionName) => {
+            if (args?.state instanceof SlashCommandClosure) throw new Error('\'state\' argument cannot be a closure.');
+            if (typeof extensionName !== 'string') throw new Error('Extension name does only support string. Closures or arrays are not allowed.');
+
+            const action = isTrueBoolean(args?.state) ? 'enable' :
+                isFalseBoolean(args?.state) ? 'disable' :
+                    'toggle';
+
+            return await getExtensionActionCallback(action)(args, extensionName);
+        },
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'reload',
+                description: 'Whether to reload the page after toggling the extension',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'true',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'state',
+                description: 'Explicitly set the state of the extension (true to enable, false to disable). If not provided, the state will be toggled to the opposite of the current state.',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Extension name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: () => extensionNames.map(name => new SlashCommandEnumValue(name)),
+                forceEnum: true,
+            }),
+        ],
+        helpString: `
+            <div>
+                Toggles the state of a specified extension.
+            </div>
+            <div>
+                By default, the page will be reloaded automatically, stopping any further commands.<br />
+                If <code>reload=false</code> named argument is passed, the page will not be reloaded, and the extension will stay in its current state until refreshed.
+                The page either needs to be refreshed, or <code>/reload-page</code> has to be called.
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <ul>
+                    <li>
+                        <pre><code class="language-stscript">/extension-toggle Summarize</code></pre>
+                    </li>
+                    <li>
+                        <pre><code class="language-stscript">/extension-toggle Summarize state=true</code></pre>
                     </li>
                 </ul>
             </div>

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1041,7 +1041,7 @@ export async function openThirdPartyExtensionMenu(suggestUrl = '') {
     await installExtension(url);
 }
 
-jQuery(async function () {
+export async function initExtensions() {
     await addExtensionsButtonAndMenu();
     $('#extensionsMenuButton').css('display', 'flex');
 
@@ -1060,4 +1060,4 @@ jQuery(async function () {
      * @listens #third_party_extension_button#click - The click event of the '#third_party_extension_button' element.
      */
     $('#third_party_extension_button').on('click', () => openThirdPartyExtensionMenu());
-});
+}


### PR DESCRIPTION
#### Summary
Added new slash commands for managing extensions directly through slash commands. This improves usability and allows extensions to be enabled, disabled, toggled, or checked for existence without manual configuration. The new commands provide straightforward control over extensions via simple inputs.

@underscorex86 You don't need to be annoyed anymore for the extension management panel to take ages to load.

#### New Commands
- **`/extension-enable`**: Enables a specified extension. Optionally reloads the page.
- **`/extension-disable`**: Disables a specified extension. Optionally reloads the page.
- **`/extension-toggle`**: Toggles the state of an extension (enable/disable). Supports setting state explicitly.
- **`/extension-state`**: Returns the current state of an extension (`true` if enabled, `false` otherwise).
- **`/extension-exists`**: Checks if an extension is installed and available.
- **`/reload-page`**: Reloads the current page immediately, stopping further commands.

#### Refactoring
- Refactored extensions to use a dedicated `init` function for setup instead of relying on jQuery initializers. This makes extension initialization cleaner and more maintainable.

These changes enhance extension management and streamline the setup process, improving both the user experience and code quality.

Side note: I needed a separate file, because when I tried to add the slash commands into `extensions.js` I ran into errors with the slash command classes not being initialized. Fucking circular references again.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
