### PR TITLE
ADetailer functionality for stable-diffusion extension

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -219,6 +219,7 @@ const defaultSettings = {
     // Automatic1111/Horde exclusives
     restore_faces: false,
     enable_hr: false,
+	aiFaceDetailer: false,
 
     // Horde settings
     horde: false,
@@ -435,6 +436,7 @@ async function loadSettings() {
     $('#sd_horde_sanitize').prop('checked', extension_settings.sd.horde_sanitize);
     $('#sd_restore_faces').prop('checked', extension_settings.sd.restore_faces);
     $('#sd_enable_hr').prop('checked', extension_settings.sd.enable_hr);
+	$('#sd_aiFaceDetailer').prop('checked', extension_settings.sd.aiFaceDetailer);
     $('#sd_refine_mode').prop('checked', extension_settings.sd.refine_mode);
     $('#sd_multimodal_captioning').prop('checked', extension_settings.sd.multimodal_captioning);
     $('#sd_auto_url').val(extension_settings.sd.auto_url);
@@ -850,6 +852,11 @@ async function onNegativePromptInput() {
 
 function onSamplerChange() {
     extension_settings.sd.sampler = $('#sd_sampler').find(':selected').val();
+    saveSettingsDebounced();
+}
+
+function onAiFaceDetailerChange() {
+	extension_settings.sd.aiFaceDetailer = $('#sd_aiFaceDetailer').prop('checked');
     saveSettingsDebounced();
 }
 
@@ -2920,42 +2927,59 @@ async function generateHordeImage(prompt, negativePrompt, signal) {
  */
 async function generateAutoImage(prompt, negativePrompt, signal) {
     const isValidVae = extension_settings.sd.vae && !['N/A', placeholderVae].includes(extension_settings.sd.vae);
+    let payload = {
+        ...getSdRequestBody(),
+        prompt: prompt,
+        negative_prompt: negativePrompt,
+        sampler_name: extension_settings.sd.sampler,
+        scheduler: extension_settings.sd.scheduler,
+        steps: extension_settings.sd.steps,
+        cfg_scale: extension_settings.sd.scale,
+        width: extension_settings.sd.width,
+        height: extension_settings.sd.height,
+        restore_faces: !!extension_settings.sd.restore_faces,
+        enable_hr: !!extension_settings.sd.enable_hr,
+        hr_upscaler: extension_settings.sd.hr_upscaler,
+        hr_scale: extension_settings.sd.hr_scale,
+        denoising_strength: extension_settings.sd.denoising_strength,
+        hr_second_pass_steps: extension_settings.sd.hr_second_pass_steps,
+        seed: extension_settings.sd.seed >= 0 ? extension_settings.sd.seed : undefined,
+        override_settings: {
+            CLIP_stop_at_last_layers: extension_settings.sd.clip_skip,
+            sd_vae: isValidVae ? extension_settings.sd.vae : undefined,
+        },
+        override_settings_restore_afterwards: true,
+        clip_skip: extension_settings.sd.clip_skip, // For SD.Next
+        save_images: true,
+        send_images: true,
+        do_not_save_grid: false,
+        do_not_save_samples: false,
+    };
+    // Conditionally add the ADetailer if aiFaceDetailer is enabled
+	console.log('extension_settings.sd.aiFaceDetailer:', extension_settings.sd.aiFaceDetailer);
+    if (extension_settings.sd.aiFaceDetailer) {
+        payload.alwayson_scripts = {
+            ADetailer: {
+                args: [
+                    true, // ad_enable
+                    true, // skip_img2img
+                    {
+                        "ad_model": "face_yolov8n.pt"
+                    }
+                ]
+            }
+        };
+    }
+
+    // Make the fetch call with the payload
     const result = await fetch('/api/sd/generate', {
         method: 'POST',
         headers: getRequestHeaders(),
         signal: signal,
-        body: JSON.stringify({
-            ...getSdRequestBody(),
-            prompt: prompt,
-            negative_prompt: negativePrompt,
-            sampler_name: extension_settings.sd.sampler,
-            scheduler: extension_settings.sd.scheduler,
-            steps: extension_settings.sd.steps,
-            cfg_scale: extension_settings.sd.scale,
-            width: extension_settings.sd.width,
-            height: extension_settings.sd.height,
-            restore_faces: !!extension_settings.sd.restore_faces,
-            enable_hr: !!extension_settings.sd.enable_hr,
-            hr_upscaler: extension_settings.sd.hr_upscaler,
-            hr_scale: extension_settings.sd.hr_scale,
-            denoising_strength: extension_settings.sd.denoising_strength,
-            hr_second_pass_steps: extension_settings.sd.hr_second_pass_steps,
-            seed: extension_settings.sd.seed >= 0 ? extension_settings.sd.seed : undefined,
-            // For AUTO1111
-            override_settings: {
-                CLIP_stop_at_last_layers: extension_settings.sd.clip_skip,
-                sd_vae: isValidVae ? extension_settings.sd.vae : undefined,
-            },
-            override_settings_restore_afterwards: true,
-            // For SD.Next
-            clip_skip: extension_settings.sd.clip_skip,
-            // Ensure generated img is saved to disk
-            save_images: true,
-            send_images: true,
-            do_not_save_grid: false,
-            do_not_save_samples: false,
-        }),
+        body: JSON.stringify(payload),
     });
+	
+	
 
     if (result.ok) {
         const data = await result.json();
@@ -4186,6 +4210,7 @@ jQuery(async () => {
     $('#sd_horde_sanitize').on('input', onHordeSanitizeInput);
     $('#sd_restore_faces').on('input', onRestoreFacesInput);
     $('#sd_enable_hr').on('input', onHighResFixInput);
+	$('#sd_aiFaceDetailer').on('change', onAiFaceDetailerChange);
     $('#sd_refine_mode').on('input', onRefineModeInput);
     $('#sd_character_prompt').on('input', onCharacterPromptInput);
     $('#sd_character_negative_prompt').on('input', onCharacterNegativePromptInput);

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -354,11 +354,16 @@
                     <small data-i18n="Karras">Karras</small>
                     <i class="fa-solid fa-info-circle fa-sm opacity50p" data-i18n="[title]Not all samplers supported." title="Not all samplers supported."></i>
                 </label>
-				<label for="sd_aiFaceDetailer" class="checkbox_label" data-i18n="[title]sd_aiFaceDetailer" title="Use AI Face Detailer in image generation.">
-					<input id="sd_aiFaceDetailer" type="checkbox" />
-					<small data-i18n="sd_aiFaceDetailer">Use AI Face Detailer</small>
-				</label>
+            </div>
 
+            <div class="flex-container marginTopBot5" data-sd-source="auto">
+                <label for="sd_adetailer_face" class="flex1 checkbox_label" data-i18n="[title]sd_adetailer_face" title="Use ADetailer with face model during the generation. The ADetailer extension must be installed on the backend.">
+                    <input id="sd_adetailer_face" type="checkbox" />
+                    <small data-i18n="Use ADetailer (Face)">Use ADetailer (Face)</small>
+                </label>
+                <div class="flex1">
+                    <!-- I will be useful later! -->
+                </div>
             </div>
 
             <div class="flex-container marginTopBot5" data-sd-source="novel">

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -356,7 +356,7 @@
                 </label>
             </div>
 
-            <div class="flex-container marginTopBot5" data-sd-source="auto">
+            <div class="flex-container marginTopBot5" data-sd-source="auto,vlad">
                 <label for="sd_adetailer_face" class="flex1 checkbox_label" data-i18n="[title]sd_adetailer_face" title="Use ADetailer with face model during the generation. The ADetailer extension must be installed on the backend.">
                     <input id="sd_adetailer_face" type="checkbox" />
                     <small data-i18n="Use ADetailer (Face)">Use ADetailer (Face)</small>

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -354,6 +354,11 @@
                     <small data-i18n="Karras">Karras</small>
                     <i class="fa-solid fa-info-circle fa-sm opacity50p" data-i18n="[title]Not all samplers supported." title="Not all samplers supported."></i>
                 </label>
+				<label for="sd_aiFaceDetailer" class="checkbox_label" data-i18n="[title]sd_aiFaceDetailer" title="Use AI Face Detailer in image generation.">
+					<input id="sd_aiFaceDetailer" type="checkbox" />
+					<small data-i18n="sd_aiFaceDetailer">Use AI Face Detailer</small>
+				</label>
+
             </div>
 
             <div class="flex-container marginTopBot5" data-sd-source="novel">

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -23,6 +23,38 @@ export const navigation_option = {
     previous: -1000,
 };
 
+/**
+ * Determines if a value is an object.
+ * @param {any} item The item to check.
+ * @returns {boolean} True if the item is an object, false otherwise.
+ */
+function isObject(item) {
+    return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+/**
+ * Merges properties of two objects. If the property is an object, it will be merged recursively.
+ * @param {object} target The target object
+ * @param {object} source The source object
+ * @returns {object} Merged object
+ */
+export function deepMerge(target, source) {
+    let output = Object.assign({}, target);
+    if (isObject(target) && isObject(source)) {
+        Object.keys(source).forEach(key => {
+            if (isObject(source[key])) {
+                if (!(key in target))
+                    Object.assign(output, { [key]: source[key] });
+                else
+                    output[key] = deepMerge(target[key], source[key]);
+            } else {
+                Object.assign(output, { [key]: source[key] });
+            }
+        });
+    }
+    return output;
+}
+
 export function escapeHtml(str) {
     return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }


### PR DESCRIPTION
added settings and checkbox for adetailer in Stable-Diffusion extension for Auto1111. rewrote generateAutoImage function to allow settings like alwayson_scripts  (or override_settings which I did not change) to be conditionally added to the Auto/Forge API request instead of sending empty fields that may not be supported on all users' setups

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
