### PR TITLE
Fix out-of-sync pinned drawer icons

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -10671,7 +10671,7 @@ jQuery(async function () {
             $('.openDrawer').not('.pinnedOpen').addClass('resizing').slideToggle(200, 'swing', async function () {
                 await delay(50); $(this).closest('.drawer-content').removeClass('resizing');
             });
-            $('.openIcon').toggleClass('closedIcon openIcon');
+            $('.openIcon').not('.drawerPinnedOpen').toggleClass('closedIcon openIcon');
             $('.openDrawer').not('.pinnedOpen').toggleClass('closedDrawer openDrawer');
             icon.toggleClass('openIcon closedIcon');
             drawer.toggleClass('openDrawer closedDrawer');
@@ -10757,7 +10757,7 @@ jQuery(async function () {
                     $('.openDrawer').not('.pinnedOpen').addClass('resizing').slideToggle(200, 'swing', function () {
                         $(this).closest('.drawer-content').removeClass('resizing');
                     });
-                    $('.openIcon').toggleClass('closedIcon openIcon');
+                    $('.openIcon').not('.drawerPinnedOpen').toggleClass('closedIcon openIcon');
                     $('.openDrawer').not('.pinnedOpen').toggleClass('closedDrawer openDrawer');
 
                 }

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -45,8 +45,11 @@ var LPanelPin = document.getElementById('lm_button_panel_pin');
 var WIPanelPin = document.getElementById('WI_panel_pin');
 
 var RightNavPanel = document.getElementById('right-nav-panel');
+var RightNavDrawerIcon = document.getElementById('rightNavDrawerIcon');
 var LeftNavPanel = document.getElementById('left-nav-panel');
+var leftNavDrawerIcon = document.getElementById('leftNavDrawerIcon');
 var WorldInfo = document.getElementById('WorldInfo');
+var WIDrawerIcon = document.getElementById('WIDrawerIcon');
 
 var SelectedCharacterTab = document.getElementById('rm_button_selected_ch');
 
@@ -761,13 +764,15 @@ export function initRossMods() {
         if ($(RPanelPin).prop('checked') == true) {
             //console.log('adding pin class to right nav');
             $(RightNavPanel).addClass('pinnedOpen');
+            $(RightNavDrawerIcon).addClass('drawerPinnedOpen');
         } else {
             //console.log('removing pin class from right nav');
             $(RightNavPanel).removeClass('pinnedOpen');
+            $(RightNavDrawerIcon).removeClass('drawerPinnedOpen');
 
             if ($(RightNavPanel).hasClass('openDrawer') && $('.openDrawer').length > 1) {
                 $(RightNavPanel).slideToggle(200, 'swing');
-                //$(rightNavDrawerIcon).toggleClass('openIcon closedIcon');
+                $(RightNavDrawerIcon).toggleClass('openIcon closedIcon');
                 $(RightNavPanel).toggleClass('openDrawer closedDrawer');
             }
         }
@@ -777,13 +782,15 @@ export function initRossMods() {
         if ($(LPanelPin).prop('checked') == true) {
             //console.log('adding pin class to Left nav');
             $(LeftNavPanel).addClass('pinnedOpen');
+            $(leftNavDrawerIcon).addClass('drawerPinnedOpen');
         } else {
             //console.log('removing pin class from Left nav');
             $(LeftNavPanel).removeClass('pinnedOpen');
+            $(leftNavDrawerIcon).removeClass('drawerPinnedOpen');
 
             if ($(LeftNavPanel).hasClass('openDrawer') && $('.openDrawer').length > 1) {
                 $(LeftNavPanel).slideToggle(200, 'swing');
-                //$(leftNavDrawerIcon).toggleClass('openIcon closedIcon');
+                $(leftNavDrawerIcon).toggleClass('openIcon closedIcon');
                 $(LeftNavPanel).toggleClass('openDrawer closedDrawer');
             }
         }
@@ -794,14 +801,16 @@ export function initRossMods() {
         if ($(WIPanelPin).prop('checked') == true) {
             console.debug('adding pin class to WI');
             $(WorldInfo).addClass('pinnedOpen');
+            $(WIDrawerIcon).addClass('drawerPinnedOpen');
         } else {
             console.debug('removing pin class from WI');
             $(WorldInfo).removeClass('pinnedOpen');
+            $(WIDrawerIcon).removeClass('drawerPinnedOpen');
 
             if ($(WorldInfo).hasClass('openDrawer') && $('.openDrawer').length > 1) {
                 console.debug('closing WI after lock removal');
                 $(WorldInfo).slideToggle(200, 'swing');
-                //$(WorldInfoDrawerIcon).toggleClass('openIcon closedIcon');
+                $(WIDrawerIcon).toggleClass('openIcon closedIcon');
                 $(WorldInfo).toggleClass('openDrawer closedDrawer');
             }
         }
@@ -812,20 +821,24 @@ export function initRossMods() {
     if (LoadLocalBool('NavLockOn') == true) {
         //console.log('setting pin class via local var');
         $(RightNavPanel).addClass('pinnedOpen');
+        $(RightNavDrawerIcon).addClass('drawerPinnedOpen');
     }
     if ($(RPanelPin).prop('checked')) {
         console.debug('setting pin class via checkbox state');
         $(RightNavPanel).addClass('pinnedOpen');
+        $(RightNavDrawerIcon).addClass('drawerPinnedOpen');
     }
     // read the state of left Nav Lock and apply to leftnav classlist
     $(LPanelPin).prop('checked', LoadLocalBool('LNavLockOn'));
     if (LoadLocalBool('LNavLockOn') == true) {
         //console.log('setting pin class via local var');
         $(LeftNavPanel).addClass('pinnedOpen');
+        $(leftNavDrawerIcon).addClass('drawerPinnedOpen');
     }
     if ($(LPanelPin).prop('checked')) {
         console.debug('setting pin class via checkbox state');
         $(LeftNavPanel).addClass('pinnedOpen');
+        $(leftNavDrawerIcon).addClass('drawerPinnedOpen');
     }
 
     // read the state of left Nav Lock and apply to leftnav classlist
@@ -833,11 +846,13 @@ export function initRossMods() {
     if (LoadLocalBool('WINavLockOn') == true) {
         //console.log('setting pin class via local var');
         $(WorldInfo).addClass('pinnedOpen');
+        $(WIDrawerIcon).addClass('drawerPinnedOpen');
     }
 
     if ($(WIPanelPin).prop('checked')) {
         console.debug('setting pin class via checkbox state');
         $(WorldInfo).addClass('pinnedOpen');
+        $(WIDrawerIcon).addClass('drawerPinnedOpen');
     }
 
     //save state of Right nav being open or closed

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -47,7 +47,7 @@ var WIPanelPin = document.getElementById('WI_panel_pin');
 var RightNavPanel = document.getElementById('right-nav-panel');
 var RightNavDrawerIcon = document.getElementById('rightNavDrawerIcon');
 var LeftNavPanel = document.getElementById('left-nav-panel');
-var leftNavDrawerIcon = document.getElementById('leftNavDrawerIcon');
+var LeftNavDrawerIcon = document.getElementById('leftNavDrawerIcon');
 var WorldInfo = document.getElementById('WorldInfo');
 var WIDrawerIcon = document.getElementById('WIDrawerIcon');
 
@@ -782,15 +782,15 @@ export function initRossMods() {
         if ($(LPanelPin).prop('checked') == true) {
             //console.log('adding pin class to Left nav');
             $(LeftNavPanel).addClass('pinnedOpen');
-            $(leftNavDrawerIcon).addClass('drawerPinnedOpen');
+            $(LeftNavDrawerIcon).addClass('drawerPinnedOpen');
         } else {
             //console.log('removing pin class from Left nav');
             $(LeftNavPanel).removeClass('pinnedOpen');
-            $(leftNavDrawerIcon).removeClass('drawerPinnedOpen');
+            $(LeftNavDrawerIcon).removeClass('drawerPinnedOpen');
 
             if ($(LeftNavPanel).hasClass('openDrawer') && $('.openDrawer').length > 1) {
                 $(LeftNavPanel).slideToggle(200, 'swing');
-                $(leftNavDrawerIcon).toggleClass('openIcon closedIcon');
+                $(LeftNavDrawerIcon).toggleClass('openIcon closedIcon');
                 $(LeftNavPanel).toggleClass('openDrawer closedDrawer');
             }
         }
@@ -833,12 +833,12 @@ export function initRossMods() {
     if (LoadLocalBool('LNavLockOn') == true) {
         //console.log('setting pin class via local var');
         $(LeftNavPanel).addClass('pinnedOpen');
-        $(leftNavDrawerIcon).addClass('drawerPinnedOpen');
+        $(LeftNavDrawerIcon).addClass('drawerPinnedOpen');
     }
     if ($(LPanelPin).prop('checked')) {
         console.debug('setting pin class via checkbox state');
         $(LeftNavPanel).addClass('pinnedOpen');
-        $(leftNavDrawerIcon).addClass('drawerPinnedOpen');
+        $(LeftNavDrawerIcon).addClass('drawerPinnedOpen');
     }
 
     // read the state of left Nav Lock and apply to leftnav classlist


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->
tldr: Fixed drawer icon highlighting being out-of-sync when drawers are pinned.

### Bug description
Before the fix, when drawers are pinned, their respective icon highlighting can get out-of-sync. (For example, clicking anywhere when a drawer is pinned and opened results in its icon going dark instead of staying highlighted.)

### Changes
Add `drawerPinnedOpen` class to icons when their respective drawer is pinned. Check for the class when toggling icons. An icon should be highlighted whenever the respective drawer is opened.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
