### PR TITLE
Fix double quotes copying text from chat history

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2007,6 +2007,7 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         mes = mes.replace(
             /```[\s\S]*?```|``[\s\S]*?``|`[\s\S]*?`|(".*?")|(\u201C.*?\u201D)|(\u00AB.*?\u00BB)|(\u300C.*?\u300D)|(\u300E.*?\u300F)|(\uFF02.*?\uFF02)/gm,
             function (match, p1, p2, p3, p4, p5, p6) {
+                //Being elements added after page load, below classes will be prefixed with custom-, see 'uponSanitizeAttribute'
                 if (p1) {
                     // English double quotes
                     return `<span class="mes_text_speech">"${p1.slice(1, -1)}"</span>`;

--- a/public/script.js
+++ b/public/script.js
@@ -2009,22 +2009,22 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
             function (match, p1, p2, p3, p4, p5, p6) {
                 if (p1) {
                     // English double quotes
-                    return `<q>"${p1.slice(1, -1)}"</q>`;
+                    return `<span class="mes_text_speech">"${p1.slice(1, -1)}"</span>`;
                 } else if (p2) {
                     // Curly double quotes “ ”
-                    return `<q>“${p2.slice(1, -1)}”</q>`;
+                    return `<span class="mes_text_speech">“${p2.slice(1, -1)}”</span>`;
                 } else if (p3) {
                     // Guillemets « »
-                    return `<q>«${p3.slice(1, -1)}»</q>`;
+                    return `<span class="mes_text_speech">«${p3.slice(1, -1)}»</span>`;
                 } else if (p4) {
                     // Corner brackets 「 」
-                    return `<q>「${p4.slice(1, -1)}」</q>`;
+                    return `<span class="mes_text_speech">「${p4.slice(1, -1)}」</span>`;
                 } else if (p5) {
                     // White corner brackets 『 』
-                    return `<q>『${p5.slice(1, -1)}』</q>`;
+                    return `<span class="mes_text_speech">『${p5.slice(1, -1)}』</span>`;
                 } else if (p6) {
                     // Fullwidth quotes ＂ ＂
-                    return `<q>＂${p6.slice(1, -1)}＂</q>`;
+                    return `<span class="mes_text_speech">＂${p6.slice(1, -1)}＂</span>`;
                 } else {
                     // Return the original match if no quotes are found
                     return match;

--- a/public/style.css
+++ b/public/style.css
@@ -341,7 +341,7 @@ input[type='checkbox']:focus-visible {
     color: var(--SmartThemeUnderlineColor);
 }
 
-.mes_text .mes_text_speech {
+.mes_text .custom-mes_text_speech {
     color: var(--SmartThemeQuoteColor);
 }
 
@@ -350,7 +350,7 @@ input[type='checkbox']:focus-visible {
     color: inherit;
 }
 
-.mes_text font[color] .mes_text_speech {
+.mes_text font[color] .custom-mes_text_speech {
     color: inherit;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -341,7 +341,7 @@ input[type='checkbox']:focus-visible {
     color: var(--SmartThemeUnderlineColor);
 }
 
-.mes_text q {
+.mes_text .mes_text_speech {
     color: var(--SmartThemeQuoteColor);
 }
 
@@ -350,7 +350,7 @@ input[type='checkbox']:focus-visible {
     color: inherit;
 }
 
-.mes_text font[color] q {
+.mes_text font[color] .mes_text_speech {
     color: inherit;
 }
 
@@ -975,12 +975,6 @@ opacity:0;
 #chat .mes.selected {
     /* background-color: rgb(from var(--SmartThemeQuoteColor) r g b / .5); */
     background-color: rgb(102, 0, 0);
-}
-
-.mes q:before,
-.mes q:after {
-    content: '';
-
 }
 
 .last_mes {


### PR DESCRIPTION
### Bug
Copying text from the chat history containing double quotes leads to duplicate double quotes. I.e. `foo "bar baz" foo` will result in `foo ""bar baz"" foo` upon pasting.

### Cause
Caused by the use of the quotation element and using css to suppress the browser-generated characters.

### Proposal

The quotation element should be used for quotes with a citation source, not for direct speech. Replace the q element with a span element.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
