### PR TITLE
Expose `tokenizers` & `getTextTokens` in `getContext`

### DIFF
--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -63,7 +63,7 @@ import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { tag_map, tags } from './tags.js';
 import { textgenerationwebui_settings } from './textgen-settings.js';
-import { getTokenCount, getTokenCountAsync, getTokenizerModel } from './tokenizers.js';
+import { tokenizers, getTextTokens, getTokenCount, getTokenCountAsync, getTokenizerModel } from './tokenizers.js';
 import { ToolManager } from './tool-calling.js';
 import { timestampToMoment } from './utils.js';
 
@@ -95,6 +95,8 @@ export function getContext() {
         sendStreamingRequest,
         sendGenerationRequest,
         stopGeneration,
+        tokenizers,
+        getTextTokens,
         /** @deprecated Use getTokenCountAsync instead */
         getTokenCount,
         getTokenCountAsync,


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

I just wanted an easy way to validate my list of logit bias strings so I exposed these functions in getContext.