### PR TITLE
feature: allow auto-use of max context size given by backend

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -220,10 +220,6 @@
                                         <div data-preset-manager-delete="textgenerationwebui" class="margin0 menu_button_icon menu_button" title="Delete the preset" data-i18n="[title]Delete the preset">
                                             <i class="fa-fw fa-solid fa-trash-can"></i>
                                         </div>
-                                        <label for="context_size_derived" class="checkbox_label flex1" title="Use backend provided context size, when available." data-i18n="[title]context_size_derived">
-                                            <input id="context_size_derived" type="checkbox" style="display:none;" />
-                                            <small><i class="fa-solid fa-bolt menu_button margin0"></i></small>
-                                        </label>
                                     </div>
                                 </div>
                                 <div class="flex-container flexNoGap">
@@ -3271,6 +3267,12 @@
                         <span data-i18n="Auto-connect to Last Server">Auto-connect to Last Server</span>
                     </label>
                     <a id="viewSecrets" href="javascript:void(0);" data-i18n="[missing_key_text]Missing key;[key_saved_text]Key saved" missing_key_text="❌ Missing key" key_saved_text="✔️ Key saved"><span data-i18n="View hidden API keys">View hidden API keys</span></a>
+                </div>
+                <div>
+                    <label data-tg-type="koboldcpp, llamacpp" class="checkbox_label margin-bot-10px" for="context_size_derived">
+                        <input type="checkbox" id="context_size_derived" />
+                        <span data-i18n="Derive settings from backend">Derive settings from backend</span>
+                    </label>
                 </div>
             </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -2573,15 +2573,21 @@
                                     <input id="koboldcpp_api_url_text" class="text_pole wide100p" value="" autocomplete="off" data-server-history="koboldcpp">
                                 </div>
                             </div>
+                            <div class="flex-container flexFlowColumn marginTopBot5">
+                                <label data-tg-type="ooba" class="checkbox_label" for="bypass_status_check_textgenerationwebui">
+                                    <input type="checkbox" id="bypass_status_check_textgenerationwebui" />
+                                    <span data-i18n="Bypass status check">Bypass status check</span>
+                                </label>
+                                <label data-tg-type="koboldcpp, llamacpp" class="checkbox_label" for="context_size_derived">
+                                    <input type="checkbox" id="context_size_derived" />
+                                    <span data-i18n="Derive context size from backend">Derive context size from backend</span>
+                                </label>
+                            </div>
                             <div class="flex-container">
                                 <div id="api_button_textgenerationwebui" class="api_button menu_button menu_button_icon" type="submit" data-i18n="Connect" data-server-connect="ooba_blocking,vllm,aphrodite,tabby,koboldcpp,ollama,llamacpp,huggingface">Connect</div>
                                 <div data-tg-type="openrouter" class="menu_button menu_button_icon openrouter_authorize" title="Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai" data-i18n="Authorize;[title]Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai">Authorize</div>
                                 <div class="api_loading menu_button menu_button_icon" data-i18n="Cancel">Cancel</div>
                             </div>
-                            <label data-tg-type="ooba" class="checkbox_label margin-bot-10px" for="bypass_status_check_textgenerationwebui">
-                                <input type="checkbox" id="bypass_status_check_textgenerationwebui" />
-                                <span data-i18n="Bypass status check">Bypass status check</span>
-                            </label>
                         </form>
                         <div class="online_status">
                             <div class="online_status_indicator"></div>
@@ -3267,12 +3273,6 @@
                         <span data-i18n="Auto-connect to Last Server">Auto-connect to Last Server</span>
                     </label>
                     <a id="viewSecrets" href="javascript:void(0);" data-i18n="[missing_key_text]Missing key;[key_saved_text]Key saved" missing_key_text="❌ Missing key" key_saved_text="✔️ Key saved"><span data-i18n="View hidden API keys">View hidden API keys</span></a>
-                </div>
-                <div>
-                    <label data-tg-type="koboldcpp, llamacpp" class="checkbox_label margin-bot-10px" for="context_size_derived">
-                        <input type="checkbox" id="context_size_derived" />
-                        <span data-i18n="Derive settings from backend">Derive settings from backend</span>
-                    </label>
                 </div>
             </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -220,6 +220,10 @@
                                         <div data-preset-manager-delete="textgenerationwebui" class="margin0 menu_button_icon menu_button" title="Delete the preset" data-i18n="[title]Delete the preset">
                                             <i class="fa-fw fa-solid fa-trash-can"></i>
                                         </div>
+                                        <label for="context_size_derived" class="checkbox_label flex1" title="Use backend provided context size, when available." data-i18n="[title]context_size_derived">
+                                            <input id="context_size_derived" type="checkbox" style="display:none;" />
+                                            <small><i class="fa-solid fa-bolt menu_button margin0"></i></small>
+                                        </label>
                                     </div>
                                 </div>
                                 <div class="flex-container flexNoGap">

--- a/public/script.js
+++ b/public/script.js
@@ -1254,8 +1254,8 @@ async function getStatusTextgen() {
                 const data = await response.json();
                 if (data) {
                     const { chat_template, chat_template_hash } = data;
-                    if (wantsContextSize && "default_generation_settings" in data) {
-                        const backend_max_context = data["default_generation_settings"]["n_ctx"];
+                    if (wantsContextSize && 'default_generation_settings' in data) {
+                        const backend_max_context = data['default_generation_settings']['n_ctx'];
                         const old_value = max_context;
                         if (max_context !== backend_max_context) {
                             setGenerationParamsFromPreset({ max_length: backend_max_context }, true);

--- a/public/script.js
+++ b/public/script.js
@@ -1258,7 +1258,7 @@ async function getStatusTextgen() {
                         const backend_max_context = data['default_generation_settings']['n_ctx'];
                         const old_value = max_context;
                         if (max_context !== backend_max_context) {
-                            setGenerationParamsFromPreset({ max_length: backend_max_context }, true);
+                            setGenerationParamsFromPreset({ max_length: backend_max_context });
                         }
                         if (old_value !== max_context) {
                             console.log(`Auto-switched max context from ${old_value} to ${max_context}`);
@@ -6837,21 +6837,10 @@ export async function saveSettings(type) {
 /**
  * Sets the generation parameters from a preset object.
  * @param {{ genamt?: number, max_length?: number }} preset Preset object
- * @param {boolean?} keepContextLock If true, will not unlock context if it needs to be unlocked
  */
-export function setGenerationParamsFromPreset(preset, keepContextLock = false) {
+export function setGenerationParamsFromPreset(preset) {
     const needsUnlock = (preset.max_length ?? max_context) > MAX_CONTEXT_DEFAULT || (preset.genamt ?? amount_gen) > MAX_RESPONSE_DEFAULT;
-    if (!keepContextLock || $('#max_context_unlocked').prop('checked')) {
-        $('#max_context_unlocked').prop('checked', needsUnlock).trigger('change');
-    } else if (needsUnlock) {
-        // cap values
-        if ((preset.max_length ?? max_context) > MAX_CONTEXT_DEFAULT) {
-            preset.max_length = MAX_CONTEXT_DEFAULT;
-        }
-        if ((preset.genamt ?? amount_gen) > MAX_RESPONSE_DEFAULT) {
-            preset.genamt = MAX_RESPONSE_DEFAULT;
-        }
-    }
+    $('#max_context_unlocked').prop('checked', needsUnlock).trigger('change');
 
     if (preset.genamt !== undefined) {
         amount_gen = preset.genamt;

--- a/public/script.js
+++ b/public/script.js
@@ -6833,9 +6833,14 @@ export async function saveSettings(type) {
     });
 }
 
-export function setGenerationParamsFromPreset(preset, keep_context_lock) {
+/**
+ * Sets the generation parameters from a preset object.
+ * @param {{ genamt?: number, max_length?: number }} preset Preset object
+ * @param {boolean?} keepContextLock If true, will not unlock context if it needs to be unlocked
+ */
+export function setGenerationParamsFromPreset(preset, keepContextLock = false) {
     const needsUnlock = (preset.max_length ?? max_context) > MAX_CONTEXT_DEFAULT || (preset.genamt ?? amount_gen) > MAX_RESPONSE_DEFAULT;
-    if (!keep_context_lock || $('#max_context_unlocked').prop('checked')) {
+    if (!keepContextLock || $('#max_context_unlocked').prop('checked')) {
         $('#max_context_unlocked').prop('checked', needsUnlock).trigger('change');
     } else if (needsUnlock) {
         // cap values

--- a/public/script.js
+++ b/public/script.js
@@ -1262,7 +1262,7 @@ async function getStatusTextgen() {
                         }
                         if (old_value !== max_context) {
                             console.log(`Auto-switched max context from ${old_value} to ${max_context}`);
-                            toastr.info(`Context Size Changed: ${old_value} ⇒ ${max_context}`);
+                            toastr.info(`${old_value} ⇒ ${max_context}`, 'Context Size Changed');
                         }
                     }
                     console.log(`We have chat template ${chat_template.split('\n')[0]}...`);

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -245,6 +245,7 @@ let power_user = {
     },
 
     context_derived: false,
+    context_size_derived: false,
 
     sysprompt: {
         enabled: true,
@@ -1481,6 +1482,7 @@ async function loadPowerUserSettings(settings, data) {
     $('#example_messages_behavior').val(getExampleMessagesBehavior());
     $(`#example_messages_behavior option[value="${getExampleMessagesBehavior()}"]`).prop('selected', true);
     $('#context_derived').parent().find('i').toggleClass('toggleEnabled', !!power_user.context_derived);
+    $('#context_size_derived').parent().find('i').toggleClass('toggleEnabled', !!power_user.context_size_derived);
 
     $('#console_log_prompts').prop('checked', power_user.console_log_prompts);
     $('#request_token_probabilities').prop('checked', power_user.request_token_probabilities);
@@ -3074,6 +3076,16 @@ $(document).ready(() => {
 
     $('#context_derived').on('change', function () {
         $('#context_derived').parent().find('i').toggleClass('toggleEnabled', !!power_user.context_derived);
+    });
+
+    $('#context_size_derived').on('input', function () {
+        const value = !!$(this).prop('checked');
+        power_user.context_size_derived = value;
+        saveSettingsDebounced();
+    });
+
+    $('#context_size_derived').on('change', function () {
+        $('#context_size_derived').parent().find('i').toggleClass('toggleEnabled', !!power_user.context_size_derived);
     });
 
     $('#always-force-name2-checkbox').change(function () {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1482,7 +1482,7 @@ async function loadPowerUserSettings(settings, data) {
     $('#example_messages_behavior').val(getExampleMessagesBehavior());
     $(`#example_messages_behavior option[value="${getExampleMessagesBehavior()}"]`).prop('selected', true);
     $('#context_derived').parent().find('i').toggleClass('toggleEnabled', !!power_user.context_derived);
-    $('#context_size_derived').parent().find('i').toggleClass('toggleEnabled', !!power_user.context_size_derived);
+    $('#context_size_derived').prop('checked', !!power_user.context_size_derived);
 
     $('#console_log_prompts').prop('checked', power_user.console_log_prompts);
     $('#request_token_probabilities').prop('checked', power_user.request_token_probabilities);
@@ -3085,7 +3085,7 @@ $(document).ready(() => {
     });
 
     $('#context_size_derived').on('change', function () {
-        $('#context_size_derived').parent().find('i').toggleClass('toggleEnabled', !!power_user.context_size_derived);
+        $('#context_size_derived').prop('checked', !!power_user.context_size_derived);
     });
 
     $('#always-force-name2-checkbox').change(function () {

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -152,7 +152,7 @@ router.post('/status', jsonParser, async function (request, response) {
 
         if (!modelsReply.ok) {
             console.log('Models endpoint is offline.');
-            return response.status(400);
+            return response.sendStatus(400);
         }
 
         /** @type {any} */
@@ -173,7 +173,7 @@ router.post('/status', jsonParser, async function (request, response) {
 
         if (!Array.isArray(data.data)) {
             console.log('Models response is not an array.');
-            return response.status(400);
+            return response.sendStatus(400);
         }
 
         const modelIds = data.data.map(x => x.id);
@@ -224,7 +224,7 @@ router.post('/status', jsonParser, async function (request, response) {
         return response.send({ result, data: data.data });
     } catch (error) {
         console.error(error);
-        return response.status(500);
+        return response.sendStatus(500);
     }
 });
 
@@ -244,7 +244,7 @@ router.post('/props', jsonParser, async function (request, response) {
         const propsReply = await fetch(propsUrl, args);
 
         if (!propsReply.ok) {
-            return response.status(400);
+            return response.sendStatus(400);
         }
 
         /** @type {any} */
@@ -258,7 +258,7 @@ router.post('/props', jsonParser, async function (request, response) {
         return response.send(props);
     } catch (error) {
         console.error(error);
-        return response.status(500);
+        return response.sendStatus(500);
     }
 });
 
@@ -450,7 +450,7 @@ ollama.post('/download', jsonParser, async function (request, response) {
         return response.send({ ok: true });
     } catch (error) {
         console.error(error);
-        return response.status(500);
+        return response.sendStatus(500);
     }
 });
 
@@ -493,7 +493,7 @@ ollama.post('/caption-image', jsonParser, async function (request, response) {
         return response.send({ caption });
     } catch (error) {
         console.error(error);
-        return response.status(500);
+        return response.sendStatus(500);
     }
 });
 
@@ -540,7 +540,7 @@ llamacpp.post('/caption-image', jsonParser, async function (request, response) {
 
     } catch (error) {
         console.error(error);
-        return response.status(500);
+        return response.sendStatus(500);
     }
 });
 
@@ -569,7 +569,7 @@ llamacpp.post('/props', jsonParser, async function (request, response) {
 
     } catch (error) {
         console.error(error);
-        return response.status(500);
+        return response.sendStatus(500);
     }
 });
 
@@ -619,7 +619,7 @@ llamacpp.post('/slots', jsonParser, async function (request, response) {
 
     } catch (error) {
         console.error(error);
-        return response.status(500);
+        return response.sendStatus(500);
     }
 });
 
@@ -665,7 +665,7 @@ tabby.post('/download', jsonParser, async function (request, response) {
         return response.send({ ok: true });
     } catch (error) {
         console.error(error);
-        return response.status(500);
+        return response.sendStatus(500);
     }
 });
 


### PR DESCRIPTION
This adds another use of the /props endpoint, which allows users to auto-select the context size via backend provided value.

It is easy to forget to update the value on one end so not having to bother is a nice feature to have. There is a lightning bolt just like the template derivation but inside the response config panel now.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
- [X] This works in llama.cpp's server already.
- [X] This works with koboldcpp v1.79 and abbove.

## Up for debate:

* The wording on this could be changed to "Use *settings* provided by backend" and be expanded in the future to adopt more stuff, but I'm not sure how intuitive it would be in the end.
* The word "derived" may not be ideal here, as all it does is pull the value out from the /props response.

## Future work:

* Warn users when backend provided max context is lower than user set max context (when users have this feature turned off).