### PR TITLE
Enhancement: Make buttons scrollable

### DIFF
--- a/public/css/scrollable-button.css
+++ b/public/css/scrollable-button.css
@@ -1,0 +1,19 @@
+.scrollable-buttons-container {
+    max-height: 50vh;  /* Use viewport height instead of fixed pixels */
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch; /* Momentum scrolling on iOS */
+    margin-top: 1rem; /* m-t-1 is equivalent to margin-top: 1rem; */
+    flex-shrink: 1;
+    min-height: 0;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+}
+
+.scrollable-buttons-container::-webkit-scrollbar {
+    width: 6px;
+}
+
+.scrollable-buttons-container::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.3);
+    border-radius: 3px;
+}

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2074,7 +2074,32 @@ async function buttonsCallback(args, text) {
             let popup;
 
             const buttonContainer = document.createElement('div');
-            buttonContainer.classList.add('flex-container', 'flexFlowColumn', 'wide100p', 'm-t-1');
+            buttonContainer.classList.add('flex-container', 'flexFlowColumn', 'wide100p');
+
+            const scrollableContainer = document.createElement('div');
+            scrollableContainer.style.maxHeight = '50vh'; // Use viewport height instead of fixed pixels
+            scrollableContainer.style.overflowY = 'auto';
+            scrollableContainer.style.WebkitOverflowScrolling = 'touch'; // Enable momentum scrolling on iOS
+            scrollableContainer.classList.add('m-t-1', 'scrollable-buttons');
+
+            // Add custom CSS for better mobile scrolling
+            const style = document.createElement('style');
+            style.textContent = `
+                .scrollable-buttons {
+                    -webkit-overflow-scrolling: touch;
+                    overflow-y: auto;
+                    flex-shrink: 1;
+                    min-height: 0;
+                }
+                .scrollable-buttons::-webkit-scrollbar {
+                    width: 6px;
+                }
+                .scrollable-buttons::-webkit-scrollbar-thumb {
+                    background-color: rgba(0, 0, 0, 0.2);
+                    border-radius: 3px;
+                }
+            `;
+            document.head.appendChild(style);
 
             for (const [result, button] of resultToButtonMap) {
                 const buttonElement = document.createElement('div');
@@ -2087,9 +2112,16 @@ async function buttonsCallback(args, text) {
                 buttonContainer.appendChild(buttonElement);
             }
 
+            scrollableContainer.appendChild(buttonContainer);
+
             const popupContainer = document.createElement('div');
             popupContainer.innerHTML = safeValue;
-            popupContainer.appendChild(buttonContainer);
+            popupContainer.appendChild(scrollableContainer);
+
+            // Ensure the popup uses flex layout
+            popupContainer.style.display = 'flex';
+            popupContainer.style.flexDirection = 'column';
+            popupContainer.style.maxHeight = '80vh'; // Limit the overall height of the popup
 
             popup = new Popup(popupContainer, POPUP_TYPE.TEXT, '', { okButton: 'Cancel' });
             popup.show()
@@ -4272,3 +4304,4 @@ sendTextarea.addEventListener('input', () => {
         sendTextarea.style.fontFamily = null;
     }
 });
+

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2084,31 +2084,7 @@ async function buttonsCallback(args, text) {
             buttonContainer.classList.add('flex-container', 'flexFlowColumn', 'wide100p');
 
             const scrollableContainer = document.createElement('div');
-            scrollableContainer.style.maxHeight = '50vh'; // Use viewport height instead of fixed pixels
-            scrollableContainer.style.overflowY = 'auto';
-            scrollableContainer.style.WebkitOverflowScrolling = 'touch'; // Enable momentum scrolling on iOS
-            scrollableContainer.classList.add('m-t-1', 'scrollable-buttons');
-
-            // Add custom CSS for better mobile scrolling
-            const style = document.createElement('style');
-            style.textContent = `
-                .scrollable-buttons {
-                    -webkit-overflow-scrolling: touch;
-                    overflow-y: auto;
-                    flex-shrink: 1;
-                    min-height: 0;
-                    scrollbar-width: thin;
-                    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
-                }
-                .scrollable-buttons::-webkit-scrollbar {
-                    width: 6px;
-                }
-                .scrollable-buttons::-webkit-scrollbar-thumb {
-                    background-color: rgba(255, 255, 255, 0.3);
-                    border-radius: 3px;
-                }
-            `;
-            document.head.appendChild(style);
+            scrollableContainer.classList.add('scrollable-buttons-container');
 
             for (const [result, button] of resultToButtonMap) {
                 const buttonElement = document.createElement('div');

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2090,12 +2090,14 @@ async function buttonsCallback(args, text) {
                     overflow-y: auto;
                     flex-shrink: 1;
                     min-height: 0;
+                    scrollbar-width: thin;
+                    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
                 }
                 .scrollable-buttons::-webkit-scrollbar {
                     width: 6px;
                 }
                 .scrollable-buttons::-webkit-scrollbar-thumb {
-                    background-color: rgba(0, 0, 0, 0.2);
+                    background-color: rgba(255, 255, 255, 0.3);
                     border-radius: 3px;
                 }
             `;
@@ -4304,4 +4306,3 @@ sendTextarea.addEventListener('input', () => {
         sendTextarea.style.fontFamily = null;
     }
 });
-

--- a/public/style.css
+++ b/public/style.css
@@ -9,6 +9,7 @@
 @import url(css/logprobs.css);
 @import url(css/accounts.css);
 @import url(css/tags.css);
+@import url(css/scrollable-button.css);
 
 :root {
     --doc-height: 100%;


### PR DESCRIPTION
Adding a simple scrollbar to buttons created via `/buttons` command.  Tested with a simple QR CoT script. I also clicked around with LenAnderson's Codex and did not see any particular regressions. 

No errors reported in console log, tested a few variations of sizes with Chrome's device toolbar and everything looked fine. 

# Before:

PC:

https://github.com/user-attachments/assets/b1ae6403-942f-4ffe-bbb0-6ec66460317b

Mobile (bonus):

https://github.com/user-attachments/assets/0dea11c6-6ac6-4f64-b2bb-1cba5c649efc




# After:

PC:


https://github.com/user-attachments/assets/d8899a87-5081-4cf1-bb03-daecef917fd0



Mobile (bonus):

https://github.com/user-attachments/assets/6db5bd98-73d0-4d31-b1f1-83d32ff7a014



## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
