### PR TITLE
Fix double double quotes when copying chat message text in Firefox

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -247,6 +247,7 @@ import { AbortReason } from './scripts/util/AbortReason.js';
 import { initSystemPrompts } from './scripts/sysprompt.js';
 import { registerExtensionSlashCommands as initExtensionSlashCommands } from './scripts/extensions-slashcommands.js';
 import { ToolManager } from './scripts/tool-calling.js';
+import { applyBrowserFixes } from './scripts/browser-fixes.js';
 
 //exporting functions and vars for mods
 export {
@@ -272,6 +273,7 @@ await new Promise((resolve) => {
 });
 
 showLoader();
+applyBrowserFixes();
 
 // Configure toast library:
 toastr.options.escapeHtml = true; // Prevent raw HTML inserts

--- a/public/script.js
+++ b/public/script.js
@@ -1,4 +1,4 @@
-import { humanizedDateTime, favsToHotswap, getMessageTimeStamp, dragElement, isMobile, initRossMods, shouldSendOnEnter, addSafariPatch } from './scripts/RossAscends-mods.js';
+import { humanizedDateTime, favsToHotswap, getMessageTimeStamp, dragElement, isMobile, initRossMods, shouldSendOnEnter } from './scripts/RossAscends-mods.js';
 import { userStatsHandler, statMesProcess, initStats } from './scripts/stats.js';
 import {
     generateKoboldWithStreaming,
@@ -273,7 +273,6 @@ await new Promise((resolve) => {
 });
 
 showLoader();
-applyBrowserFixes();
 
 // Configure toast library:
 toastr.options.escapeHtml = true; // Prevent raw HTML inserts
@@ -940,7 +939,7 @@ async function firstLoadInit() {
         throw new Error('Initialization failed');
     }
 
-    addSafariPatch();
+    applyBrowserFixes();
     await getClientVersion();
     await readSecretState();
     await initLocales();

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -121,7 +121,7 @@ export function humanizeGenTime(total_gen_time) {
  */
 var parsedUA = null;
 
-function getParsedUA() {
+export function getParsedUA() {
     if (!parsedUA) {
         try {
             parsedUA = Bowser.parse(navigator.userAgent);
@@ -717,18 +717,6 @@ export const autoFitSendTextAreaDebounced = debounce(autoFitSendTextArea, deboun
 
 // ---------------------------------------------------
 
-export function addSafariPatch() {
-    const userAgent = getParsedUA();
-    console.debug('User Agent', userAgent);
-    const isMobileSafari = /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-    const isDesktopSafari = userAgent?.browser?.name === 'Safari' && userAgent?.platform?.type === 'desktop';
-    const isIOS = userAgent?.os?.name === 'iOS';
-
-    if (isIOS || isMobileSafari || isDesktopSafari) {
-        document.body.classList.add('safari');
-    }
-}
-
 export function initRossMods() {
     // initial status check
     checkStatusDebounced();
@@ -739,16 +727,6 @@ export function initRossMods() {
 
     if (power_user.auto_connect) {
         RA_autoconnect();
-    }
-
-    if (isMobile()) {
-        const fixFunkyPositioning = () => {
-            console.debug('[Mobile] Device viewport change detected.');
-            document.documentElement.style.position = 'fixed';
-            requestAnimationFrame(() => document.documentElement.style.position = '');
-        };
-        window.addEventListener('resize', fixFunkyPositioning);
-        window.addEventListener('orientationchange', fixFunkyPositioning);
     }
 
     $('#main_api').change(function () {

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -1,3 +1,5 @@
+import { getParsedUA, isMobile } from './RossAscends-mods.js';
+
 const isFirefox = () => /firefox/i.test(navigator.userAgent);
 
 function sanitizeInlineQuotationOnCopy() {
@@ -43,10 +45,34 @@ function sanitizeInlineQuotationOnCopy() {
     });
 }
 
+function addSafariPatch() {
+    const userAgent = getParsedUA();
+    console.debug('User Agent', userAgent);
+    const isMobileSafari = /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    const isDesktopSafari = userAgent?.browser?.name === 'Safari' && userAgent?.platform?.type === 'desktop';
+    const isIOS = userAgent?.os?.name === 'iOS';
+
+    if (isIOS || isMobileSafari || isDesktopSafari) {
+        document.body.classList.add('safari');
+    }
+}
+
 function applyBrowserFixes() {
     if (isFirefox()) {
         sanitizeInlineQuotationOnCopy();
     }
+
+    if (isMobile()) {
+        const fixFunkyPositioning = () => {
+            console.debug('[Mobile] Device viewport change detected.');
+            document.documentElement.style.position = 'fixed';
+            requestAnimationFrame(() => document.documentElement.style.position = '');
+        };
+        window.addEventListener('resize', fixFunkyPositioning);
+        window.addEventListener('orientationchange', fixFunkyPositioning);
+    }
+
+    addSafariPatch();
 }
 
 export { isFirefox, applyBrowserFixes };

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -1,0 +1,52 @@
+const isFirefox = () => /firefox/i.test(navigator.userAgent);
+
+function sanitizeInlineQuotationOnCopy() {
+    // STRG+C, STRG+V on firefox leads to duplicate double quotes when inline quotation elements are copied.
+    // To work around this, take the selection and transform <q> to <span> before calling toString().
+    document.addEventListener('copy', function (event) {
+        const selection = window.getSelection();
+        if (selection.anchorNode.nodeName !== '#text' || selection.focusNode.nodeName !== '#text' || !selection.anchorNode?.parentElement.closest('.mes_text')) {
+            // Complex selection, skip.
+            return;
+        }
+
+        const range = selection.getRangeAt(0).cloneContents();
+        const tempDOM = document.createDocumentFragment();
+
+        function processNode(node) {
+            if (node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === 'q') {
+                // Transform <q> to <span>, preserve children
+                const span = document.createElement('span');
+
+                [...node.childNodes].forEach(child => {
+                    const processedChild = processNode(child);
+                    span.appendChild(processedChild);
+                });
+
+                return span;
+            } else {
+                // Nested structures containing <q> elements are unlikely
+                return node.cloneNode(true);
+            }
+        }
+
+        [...range.childNodes].forEach(child => {
+            const processedChild = processNode(child);
+            tempDOM.appendChild(processedChild);
+        });
+
+        const newRange = document.createRange();
+        newRange.selectNodeContents(tempDOM);
+
+        event.preventDefault();
+        event.clipboardData.setData('text/plain', newRange.toString());
+    });
+}
+
+function applyBrowserFixes() {
+    if (isFirefox()) {
+        sanitizeInlineQuotationOnCopy();
+    }
+}
+
+export { isFirefox, applyBrowserFixes };

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -7,8 +7,7 @@ function sanitizeInlineQuotationOnCopy() {
     // To work around this, take the selection and transform <q> to <span> before calling toString().
     document.addEventListener('copy', function (event) {
         const selection = window.getSelection();
-        if (selection.anchorNode.nodeName !== '#text' || selection.focusNode.nodeName !== '#text' || !selection.anchorNode?.parentElement.closest('.mes_text')) {
-            // Complex selection, skip.
+        if (!selection.anchorNode?.parentElement.closest('.mes_text')) {
             return;
         }
 


### PR DESCRIPTION
## Why
Fixes double double quotes when copying text in Firefox.

## How
When the browser is a Firefox, we hijack the copy event. Upon copying inside the chat history, we walk trough the selection and  transform all occurrences of q to span. Original DOM is preserved. Higher success rate when compared to regex shenanigans, should be 100%. 

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
