### PR TITLE
Filter out hidden items in context menus

### DIFF
--- a/public/scripts/extensions/quick-reply/src/ui/ctx/MenuHeader.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/MenuHeader.js
@@ -2,7 +2,7 @@ import { MenuItem } from './MenuItem.js';
 
 export class MenuHeader extends MenuItem {
     constructor(/**@type {String}*/label) {
-        super(null, null, label, null, null, false, null, []);
+        super(null, null, label, null, null, null, []);
     }
 
 

--- a/public/scripts/extensions/quick-reply/src/ui/ctx/MenuItem.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ctx/MenuItem.js
@@ -6,7 +6,6 @@ export class MenuItem {
     /**@type {string}*/ label;
     /**@type {string}*/ title;
     /**@type {object}*/ value;
-    /**@type {boolean}*/ isHidden = false;
     /**@type {function}*/ callback;
     /**@type {MenuItem[]}*/ childList = [];
     /**@type {SubMenu}*/ subMenu;
@@ -25,53 +24,26 @@ export class MenuItem {
      * @param {string} label
      * @param {?string} title Tooltip
      * @param {object} value
-     * @param {boolean} isHidden QR is Invisible (auto-execute only)
      * @param {function} callback
      * @param {MenuItem[]} children
      */
-    constructor(icon, showLabel, label, title, value, isHidden, callback, children = []) {
+    constructor(icon, showLabel, label, title, value, callback, children = []) {
         this.icon = icon;
         this.showLabel = showLabel;
         this.label = label;
         this.title = title;
         this.value = value;
-        this.isHidden = isHidden;
         this.callback = callback;
         this.childList = children;
     }
 
 
-    /**
-     * Renders the MenuItem
-     *
-     * A .qr--hidden class is added to:
-     * - the item if it is "Invisible (auto-execute only)"
-     * - the icon if no icon is set
-     * - the label if an icon is set and showLabel is false
-     *
-     * There is no .qr--hidden class defined in default CSS, since having items
-     * that are invisible on the QR bar but visible in the context menu,
-     * or icon-only on the QR bar but labelled in the context menu, is a valid use case.
-     *
-     * To hide optional labels when icons are present, add this user CSS:
-     * .ctx-menu .ctx-item .qr--button-label.qr--hidden {display: none;}
-     * To hide icons when no icon is present (removes unwanted padding):
-     * .ctx-menu .ctx-item .qr--button-icon.qr--hidden {display: none;}
-     * To hide items that are set "invisible":
-     * .ctx-menu .ctx-item.qr--hidden {display: none;}
-     * To target submenus only, use .ctx-menu .ctx-sub-menu .qr--hidden {display: none;}
-     *
-     * @returns {HTMLElement}
-     */
     render() {
         if (!this.root) {
             const item = document.createElement('li'); {
                 this.root = item;
                 item.classList.add('list-group-item');
                 item.classList.add('ctx-item');
-
-                // if this item is Invisible, add the hidden class
-                if (this.isHidden) item.classList.add('qr--hidden');
 
                 // if a title/tooltip is set, add it, otherwise use the QR content
                 // same as for the main QR list

--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -174,6 +174,9 @@
   position: absolute;
   overflow: visible;
 }
+.ctx-menu .ctx-item .qr--hidden {
+    display: none;
+}
 .list-group .list-group-item.ctx-header {
   font-weight: bold;
   cursor: default;

--- a/public/scripts/extensions/quick-reply/style.less
+++ b/public/scripts/extensions/quick-reply/style.less
@@ -176,6 +176,10 @@
     overflow: visible;
 }
 
+.ctx-menu .ctx-item .qr--hidden {
+    display: none;
+}
+
 .list-group .list-group-item.ctx-header {
     font-weight: bold;
     cursor: default;


### PR DESCRIPTION
Add CSS to apply label show/hide settings to QRs in context menus

Add logic for when a QR set is linked to one of its own buttons as "burger" menu

("logic" also includes borrowing 1 bit of information off the icon field to avoid adding any flags to the QR UI which currently has the perfect amount of flags)

With a bit of special handling for the burger case, the existing UI controls should be flexible enough for all use cases so the CSS can just go in. And hidden items can be filtered out entirely like the code for the main QR bars does, so no need for the .isHidden prop I added in #3122.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
