### PR TITLE
Keyboard shortcut related fixes

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1885,6 +1885,7 @@ export async function reloadCurrentChat() {
 export async function sendTextareaMessage() {
     if (is_send_press) return;
     if (isExecutingCommandsFromChatInput) return;
+    if (this_edit_mes_id) return; // don't proceed if editing a message
 
     let generateType;
     // "Continue on send" is activated when the user hits "send" (or presses enter) on an empty chat box, and the last
@@ -10002,6 +10003,8 @@ jQuery(async function () {
         }
 
         else if (id == 'option_continue') {
+            if (this_edit_mes_id) return; // don't proceed if editing a message
+
             if (is_send_press == false || fromSlashCommand) {
                 is_send_press = true;
                 Generate('continue', buildOrFillAdditionalArgs());

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -1027,6 +1027,7 @@ export function initRossMods() {
             const editMesDone = $('.mes_edit_done:visible');
             if (editMesDone.length > 0) {
                 console.debug('Accepting edits with Ctrl+Enter');
+                $('#send_textarea').focus();
                 editMesDone.trigger('click');
                 return;
             } else if (is_send_press == false) {


### PR DESCRIPTION
Two small fixes:

### Ctrl-Enter did not give focus back to the input area

When editing a message and hitting Escape, focus went back to the input area, but not when using Ctrl-Enter to accept the edit.

The first commit fixes this so that input does go back to the input area, symmetrical to canceling the edit.

### Bug when hitting Continue or Send while editing a message

While editing a message, using the Continue or Send buttons (or keyboard shortcuts) resulted in a UI bug involving data loss; instead of continuing from the state being edited, the generation resumed from the message state before it started being edited.

Afterwards, attempting to edit the message pulls up blank content, after which accepting or canceling the edit also blanks out the message, which is now lost forever (unless you're logging prompts to console).

The second commit makes it so that the `on('click')` callbacks abort when in editing mode. This is the tiniest fix, although arguably the buttons should be grayed out as well for better user feedback.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
