### PR TITLE
Fix piping not actually using/inputting an array for empty unnamed args

### DIFF
--- a/public/scripts/slash-commands/SlashCommandClosure.js
+++ b/public/scripts/slash-commands/SlashCommandClosure.js
@@ -508,6 +508,14 @@ export class SlashCommandClosure {
                 return v;
             });
         }
+
+        value ??= '';
+
+        // Make sure that if unnamed args are split, it should always return an array
+        if (executor.command.splitUnnamedArgument && !Array.isArray(value)) {
+            value = [value];
+        }
+
         return value;
     }
 


### PR DESCRIPTION
- Lenny said if `splitUnnamedArgument` is enabled, the callback should always receive an array.
- It is intended that if no value was provided, it'll get an array with an empty string. Because.. if no argument was provided for a non-split arg, it'll receive an empty string too.

Could likely be made a bit cleaner by checking at the places at the top in each branch. I tried. But this is the most consistent with any edge cases that might appear.
If you want a split, you are always getting a split.

Returning `[]` instead of `['']` if there was no piped value *might* be another approach, but I don't like it that much. Let the callbacks handle empty values inside the array. Same as callback handle empty values for named args or non-split unnameds too.

The fallback for empty string is also a good idea, because in a few places after this, there is a hardcoded fallback on `?? ''`, which will again not respect any specified split/array.

This should not break anything. Very few commands used splits yet.

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
