### PR TITLE
Add client side cacheing of vector summaries

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -709,7 +709,7 @@ async function getQueryText(chat, initiator) {
     let queryText = '';
     let i = 0;
 
-    let hashedMessages = chat.map(x => ({ text: String(substituteParams(x.mes)) }));
+    let hashedMessages = chat.map(x => ({ text: String(substituteParams(x.mes)), hash: getStringHash(substituteParams(x.mes)) }));
 
     if (initiator === 'chat' && settings.enabled_chats && settings.summarize && settings.summarize_sent) {
         hashedMessages = await summarize(hashedMessages, settings.summary_source);

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -706,25 +706,17 @@ const onChatEvent = debounce(async () => await moduleWorker.update(), debounce_t
  * @returns {Promise<string>} Text to query
  */
 async function getQueryText(chat, initiator) {
-    let queryText = '';
-    let i = 0;
-
-    let hashedMessages = chat.map(x => ({ text: String(substituteParams(x.mes)), hash: getStringHash(substituteParams(x.mes)) }));
+    let hashedMessages = chat
+        .map(x => ({ text: String(substituteParams(x.mes)), hash: getStringHash(substituteParams(x.mes)) }))
+        .filter(x => x.text)
+        .reverse()
+        .slice(0, settings.query);
 
     if (initiator === 'chat' && settings.enabled_chats && settings.summarize && settings.summarize_sent) {
         hashedMessages = await summarize(hashedMessages, settings.summary_source);
     }
 
-    for (const message of hashedMessages.slice().reverse()) {
-        if (message.text) {
-            queryText += message.text + '\n';
-            i++;
-        }
-
-        if (i === settings.query) {
-            break;
-        }
-    }
+    const queryText = hashedMessages.map(x => x.text).join('\n');
 
     return collapseNewlines(queryText).trim();
 }

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -261,7 +261,7 @@ async function summarizeWebLLM(element) {
         return false;
     }
 
-    const messages = [{ role:'system', content: settings.summary_prompt }, { role:'user', content: element.text }];
+    const messages = [{ role: 'system', content: settings.summary_prompt }, { role: 'user', content: element.text }];
     element.text = await generateWebLlmChatPrompt(messages);
 
     return true;
@@ -275,29 +275,29 @@ async function summarizeWebLLM(element) {
  */
 async function summarize(hashedMessages, endpoint = 'main') {
     for (const element of hashedMessages) {
-        const cachedSummary = cachedSummaries.get(element.hash)
+        const cachedSummary = cachedSummaries.get(element.hash);
         if (!cachedSummary) {
-            let sucess = true;
+            let success = true;
             switch (endpoint) {
                 case 'main':
-                    sucess = await summarizeMain(element);
+                    success = await summarizeMain(element);
                     break;
                 case 'extras':
-                    sucess = await summarizeExtra(element);
+                    success = await summarizeExtra(element);
                     break;
                 case 'webllm':
-                    sucess = await summarizeWebLLM(element);
+                    success = await summarizeWebLLM(element);
                     break;
                 default:
                     console.error('Unsupported endpoint', endpoint);
-                    sucess = false;
+                    success = false;
                     break;
             }
-            if (sucess) {
+            if (success) {
                 cachedSummaries.set(element.hash, element.text);
             } else {
                 break;
-            } 
+            }
         } else {
             element.text = cachedSummary;
         }


### PR DESCRIPTION
This is the PR for issue #2968 

This should address constant re-summarisation for vector storage which is simply wateful

Currently:

- Summaries start (Attempt 1):
   - Let say 5/100 are done
- Summaries started again by another message being sent (Attempt 2)
   - Returns to 0/101 again

Instead we could do

- Summaries start (Attempt 1):
   - Let say 5/100 are done
   - After each one they are added to a client side cache
- Summaries started again by another message being sent (Attempt 2)
   - Would start at  5/101, after seeing the cache

This implementation keeps the cache client side (in js) and is regenerated from scratch when browser is refreshed. 

The button in the extension settings `Vectorize All` was altered to also delete this cache

The old tooltip for this button was as followins

```
Old messages are vectorized gradually as you chat. To process all previous messages, click the button below.
```

Which to me, is already worded like it was meant to gradually summaries which is what this PR actually achieves. So no changes to the button description were made.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
