### PR TITLE
feat: Add preferences parameter to /searxng endpoint

### DIFF
--- a/src/endpoints/search.js
+++ b/src/endpoints/search.js
@@ -160,7 +160,7 @@ router.post('/transcript', jsonParser, async (request, response) => {
 
 router.post('/searxng', jsonParser, async (request, response) => {
     try {
-        const { baseUrl, query } = request.body;
+        const { baseUrl, query, preferences } = request.body;
 
         if (!baseUrl || !query) {
             console.log('Missing required parameters for /searxng');
@@ -188,6 +188,9 @@ router.post('/searxng', jsonParser, async (request, response) => {
         const searchUrl = new URL('/search', baseUrl);
         const searchParams = new URLSearchParams();
         searchParams.append('q', query);
+        if (preferences.length > 0) {
+            searchParams.append('preferences', preferences);
+        }
         searchUrl.search = searchParams.toString();
 
         const searchResult = await fetch(searchUrl, { headers: visitHeaders });

--- a/src/endpoints/search.js
+++ b/src/endpoints/search.js
@@ -188,7 +188,7 @@ router.post('/searxng', jsonParser, async (request, response) => {
         const searchUrl = new URL('/search', baseUrl);
         const searchParams = new URLSearchParams();
         searchParams.append('q', query);
-        if (preferences.length > 0) {
+        if (preferences) {
             searchParams.append('preferences', preferences);
         }
         searchUrl.search = searchParams.toString();


### PR DESCRIPTION
Added paramater and handles it in the query parameters.

SearXNG has a feature to allow preferences to be saved as a string and included in queries. This string can be appended to the query with `preferences=`.
Many instances only have google as the default, and this often gets temporarily shut down due to over-usage, so being able to set the preferences to have searxng use other engines, and save this in the preferences string, is an important feature.

Sister Pull Reqeust in the web search extension:
https://github.com/SillyTavern/Extension-WebSearch/pull/3

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
