### PR TITLE
Make QR context menu display options more consistent with QR bar

### DIFF
--- a/public/scripts/extensions/quick-reply/src/ui/ctx/ContextMenu.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/ContextMenu.js
@@ -19,7 +19,7 @@ export class ContextMenu {
         this.itemList = this.build(qr).children;
         this.itemList.forEach(item => {
             item.onExpand = () => {
-                this.itemList.filter(it => it != item)
+                this.itemList.filter(it => it !== item)
                     .forEach(it => it.collapse());
             };
         });
@@ -36,7 +36,9 @@ export class ContextMenu {
             icon: qr.icon,
             showLabel: qr.showLabel,
             label: qr.label,
+            title: qr.title,
             message: (chainedMessage && qr.message ? `${chainedMessage} | ` : '') + qr.message,
+            isHidden: qr.isHidden,
             children: [],
         };
         qr.contextList.forEach((cl) => {
@@ -51,7 +53,9 @@ export class ContextMenu {
                         subTree.icon,
                         subTree.showLabel,
                         subTree.label,
+                        subTree.title,
                         subTree.message,
+                        subTree.isHidden,
                         (evt) => {
                             evt.stopPropagation();
                             const finalQr = Object.assign(new QuickReply(), subQr);

--- a/public/scripts/extensions/quick-reply/src/ui/ctx/MenuHeader.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/MenuHeader.js
@@ -2,7 +2,7 @@ import { MenuItem } from './MenuItem.js';
 
 export class MenuHeader extends MenuItem {
     constructor(/**@type {String}*/label) {
-        super(null, null, label, null, null);
+        super(null, null, label, null, null, false, null, []);
     }
 
 

--- a/public/scripts/extensions/quick-reply/src/ui/ctx/MenuItem.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/MenuItem.js
@@ -4,11 +4,12 @@ export class MenuItem {
     /**@type {string}*/ icon;
     /**@type {boolean}*/ showLabel;
     /**@type {string}*/ label;
+    /**@type {string}*/ title;
     /**@type {object}*/ value;
+    /**@type {boolean}*/ isHidden = false;
     /**@type {function}*/ callback;
     /**@type {MenuItem[]}*/ childList = [];
     /**@type {SubMenu}*/ subMenu;
-    /**@type {boolean}*/ isForceExpanded = false;
 
     /**@type {HTMLElement}*/ root;
 
@@ -19,35 +20,67 @@ export class MenuItem {
 
     /**
      *
-     * @param {string} icon
-     * @param {boolean} showLabel
+     * @param {?string} icon
+     * @param {?boolean} showLabel
      * @param {string} label
+     * @param {?string} title Tooltip
      * @param {object} value
+     * @param {boolean} isHidden QR is Invisible (auto-execute only)
      * @param {function} callback
      * @param {MenuItem[]} children
      */
-    constructor(icon, showLabel, label, value, callback, children = []) {
+    constructor(icon, showLabel, label, title, value, isHidden, callback, children = []) {
         this.icon = icon;
         this.showLabel = showLabel;
         this.label = label;
+        this.title = title;
         this.value = value;
+        this.isHidden = isHidden;
         this.callback = callback;
         this.childList = children;
     }
 
 
+    /**
+     * Renders the MenuItem
+     *
+     * A .qr--hidden class is added to:
+     * - the item if it is "Invisible (auto-execute only)"
+     * - the icon if no icon is set
+     * - the label if an icon is set and showLabel is false
+     *
+     * There is no .qr--hidden class defined in default CSS, since having items
+     * that are invisible on the QR bar but visible in the context menu,
+     * or icon-only on the QR bar but labelled in the context menu, is a valid use case.
+     *
+     * To hide optional labels when icons are present, add this user CSS:
+     * .ctx-menu .ctx-item .qr--button-label.qr--hidden {display: none;}
+     * To hide icons when no icon is present (removes unwanted padding):
+     * .ctx-menu .ctx-item .qr--button-icon.qr--hidden {display: none;}
+     * To hide items that are set "invisible":
+     * .ctx-menu .ctx-item.qr--hidden {display: none;}
+     * To target submenus only, use .ctx-menu .ctx-sub-menu .qr--hidden {display: none;}
+     *
+     * @returns {HTMLElement}
+     */
     render() {
         if (!this.root) {
             const item = document.createElement('li'); {
                 this.root = item;
                 item.classList.add('list-group-item');
                 item.classList.add('ctx-item');
-                item.title = this.value;
+
+                // if this item is Invisible, add the hidden class
+                if (this.isHidden) item.classList.add('qr--hidden');
+
+                // if a title/tooltip is set, add it, otherwise use the QR content
+                // same as for the main QR list
+                item.title = this.title || this.value;
+
                 if (this.callback) {
                     item.addEventListener('click', (evt) => this.callback(evt, this));
                 }
                 const icon = document.createElement('div'); {
-                    this.domIcon = icon;
                     icon.classList.add('qr--button-icon');
                     icon.classList.add('fa-solid');
                     if (!this.icon) icon.classList.add('qr--hidden');
@@ -55,7 +88,6 @@ export class MenuItem {
                     item.append(icon);
                 }
                 const lbl = document.createElement('div'); {
-                    this.domLabel = lbl;
                     lbl.classList.add('qr--button-label');
                     if (this.icon && !this.showLabel) lbl.classList.add('qr--hidden');
                     lbl.textContent = this.label;


### PR DESCRIPTION
Use QR title as tooltip if set on the QR

Add qr--hidden class to "invisible" context items to allow hiding with CSS

Add title and isHidden props to MenuItem

Remove domIcon and domLabel props: not needed for ctx menu rendering; isForceExpanded: unimplemented

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
