### PR TITLE
Disable swipe gestures while in edit mode

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -933,7 +933,7 @@ export function initRossMods() {
         if (!$(e.target).closest('#sheld').length) {
             return;
         }
-        if ($('#curEditTextarea')) {
+        if ($('#curEditTextarea').length) {
             // Don't swipe while in text edit mode
             // the ios selection gestures get picked up
             // as swipe gestures
@@ -957,7 +957,7 @@ export function initRossMods() {
         if (!$(e.target).closest('#sheld').length) {
             return;
         }
-        if ($('#curEditTextarea')) {
+        if ($('#curEditTextarea').length) {
             // Don't swipe while in text edit mode
             // the ios selection gestures get picked up
             // as swipe gestures

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -933,6 +933,12 @@ export function initRossMods() {
         if (!$(e.target).closest('#sheld').length) {
             return;
         }
+        if ($('#curEditTextarea')) {
+            // Don't swipe while in text edit mode
+            // the ios selection gestures get picked up
+            // as swipe gestures
+            return;
+        }
         var SwipeButR = $('.swipe_right:last');
         var SwipeTargetMesClassParent = $(e.target).closest('.last_mes');
         if (SwipeTargetMesClassParent !== null) {
@@ -949,6 +955,12 @@ export function initRossMods() {
             return;
         }
         if (!$(e.target).closest('#sheld').length) {
+            return;
+        }
+        if ($('#curEditTextarea')) {
+            // Don't swipe while in text edit mode
+            // the ios selection gestures get picked up
+            // as swipe gestures
             return;
         }
         var SwipeButL = $('.swipe_left:last');


### PR DESCRIPTION
This aims to stop swipe gestures while in edit mode. Certain actions that are done during edit mode trigger a swipe (like making a selection see gif)

![RPReplay_Final1729129618](https://github.com/user-attachments/assets/12f65186-4e69-48e7-9c09-3cf28c9090ef)


## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
