### PR TITLE
Remove brackets around `{{name}}` in `ChatML-Names` and `Llama-3-Instruct-Names`

### DIFF
--- a/default/content/presets/instruct/ChatML-Names.json
+++ b/default/content/presets/instruct/ChatML-Names.json
@@ -1,6 +1,6 @@
 {
-    "input_sequence": "<|im_start|>[{{name}}]",
-    "output_sequence": "<|im_start|>[{{name}}]",
+    "input_sequence": "<|im_start|>{{name}}",
+    "output_sequence": "<|im_start|>{{name}}",
     "last_output_sequence": "",
     "system_sequence": "<|im_start|>system",
     "stop_sequence": "<|im_end|>",

--- a/default/content/presets/instruct/Llama-3-Instruct-Names.json
+++ b/default/content/presets/instruct/Llama-3-Instruct-Names.json
@@ -1,6 +1,6 @@
 {
-    "input_sequence": "<|start_header_id|>[{{name}}]<|end_header_id|>\n\n",
-    "output_sequence": "<|start_header_id|>[{{name}}]<|end_header_id|>\n\n",
+    "input_sequence": "<|start_header_id|>{{name}}<|end_header_id|>\n\n",
+    "output_sequence": "<|start_header_id|>{{name}}<|end_header_id|>\n\n",
     "last_output_sequence": "",
     "system_sequence": "<|start_header_id|>system<|end_header_id|>\n\n",
     "stop_sequence": "<|eot_id|>",


### PR DESCRIPTION
I created these presets, and my decision to add the brackets around `{{name}}` was because of a subjective test I did when the first few models trained on ChatML were released; upon retesting it with recent models, I've found that it's not necessary or may even hurt performance slightly compared to not using brackets; this is also the case with `Llama-3-Instruct-Names`.

I hope it was okay to submit it directly to release since the PR doesn't change any code; I can resubmit it if needed.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
