### PR TITLE
Fix recent llama.cpp server logprobs

### DIFF
--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1046,7 +1046,7 @@ export function parseTextgenLogprobs(token, logprobs) {
             // 3 cases:
             // 1. Before commit 6c5bc06, "probs" key with "tok_str"/"prob", and probs are [0, 1] so use them directly.
             // 2. After commit 6c5bc06 but before commit 89d604f broke logprobs (they all return the first token's logprobs)
-            //    We don't know the client version so we can't do much about this.
+            //    We don't know the llama.cpp version so we can't do much about this.
             // 3. After commit 89d604f uses OpenAI-compatible format with "completion_probabilities" and "token"/"logprob" keys.
             //    Note that it is also the *actual* logprob (negative number), so we need to convert to [0, 1].
             if (logprobs?.[0]?.probs) {

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1042,11 +1042,27 @@ export function parseTextgenLogprobs(token, logprobs) {
             if (!logprobs?.length) {
                 return null;
             }
-            const candidates = logprobs?.[0]?.probs?.map(x => [x.tok_str, x.prob]);
-            if (!candidates) {
-                return null;
+
+            // 3 cases:
+            // 1. Before commit 6c5bc06, "probs" key with "tok_str"/"prob", and probs are [0, 1] so use them directly.
+            // 2. After commit 6c5bc06 but before commit 89d604f broke logprobs (they all return the first token's logprobs)
+            //    We don't know the client version so we can't do much about this.
+            // 3. After commit 89d604f uses OpenAI-compatible format with "completion_probabilities" and "token"/"logprob" keys.
+            //    Note that it is also the *actual* logprob (negative number), so we need to convert to [0, 1].
+            if (logprobs?.[0]?.probs) {
+                const candidates = logprobs?.[0]?.probs?.map(x => [x.tok_str, x.prob]);
+                if (!candidates) {
+                    return null;
+                }
+                return { token, topLogprobs: candidates };
+            } else if (logprobs?.[0].top_logprobs) {
+                const candidates = logprobs?.[0]?.top_logprobs?.map(x => [x.token, Math.exp(x.logprob)]);
+                if (!candidates) {
+                    return null;
+                }
+                return { token, topLogprobs: candidates };
             }
-            return { token, topLogprobs: candidates };
+            return null;
         }
         default:
             return null;


### PR DESCRIPTION
## Problem

It seems that recent changes in the `llama.cpp` server broke how SillyTavern parses logprobs.

**TLDR:** They switched the server format, but for about 5-10 days before they did that they accidentally broke logprobs altogether. This PR fixes ST to work with the new format and keeps compatibility with the old format but we can't do anything about those few broken versions.

Some investigation points to two commits (I checked before and after the commits and verified they did indeed break things):
1. `llama.cpp` did a refactor of the server at https://github.com/ggerganov/llama.cpp/commit/6c5bc0625fae6909cb40def15bc4bb45db6f7f4d. This *partially* broke logprobs. It seems they accidentally started returning the logprobs for the first token for all subsequent tokens.
2. Then they fixed/changed the logprobs response format to be OpenAI compatible, which was in https://github.com/ggerganov/llama.cpp/commit/89d604f2c87af9db657d8a27a1528bc4b7579c29 and broke ST's current parsing completely.

## Fixes in this PR

1. For prior to `6c5bc06`, I left existing code so it should be fully backwards compatible (I tested and it's identical behavior).
2. Server versions between `6c5bc06` and `89d604f` just broke logprobs completely. I had hoped to give the user a message warning them to upgrade but can't think of an easy way to add this in `parseTextgenLogprobs` given it operates on a single token at a time (and must only do that because it's streamed). So it remains broken.
3. For after `89d604f` I added the appropriate code to parse logprobs and can confirm it's working as of https://github.com/ggerganov/llama.cpp/commit/d79d8f39b4da6deca4aea8bf130c6034c482b320 which was released yesterday.

## Testing

This requires somewhat manual testing. If you need to check:
1. Build `llama.cpp` server using commit `7736837` which was before the first issue and try logprobs in ST.
2. You can verify `6c5bc06` if you want but since the issue was on there end we can't fix things.
3. Build `llama.cpp` server using commit `d79d8f3` which is after the format change and try logprobs in ST.

Let me know if there's anything else that I need to do to get this merged. 😄 

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
