### PR TITLE
fix waifu mode auto-scroll

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2440,14 +2440,6 @@ export function scrollChatToBottom() {
     if (power_user.auto_scroll_chat_to_bottom) {
         let position = chatElement[0].scrollHeight;
 
-        if (power_user.waifuMode) {
-            const lastMessage = chatElement.find('.mes').last();
-            if (lastMessage.length) {
-                const lastMessagePosition = lastMessage.position().top;
-                position = chatElement.scrollTop() + lastMessagePosition;
-            }
-        }
-
         chatElement.scrollTop(position);
     }
 }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->
PR reason:
Currently in waifu mode, the auto scroll function does not continue scrolling to the bottom once the message fills the sheld.

Changes:
Remove the scroll position code specific to waifu mode that prevents the auto scrolling.

Testing:
Before change: auto scroll stops once the last message fills the sheld in waifu mode.
After change: auto scroll will continue scrolling to bottom until message completes.
*Can be easier tested when chat width is narrower.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
