### PR TITLE
Center the crop popup on change, when polyfilled

### DIFF
--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -182,6 +182,14 @@ export class Popup {
         if (!this.dlg.showModal) {
             this.dlg.classList.add('poly_dialog');
             dialogPolyfill.registerDialog(this.dlg);
+            // Force a vertical reposition after the content
+            // (like crop image) has been set
+            const resizeObserver = new ResizeObserver((entries) => {
+                for (const entry of entries) {
+                    dialogPolyfill.reposition(entry.target);
+                }
+            });
+            resizeObserver.observe(this.dlg);
         }
         this.body = this.dlg.querySelector('.popup-body');
         this.content = this.dlg.querySelector('.popup-content');


### PR DESCRIPTION
A minor addition to correct this in the poly-filled dialogues:

<img src="https://github.com/user-attachments/assets/8f977cc7-7ec5-45f4-97c1-2a74eb3e2b4e" width="300px" />

Where the popups aren't centered properly if their contents change (e.g. when an image is added to it)

Since on mobile we cannot scroll it means that this popup will stay there until refreshed

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
