### PR TITLE
Update azure.js

### DIFF
--- a/src/endpoints/azure.js
+++ b/src/endpoints/azure.js
@@ -69,7 +69,7 @@ router.post('/generate', jsonParser, async (req, res) => {
             headers: {
                 'Ocp-Apim-Subscription-Key': key,
                 'Content-Type': 'application/ssml+xml',
-                'X-Microsoft-OutputFormat': 'ogg-48khz-16bit-mono-opus',
+                'X-Microsoft-OutputFormat': 'webm-24khz-16bit-mono-opus',
             },
             body: ssml,
         });


### PR DESCRIPTION
Change Azure TTS audio format from ogg-48khz-16bit-mono-opus to webm-24khz-16bit-mono-opus because this works with WebKit-based browsers so brings Azure TTS to iOS, iPadOS and Safari on macOS.
To test, simply use a browser on iOS/iPadOS (that must use WebKit) or Safari on macOS and try using Azure TTS with the current OGG format. It will silently fail (literally). With this version of azure.js, it will play on those types of devices. The downside is lower quality.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
