### PR TITLE
add /getpromptentry command

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -379,8 +379,8 @@ export let selected_proxy = proxies[0];
 let openai_setting_names;
 let openai_settings;
 
-
-let promptManager = null;
+/** @type {import('./PromptManager.js').PromptManager} */
+export let promptManager = null;
 
 async function validateReverseProxy() {
     if (!oai_settings.reverse_proxy) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

There was a setter but not a getter. This made me sad. I purposely made it so the code would be similar to setpromptentry's.

`return=simple` (which is default if not set) will try to return a single value. If there's more, then it will either be a dict (if the `identifier` parameter was used) or a list.