### PR TITLE
Replace webpack-dev-middleware with a statically compiled file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
                 "vectra": "^0.2.2",
                 "wavefile": "^11.0.0",
                 "webpack": "^5.95.0",
-                "webpack-dev-middleware": "^7.4.2",
                 "write-file-atomic": "^5.0.1",
                 "ws": "^8.17.1",
                 "yaml": "^2.3.4",
@@ -864,60 +863,6 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
-        "node_modules/@jsonjoy.com/base64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
-            }
-        },
-        "node_modules/@jsonjoy.com/json-pack": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.1.0.tgz",
-            "integrity": "sha512-zlQONA+msXPPwHWZMKFVS78ewFczIll5lXiVPwFPCZUsrOKdxc2AvxU1HoNBmMRhqDZUR9HkC3UOm+6pME6Xsg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jsonjoy.com/base64": "^1.1.1",
-                "@jsonjoy.com/util": "^1.1.2",
-                "hyperdyperid": "^1.2.0",
-                "thingies": "^1.20.0"
-            },
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
-            }
-        },
-        "node_modules/@jsonjoy.com/util": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.5.0.tgz",
-            "integrity": "sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
             }
         },
         "node_modules/@kwsites/file-exists": {
@@ -1803,45 +1748,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/ajv-formats": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT"
-        },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -2600,12 +2506,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "license": "MIT"
-        },
-        "node_modules/colorette": {
-            "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "license": "MIT"
         },
         "node_modules/combined-stream": {
@@ -3785,12 +3685,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-uri": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-            "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/fastq": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -4541,15 +4435,6 @@
                 "ms": "^2.0.0"
             }
         },
-        "node_modules/hyperdyperid": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
-            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.18"
-            }
-        },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -5174,25 +5059,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/memfs": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.14.0.tgz",
-            "integrity": "sha512-JUeY0F/fQZgIod31Ja1eJgiSxLn7BfQlCnqhwXFBzFHEw63OdLK7VJUJ7bnzNsWgCyoUP5tEp1VRY8rDaYzqOA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jsonjoy.com/json-pack": "^1.0.3",
-                "@jsonjoy.com/util": "^1.3.0",
-                "tree-dump": "^1.0.1",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
             }
         },
         "node_modules/merge-descriptors": {
@@ -6310,15 +6176,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/resolve-alpn": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
@@ -6446,59 +6303,6 @@
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
             "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
             "license": "ISC"
-        },
-        "node_modules/schema-utils": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-            "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 12.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/schema-utils/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/schema-utils/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "node_modules/schema-utils/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT"
         },
         "node_modules/seedrandom": {
             "version": "3.0.5",
@@ -7038,18 +6842,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/thingies": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
-            "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
-            "license": "Unlicense",
-            "engines": {
-                "node": ">=10.18"
-            },
-            "peerDependencies": {
-                "tslib": "^2"
-            }
-        },
         "node_modules/tiktoken": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/tiktoken/-/tiktoken-1.0.16.tgz",
@@ -7104,22 +6896,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/tree-dump": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
-            "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/streamich"
-            },
-            "peerDependencies": {
-                "tslib": "2"
             }
         },
         "node_modules/truncate-utf8-bytes": {
@@ -7421,35 +7197,6 @@
             },
             "peerDependenciesMeta": {
                 "webpack-cli": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/webpack-dev-middleware": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
-            "integrity": "sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==",
-            "license": "MIT",
-            "dependencies": {
-                "colorette": "^2.0.10",
-                "memfs": "^4.6.0",
-                "mime-types": "^2.1.31",
-                "on-finished": "^2.4.1",
-                "range-parser": "^1.2.1",
-                "schema-utils": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 18.12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "webpack": {
                     "optional": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
         "vectra": "^0.2.2",
         "wavefile": "^11.0.0",
         "webpack": "^5.95.0",
-        "webpack-dev-middleware": "^7.4.2",
         "write-file-atomic": "^5.0.1",
         "ws": "^8.17.1",
         "yaml": "^2.3.4",

--- a/server.js
+++ b/server.js
@@ -627,10 +627,6 @@ const tavernUrl = new URL(
     (':' + server_port),
 );
 
-function prepareFrontendBundle() {
-    return new Promise((resolve) => webpackMiddleware.waitUntilValid(resolve));
-}
-
 /**
  * Tasks that need to be run before the server starts listening.
  */
@@ -682,7 +678,7 @@ const preSetupTasks = async function () {
     initRequestProxy({ enabled: proxyEnabled, url: proxyUrl, bypass: proxyBypass });
 
     // Wait for frontend libs to compile
-    await prepareFrontendBundle();
+    await webpackMiddleware.runWebpackCompiler();
 };
 
 /**

--- a/src/middleware/webpack-serve.js
+++ b/src/middleware/webpack-serve.js
@@ -1,4 +1,3 @@
-import process from 'node:process';
 import path from 'node:path';
 import webpack from 'webpack';
 import { publicLibConfig } from '../../webpack.config.js';
@@ -7,16 +6,6 @@ export default function getWebpackServeMiddleware() {
     const outputPath = publicLibConfig.output?.path;
     const outputFile = publicLibConfig.output?.filename;
     const compiler = webpack(publicLibConfig);
-
-    if (process.env.NODE_ENV === 'production' || process.platform === 'android') {
-        compiler.hooks.done.tap('serve', () => {
-            if (compiler.watching) {
-                compiler.watching.close(() => { });
-            }
-            compiler.watchFileSystem = null;
-            compiler.watchMode = false;
-        });
-    }
 
     /**
      * A very spartan recreation of webpack-dev-middleware.

--- a/src/middleware/webpack-serve.js
+++ b/src/middleware/webpack-serve.js
@@ -14,7 +14,7 @@ export default function getWebpackServeMiddleware() {
      * @param {import('express').NextFunction} next Next function.
      * @type {import('express').RequestHandler}
      */
-    async function devMiddleware(req, res, next) {
+    function devMiddleware(req, res, next) {
         if (req.method === 'GET' && path.parse(req.path).base === outputFile) {
             return res.sendFile(outputFile, { root: outputPath });
         }

--- a/src/middleware/webpack-serve.js
+++ b/src/middleware/webpack-serve.js
@@ -28,10 +28,13 @@ export default function getWebpackServeMiddleware() {
      */
     devMiddleware.runWebpackCompiler = () => {
         return new Promise((resolve) => {
+            console.log();
+            console.log('Compiling frontend libraries...');
             compiler.run((_error, stats) => {
                 const output = stats?.toString(publicLibConfig.stats);
                 if (output) {
                     console.log(output);
+                    console.log();
                 }
                 resolve();
             });

--- a/src/middleware/webpack-serve.js
+++ b/src/middleware/webpack-serve.js
@@ -1,4 +1,5 @@
 import process from 'node:process';
+import fs from 'node:fs';
 import webpack from 'webpack';
 import middleware from 'webpack-dev-middleware';
 import { publicLibConfig } from '../../webpack.config.js';
@@ -16,5 +17,8 @@ export default function getWebpackServeMiddleware() {
         });
     }
 
-    return middleware(compiler, {});
+    return middleware(compiler, {
+        // @ts-ignore Use actual file system to ease on heap memory usage
+        outputFileSystem: fs,
+    });
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,8 @@ export const publicLibConfig = {
     cache: {
         type: 'filesystem',
         cacheDirectory: path.resolve(process.cwd(), 'dist/webpack'),
+        store: 'pack',
+        compression: 'gzip',
     },
     devtool: false,
     watch: false,
@@ -16,6 +18,8 @@ export const publicLibConfig = {
         preset: 'minimal',
         assets: false,
         modules: false,
+        colors: true,
+        timings: true,
     },
     experiments: {
         outputModule: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ export const publicLibConfig = {
         hints: false,
     },
     output: {
+        path: path.resolve(process.cwd(), 'dist'),
         filename: 'lib.js',
         libraryTarget: 'module',
     },


### PR DESCRIPTION
webpack-dev-middleware uses lots of memory which caused OOM for some users (most notably on Android). So we run Webpack on start and serve lib.js as a static file. The part with forceful watch removal is probably not needed anymore. I'll need a couple of tests on Android emulator to make sure.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
