### PR TITLE
Add `/sort` slash command

### DIFF
--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -836,6 +836,32 @@ function randValuesCallback(from, to, args) {
     return value;
 }
 
+function sortArrayObjectCallback(args, value) {
+    let parsedValue;
+    if (typeof value == 'string') {
+        try {
+            parsedValue = JSON.parse(value);
+        } catch { 
+          // return the original input if it was invalid
+          return value;
+        }
+    } else {
+        parsedValue = value
+    }
+    if (Array.isArray(parsedValue)) {
+        // always sort lists by value
+        parsedValue.sort()
+    } else if (typeof parsedValue == 'object') {
+        let keysort = args.keysort;
+        if (isFalseBoolean(keysort)) {
+            parsedValue = Object.keys(parsedValue).sort(function(a,b){return parsedValue[a]-parsedValue[b]});
+        } else {
+            parsedValue = Object.keys(parsedValue).sort();
+        }
+    }
+    return JSON.stringify(parsedValue);    
+}
+
 /**
  * Declare a new variable in the current scope.
  * @param {NamedArguments} args Named arguments.
@@ -2104,6 +2130,51 @@ export function registerVariableCommands() {
                 <ul>
                     <li>
                         <pre><code class="language-stscript">/len Lorem ipsum | /echo</code></pre>
+                    </li>
+                </ul>
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'sort',
+        callback: sortArrayObjectCallback,
+        returns: 'the sorted list or dictionary keys',
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({ name: 'keysort',
+                description: 'whether to sort by key or value; ignored for lists',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: ['true', 'false'],
+                defaultValue: 'true',
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'value',
+                typeList: [ARGUMENT_TYPE.STRING, ARGUMENT_TYPE.NUMBER, ARGUMENT_TYPE.LIST, ARGUMENT_TYPE.DICTIONARY],
+                isRequired: true,
+                forceEnum: false,
+            }),
+        ],
+        helpString: `
+            <div>
+                Sorts a list or dictionary in ascending order and passes the result down the pipe.
+                <ul>
+                    <li>
+                        For lists, returns the list sorted by value.
+                    </li>
+                    <li>
+                        For dictionaries, returns the ordered list of keys after sorting. Setting keysort=false means keys are sorted by associated value.
+                    </li>
+                </ul>
+            </div>
+            <div>
+                <strong>Examples:</strong>
+                <ul>
+                    <li>
+                        <pre><code class="language-stscript">/sort [5,3,4,1,2] | /echo</code></pre>
+                    </li>
+                    <li>
+                        <pre><code class="language-stscript">/sort keysort=false {"a": 1, "d": 3, "c": 2, "b": 5} | /echo</code></pre>
                     </li>
                 </ul>
             </div>

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -849,25 +849,25 @@ function sortArrayObjectCallback(args, value) {
     if (typeof value == 'string') {
         try {
             parsedValue = JSON.parse(value);
-        } catch { 
-          // return the original input if it was invalid
-          return value;
+        } catch {
+            // return the original input if it was invalid
+            return value;
         }
     } else {
-        parsedValue = value
+        parsedValue = value;
     }
     if (Array.isArray(parsedValue)) {
         // always sort lists by value
-        parsedValue.sort(customSortComparitor)
+        parsedValue.sort(customSortComparitor);
     } else if (typeof parsedValue == 'object') {
         let keysort = args.keysort;
         if (isFalseBoolean(keysort)) {
-            parsedValue = Object.keys(parsedValue).sort(function(a,b){return customSortComparitor(parsedValue[a], parsedValue[b])});
+            parsedValue = Object.keys(parsedValue).sort(function (a, b) { return customSortComparitor(parsedValue[a], parsedValue[b]); });
         } else {
             parsedValue = Object.keys(parsedValue).sort(customSortComparitor);
         }
     }
-    return JSON.stringify(parsedValue);    
+    return JSON.stringify(parsedValue);
 }
 
 /**

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -836,6 +836,14 @@ function randValuesCallback(from, to, args) {
     return value;
 }
 
+function customSortComparitor(a, b) {
+    if (typeof a != typeof b) {
+        a = typeof a;
+        b = typeof b;
+    }
+    return a > b ? 1 : a < b ? -1 : 0;
+}
+
 function sortArrayObjectCallback(args, value) {
     let parsedValue;
     if (typeof value == 'string') {
@@ -850,13 +858,13 @@ function sortArrayObjectCallback(args, value) {
     }
     if (Array.isArray(parsedValue)) {
         // always sort lists by value
-        parsedValue.sort()
+        parsedValue.sort(customSortComparitor)
     } else if (typeof parsedValue == 'object') {
         let keysort = args.keysort;
         if (isFalseBoolean(keysort)) {
-            parsedValue = Object.keys(parsedValue).sort(function(a,b){return parsedValue[a]-parsedValue[b]});
+            parsedValue = Object.keys(parsedValue).sort(function(a,b){return customSortComparitor(parsedValue[a], parsedValue[b])});
         } else {
-            parsedValue = Object.keys(parsedValue).sort();
+            parsedValue = Object.keys(parsedValue).sort(customSortComparitor);
         }
     }
     return JSON.stringify(parsedValue);    


### PR DESCRIPTION
This PR adds basic sort functionality to the core STscript library of slash commands.

The new `/sort` command takes a list or dictionary as the argument, and optionally has a named argument `keysort` that allows you to specify whether or not a dictionary argument should be sorted by keys versus values. (By default, it is treated as "true" and sorts by keys.)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
