### PR TITLE
Support the non-deprecated Together.ai Create Image API

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2675,8 +2675,7 @@ async function generateTogetherAIImage(prompt, negativePrompt, signal) {
     });
 
     if (result.ok) {
-        const data = await result.json();
-        return { format: 'jpg', data: data?.output?.choices?.[0]?.image_base64 };
+        return await result.json();
     } else {
         const text = await result.text();
         throw new Error(text);

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -637,7 +637,7 @@ together.post('/generate', jsonParser, async (request, response) => {
         const choice = data?.data?.[0];
         let b64_json = choice.b64_json;
 
-        if(! b64_json) {
+        if (!b64_json) {
             const buffer = await (await fetch(choice.url)).buffer();
             b64_json = buffer.toString('base64');
         }

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -607,10 +607,9 @@ together.post('/generate', jsonParser, async (request, response) => {
 
         console.log('TogetherAI request:', request.body);
 
-        const result = await fetch('https://api.together.xyz/api/inference', {
+        const result = await fetch('https://api.together.xyz/v1/images/generations', {
             method: 'POST',
             body: JSON.stringify({
-                request_type: 'image-model-inference',
                 prompt: request.body.prompt,
                 negative_prompt: request.body.negative_prompt,
                 height: request.body.height,
@@ -620,8 +619,6 @@ together.post('/generate', jsonParser, async (request, response) => {
                 n: 1,
                 // Limited to 10000 on playground, works fine with more.
                 seed: request.body.seed >= 0 ? request.body.seed : Math.floor(Math.random() * 10_000_000),
-                // Don't know if that's supposed to be random or not. It works either way.
-                sessionKey: getHexString(40),
             }),
             headers: {
                 'Content-Type': 'application/json',
@@ -630,19 +627,22 @@ together.post('/generate', jsonParser, async (request, response) => {
         });
 
         if (!result.ok) {
-            console.log('TogetherAI returned an error.');
+            console.log('TogetherAI returned an error.', { body: await result.text() });
             return response.sendStatus(500);
         }
 
         const data = await result.json();
         console.log('TogetherAI response:', data);
 
-        if (data.status !== 'finished') {
-            console.log('TogetherAI job failed.');
-            return response.sendStatus(500);
+        const choice = data?.data?.[0];
+        let b64_json = choice.b64_json;
+
+        if(! b64_json) {
+            const buffer = await (await fetch(choice.url)).buffer();
+            b64_json = buffer.toString('base64');
         }
 
-        return response.send(data);
+        return response.send({ format: 'jpg', data: b64_json });
     } catch (error) {
         console.log(error);
         return response.sendStatus(500);


### PR DESCRIPTION
The together.ai image generation hasn't been working for me for a while.

I saw that the Inference API used by SillyTavern is deprecated[^1], so I thought that might be the problem. This patch switches to the supported image generation API[^2]. However the API isn't documented very well, because it returns a URL instead of a `b64_json` field like it says. This supports both, like the official python API[^3].

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

[^1]: https://docs.together.ai/reference/inference
[^2]: https://docs.together.ai/reference/post_images-generations
[^3]: https://github.com/togethercomputer/together-python