### PR TITLE
Enable no-unneeded-ternary ESLint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -91,6 +91,7 @@ module.exports = {
         'space-infix-ops': 'error',
         'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
         'no-cond-assign': 'error',
+        'no-unneeded-ternary': 'error',
 
         // These rules should eventually be enabled.
         'no-async-promise-executor': 'off',

--- a/public/scripts/authors-note.js
+++ b/public/scripts/authors-note.js
@@ -440,7 +440,7 @@ async function onChatChanged() {
     const context = getContext();
 
     // Disable the chara note if in a group
-    $('#extension_floating_chara').prop('disabled', context.groupId ? true : false);
+    $('#extension_floating_chara').prop('disabled', !!context.groupId);
 
     const tokenCounter1 = chat_metadata[metadata_keys.prompt] ? await getTokenCountAsync(chat_metadata[metadata_keys.prompt]) : 0;
     $('#extension_floating_prompt_token_counter').text(tokenCounter1);

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4681,7 +4681,7 @@ function convertCharacterBook(characterBook) {
             preventRecursion: entry.extensions?.prevent_recursion ?? false,
             delayUntilRecursion: entry.extensions?.delay_until_recursion ?? false,
             disable: !entry.enabled,
-            addMemo: entry.comment ? true : false,
+            addMemo: !!entry.comment,
             displayIndex: entry.extensions?.display_index ?? index,
             probability: entry.extensions?.probability ?? 100,
             useProbability: entry.extensions?.useProbability ?? true,


### PR DESCRIPTION
Unnecessary ternary conditionals occasionally appear in the codebase. I believe casting to a boolean via double negation (`!!someVariable`) is clearer. An alternative would be an explicit `Boolean` cast (`Boolean(someVariable)`), which I can change this PR to do.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
