### PR TITLE
add swipe counter to all messages (needs debug)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5943,7 +5943,8 @@
                     </div>
                     <div class="mes_bias"></div>
                 </div>
-                <div class="swipe_right fa-solid" style="display: none;">
+                <div class="flex-container swipeRightBlock flexFlowColumn flexNoGap">
+                    <div class="swipe_right fa-solid fa-chevron-right" style="display: none;"></div>
                     <div class="swipes-counter"></div>
                 </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -4011,6 +4011,10 @@
                                     <input id="compact_input_area" type="checkbox" />
                                     <small data-i18n="Compact Input Area (Mobile)">Compact Input Area</small><i class="fa-solid fa-mobile-screen-button"></i>
                                 </label>
+                                <label for="show_swipe_num_all_messages" class="checkbox_label" title="Display swipe numbers for all messages, not just the last." data-i18n="[title]Display swipe numbers for all messages, not just the last.">
+                                    <input id="show_swipe_num_all_messages" type="checkbox" />
+                                    <small data-i18n="Swipe # for All Messages">Swipe # for All Messages</small><i class="fa-solid fa-mobile-screen-button"></i>
+                                </label>
                                 <label for="hotswapEnabled" class="checkbox_label" title="In the Character Management panel, show quick selection buttons for favorited characters." data-i18n="[title]In the Character Management panel, show quick selection buttons for favorited characters">
                                     <input id="hotswapEnabled" type="checkbox" />
                                     <small data-i18n="Characters Hotswap">Characters Hotswap</small>
@@ -5939,7 +5943,7 @@
                     </div>
                     <div class="mes_bias"></div>
                 </div>
-                <div class="swipe_right fa-solid fa-chevron-right" style="display: none;">
+                <div class="swipe_right fa-solid" style="display: none;">
                     <div class="swipes-counter"></div>
                 </div>
             </div>

--- a/public/script.js
+++ b/public/script.js
@@ -2370,8 +2370,6 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
 
     addCopyToCodeBlocks(newMessage);
 
-    //const currentMessage = $('#chat').children().filter(`[mesid="${chat.length - 1}"]`);
-
     // Set the swipes counter for past messages, only visible if 'Show Swipes on All Message' is enabled
     if (!params.isUser && newMessageId !== 0 && newMessageId !== chat.length - 1) {
         const swipesNum = chat[newMessageId].swipes?.length;
@@ -2379,11 +2377,9 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         newMessage.find('.swipes-counter').text(`${swipeId}\u200B/\u200b${swipesNum}`);
     }
 
-
     if (showSwipes) {
         $('#chat .mes').last().addClass('last_mes');
         $('#chat .mes').eq(-2).removeClass('last_mes');
-        //.find('.swipe_right').hide(); //otherwise it stays looking like it did when it was last_mes
         hideSwipeButtons();
         showSwipeButtons();
     }
@@ -7483,7 +7479,6 @@ export function showSwipeButtons() {
     //had to add this to make the swipe counter work
     //(copied from the onclick functions for swipe buttons..
     //don't know why the array isn't set for non-swipe messsages in Generate or addOneMessage..)
-
     if (chat[chat.length - 1]['swipe_id'] === undefined) {              // if there is no swipe-message in the last spot of the chat array
         chat[chat.length - 1]['swipe_id'] = 0;                        // set it to id 0
         chat[chat.length - 1]['swipes'] = [];                         // empty the array
@@ -7502,33 +7497,24 @@ export function showSwipeButtons() {
     }
     //only show right when generate is off, or when next right swipe would not make a generate happen
     if (is_send_press === false || chat[chat.length - 1].swipes.length >= swipeId) {
-        // console.error('showingSwipeButtons: showing.');
         swipeRight.css('display', 'flex').css('opacity', '0.3');
         swipeCounter.css('opacity', '0.3');
     }
-    //console.log((chat[chat.length - 1]));
     if ((chat[chat.length - 1].swipes.length - swipeId) === 1) {
-        // console.error('highlighting R swipe');
-
         //chevron was moved out of hardcode in HTML to class toggle dependent on last_mes or not
         //necessary for 'swipe_right' div in past messages to have no chevron if 'show swipes for all messages' is turned on
         swipeRight.css('opacity', '0.7');
         swipeCounter.css('opacity', '0.7');
     }
-    //console.log(swipesCounterHTML);
 
     //allows for writing individual swipe counters for past messages
     const lastSwipeCounter = $('.last_mes .swipes-counter');
     lastSwipeCounter.text(swipeCounterText).show();
 
-    //console.log(swipeId);
-    //console.log(chat[chat.length - 1].swipes.length);
-
     switchSwipeNumAllMessages();
 }
 
 export function hideSwipeButtons() {
-    // console.error('hideswipebuttons entered');
     $('#chat').find('.swipe_right').hide();
     $('#chat').find('.last_mes .swipes-counter').hide();
     $('#chat').find('.swipe_left').hide();

--- a/public/script.js
+++ b/public/script.js
@@ -2370,8 +2370,8 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
 
     //const currentMessage = $('#chat').children().filter(`[mesid="${chat.length - 1}"]`);
 
-    // Set the swipes counter for past messages, only visible if 'Show Sipes on All Message' is enabled
-    if (!params.isUser && newMessageId !== 0) {
+    // Set the swipes counter for past messages, only visible if 'Show Swipes on All Message' is enabled
+    if (!params.isUser && newMessageId !== 0 && newMessageId !== chat.length - 1) {
         const swipesNum = chat[newMessageId].swipes?.length;
         const swipeId = chat[newMessageId].swipe_id + 1;
         newMessage.find('.swipes-counter').text(`${swipeId}\u200B/\u200b${swipesNum}`);
@@ -7510,6 +7510,7 @@ export function showSwipeButtons() {
 
     //allows for writing individual swipe counters for past messages
     $('.last_mes .swipes-counter').text(swipeCounterText);
+    $('.last_mes .swipes-counter').show();
 
     //console.log(swipeId);
     //console.log(chat[chat.length - 1].swipes.length);
@@ -7520,6 +7521,7 @@ export function showSwipeButtons() {
 export function hideSwipeButtons() {
     console.error('hideswipebuttons entered');
     $('#chat').find('.swipe_right').hide();
+    $('#chat').find('.last_mes .swipes-counter').hide();
     $('#chat').find('.swipe_left').hide();
 }
 

--- a/public/script.js
+++ b/public/script.js
@@ -83,7 +83,6 @@ import {
     resetMovableStyles,
     forceCharacterEditorTokenize,
     applyPowerUserSettings,
-    switchSwipeNumAllMessages,
 } from './scripts/power-user.js';
 
 import {
@@ -2381,8 +2380,8 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
 
     if (showSwipes) {
         $('#chat .mes').last().addClass('last_mes');
-        $('#chat .mes').eq(-2).removeClass('last_mes')
-            .find('.swipe_right').removeClass('fa-chevron-right'); //otherwise it stays looking like it did when it was last_mes
+        $('#chat .mes').eq(-2).removeClass('last_mes');
+        //.find('.swipe_right').hide(); //otherwise it stays looking like it did when it was last_mes
         hideSwipeButtons();
         showSwipeButtons();
     }
@@ -7495,16 +7494,17 @@ export function showSwipeButtons() {
     }
     //only show right when generate is off, or when next right swipe would not make a generate happen
     if (is_send_press === false || chat[chat.length - 1].swipes.length >= swipeId) {
-        currentMessage.children('.swipe_right').css('display', 'flex');
-        currentMessage.children('.swipe_right').css('opacity', '0.3');
+        console.error('showingSwipeButtons: showing.');
+        currentMessage.find('.swipe_right').css('display', 'flex');
+        currentMessage.find('.swipe_right').css('opacity', '0.3');
     }
     //console.log((chat[chat.length - 1]));
     if ((chat[chat.length - 1].swipes.length - swipeId) === 1) {
-        //console.log('highlighting R swipe');
+        console.error('highlighting R swipe');
 
         //chevron was moved out of hardcode in HTML to class toggle dependent on last_mes or not
         //necessary for 'swipe_right' div in past messages to have no chevron if 'show swipes for all messages' is turned on
-        currentMessage.children('.swipe_right').addClass('fa-chevron-right').css('opacity', '0.7');
+        currentMessage.find('.swipe_right').css('opacity', '0.7');
     }
     //console.log(swipesCounterHTML);
 
@@ -7514,13 +7514,13 @@ export function showSwipeButtons() {
     //console.log(swipeId);
     //console.log(chat[chat.length - 1].swipes.length);
 
-    switchSwipeNumAllMessages();
+    //switchSwipeNumAllMessages();
 }
 
 export function hideSwipeButtons() {
-    //console.log('hideswipebuttons entered');
-    $('#chat').find('.last_mes .swipe_right').css('display', 'none');
-    $('#chat').find('.swipe_left').css('display', 'none');
+    console.error('hideswipebuttons entered');
+    $('#chat').find('.swipe_right').hide();
+    $('#chat').find('.swipe_left').hide();
 }
 
 /**
@@ -8355,8 +8355,8 @@ const swipe_right = () => {
     }
 
     const currentMessage = $('#chat').children().filter(`[mesid="${chat.length - 1}"]`);
-    let this_div = currentMessage.children('.swipe_right');
-    let this_mes_div = this_div.parent();
+    let this_div = currentMessage.find('.swipe_right');
+    let this_mes_div = this_div.parent().parent();
 
     if (chat[chat.length - 1]['swipe_id'] > chat[chat.length - 1]['swipes'].length) { //if we swipe right while generating (the swipe ID is greater than what we are viewing now)
         chat[chat.length - 1]['swipe_id'] = chat[chat.length - 1]['swipes'].length; //show that message slot (will be '...' while generating)
@@ -8366,7 +8366,7 @@ const swipe_right = () => {
     }
     // handles animated transitions when swipe right, specifically height transitions between messages
     if (run_generate || run_swipe_right) {
-        let this_mes_block = this_mes_div.children('.mes_block').children('.mes_text');
+        let this_mes_block = this_mes_div.find('.mes_block .mes_text');
         const this_mes_div_height = this_mes_div[0].scrollHeight;
         const this_mes_block_height = this_mes_block[0].scrollHeight;
 

--- a/public/script.js
+++ b/public/script.js
@@ -7493,29 +7493,33 @@ export function showSwipeButtons() {
     const currentMessage = $('#chat').children().filter(`[mesid="${chat.length - 1}"]`);
     const swipeId = chat[chat.length - 1].swipe_id;
     const swipeCounterText = (`${(swipeId + 1)}\u200B/\u200b${(chat[chat.length - 1].swipes.length)}`);
+    const swipeRight = currentMessage.find('.swipe_right');
+    const swipeLeft = currentMessage.find('.swipe_left');
+    const swipeCounter = currentMessage.find('.swipes-counter');
 
     if (swipeId !== undefined && (chat[chat.length - 1].swipes.length > 1 || swipeId > 0)) {
-        currentMessage.children('.swipe_left').css('display', 'flex');
+        swipeLeft.css('display', 'flex');
     }
     //only show right when generate is off, or when next right swipe would not make a generate happen
     if (is_send_press === false || chat[chat.length - 1].swipes.length >= swipeId) {
-        console.error('showingSwipeButtons: showing.');
-        currentMessage.find('.swipe_right').css('display', 'flex');
-        currentMessage.find('.swipe_right').css('opacity', '0.3');
+        // console.error('showingSwipeButtons: showing.');
+        swipeRight.css('display', 'flex').css('opacity', '0.3');
+        swipeCounter.css('opacity', '0.3');
     }
     //console.log((chat[chat.length - 1]));
     if ((chat[chat.length - 1].swipes.length - swipeId) === 1) {
-        console.error('highlighting R swipe');
+        // console.error('highlighting R swipe');
 
         //chevron was moved out of hardcode in HTML to class toggle dependent on last_mes or not
         //necessary for 'swipe_right' div in past messages to have no chevron if 'show swipes for all messages' is turned on
-        currentMessage.find('.swipe_right').css('opacity', '0.7');
+        swipeRight.css('opacity', '0.7');
+        swipeCounter.css('opacity', '0.7');
     }
     //console.log(swipesCounterHTML);
 
     //allows for writing individual swipe counters for past messages
-    $('.last_mes .swipes-counter').text(swipeCounterText);
-    $('.last_mes .swipes-counter').show();
+    const lastSwipeCounter = $('.last_mes .swipes-counter');
+    lastSwipeCounter.text(swipeCounterText).show();
 
     //console.log(swipeId);
     //console.log(chat[chat.length - 1].swipes.length);

--- a/public/script.js
+++ b/public/script.js
@@ -83,6 +83,7 @@ import {
     resetMovableStyles,
     forceCharacterEditorTokenize,
     applyPowerUserSettings,
+    switchSwipeNumAllMessages,
 } from './scripts/power-user.js';
 
 import {
@@ -2368,9 +2369,20 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
 
     addCopyToCodeBlocks(newMessage);
 
+    //const currentMessage = $('#chat').children().filter(`[mesid="${chat.length - 1}"]`);
+
+    // Set the swipes counter for past messages, only visible if 'Show Sipes on All Message' is enabled
+    if (!params.isUser && newMessageId !== 0) {
+        const swipesNum = chat[newMessageId].swipes?.length;
+        const swipeId = chat[newMessageId].swipe_id + 1;
+        newMessage.find('.swipes-counter').text(`${swipeId}\u200B/\u200b${swipesNum}`);
+    }
+
+
     if (showSwipes) {
         $('#chat .mes').last().addClass('last_mes');
-        $('#chat .mes').eq(-2).removeClass('last_mes');
+        $('#chat .mes').eq(-2).removeClass('last_mes')
+            .find('.swipe_right').removeClass('fa-chevron-right'); //otherwise it stays looking like it did when it was last_mes
         hideSwipeButtons();
         showSwipeButtons();
     }
@@ -7489,19 +7501,25 @@ export function showSwipeButtons() {
     //console.log((chat[chat.length - 1]));
     if ((chat[chat.length - 1].swipes.length - swipeId) === 1) {
         //console.log('highlighting R swipe');
-        currentMessage.children('.swipe_right').css('opacity', '0.7');
+
+        //chevron was moved out of hardcode in HTML to class toggle dependent on last_mes or not
+        //necessary for 'swipe_right' div in past messages to have no chevron if 'show swipes for all messages' is turned on
+        currentMessage.children('.swipe_right').addClass('fa-chevron-right').css('opacity', '0.7');
     }
     //console.log(swipesCounterHTML);
 
-    $('.swipes-counter').text(swipeCounterText);
+    //allows for writing individual swipe counters for past messages
+    $('.last_mes .swipes-counter').text(swipeCounterText);
 
     //console.log(swipeId);
     //console.log(chat[chat.length - 1].swipes.length);
+
+    switchSwipeNumAllMessages();
 }
 
 export function hideSwipeButtons() {
     //console.log('hideswipebuttons entered');
-    $('#chat').find('.swipe_right').css('display', 'none');
+    $('#chat').find('.last_mes .swipe_right').css('display', 'none');
     $('#chat').find('.swipe_left').css('display', 'none');
 }
 
@@ -9395,9 +9413,9 @@ jQuery(async function () {
 
     ///// SWIPE BUTTON CLICKS ///////
 
-    $(document).on('click', '.swipe_right', swipe_right);
-
-    $(document).on('click', '.swipe_left', swipe_left);
+    //limit swiping to only last message clicks
+    $(document).on('click', '.last_mes .swipe_right', swipe_right);
+    $(document).on('click', '.last_mes .swipe_left', swipe_left);
 
     const debouncedCharacterSearch = debounce((searchQuery) => {
         entitiesFilter.setFilterData(FILTER_TYPES.SEARCH, searchQuery);

--- a/public/script.js
+++ b/public/script.js
@@ -83,6 +83,7 @@ import {
     resetMovableStyles,
     forceCharacterEditorTokenize,
     applyPowerUserSettings,
+    switchSwipeNumAllMessages,
 } from './scripts/power-user.js';
 
 import {
@@ -7515,7 +7516,7 @@ export function showSwipeButtons() {
     //console.log(swipeId);
     //console.log(chat[chat.length - 1].swipes.length);
 
-    //switchSwipeNumAllMessages();
+    switchSwipeNumAllMessages();
 }
 
 export function hideSwipeButtons() {

--- a/public/script.js
+++ b/public/script.js
@@ -7528,7 +7528,7 @@ export function showSwipeButtons() {
 }
 
 export function hideSwipeButtons() {
-    console.error('hideswipebuttons entered');
+    // console.error('hideswipebuttons entered');
     $('#chat').find('.swipe_right').hide();
     $('#chat').find('.last_mes .swipes-counter').hide();
     $('#chat').find('.swipe_left').hide();

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -290,6 +290,7 @@ let power_user = {
     restore_user_input: true,
     reduced_motion: false,
     compact_input_area: true,
+    show_swipe_num_all_messages: false,
     auto_connect: false,
     auto_load_chat: false,
     forbid_external_media: true,
@@ -467,6 +468,35 @@ function switchReducedMotion() {
 function switchCompactInputArea() {
     $('#send_form').toggleClass('compact', power_user.compact_input_area);
     $('#compact_input_area').prop('checked', power_user.compact_input_area);
+}
+
+export function switchSwipeNumAllMessages() {
+    console.error('switching branch button initialted, function start!');
+    $('#show_swipe_num_all_messages').prop('checked', power_user.show_swipe_num_all_messages);
+
+    if (power_user.show_swipe_num_all_messages) {
+
+        $('.mes').each(function () {
+            //if the div also has the .lst_mes class, skip the loop for that item
+            if ($(this).hasClass('last_mes')) {
+                return;
+            }
+            //add the cloned button to every .mes .swipe_right EXCLUDING .mes.last_mes
+            $(this).find('.swipe_right').css('display', 'flex');
+        });
+
+    } else if (!power_user.show_swipe_num_all_messages) {
+        $('.mes:not(.last_mes)').each(function () {
+            if ($(this).hasClass('last_mes')) {
+                return;
+            }
+            //add the cloned button back to its original spot
+            $(this).find('.swipe_right').css('display', 'none');
+        });
+
+    }
+
+
 }
 
 var originalSliderValues = [];
@@ -1283,6 +1313,13 @@ function applyTheme(name) {
                 switchCompactInputArea();
             },
         },
+        {
+            key: 'show_swipe_num_all_messages',
+            action: () => {
+                $('#show_swipe_num_all_messages').prop('checked', power_user.show_swipe_num_all_messages);
+                switchSwipeNumAllMessages();
+            },
+        },
     ];
 
     for (const { key, selector, type, action } of themeProperties) {
@@ -1352,6 +1389,7 @@ function applyPowerUserSettings() {
     switchHideChatAvatars();
     switchTokenCount();
     switchMessageActions();
+    switchSwipeNumAllMessages();
 }
 
 function getExampleMessagesBehavior() {
@@ -2296,6 +2334,7 @@ function getThemeObject(name) {
         zoomed_avatar_magnification: power_user.zoomed_avatar_magnification,
         reduced_motion: power_user.reduced_motion,
         compact_input_area: power_user.compact_input_area,
+        show_swipe_num_all_messages: power_user.show_swipe_num_all_messages,
     };
 }
 
@@ -3752,6 +3791,12 @@ $(document).ready(() => {
     $('#compact_input_area').on('input', function () {
         power_user.compact_input_area = !!$(this).prop('checked');
         switchCompactInputArea();
+        saveSettingsDebounced();
+    });
+
+    $('#show_swipe_num_all_messages').on('input', function () {
+        power_user.show_swipe_num_all_messages = !!$(this).prop('checked');
+        switchSwipeNumAllMessages();
         saveSettingsDebounced();
     });
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -472,7 +472,7 @@ function switchCompactInputArea() {
 
 export function switchSwipeNumAllMessages() {
     $('#show_swipe_num_all_messages').prop('checked', power_user.show_swipe_num_all_messages);
-    $('.mes:not(.last_mes) .swipes-counter').toggle(power_user.show_swipe_num_all_messages);
+    $('.mes:not(.last_mes) .swipes-counter').css('opacity', '').toggle(power_user.show_swipe_num_all_messages);
 }
 
 var originalSliderValues = [];

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -472,30 +472,7 @@ function switchCompactInputArea() {
 
 export function switchSwipeNumAllMessages() {
     $('#show_swipe_num_all_messages').prop('checked', power_user.show_swipe_num_all_messages);
-
-    if (power_user.show_swipe_num_all_messages) {
-
-        $('.mes').each(function () {
-            //if the div also has the .lst_mes class, skip the loop for that item
-            if ($(this).hasClass('last_mes')) {
-                return;
-            }
-            //add the cloned button to every .mes .swipe_right EXCLUDING .mes.last_mes
-            $(this).find('.swipe_right').css('display', 'flex');
-        });
-
-    } else if (!power_user.show_swipe_num_all_messages) {
-        $('.mes:not(.last_mes)').each(function () {
-            if ($(this).hasClass('last_mes')) {
-                return;
-            }
-            //add the cloned button back to its original spot
-            $(this).find('.swipe_right').css('display', 'none');
-        });
-
-    }
-
-
+    $('.mes:not(.last_mes) .swipes-counter').toggle(power_user.show_swipe_num_all_messages);
 }
 
 var originalSliderValues = [];

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -471,7 +471,6 @@ function switchCompactInputArea() {
 }
 
 export function switchSwipeNumAllMessages() {
-    console.error('switching branch button initialted, function start!');
     $('#show_swipe_num_all_messages').prop('checked', power_user.show_swipe_num_all_messages);
 
     if (power_user.show_swipe_num_all_messages) {

--- a/public/style.css
+++ b/public/style.css
@@ -1010,9 +1010,12 @@ body .panelControlBar {
     min-width: 40px;
     display: flex;
     justify-content: center;
-    opacity: 0.7;
     margin-bottom: var(--swipeCounterMargin);
     height: var(--swipeCounterHeight);
+}
+
+.mes:not(.last_mes) .swipes-counter {
+    opacity: 0.3;
 }
 
 .swipe_left {

--- a/public/style.css
+++ b/public/style.css
@@ -978,13 +978,21 @@ body .panelControlBar {
     justify-content: center;
     z-index: 9999;
     grid-row-start: 2;
-    grid-column-start: 4;
-    flex-flow: column;
     font-size: 30px;
     cursor: pointer;
     align-self: center;
+
+}
+.swipe_left{
+position: absolute;
+bottom: 15px;
+flex-flow: column;
+}
+
+.swipeRightBlock {
     position: absolute;
-    bottom: 15px;
+    right: 0;
+    bottom: 0;
 }
 
 .swipes-counter {
@@ -994,6 +1002,9 @@ body .panelControlBar {
     font-family: var(--mainFontFamily);
     font-weight: 400;
     align-self: center;
+    min-width: 40px;
+    display: flex;
+    justify-content: center;
 }
 
 .swipe_left {
@@ -1003,6 +1014,7 @@ body .panelControlBar {
 
 .swipe_right {
     right: 5px;
+    align-self:end;
 }
 
 .ui-settings {

--- a/public/style.css
+++ b/public/style.css
@@ -969,24 +969,29 @@ body .panelControlBar {
 
 /* SWIPE RELATED STYLES*/
 
+.mes {
+    --swipeCounterHeight: 15px;
+    --swipeCounterMargin: 5px;
+}
+
 .swipe_right,
 .swipe_left {
-    height: 40px;
-    width: 40px;
+    width: 25px;
+    height: 25px;
     opacity: 0.3;
     align-items: center;
     justify-content: center;
     z-index: 9999;
     grid-row-start: 2;
-    font-size: 30px;
+    font-size: 20px;
     cursor: pointer;
     align-self: center;
-
 }
-.swipe_left{
-position: absolute;
-bottom: 15px;
-flex-flow: column;
+
+.swipe_left {
+    position: absolute;
+    bottom: calc(var(--swipeCounterHeight) + var(--swipeCounterMargin));
+    flex-flow: column;
 }
 
 .swipeRightBlock {
@@ -995,17 +1000,19 @@ flex-flow: column;
     bottom: 0;
 }
 
-
 .swipes-counter {
     color: var(--SmartThemeBodyColor);
     font-size: 12px;
-    padding: 0;
+    padding: 0 5px;
     font-family: var(--mainFontFamily);
     font-weight: 400;
     align-self: center;
     min-width: 40px;
     display: flex;
     justify-content: center;
+    opacity: 0.7;
+    margin-bottom: var(--swipeCounterMargin);
+    height: var(--swipeCounterHeight);
 }
 
 .swipe_left {
@@ -1015,7 +1022,7 @@ flex-flow: column;
 
 .swipe_right {
     right: 5px;
-    align-self:end;
+    align-self: center;
 }
 
 .ui-settings {
@@ -2649,7 +2656,7 @@ select option:not(:checked) {
 
 #instruct_enabled_label .menu_button:not(.toggleEnabled),
 #sysprompt_enabled_label .menu_button:not(.toggleEnabled) {
- color: Red;
+    color: Red;
 }
 
 .displayBlock {


### PR DESCRIPTION
Adds a theme toggle to show swipe numbers for all past messages.

This requires making .swipe_right visible, so had to juggle  .fa-chevron-right for past message .swipe_right divs.

Also - limited scope of some swipe_right actions and asignments to .last_mes only.