### PR TITLE
Make featherless.ai Search bar take up 1 entire row on mobile devices.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -5673,7 +5673,8 @@ body:not(.movingUI) .drawer-content.maximized {
     }
 
     #featherless_model_search_bar {
-        width: 100%;
+        flex: 1;
+        flex-basis:100%;
     }
 
 }


### PR DESCRIPTION
Extremely tiny CSS change but it makes the search bar for featherless.ai models much more usable on phones.

Screenshot shows what it looks like on a mobile phone (Simulated). I've tested it and it works on my device.

![image](https://github.com/user-attachments/assets/7c9d1afe-542a-42fd-b9c5-4d2885871a10)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
