### PR TITLE
Automatically detect what IP versions are available and use them

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -7,9 +7,11 @@ cardsCacheCapacity: 100
 # Listen for incoming connections
 listen: false
 # Enables IPv6 and/or IPv4 protocols. Need to have at least one enabled!
+# - Use option "auto" to automatically detect support
+# - Use "enabled" or "disabled" to enable or disabled each protocol
 protocol:
-    ipv4: true
-    ipv6: false
+    ipv4: auto
+    ipv6: auto
 # Prefers IPv6 for DNS. Enable this on ISPs that don't have issues with IPv6
 dnsPreferIPv6: false
 # The hostname that autorun opens.

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -8,7 +8,7 @@ cardsCacheCapacity: 100
 listen: false
 # Enables IPv6 and/or IPv4 protocols. Need to have at least one enabled!
 # - Use option "auto" to automatically detect support
-# - Use "enabled" or "disabled" to enable or disabled each protocol
+# - Use "enabled" or "disabled" to enable or disable each protocol
 protocol:
     ipv4: auto
     ipv6: auto

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -8,7 +8,7 @@ cardsCacheCapacity: 100
 listen: false
 # Enables IPv6 and/or IPv4 protocols. Need to have at least one enabled!
 # - Use option "auto" to automatically detect support
-# - Use "enabled" or "disabled" to enable or disable each protocol
+# - Use true or false (no qoutes) to enable or disable each protocol
 protocol:
     ipv4: auto
     ipv6: auto

--- a/server.js
+++ b/server.js
@@ -930,32 +930,41 @@ async function startServer() {
     const [hasIPv6, hasIPv4] = await getHasIP();
     if (enableIPv6 === 'auto') {
         useIPv6 = hasIPv6;
+    }
+    if (hasIPv6) {
         if (useIPv6) {
             console.log(color.green('IPv6 support detected'));
+        } else {
+            console.log('IPv6 support detected');
         }
-    } else if (hasIPv6) {
-        console.log('IPv6 support detected');
     }
+
 
     if (enableIPv4 === 'auto') {
         useIPv4 = hasIPv4;
         if (useIPv4) {
             console.log(color.green('IPv4 support detected'));
         }
-    } else if (hasIPv4) {
-        console.log('IPv4 support detected');
     }
+    if (hasIPv4) {
+        if (useIPv4) {
+            console.log(color.green('IPv4 support detected'));
+        } else {
+            console.log('IPv4 support detected');
+        }
+    }
+
 
     if (enableIPv6 === 'auto' && enableIPv4 === 'auto') {
         if (!hasIPv6 && !hasIPv4) {
             console.error('Both IPv6 and IPv4 are not detected');
-            process.exit(1)
+            process.exit(1);
         }
     }
 
     if (!useIPv6 && !useIPv6) {
         console.error('Both IPv6 and IPv4 are disabled,\nP.S. you should never see this error, at least at one point it was checked for before this, with the rest of the config options');
-        process.exit(1)
+        process.exit(1);
     }
 
     const [v6Failed, v4Failed] = await startHTTPorHTTPS(useIPv6, useIPv4);

--- a/server.js
+++ b/server.js
@@ -281,6 +281,17 @@ if (dnsPreferIPv6) {
     console.log('Preferring IPv4 for DNS resolution');
 }
 
+const ipOptions = ["enabled", "auto", "disabled"];
+
+if (!ipOptions.includes(enableIPv6)) {
+    console.error("`protocol: ipv6` option invalid");
+    process.exit(1)
+}
+if (!ipOptions.includes(enableIPv4)) {
+    console.error("`protocol: ipv4` option invalid");
+    process.exit(1)
+}
+
 if (enableIPv6 == "disabled" && enableIPv4 == "disabled") {
     console.error('error: You can\'t disable all internet protocols: at least IPv6 or IPv4 must be enabled.');
     process.exit(1);

--- a/server.js
+++ b/server.js
@@ -394,7 +394,6 @@ async function getHasIP() {
             continue;
         }
         for (const info of iface) {
-            //! change this if you ever add configurable addresses to bind to
             if (info.family === 'IPv6') {
                 hasIPv6 = true;
                 if (info.internal === true) {

--- a/server.js
+++ b/server.js
@@ -257,8 +257,8 @@ const enableAccounts = getConfigValue('enableUserAccounts', DEFAULT_ACCOUNTS);
 
 const uploadsPath = path.join(dataRoot, UPLOADS_DIRECTORY);
 
-let enableIPv6 = cliArguments.enableIPv6 ?? getConfigValue('protocol.ipv6', DEFAULT_ENABLE_IPV6);
-let enableIPv4 = cliArguments.enableIPv4 ?? getConfigValue('protocol.ipv4', DEFAULT_ENABLE_IPV4);
+const enableIPv6 = cliArguments.enableIPv6 ?? getConfigValue('protocol.ipv6', DEFAULT_ENABLE_IPV6);
+const enableIPv4 = cliArguments.enableIPv4 ?? getConfigValue('protocol.ipv4', DEFAULT_ENABLE_IPV4);
 
 const autorunHostname = cliArguments.autorunHostname ?? getConfigValue('autorunHostname', DEFAULT_AUTORUN_HOSTNAME);
 const autorunPortOverride = cliArguments.autorunPortOverride ?? getConfigValue('autorunPortOverride', DEFAULT_AUTORUN_PORT);

--- a/server.js
+++ b/server.js
@@ -134,8 +134,8 @@ const DEFAULT_CSRF_DISABLED = false;
 const DEFAULT_BASIC_AUTH = false;
 const DEFAULT_PER_USER_BASIC_AUTH = false;
 
-const DEFAULT_ENABLE_IPV6 = "auto";
-const DEFAULT_ENABLE_IPV4 = "auto";
+const DEFAULT_ENABLE_IPV6 = 'auto';
+const DEFAULT_ENABLE_IPV4 = 'auto';
 
 const DEFAULT_PREFER_IPV6 = false;
 
@@ -281,18 +281,18 @@ if (dnsPreferIPv6) {
     console.log('Preferring IPv4 for DNS resolution');
 }
 
-const ipOptions = ["enabled", "auto", "disabled"];
+const ipOptions = ['enabled', 'auto', 'disabled'];
 
 if (!ipOptions.includes(enableIPv6)) {
-    console.error("`protocol: ipv6` option invalid");
-    process.exit(1)
+    console.error('`protocol: ipv6` option invalid');
+    process.exit(1);
 }
 if (!ipOptions.includes(enableIPv4)) {
-    console.error("`protocol: ipv4` option invalid");
-    process.exit(1)
+    console.error('`protocol: ipv4` option invalid');
+    process.exit(1);
 }
 
-if (enableIPv6 == "disabled" && enableIPv4 == "disabled") {
+if (enableIPv6 == 'disabled' && enableIPv4 == 'disabled') {
     console.error('error: You can\'t disable all internet protocols: at least IPv6 or IPv4 must be enabled.');
     process.exit(1);
 }
@@ -384,7 +384,7 @@ async function getHasIP() {
 
     for (const iface of Object.values(interfaces)) {
         if (iface === undefined) {
-            continue
+            continue;
         }
         for (const info of iface) {
             if (info.family === 'IPv6') {
@@ -924,26 +924,26 @@ async function startHTTPorHTTPS(useIPv6, useIPv4) {
 }
 
 async function startServer() {
-    let useIPv6 = (enableIPv6 == "enabled")
-    let useIPv4 = (enableIPv4 == "enabled")
+    let useIPv6 = (enableIPv6 == 'enabled');
+    let useIPv4 = (enableIPv4 == 'enabled');
 
-    const [hasIPv6, hasIPv4] = await getHasIP()
-    if (enableIPv6 == "auto") {
+    const [hasIPv6, hasIPv4] = await getHasIP();
+    if (enableIPv6 == 'auto') {
         useIPv6 = hasIPv6;
         if (useIPv6) {
-            console.log("IPv6 support detected")
+            console.log('IPv6 support detected');
         }
     }
 
-    if (enableIPv4 == "auto") {
+    if (enableIPv4 == 'auto') {
         useIPv4 = hasIPv4;
         if (useIPv4) {
-            console.log("IPv4 support detected")
+            console.log('IPv4 support detected');
         }
     }
 
     if (!useIPv6 && !useIPv4) {
-        console.log("No IPv6 and no IPv4 enabled")
+        console.log('No IPv6 and no IPv4 enabled');
     }
 
     const [v6Failed, v4Failed] = await startHTTPorHTTPS(useIPv6, useIPv4);

--- a/server.js
+++ b/server.js
@@ -68,6 +68,7 @@ import {
     forwardFetchResponse,
     removeColorFormatting,
     getSeparator,
+    stringToBool,
 } from './src/util.js';
 import { UPLOADS_DIRECTORY } from './src/constants.js';
 import { ensureThumbnailCache } from './src/endpoints/thumbnails.js';
@@ -244,11 +245,6 @@ app.use(helmet({
 app.use(compression());
 app.use(responseTime());
 
-function stringToBool(str) {
-    if (str === 'true') return true;
-    if (str === 'false') return false;
-    return str;
-}
 
 const server_port = cliArguments.port ?? process.env.SILLY_TAVERN_PORT ?? getConfigValue('port', DEFAULT_PORT);
 const autorun = (cliArguments.autorun ?? getConfigValue('autorun', DEFAULT_AUTORUN)) && !cliArguments.ssl;

--- a/server.js
+++ b/server.js
@@ -955,13 +955,13 @@ async function startHTTPorHTTPS(useIPv6, useIPv4) {
 async function startServer() {
     let useIPv6 = (enableIPv6 === true);
     let useIPv4 = (enableIPv4 === true);
-    let hasIPv6, hasIPv4, hasIPv6Local, hasIPv4Local, hasIPv6NonLocal, hasIPv4NonLocal;
+    let hasIPv6, hasIPv4, hasIPv6Local, hasIPv4Local, hasIPv6Any, hasIPv4Any;
 
 
     if (enableIPv6 === 'auto' || enableIPv4 === 'auto') {
-        [hasIPv6NonLocal, hasIPv4NonLocal, hasIPv6Local, hasIPv4Local] = await getHasIP();
+        [hasIPv6Any, hasIPv4Any, hasIPv6Local, hasIPv4Local] = await getHasIP();
 
-        hasIPv6 = listen ? hasIPv6NonLocal : hasIPv6Local;
+        hasIPv6 = listen ? hasIPv6Any : hasIPv6Local;
         if (enableIPv6 === 'auto') {
             useIPv6 = hasIPv6;
         }
@@ -974,7 +974,7 @@ async function startServer() {
         }
 
 
-        hasIPv4 = listen ? hasIPv4NonLocal : hasIPv4Local;
+        hasIPv4 = listen ? hasIPv4Any : hasIPv4Local;
         if (enableIPv4 === 'auto') {
             useIPv4 = hasIPv4;
         }

--- a/server.js
+++ b/server.js
@@ -247,7 +247,7 @@ app.use(responseTime());
 function stringToBool(str) {
     if (str === 'true') return true;
     if (str === 'false') return false;
-    return str; // or throw an error
+    return str;
 }
 
 const server_port = cliArguments.port ?? process.env.SILLY_TAVERN_PORT ?? getConfigValue('port', DEFAULT_PORT);

--- a/server.js
+++ b/server.js
@@ -284,11 +284,11 @@ if (dnsPreferIPv6) {
 const ipOptions = ['enabled', 'auto', 'disabled'];
 
 if (!ipOptions.includes(enableIPv6)) {
-    console.error('`protocol: ipv6` option invalid');
+    console.error('`protocol: ipv6` option invalid\n use:', ipOptions);
     process.exit(1);
 }
 if (!ipOptions.includes(enableIPv4)) {
-    console.error('`protocol: ipv4` option invalid');
+    console.error('`protocol: ipv4` option invalid\n use:', ipOptions);
     process.exit(1);
 }
 

--- a/server.js
+++ b/server.js
@@ -971,7 +971,7 @@ async function startServer() {
             if (useIPv6) {
                 console.log(color.green('IPv6 support detected'));
             } else {
-                console.log('IPv6 support detected');
+                console.log('IPv6 support detected (but disabled)');
             }
         }
 
@@ -984,7 +984,7 @@ async function startServer() {
             if (useIPv4) {
                 console.log(color.green('IPv4 support detected'));
             } else {
-                console.log('IPv4 support detected');
+                console.log('IPv4 support detected (but disabled)');
             }
         }
     } else {

--- a/server.js
+++ b/server.js
@@ -987,6 +987,8 @@ async function startServer() {
                 console.log('IPv4 support detected');
             }
         }
+    } else {
+        console.log("Neither protocol: ipv6, nor ipv4 are set to auto, skipping detection")
     }
 
 

--- a/server.js
+++ b/server.js
@@ -950,7 +950,7 @@ async function startServer() {
     }
 
     if (!useIPv6 && !useIPv6) {
-        console.error('Both IPv6 and IPv4 are disabled,\nP.S. you should never see this error, at least at one point it was checked for before this');
+        console.error('Both IPv6 and IPv4 are disabled,\nP.S. you should never see this error, at least at one point it was checked for before this, with the rest of the config options');
         process.exit(1)
     }
 

--- a/server.js
+++ b/server.js
@@ -244,6 +244,12 @@ app.use(helmet({
 app.use(compression());
 app.use(responseTime());
 
+function stringToBool(str) {
+    if (str === 'true') return true;
+    if (str === 'false') return false;
+    return str; // or throw an error
+}
+
 const server_port = cliArguments.port ?? process.env.SILLY_TAVERN_PORT ?? getConfigValue('port', DEFAULT_PORT);
 const autorun = (cliArguments.autorun ?? getConfigValue('autorun', DEFAULT_AUTORUN)) && !cliArguments.ssl;
 const listen = cliArguments.listen ?? getConfigValue('listen', DEFAULT_LISTEN);
@@ -257,8 +263,9 @@ const enableAccounts = getConfigValue('enableUserAccounts', DEFAULT_ACCOUNTS);
 
 const uploadsPath = path.join(dataRoot, UPLOADS_DIRECTORY);
 
-const enableIPv6 = cliArguments.enableIPv6 ?? getConfigValue('protocol.ipv6', DEFAULT_ENABLE_IPV6);
-const enableIPv4 = cliArguments.enableIPv4 ?? getConfigValue('protocol.ipv4', DEFAULT_ENABLE_IPV4);
+
+const enableIPv6 = stringToBool(cliArguments.enableIPv6) ?? getConfigValue('protocol.ipv6', DEFAULT_ENABLE_IPV6);
+const enableIPv4 = stringToBool(cliArguments.enableIPv4) ?? getConfigValue('protocol.ipv4', DEFAULT_ENABLE_IPV4);
 
 const autorunHostname = cliArguments.autorunHostname ?? getConfigValue('autorunHostname', DEFAULT_AUTORUN_HOSTNAME);
 const autorunPortOverride = cliArguments.autorunPortOverride ?? getConfigValue('autorunPortOverride', DEFAULT_AUTORUN_PORT);
@@ -957,6 +964,7 @@ async function startServer() {
     }
 
 
+
     if (enableIPv6 === 'auto' && enableIPv4 === 'auto') {
         if (!hasIPv6 && !hasIPv4) {
             console.error('Both IPv6 and IPv4 are not detected');
@@ -964,7 +972,7 @@ async function startServer() {
         }
     }
 
-    if (!useIPv6 && !useIPv6) {
+    if (!useIPv6 && !useIPv4) {
         console.error('Both IPv6 and IPv4 are disabled,\nP.S. you should never see this error, at least at one point it was checked for before this, with the rest of the config options');
         process.exit(1);
     }

--- a/server.js
+++ b/server.js
@@ -924,26 +924,34 @@ async function startHTTPorHTTPS(useIPv6, useIPv4) {
 }
 
 async function startServer() {
-    let useIPv6 = (enableIPv6 == 'enabled');
-    let useIPv4 = (enableIPv4 == 'enabled');
+    let useIPv6 = (enableIPv6 === 'enabled');
+    let useIPv4 = (enableIPv4 === 'enabled');
 
     const [hasIPv6, hasIPv4] = await getHasIP();
-    if (enableIPv6 == 'auto') {
+    if (enableIPv6 === 'auto') {
         useIPv6 = hasIPv6;
         if (useIPv6) {
             console.log('IPv6 support detected');
         }
     }
 
-    if (enableIPv4 == 'auto') {
+    if (enableIPv4 === 'auto') {
         useIPv4 = hasIPv4;
         if (useIPv4) {
             console.log('IPv4 support detected');
         }
     }
 
-    if (!useIPv6 && !useIPv4) {
-        console.log('No IPv6 and no IPv4 enabled');
+    if (enableIPv6 === 'auto' && enableIPv4 === 'auto') {
+        if (!hasIPv6 && !hasIPv4) {
+            console.error('Both IPv6 and IPv4 are not detected');
+            process.exit(1)
+        }
+    }
+
+    if (!useIPv6 && !useIPv6) {
+        console.error('Both IPv6 and IPv4 are disabled,\nP.S. you should never see this error, at least at one point it was checked for before this');
+        process.exit(1)
     }
 
     const [v6Failed, v4Failed] = await startHTTPorHTTPS(useIPv6, useIPv4);

--- a/server.js
+++ b/server.js
@@ -150,12 +150,12 @@ const DEFAULT_PROXY_BYPASS = [];
 
 const cliArguments = yargs(hideBin(process.argv))
     .usage('Usage: <your-start-script> <command> [options]')
-    .option('string', {
-        type: 'boolean',
+    .option('enableIPv6', {
+        type: 'string',
         default: null,
         describe: `Enables IPv6.\n[config default: ${DEFAULT_ENABLE_IPV6}]`,
-    }).option('string', {
-        type: 'boolean',
+    }).option('enableIPv4', {
+        type: 'string',
         default: null,
         describe: `Enables IPv4.\n[config default: ${DEFAULT_ENABLE_IPV4}]`,
     }).option('port', {

--- a/server.js
+++ b/server.js
@@ -289,11 +289,11 @@ if (dnsPreferIPv6) {
 const ipOptions = [true, 'auto', false];
 
 if (!ipOptions.includes(enableIPv6)) {
-    console.warn(color.red('`protocol: ipv6` option invalid'), "\n use:", ipOptions, "\n setting to: auto");
+    console.warn(color.red('`protocol: ipv6` option invalid'), '\n use:', ipOptions, '\n setting to: auto');
     enableIPv6 = 'auto';
 }
 if (!ipOptions.includes(enableIPv4)) {
-    console.warn(color.red('`protocol: ipv4` option invalid'), "\n use:", ipOptions, "\n setting to: auto");
+    console.warn(color.red('`protocol: ipv4` option invalid'), '\n use:', ipOptions, '\n setting to: auto');
     enableIPv4 = 'auto';
 }
 
@@ -887,7 +887,7 @@ function createHttpsServer(url, ipVersion) {
         server.on('error', reject);
         server.on('listening', resolve);
 
-        let host = url.hostname
+        let host = url.hostname;
         if (ipVersion === 6) host = urlHostnameToIPv6(url.hostname);
         server.listen({
             host: host,
@@ -910,7 +910,7 @@ function createHttpServer(url, ipVersion) {
         server.on('error', reject);
         server.on('listening', resolve);
 
-        let host = url.hostname
+        let host = url.hostname;
         if (ipVersion === 6) host = urlHostnameToIPv6(url.hostname);
         server.listen({
             host: host,

--- a/server.js
+++ b/server.js
@@ -396,14 +396,14 @@ async function getHasIP() {
         for (const info of iface) {
             if (info.family === 'IPv6') {
                 hasIPv6 = true;
-                if (info.internal === true) {
+                if (info.address === '::1') {
                     hasIPv6Local = true;
                 }
             }
 
             if (info.family === 'IPv4') {
                 hasIPv4 = true;
-                if (info.internal === true) {
+                if (info.address === '127.0.0.1') {
                     hasIPv4Local = true;
                 }
             }

--- a/server.js
+++ b/server.js
@@ -385,8 +385,10 @@ function getSessionCookieAge() {
 async function getHasIP() {
     let hasIPv6 = false;
     let hasIPv6Local = false;
+
     let hasIPv4 = false;
     let hasIPv4Local = false;
+
     const interfaces = os.networkInterfaces();
 
     for (const iface of Object.values(interfaces)) {

--- a/server.js
+++ b/server.js
@@ -931,15 +931,19 @@ async function startServer() {
     if (enableIPv6 === 'auto') {
         useIPv6 = hasIPv6;
         if (useIPv6) {
-            console.log('IPv6 support detected');
+            console.log(color.green('IPv6 support detected'));
         }
+    } else if (hasIPv6) {
+        console.log('IPv6 support detected');
     }
 
     if (enableIPv4 === 'auto') {
         useIPv4 = hasIPv4;
         if (useIPv4) {
-            console.log('IPv4 support detected');
+            console.log(color.green('IPv4 support detected'));
         }
+    } else if (hasIPv4) {
+        console.log('IPv4 support detected');
     }
 
     if (enableIPv6 === 'auto' && enableIPv4 === 'auto') {

--- a/server.js
+++ b/server.js
@@ -394,7 +394,9 @@ async function getHasIP() {
             if (info.family === 'IPv4') {
                 hasIPv4 = true;
             }
+            if (hasIPv6 && hasIPv4) break;
         }
+        if (hasIPv6 && hasIPv4) break;
     }
     return [hasIPv6, hasIPv4];
 }

--- a/server.js
+++ b/server.js
@@ -264,8 +264,8 @@ const enableAccounts = getConfigValue('enableUserAccounts', DEFAULT_ACCOUNTS);
 const uploadsPath = path.join(dataRoot, UPLOADS_DIRECTORY);
 
 
-const enableIPv6 = stringToBool(cliArguments.enableIPv6) ?? getConfigValue('protocol.ipv6', DEFAULT_ENABLE_IPV6);
-const enableIPv4 = stringToBool(cliArguments.enableIPv4) ?? getConfigValue('protocol.ipv4', DEFAULT_ENABLE_IPV4);
+let enableIPv6 = stringToBool(cliArguments.enableIPv6) ?? getConfigValue('protocol.ipv6', DEFAULT_ENABLE_IPV6);
+let enableIPv4 = stringToBool(cliArguments.enableIPv4) ?? getConfigValue('protocol.ipv4', DEFAULT_ENABLE_IPV4);
 
 const autorunHostname = cliArguments.autorunHostname ?? getConfigValue('autorunHostname', DEFAULT_AUTORUN_HOSTNAME);
 const autorunPortOverride = cliArguments.autorunPortOverride ?? getConfigValue('autorunPortOverride', DEFAULT_AUTORUN_PORT);
@@ -292,12 +292,12 @@ if (dnsPreferIPv6) {
 const ipOptions = [true, 'auto', false];
 
 if (!ipOptions.includes(enableIPv6)) {
-    console.error('`protocol: ipv6` option invalid\n use:', ipOptions);
-    process.exit(1);
+    console.warn('`protocol: ipv6` option invalid\n use:', ipOptions, "\n setting to: auto");
+    enableIPv6 = 'auto';
 }
 if (!ipOptions.includes(enableIPv4)) {
-    console.error('`protocol: ipv4` option invalid\n use:', ipOptions);
-    process.exit(1);
+    console.warn('`protocol: ipv4` option invalid\n use:', ipOptions, "\n setting to: auto");
+    enableIPv4 = 'auto';
 }
 
 if (enableIPv6 === false  && enableIPv4 === false) {

--- a/server.js
+++ b/server.js
@@ -257,8 +257,8 @@ const enableAccounts = getConfigValue('enableUserAccounts', DEFAULT_ACCOUNTS);
 
 const uploadsPath = path.join(dataRoot, UPLOADS_DIRECTORY);
 
-const enableIPv6 = cliArguments.enableIPv6 ?? getConfigValue('protocol.ipv6', DEFAULT_ENABLE_IPV6);
-const enableIPv4 = cliArguments.enableIPv4 ?? getConfigValue('protocol.ipv4', DEFAULT_ENABLE_IPV4);
+let enableIPv6 = cliArguments.enableIPv6 ?? getConfigValue('protocol.ipv6', DEFAULT_ENABLE_IPV6);
+let enableIPv4 = cliArguments.enableIPv4 ?? getConfigValue('protocol.ipv4', DEFAULT_ENABLE_IPV4);
 
 const autorunHostname = cliArguments.autorunHostname ?? getConfigValue('autorunHostname', DEFAULT_AUTORUN_HOSTNAME);
 const autorunPortOverride = cliArguments.autorunPortOverride ?? getConfigValue('autorunPortOverride', DEFAULT_AUTORUN_PORT);
@@ -281,7 +281,8 @@ if (dnsPreferIPv6) {
     console.log('Preferring IPv4 for DNS resolution');
 }
 
-const ipOptions = ['enabled', 'auto', 'disabled'];
+
+const ipOptions = [true, 'auto', false];
 
 if (!ipOptions.includes(enableIPv6)) {
     console.error('`protocol: ipv6` option invalid\n use:', ipOptions);
@@ -292,7 +293,7 @@ if (!ipOptions.includes(enableIPv4)) {
     process.exit(1);
 }
 
-if (enableIPv6 == 'disabled' && enableIPv4 == 'disabled') {
+if (enableIPv6 === false  && enableIPv4 === false) {
     console.error('error: You can\'t disable all internet protocols: at least IPv6 or IPv4 must be enabled.');
     process.exit(1);
 }
@@ -924,33 +925,34 @@ async function startHTTPorHTTPS(useIPv6, useIPv4) {
 }
 
 async function startServer() {
-    let useIPv6 = (enableIPv6 === 'enabled');
-    let useIPv4 = (enableIPv4 === 'enabled');
+    let useIPv6 = (enableIPv6 === true);
+    let useIPv4 = (enableIPv4 === true);
+    let hasIPv6, hasIPv4;
 
-    const [hasIPv6, hasIPv4] = await getHasIP();
-    if (enableIPv6 === 'auto') {
-        useIPv6 = hasIPv6;
-    }
-    if (hasIPv6) {
-        if (useIPv6) {
-            console.log(color.green('IPv6 support detected'));
-        } else {
-            console.log('IPv6 support detected');
+
+    if (enableIPv6 === 'auto' || enableIPv4 === 'auto') {
+        [hasIPv6, hasIPv4] = await getHasIP();
+        if (enableIPv6 === 'auto') {
+            useIPv6 = hasIPv6;
         }
-    }
-
-
-    if (enableIPv4 === 'auto') {
-        useIPv4 = hasIPv4;
-        if (useIPv4) {
-            console.log(color.green('IPv4 support detected'));
+        if (hasIPv6) {
+            if (useIPv6) {
+                console.log(color.green('IPv6 support detected'));
+            } else {
+                console.log('IPv6 support detected');
+            }
         }
-    }
-    if (hasIPv4) {
-        if (useIPv4) {
-            console.log(color.green('IPv4 support detected'));
-        } else {
-            console.log('IPv4 support detected');
+
+
+        if (enableIPv4 === 'auto') {
+            useIPv4 = hasIPv4;
+        }
+        if (hasIPv4) {
+            if (useIPv4) {
+                console.log(color.green('IPv4 support detected'));
+            } else {
+                console.log('IPv4 support detected');
+            }
         }
     }
 

--- a/server.js
+++ b/server.js
@@ -288,11 +288,11 @@ if (dnsPreferIPv6) {
 const ipOptions = [true, 'auto', false];
 
 if (!ipOptions.includes(enableIPv6)) {
-    console.warn('`protocol: ipv6` option invalid\n use:', ipOptions, "\n setting to: auto");
+    console.warn(color.red('`protocol: ipv6` option invalid'), "\n use:", ipOptions, "\n setting to: auto");
     enableIPv6 = 'auto';
 }
 if (!ipOptions.includes(enableIPv4)) {
-    console.warn('`protocol: ipv4` option invalid\n use:', ipOptions, "\n setting to: auto");
+    console.warn(color.red('`protocol: ipv4` option invalid'), "\n use:", ipOptions, "\n setting to: auto");
     enableIPv4 = 'auto';
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -693,10 +693,10 @@ export function isValidUrl(url) {
 }
 
 export function urlHostnameToIPv6(hostname) {
-    if (hostname.charAt(0) === '[') {
+    if (hostname.startsWith("[")) {
         hostname = hostname.slice(1);
     }
-    if (hostname.charAt(hostname.length - 1) === ']') {
+    if (hostname.endsWith("]")) {
         hostname = hostname.slice(0, -1);
     }
     return hostname

--- a/src/util.js
+++ b/src/util.js
@@ -699,7 +699,6 @@ export function urlHostnameToIPv6(hostname) {
     if (hostname.charAt(hostname.length - 1) === ']') {
         hostname = hostname.slice(0, -1);
     }
-    // console.log(hostname)
     return hostname
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -693,13 +693,13 @@ export function isValidUrl(url) {
 }
 
 export function urlHostnameToIPv6(hostname) {
-    if (hostname.startsWith("[")) {
+    if (hostname.startsWith('[')) {
         hostname = hostname.slice(1);
     }
-    if (hostname.endsWith("]")) {
+    if (hostname.endsWith(']')) {
         hostname = hostname.slice(0, -1);
     }
-    return hostname
+    return hostname;
 }
 
 export function stringToBool(str) {

--- a/src/util.js
+++ b/src/util.js
@@ -692,6 +692,23 @@ export function isValidUrl(url) {
     }
 }
 
+export function urlHostnameToIPv6(hostname) {
+    if (hostname.charAt(0) === '[') {
+        hostname = hostname.slice(1);
+    }
+    if (hostname.charAt(hostname.length - 1) === ']') {
+        hostname = hostname.slice(0, -1);
+    }
+    // console.log(hostname)
+    return hostname
+}
+
+export function stringToBool(str) {
+    if (str === 'true') return true;
+    if (str === 'false') return false;
+    return str;
+}
+
 /**
  * MemoryLimitedMap class that limits the memory usage of string values.
  */


### PR DESCRIPTION
this detects if IPv6 and/or IPv4 are available and uses them automatically, with an option to manually set if they are enabled or not

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
