### PR TITLE
Improve gallery layout

### DIFF
--- a/public/scripts/extensions/gallery/index.js
+++ b/public/scripts/extensions/gallery/index.js
@@ -26,9 +26,9 @@ let paginationVisiblePages = 10;
 let paginationMaxLinesPerPage = 2;
 let galleryMaxRows = 3;
 
-$('body').on('click', '.dragClose', function () {
+$('#movingDivs').on('click', '.dragClose', function () {
     const relatedId = $(this).data('related-id');  // Get the ID of the related draggable
-    $(`body > .draggable[id="${relatedId}"]`).remove();  // Remove the associated draggable
+    $(`#movingDivs > .draggable[id="${relatedId}"]`).remove();  // Remove the associated draggable
 });
 
 const CUSTOM_GALLERY_REMOVED_EVENT = 'galleryRemoved';
@@ -290,7 +290,7 @@ function makeMovable(id = 'gallery') {
 
     $('#dragGallery').css('display', 'block');
 
-    $('body').append(newElement);
+    $('#movingDivs').append(newElement);
 
     loadMovingUIState();
     $(`.draggable[forChar="${id}"]`).css('display', 'block');
@@ -362,8 +362,8 @@ function makeDragImg(id, url) {
         }
     }
 
-    // Step 3: Attach it to the body
-    document.body.appendChild(newElement);
+    // Step 3: Attach it to the movingDivs container
+    document.getElementById('movingDivs').appendChild(newElement);
 
     // Step 4: Call dragElement and loadMovingUIState
     const appendedElement = document.getElementById(uniqueId);

--- a/public/scripts/extensions/gallery/index.js
+++ b/public/scripts/extensions/gallery/index.js
@@ -26,9 +26,11 @@ let paginationVisiblePages = 10;
 let paginationMaxLinesPerPage = 2;
 let galleryMaxRows = 3;
 
+// Remove all draggables associated with the gallery
 $('#movingDivs').on('click', '.dragClose', function () {
-    const relatedId = $(this).data('related-id');  // Get the ID of the related draggable
-    $(`#movingDivs > .draggable[id="${relatedId}"]`).remove();  // Remove the associated draggable
+    const relatedId = $(this).data('related-id');
+    if (!relatedId) return;
+    $(`#movingDivs > .draggable[id="${relatedId}"]`).remove();
 });
 
 const CUSTOM_GALLERY_REMOVED_EVENT = 'galleryRemoved';

--- a/public/style.css
+++ b/public/style.css
@@ -5386,13 +5386,6 @@ body:not(.movingUI) .drawer-content.maximized {
 
 /* Jank mobile support for gallery and future draggables */
 @media screen and (max-width: 1000px) {
-    #gallery {
-        display: block;
-        width: 100vw;
-        height: 100vh;
-        z-index: 9999;
-    }
-
     .draggable {
         display: block;
         width: 100vw;


### PR DESCRIPTION
Fixes #2907

Puts all gallery-related draggables to `#movingDivs` instead of body. Also coincidentally makes it somewhat usable on phones.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
