### PR TITLE
Add DRY to llama.cpp sampler order

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1736,6 +1736,7 @@
                                             <div data-name="tfs_z" draggable="true"><span>Tail Free Sampling</span><small></small></div>
                                             <div data-name="min_p" draggable="true"><span>Min P</span><small></small></div>
                                             <div data-name="xtc" draggable="true"><span>Exclude Top Choices</span><small></small></div>
+                                            <div data-name="dry" draggable="true"><span>DRY</span><small></small></div>
                                         </div>
                                         <div id="llamacpp_samplers_default_order" class="menu_button menu_button_icon">
                                             <span data-i18n="Load default order">Load default order</span>

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -55,6 +55,7 @@ const {
 } = textgen_types;
 
 const LLAMACPP_DEFAULT_ORDER = [
+    'dry',
     'top_k',
     'tfs_z',
     'typical_p',


### PR DESCRIPTION
Add DRY to the llama.cpp sampler order block. If DRY is missing from the sampler order arg, it is implicitly disabled even if its args are otherwise configured. Here I've done some testing using DRY with the multiplier and base maxed out:

DRY in sampler order block:
![image](https://github.com/user-attachments/assets/7075cfb4-ccfe-4661-af35-0d7758ebdbb1)
![image](https://github.com/user-attachments/assets/d59a435b-ce36-44ab-bfe5-d03b80ab0cd7)

No DRY in sampler order block:
![image](https://github.com/user-attachments/assets/d3687071-2579-43a9-be49-e79929ab6d63)
![image](https://github.com/user-attachments/assets/0d3fa8f8-e537-4ee8-bd35-96a45b1d884f)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
