### PR TITLE
Add escaped quoted unnamed arguments parsing mode.

### DIFF
--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -1053,9 +1053,9 @@ export class SlashCommandParser {
             if (split && splitCount && listValues.length >= splitCount) {
                 // the split count has just been reached: stop splitting, the rest is one singular value
                 split = false;
-                if (this.testQuotedValue()) {
+                if (this.testEscapedQuotedValue()) {
                     // if the next bit is a quoted value, take the whole value
-                    assignment.value = this.parseQuotedValue();
+                    assignment.value = this.parseEscapedQuotedValue();
                     assignment.end = this.index;
                     listValues.push(assignment);
                     listQuoted.push(true);
@@ -1072,9 +1072,9 @@ export class SlashCommandParser {
                     listQuoted.push(false);
                     assignment = new SlashCommandUnnamedArgumentAssignment();
                     assignment.start = this.index;
-                    if (!split && this.testQuotedValue()) {
+                    if (!split && this.testEscapedQuotedValue()) {
                         // if where currently not splitting and the next bit is a quoted value, take the whole value
-                        assignment.value = this.parseQuotedValue();
+                        assignment.value = this.parseEscapedQuotedValue();
                         assignment.end = this.index;
                         listValues.push(assignment);
                         listQuoted.push(true);
@@ -1092,9 +1092,9 @@ export class SlashCommandParser {
                 assignment.start = this.index;
                 if (split) this.discardWhitespace();
             } else if (split) {
-                if (this.testQuotedValue()) {
+                if (this.testEscapedQuotedValue()) {
                     assignment.start = this.index;
-                    assignment.value = this.parseQuotedValue();
+                    assignment.value = this.parseEscapedQuotedValue();
                     assignment.end = this.index;
                     listValues.push(assignment);
                     listQuoted.push(true);

--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -1039,9 +1039,9 @@ export class SlashCommandParser {
         /**@type {SlashCommandUnnamedArgumentAssignment}*/
         let assignment = new SlashCommandUnnamedArgumentAssignment();
         assignment.start = this.index;
-        if (!split && this.testQuotedValue()) {
+        if (!split && this.testEscapedQuotedValue()) {
             // if the next bit is a quoted value, take the whole value and gather contents as a list
-            assignment.value = this.parseQuotedValue();
+            assignment.value = this.parseEscapedQuotedValue();
             assignment.end = this.index;
             isList = true;
             listValues.push(assignment);
@@ -1181,6 +1181,9 @@ export class SlashCommandParser {
     testQuotedValue() {
         return this.testSymbol('"');
     }
+    testEscapedQuotedValue() {
+        return this.testSymbol('="');
+    }
     testQuotedValueEnd() {
         if (this.endOfText) {
             if (this.verifyCommandNames) throw new SlashCommandParserError(`Unexpected end of quoted value at position ${this.index}`, this.text, this.index);
@@ -1191,6 +1194,10 @@ export class SlashCommandParser {
             throw new SlashCommandParserError(`Unexpected end of quoted value at position ${this.index}`, this.text, this.index);
         }
         return this.testSymbol('"') || (!this.flags[PARSER_FLAG.STRICT_ESCAPING] && this.testCommandEnd());
+    }
+    parseEscapedQuotedValue() {
+        this.take();
+        return this.parseQuotedValue();
     }
     parseQuotedValue() {
         this.take(); // discard opening quote


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Closes #2739

New syntax:

```
/send ="blah blah" || // will explicitly remove quotes
/send  "blah blah" || // will not remove quotes
```

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
