### PR TITLE
fix google-ai reverse proxy ignoring user provided path

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -323,7 +323,7 @@ async function sendMakerSuiteRequest(request, response) {
             ? (stream ? 'streamGenerateContent' : 'generateContent')
             : (isText ? 'generateText' : 'generateMessage');
 
-        const generateResponse = await fetch(`${apiUrl.origin}/${apiVersion}/models/${model}:${responseType}?key=${apiKey}${stream ? '&alt=sse' : ''}`, {
+        const generateResponse = await fetch(`${apiUrl}/${apiVersion}/models/${model}:${responseType}?key=${apiKey}${stream ? '&alt=sse' : ''}`, {
             body: JSON.stringify(body),
             method: 'POST',
             headers: {


### PR DESCRIPTION
Currently, ST ignores the path the user provides for gemini models. This will fix the issue,
example:
user provided proxy link: https://localhost:7860/google-ai
current final link: https://localhost:7860/v1beta/models/gemini-1.5-pro:generateContent?key=key
expected: https://localhost:7860/google-ai/v1beta/models/gemini-1.5-pro:generateContent?key=key

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
