### PR TITLE
/uploadsprite slashcommand

### DIFF
--- a/public/lib/eventemitter.js
+++ b/public/lib/eventemitter.js
@@ -95,13 +95,14 @@ EventEmitter.prototype.removeListener = function (event, listener) {
 };
 
 EventEmitter.prototype.emit = async function (event) {
+    let args = [].slice.call(arguments, 1);
     if (localStorage.getItem('eventTracing') === 'true') {
         console.trace('Event emitted: ' + event, args);
     } else {
         console.debug('Event emitted: ' + event);
     }
 
-    var i, listeners, length, args = [].slice.call(arguments, 1);
+    let i, listeners, length;
 
     if (typeof this.events[event] === 'object') {
         listeners = this.events[event].slice();
@@ -120,13 +121,14 @@ EventEmitter.prototype.emit = async function (event) {
 };
 
 EventEmitter.prototype.emitAndWait = function (event) {
+    let args = [].slice.call(arguments, 1);
     if (localStorage.getItem('eventTracing') === 'true') {
         console.trace('Event emitted: ' + event, args);
     } else {
         console.debug('Event emitted: ' + event);
     }
 
-    var i, listeners, length, args = [].slice.call(arguments, 1);
+    let i, listeners, length;
 
     if (typeof this.events[event] === 'object') {
         listeners = this.events[event].slice();

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -2281,9 +2281,9 @@ function migrateSettings() {
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'uploadsprite',
-        description: 'Upload a sprite',
         callback: async (args, url) => {
             await uploadSpriteCommand(args, url);
+            return '';
         },
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
@@ -2296,19 +2296,26 @@ function migrateSettings() {
             SlashCommandNamedArgument.fromProps({
                 name: 'name',
                 description: 'Character name or avatar key (default is current character)',
-                type: ARGUMENT_TYPE.STRING,
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: false,
+                acceptsMultiple: false,
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'label',
                 description: 'Sprite label/expression name',
-                type: ARGUMENT_TYPE.STRING,
+                typeList: [ARGUMENT_TYPE.STRING],
+                enumProvider: localEnumProviders.expressions,
+                isRequired: true,
+                acceptsMultiple: false,
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'folder',
                 description: 'Override folder to upload into',
-                type: ARGUMENT_TYPE.STRING,
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: false,
+                acceptsMultiple: false,
             }),
         ],
-        helpString: 'Upload a sprite from a URL. Example: /uploadsprite name=Seraphina label=happy /user/images/Seraphina/Seraphina_2024-12-22@12h37m57s.png',
+        helpString: '<div>Upload a sprite from a URL.</div><div>Example:</div><pre><code>/uploadsprite name=Seraphina label=joy /user/images/Seraphina/Seraphina_2024-12-22@12h37m57s.png</code></pre>',
     }));
 })();

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1283,8 +1283,6 @@ async function drawSpritesList(character, labels, sprites) {
  * @returns {Promise<string>} Rendered list item template
  */
 async function getListItem(item, imageSrc, textClass, isCustom) {
-    const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-    imageSrc = isFirefox ? `${imageSrc}?t=${Date.now()}` : imageSrc;
     return renderExtensionTemplateAsync(MODULE_NAME, 'list-item', { item, imageSrc, textClass, isCustom });
 }
 

--- a/src/endpoints/sprites.js
+++ b/src/endpoints/sprites.js
@@ -124,9 +124,10 @@ router.get('/get', jsonParser, function (request, response) {
                 })
                 .map((file) => {
                     const pathToSprite = path.join(spritesPath, file);
+                    const mtime = fs.statSync(pathToSprite).mtime?.toISOString().replace(/[^0-9]/g, '').slice(0, 14);
                     return {
                         label: path.parse(pathToSprite).name.toLowerCase(),
-                        path: `/characters/${name}/${file}`,
+                        path: `/characters/${name}/${file}` + (mtime ? `?t=${mtime}` : ''),
                     };
                 });
         }


### PR DESCRIPTION
This command makes it possible (though still very difficult) for adventurous people to dynamically update expression images or pre-generate them using STscript. It provides reliable cache invalidation for expression images even on Firefox.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
