### PR TITLE
Remove `best_of` for VLLM

### DIFF
--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1209,7 +1209,6 @@ export function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, 
     };
     const vllmParams = {
         'n': canMultiSwipe ? settings.n : 1,
-        'best_of': canMultiSwipe ? settings.n : 1,
         'ignore_eos': settings.ignore_eos_token,
         'spaces_between_special_tokens': settings.spaces_between_special_tokens,
         'seed': settings.seed >= 0 ? settings.seed : undefined,


### PR DESCRIPTION
It defaults to `n` anyways, and for some reason it was being incorrectly received on 0.6.4.post1

Should allow multi-swipe generations again.