### PR TITLE
Better console output

### DIFF
--- a/src/endpoints/users-public.js
+++ b/src/endpoints/users-public.js
@@ -88,7 +88,7 @@ router.post('/login', jsonParser, async (request, response) => {
 
         await loginLimiter.delete(ip);
         request.session.handle = user.handle;
-        console.log('Login successful:', user.handle, 'from', ip, 'at', Date().toLocaleString());
+        console.log('Login successful:', user.handle, 'from', ip, 'at', new Date().toLocaleString());
         return response.json({ handle: user.handle });
     } catch (error) {
         if (error instanceof RateLimiterRes) {

--- a/src/endpoints/users-public.js
+++ b/src/endpoints/users-public.js
@@ -88,7 +88,7 @@ router.post('/login', jsonParser, async (request, response) => {
 
         await loginLimiter.delete(ip);
         request.session.handle = user.handle;
-        console.log('Login successful:', user.handle, 'from', ip, 'at', request.session.touch);
+        console.log('Login successful:', user.handle, 'from', ip, 'at', Date().toLocaleString());
         return response.json({ handle: user.handle });
     } catch (error) {
         if (error instanceof RateLimiterRes) {

--- a/src/endpoints/users-public.js
+++ b/src/endpoints/users-public.js
@@ -67,17 +67,17 @@ router.post('/login', jsonParser, async (request, response) => {
         const user = await storage.getItem(toKey(request.body.handle));
 
         if (!user) {
-            console.log('Login failed: User not found');
+            console.log('Login failed: User', request.body.handle, 'not found');
             return response.status(403).json({ error: 'Incorrect credentials' });
         }
 
         if (!user.enabled) {
-            console.log('Login failed: User is disabled');
+            console.log('Login failed: User', user.handle, 'is disabled');
             return response.status(403).json({ error: 'User is disabled' });
         }
 
         if (user.password && user.password !== getPasswordHash(request.body.password, user.salt)) {
-            console.log('Login failed: Incorrect password');
+            console.log('Login failed: Incorrect password for', user.handle);
             return response.status(403).json({ error: 'Incorrect credentials' });
         }
 
@@ -88,7 +88,7 @@ router.post('/login', jsonParser, async (request, response) => {
 
         await loginLimiter.delete(ip);
         request.session.handle = user.handle;
-        console.log('Login successful:', user.handle, request.session);
+        console.log('Login successful:', user.handle, 'from', ip, 'at', request.session.touch);
         return response.json({ handle: user.handle });
     } catch (error) {
         if (error instanceof RateLimiterRes) {
@@ -115,12 +115,12 @@ router.post('/recover-step1', jsonParser, async (request, response) => {
         const user = await storage.getItem(toKey(request.body.handle));
 
         if (!user) {
-            console.log('Recover step 1 failed: User not found');
+            console.log('Recover step 1 failed: User', request.body.handle, 'not found');
             return response.status(404).json({ error: 'User not found' });
         }
 
         if (!user.enabled) {
-            console.log('Recover step 1 failed: User is disabled');
+            console.log('Recover step 1 failed: User', user.handle, 'is disabled');
             return response.status(403).json({ error: 'User is disabled' });
         }
 
@@ -153,12 +153,12 @@ router.post('/recover-step2', jsonParser, async (request, response) => {
         const ip = getIpFromRequest(request);
 
         if (!user) {
-            console.log('Recover step 2 failed: User not found');
+            console.log('Recover step 2 failed: User', request.body.handle, 'not found');
             return response.status(404).json({ error: 'User not found' });
         }
 
         if (!user.enabled) {
-            console.log('Recover step 2 failed: User is disabled');
+            console.log('Recover step 2 failed: User', user.handle, 'is disabled');
             return response.status(403).json({ error: 'User is disabled' });
         }
 


### PR DESCRIPTION
I host an instance of ST for multiple people and frequently see failed logins and (sometimes) subsequent recovery codes, usually without the owner of the account notifying me that they need them until (days) later. This is my attempt at having the ability to (more quickly) solve that problem. Bonus points if it slightly helps security for other people.

May also need a function like getForwardedIp from [whitelist.js](https://github.com/SillyTavern/SillyTavern/blob/release/src/middleware/whitelist.js) for people hosting behind reverse proxies or w/e.

Should output messages like `Login successful: example from 10.0.0.1 at 1733207360480` and `Login failed: Incorrect password for example` instead of `Login successful: example Session { handle: 'example', touch: 1733207360480 }` and `Login failed: Incorrect password`

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).