### PR TITLE
Template derivation: explicitly skip empty templates

### DIFF
--- a/public/scripts/chat-templates.js
+++ b/public/scripts/chat-templates.js
@@ -65,6 +65,11 @@ const parse_derivation = derivation => (typeof derivation === 'string') ? {
 } : derivation;
 
 export async function deriveTemplatesFromChatTemplate(chat_template, hash) {
+    if (chat_template.trim() === '') {
+        console.log('Missing chat template.');
+        return null;
+    }
+
     if (hash in hash_derivations) {
         return parse_derivation(hash_derivations[hash]);
     }


### PR DESCRIPTION
Simple check that the chat template is not empty, suppressing hint about chat template missing for the hash. Although probably very unlikely, we don't want to accidentally add a hash for an empty chat template in the future.