### PR TITLE
Correctly view token probabilities when 'Continue'-ing a response.

### DIFF
--- a/public/css/logprobs.css
+++ b/public/css/logprobs.css
@@ -56,6 +56,7 @@
     user-select: none;
     height: 100%;
     overflow-y: auto;
+    word-break: break-all;
 }
 
 .logprobs_empty_state {

--- a/public/script.js
+++ b/public/script.js
@@ -3194,7 +3194,8 @@ class StreamingProcessor {
     }
 
     onStopStreaming() {
-        this.onErrorStreaming();
+        this.abortController.abort();
+        this.isFinished = true;
     }
 
     /**
@@ -3239,9 +3240,13 @@ class StreamingProcessor {
             console.warn(`Stream stats: ${timestamps.length} tokens, ${seconds.toFixed(2)} seconds, rate: ${Number(timestamps.length / seconds).toFixed(2)} TPS`);
         }
         catch (err) {
-            console.error(err);
-            this.onErrorStreaming();
-            return;
+            // in the case of a self-inflicted abort, we have already cleaned up
+            if (!this.isFinished)
+            {
+                console.error(err);
+                this.onErrorStreaming();
+            }
+            return this.result;
         }
 
         this.isFinished = true;
@@ -4641,7 +4646,6 @@ export function stopGeneration() {
     let stopped = false;
     if (streamingProcessor) {
         streamingProcessor.onStopStreaming();
-        streamingProcessor = null;
         stopped = true;
     }
     if (abortController) {

--- a/public/script.js
+++ b/public/script.js
@@ -3241,8 +3241,7 @@ class StreamingProcessor {
         }
         catch (err) {
             // in the case of a self-inflicted abort, we have already cleaned up
-            if (!this.isFinished)
-            {
+            if (!this.isFinished) {
                 console.error(err);
                 this.onErrorStreaming();
             }


### PR DESCRIPTION
Tweaks handling of stream abort when triggered by a user cancelling it, so that the token probabilities collected during the stream aren't lost to the abyss.

I've tested what I can, but have no confidence it's comprehensive. The code isn't spaghetti, it's an entire Italian kitchen.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
