### PR TITLE
Fix: Inconsistent Textarea resizing in small width windows

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -699,20 +699,26 @@ const chatBlock = document.getElementById('chat');
 const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
 /**
- * this makes the chat input text area resize vertically to match the text size (limited by CSS at 50% window height)
+ * Auto-resizes the send message textarea to fit its content, up to a maximum height defined by CSS.
+ * This function preserves chat scroll position, resets the textarea height for accurate measurement,
+ * calculates the required height, sets the new height, and then restores the chat scroll position.
+ * Firefox-specific scrolling adjustments are included for smoother behavior.
  */
 function autoFitSendTextArea() {
-    const originalScrollBottom = chatBlock.scrollHeight - (chatBlock.scrollTop + chatBlock.offsetHeight);
-    if (Math.ceil(sendTextArea.scrollHeight + 3) >= Math.floor(sendTextArea.offsetHeight)) {
-        const sendTextAreaMinHeight = '0px';
-        sendTextArea.style.height = sendTextAreaMinHeight;
-    }
-    const newHeight = sendTextArea.scrollHeight + 3;
+    const originalScrollTop = chatBlock.scrollTop;
+    const originalScrollHeight = chatBlock.scrollHeight;
+
+    sendTextArea.style.height = '1px';
+
+    const newHeight = sendTextArea.scrollHeight; 
+
     sendTextArea.style.height = `${newHeight}px`;
 
+    // Restore chat scroll position (Firefox-specific adjustment for smoothness).
     if (!isFirefox) {
-        const newScrollTop = Math.round(chatBlock.scrollHeight - (chatBlock.offsetHeight + originalScrollBottom));
-        chatBlock.scrollTop = newScrollTop;
+        chatBlock.scrollTop = originalScrollTop + (chatBlock.scrollHeight - originalScrollHeight);
+    } else {
+       chatBlock.scrollTo({ top: chatBlock.scrollHeight, behavior: 'auto' }); 
     }
 }
 export const autoFitSendTextAreaDebounced = debounce(autoFitSendTextArea, debounce_timeout.short);

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -699,26 +699,18 @@ const chatBlock = document.getElementById('chat');
 const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
 /**
- * Auto-resizes the send message textarea to fit its content, up to a maximum height defined by CSS.
- * This function preserves chat scroll position, resets the textarea height for accurate measurement,
- * calculates the required height, sets the new height, and then restores the chat scroll position.
- * Firefox-specific scrolling adjustments are included for smoother behavior.
+ * Resizes the chat input textarea vertically to match its text content, up to a maximum height defined in CSS.
+ * Preserves scroll position in Chrome. In Firefox, the textarea grows to cover the chat history.
  */
 function autoFitSendTextArea() {
-    const originalScrollTop = chatBlock.scrollTop;
-    const originalScrollHeight = chatBlock.scrollHeight;
+    const originalScrollBottom = chatBlock.scrollHeight - (chatBlock.scrollTop + chatBlock.offsetHeight);
 
-    sendTextArea.style.height = '1px';
-
-    const newHeight = sendTextArea.scrollHeight; 
-
+    sendTextArea.style.height = '1px'; // Reset height to 1px to force recalculation of scrollHeight
+    const newHeight = sendTextArea.scrollHeight;
     sendTextArea.style.height = `${newHeight}px`;
 
-    // Restore chat scroll position (Firefox-specific adjustment for smoothness).
     if (!isFirefox) {
-        chatBlock.scrollTop = originalScrollTop + (chatBlock.scrollHeight - originalScrollHeight);
-    } else {
-       chatBlock.scrollTo({ top: chatBlock.scrollHeight, behavior: 'auto' }); 
+        chatBlock.scrollTop = chatBlock.scrollHeight - (chatBlock.offsetHeight + originalScrollBottom);
     }
 }
 export const autoFitSendTextAreaDebounced = debounce(autoFitSendTextArea, debounce_timeout.short);

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -697,20 +697,26 @@ const chatBlock = document.getElementById('chat');
 const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
 /**
- * this makes the chat input text area resize vertically to match the text size (limited by CSS at 50% window height)
+ * Auto-resizes the send message textarea to fit its content, up to a maximum height defined by CSS.
+ * This function preserves chat scroll position, resets the textarea height for accurate measurement,
+ * calculates the required height, sets the new height, and then restores the chat scroll position.
+ * Firefox-specific scrolling adjustments are included for smoother behavior.
  */
 function autoFitSendTextArea() {
-    const originalScrollBottom = chatBlock.scrollHeight - (chatBlock.scrollTop + chatBlock.offsetHeight);
-    if (Math.ceil(sendTextArea.scrollHeight + 3) >= Math.floor(sendTextArea.offsetHeight)) {
-        const sendTextAreaMinHeight = '0px';
-        sendTextArea.style.height = sendTextAreaMinHeight;
-    }
-    const newHeight = sendTextArea.scrollHeight + 3;
+    const originalScrollTop = chatBlock.scrollTop;
+    const originalScrollHeight = chatBlock.scrollHeight;
+
+    sendTextArea.style.height = '1px';
+
+    const newHeight = sendTextArea.scrollHeight; 
+
     sendTextArea.style.height = `${newHeight}px`;
 
+    // Restore chat scroll position (Firefox-specific adjustment for smoothness).
     if (!isFirefox) {
-        const newScrollTop = Math.round(chatBlock.scrollHeight - (chatBlock.offsetHeight + originalScrollBottom));
-        chatBlock.scrollTop = newScrollTop;
+        chatBlock.scrollTop = originalScrollTop + (chatBlock.scrollHeight - originalScrollHeight);
+    } else {
+       chatBlock.scrollTo({ top: chatBlock.scrollHeight, behavior: 'auto' }); 
     }
 }
 export const autoFitSendTextAreaDebounced = debounce(autoFitSendTextArea, debounce_timeout.short);

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -699,8 +699,7 @@ const chatBlock = document.getElementById('chat');
 const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
 /**
- * Resizes the chat input textarea vertically to match its text content, up to a maximum height defined in CSS.
- * Preserves scroll position in Chrome. In Firefox, the textarea grows to cover the chat history.
+ * this makes the chat input text area resize vertically to match the text size (limited by CSS at 50% window height)
  */
 function autoFitSendTextArea() {
     const originalScrollBottom = chatBlock.scrollHeight - (chatBlock.scrollTop + chatBlock.offsetHeight);


### PR DESCRIPTION
Addresses a bug causing inconsistent resizing of the send message textarea when the window width is small, and preventing it from returning to its minimum height after sending a message.

# Problem:

The original textarea resizing logic relied on `scrollHeight` to determine the necessary height.  However, this approach failed to account for how changes in window width affected the text wrapping and subsequent `scrollHeight` calculation. After sending a message and clearing the textarea's content, the `scrollHeight` often retained a value larger than the actual minimum height, preventing the textarea from shrinking as expected. This was particularly noticeable at smaller widths where text wrapping significantly impacts `scrollHeight`.


# Solution:

This PR resolves the issue by explicitly resetting the textarea height to `1px` before recalculating `scrollHeight`. This ensures that the browser computes the height based on the *currently visible text* as not doing so could lead to potentially caching stale `scrolHeight` after content cleared. The new calculation, using only `sendTextArea.scrollHeight`, is simpler and more accurate.

This change provides more reliable and consistent resizing behavior, ensuring the textarea shrinks correctly to its minimum height after sending a message, regardless of window width changes or previous text wrapping states.



# Tests:

Before:

Excuse the potato quality as I can't upload more than 10MB. Just notice the size of the text area, here's a picture to show the px height:
![image](https://github.com/user-attachments/assets/59ab9310-81c3-4857-89c9-63ec2be2f2fd)

https://github.com/user-attachments/assets/aed9c2c7-32d9-467e-a8e7-4a91b7dca6be

After:

Chrome:


https://github.com/user-attachments/assets/b6074546-f1ef-4fb3-a246-fe2b013848f2



Firefox:


https://github.com/user-attachments/assets/4d781dbb-5b29-46aa-90a4-380850454fc4



## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
