### PR TITLE
Enable XTC support for llama.cpp

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1376,7 +1376,7 @@
                                         </div>
                                     </div>
 
-                                    <div data-tg-type="koboldcpp, aphrodite, tabby, ooba" id="xtc_block" class="wide100p">
+                                    <div data-tg-type="koboldcpp, aphrodite, tabby, ooba, llamacpp" id="xtc_block" class="wide100p">
                                         <h4 class="wide100p textAlignCenter">
                                             <label data-i18n="Exclude Top Choices (XTC)">Exclude Top Choices (XTC)</label>
                                             <a href="https://github.com/oobabooga/text-generation-webui/pull/6335" target="_blank">
@@ -1730,6 +1730,7 @@
                                             <div data-name="typical_p" draggable="true"><span>Typical P</span><small></small></div>
                                             <div data-name="tfs_z" draggable="true"><span>Tail Free Sampling</span><small></small></div>
                                             <div data-name="min_p" draggable="true"><span>Min P</span><small></small></div>
+                                            <div data-name="xtc" draggable="true"><span>Exclude Top Choices</span><small></small></div>
                                         </div>
                                         <div id="llamacpp_samplers_default_order" class="menu_button menu_button_icon">
                                             <span data-i18n="Load default order">Load default order</span>

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -848,6 +848,7 @@ function setSettingByName(setting, value, trigger) {
 
     if ('samplers' === setting) {
         value = Array.isArray(value) ? value : LLAMACPP_DEFAULT_ORDER;
+        insertMissingArrayItems(LLAMACPP_DEFAULT_ORDER, value);
         sortLlamacppItemsByOrder(value);
         settings.samplers = value;
         return;

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -65,6 +65,7 @@ const LLAMACPP_DEFAULT_ORDER = [
     'typical_p',
     'top_p',
     'min_p',
+    'xtc',
     'temperature',
 ];
 const OOBA_DEFAULT_ORDER = [


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->
This PR enables support for XTC with llama.cpp server as https://github.com/ggerganov/llama.cpp/pull/9742 that introduces XTC support got merged.
- Enabled the XTC options
- Added XTC to the samplers order

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
