### PR TITLE
Add author's note STscript returns, role changing, and aliases

### DIFF
--- a/public/scripts/authors-note.js
+++ b/public/scripts/authors-note.js
@@ -37,53 +37,82 @@ const chara_note_position = {
 };
 
 function setNoteTextCommand(_, text) {
-    $('#extension_floating_prompt').val(text).trigger('input');
-    toastr.success(t`Author's Note text updated`);
-    return '';
+    if (text) {
+        $('#extension_floating_prompt').val(text).trigger('input');
+        toastr.success(t`Author's Note text updated`);
+    }
+    return chat_metadata[metadata_keys.prompt];
 }
 
 function setNoteDepthCommand(_, text) {
-    const value = Number(text);
+    if (text) {
+        const value = Number(text);
 
-    if (Number.isNaN(value)) {
-        toastr.error(t`Not a valid number`);
-        return;
+        if (Number.isNaN(value)) {
+            toastr.error(t`Not a valid number`);
+            return;
+        }
+    
+        $('#extension_floating_depth').val(Math.abs(value)).trigger('input');
+        toastr.success(t`Author's Note depth updated`);
     }
-
-    $('#extension_floating_depth').val(Math.abs(value)).trigger('input');
-    toastr.success(t`Author's Note depth updated`);
-    return '';
+    return chat_metadata[metadata_keys.depth];
 }
 
 function setNoteIntervalCommand(_, text) {
-    const value = Number(text);
+    if (text) {
+        const value = Number(text);
 
-    if (Number.isNaN(value)) {
-        toastr.error(t`Not a valid number`);
-        return;
+        if (Number.isNaN(value)) {
+            toastr.error(t`Not a valid number`);
+            return;
+        }
+
+        $('#extension_floating_interval').val(Math.abs(value)).trigger('input');
+        toastr.success(t`Author's Note frequency updated`);
     }
-
-    $('#extension_floating_interval').val(Math.abs(value)).trigger('input');
-    toastr.success(t`Author's Note frequency updated`);
-    return '';
+    return chat_metadata[metadata_keys.interval];
 }
 
 function setNotePositionCommand(_, text) {
     const validPositions = {
         'scenario': 0,
         'chat': 1,
+        'before_scenario': 2
     };
 
-    const position = validPositions[text?.trim()];
+    if (text) {
+        const position = validPositions[text?.trim()];
 
-    if (Number.isNaN(position)) {
-        toastr.error(t`Not a valid position`);
-        return;
+        if (typeof position == 'undefined') {
+            toastr.error(t`Not a valid position`);
+            return;
+        }
+
+        $(`input[name="extension_floating_position"][value="${position}"]`).prop('checked', true).trigger('input');
+        toastr.info(t`Author's Note position updated`);
     }
+    return Object.keys(validPositions).find(key => validPositions[key] == chat_metadata[metadata_keys.position]);
+}
+function setNoteRoleCommand(_, text) {
+    const validRoles = {
+        'system': 0,
+        'user': 1,
+        'assistant': 2
+    };
 
-    $(`input[name="extension_floating_position"][value="${position}"]`).prop('checked', true).trigger('input');
-    toastr.info(t`Author's Note position updated`);
-    return '';
+    if (text) {
+        const role = validRoles[text?.trim()];
+
+        if (typeof role == 'undefined') {
+            toastr.error(t`Not a valid role`);
+            return;
+        }
+
+        $(`#extension_floating_role`).val(Math.abs(role)).trigger('input');
+        toastr.info(t`Author's Note role updated`);
+    }
+    return Object.keys(validRoles).find(key => validRoles[key] == chat_metadata[metadata_keys.role]);
 }
 
 function updateSettings() {
@@ -464,55 +493,77 @@ export function initAuthorsNote() {
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({ name: 'note',
         callback: setNoteTextCommand,
+        returns: 'current author\'s note',
         unnamedArgumentList: [
             new SlashCommandArgument(
-                'text', [ARGUMENT_TYPE.STRING], true,
+                'text', [ARGUMENT_TYPE.STRING], false,
             ),
         ],
         helpString: `
             <div>
-                Sets an author's note for the currently selected chat.
+                Sets an author's note for the currently selected chat if specified and returns the current note.
             </div>
         `,
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({ name: 'depth',
+        aliases: ['note-depth'],
         callback: setNoteDepthCommand,
+        returns: 'current author\'s note depth',
         unnamedArgumentList: [
             new SlashCommandArgument(
-                'number', [ARGUMENT_TYPE.NUMBER], true,
+                'number', [ARGUMENT_TYPE.NUMBER], false,
             ),
         ],
         helpString: `
             <div>
-                Sets an author's note depth for in-chat positioning.
+                Sets an author's note depth for in-chat positioning if specified and returns the current depth.
             </div>
         `,
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({ name: 'freq',
+        aliases: ['note-freq'],
         callback: setNoteIntervalCommand,
+        returns: 'current author\'s note insertion frequency',
         namedArgumentList: [],
         unnamedArgumentList: [
             new SlashCommandArgument(
-                'number', [ARGUMENT_TYPE.NUMBER], true,
+                'number', [ARGUMENT_TYPE.NUMBER], false,
             ),
         ],
         helpString: `
             <div>
-                Sets an author's note insertion frequency.
+                Sets an author's note insertion frequency if specified and returns the current frequency.
             </div>
         `,
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({ name: 'pos',
         callback: setNotePositionCommand,
+        aliases: ['note-pos'],
+        returns: 'current author\'s note insertion position',
         namedArgumentList: [],
         unnamedArgumentList: [
             new SlashCommandArgument(
-                'position', [ARGUMENT_TYPE.STRING], true, false, null, ['chat', 'scenario'],
+                'position', [ARGUMENT_TYPE.STRING], false, false, null, ['chat', 'scenario','before_scenario'],
             ),
         ],
         helpString: `
             <div>
-                Sets an author's note position.
+                Sets an author's note position if specified and returns the current position.
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({ name: 'note-role',
+        callback: setNoteRoleCommand,
+        returns: 'current author\'s note chat insertion role',
+        namedArgumentList: [],
+        unnamedArgumentList: [
+            new SlashCommandArgument(
+                'position', [ARGUMENT_TYPE.STRING], false, false, null, ['system', 'user','assistant'],
+            ),
+        ],
+        helpString: `
+            <div>
+                Sets an author's note chat insertion role if specified and returns the current role.
             </div>
         `,
     }));


### PR DESCRIPTION
Adds the following author's note STscript changes:
- Returns to all commands and makes arguments optional
- before_scenario option for chat insertion position (to match UI)
- /note-role to change the chat insertion role
- /note- Aliases to all commands so they're centralized

Does not break any existing STscripts.
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
