### PR TITLE
Support new gemini-1.5-flash-8B model, and flash-002's context reduction.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2888,6 +2888,7 @@
                                         <option value="gemini-1.5-pro-latest">Gemini 1.5 Pro [latest]</option>
                                         <option value="gemini-1.5-pro-001">Gemini 1.5 Pro [001]</option>
                                         <option value="gemini-1.5-pro-002">Gemini 1.5 Pro [002]</option>
+                                        <option value="gemini-1.5-flash-8b">Gemini 1.5 Flash 8B</option>
                                         <option value="gemini-1.5-flash-exp-0827">Gemini 1.5 Flash Experiment 2024-08-27</option>
                                         <option value="gemini-1.5-flash-8b-exp-0827">Gemini 1.5 Flash 8B Experiment 2024-08-27</option>
                                         <option value="gemini-1.5-flash-8b-exp-0924">Gemini 1.5 Flash 8B Experiment 2024-09-24</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4662,6 +4662,7 @@ export function isImageInliningSupported() {
         'gemini-1.5-flash-001',
         'gemini-1.5-flash-002',
         'gemini-1.5-flash-exp-0827',
+        'gemini-1.5-flash-8b',
         'gemini-1.5-flash-8b-exp-0827',
         'gemini-1.5-flash-8b-exp-0924',
         'gemini-1.0-pro-vision-latest',

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4009,8 +4009,6 @@ async function onModelChange() {
             $('#openai_max_context').attr('max', max_2mil);
         } else if (value.includes('gemini-1.5-pro')) {
             $('#openai_max_context').attr('max', max_2mil);
-        } else if (value.match('gemini-1.5-flash-002')) {
-            $('#openai_max_context').attr('max', max_2mil);
         } else if (value.includes('gemini-1.5-flash')) {
             $('#openai_max_context').attr('max', max_1mil);
         } else if (value.includes('gemini-1.0-pro-vision') || value === 'gemini-pro-vision') {

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -269,6 +269,7 @@ function convertGooglePrompt(messages, model, useSysPrompt = false, charName = '
         'gemini-1.5-flash-001',
         'gemini-1.5-flash-002',
         'gemini-1.5-flash-exp-0827',
+        'gemini-1.5-flash-8b',
         'gemini-1.5-flash-8b-exp-0827',
         'gemini-1.5-flash-8b-exp-0924',
         'gemini-1.5-pro',


### PR DESCRIPTION
Following the release of Google's new production-ready model Gemini-1.5-Flash-8B, the following models have been added to Google AI Studio tab:

- Gemini-1.5-Flash-8B

This PR also includes support for Gemini 1.5 Flash 002's context length reduction. (1milion from 2mil+97152...)

Tested on local and confirmed to be working.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
