### PR TITLE
Add Featherless to modelSelectMap for /model

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3612,6 +3612,7 @@ function getModelOptions(quiet) {
         { id: 'aphrodite_model', api: 'textgenerationwebui', type: textgen_types.APHRODITE },
         { id: 'ollama_model', api: 'textgenerationwebui', type: textgen_types.OLLAMA },
         { id: 'tabby_model', api: 'textgenerationwebui', type: textgen_types.TABBY },
+        { id: 'featherless_model', api: 'textgenerationwebui', type: textgen_types.FEATHERLESS },
         { id: 'model_openai_select', api: 'openai', type: chat_completion_sources.OPENAI },
         { id: 'model_claude_select', api: 'openai', type: chat_completion_sources.CLAUDE },
         { id: 'model_windowai_select', api: 'openai', type: chat_completion_sources.WINDOWAI },


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
- What is the reason for a change? get Connection Profile for Featherless to save the model in use
-   What did you do to achieve this? added Featherless to slash-commands.js:getModelOptions:modelSelectMap so /model works
-   How would a reviewer test the change? when API/TC/Featherless selected observe that /model | /echo {{pipe}} 🎉 works as expected. create a Connection Profile for Featherless, Model should now be one of the saveable options. if selecting a Featherless CP with saved model option, the currently selected model should update
