### PR TITLE
Fixed typo in HTML title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4503,7 +4503,7 @@
                                 </div>
                             </div>
                             <div name="AutoCompleteToggle" class="inline-drawer wide100p flexFlowColumn">
-                                <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable" title="Options for the various autocompelte input boxes.">
+                                <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable" title="Options for the various autocomplete input boxes.">
                                     <b><span data-i18n="AutoComplete Settings">AutoComplete Settings</span></b>
                                     <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                 </div>


### PR DESCRIPTION
### Changed "autocompelte" to "autocomplete".

I did not test the staging branch, however it did not seem to cause issues on release branch and there was only one instance of this misspelling across the repo.

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
