### PR TITLE
Folders should not be sorted in the char list

### DIFF
--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -2094,12 +2094,10 @@ export function sortEntitiesList(entities, forceSearch, filterHelper = null) {
     }
 
     entities.sort((a, b) => {
-        // Sort tags/folders will always be at the top
-        if (a.type === 'tag' && b.type !== 'tag') {
-            return -1;
-        }
-        if (a.type !== 'tag' && b.type === 'tag') {
-            return 1;
+        // Sort tags/folders will always be at the top. Their original sorting will be kept, to respect manual tag sorting.
+        if (a.type === 'tag' || b.type === 'tag') {
+            // The one that is a tag will be at the top
+            return (a.type === 'tag' ? -1 : 1) - (b.type === 'tag' ? -1 : 1);
         }
 
         // If we have search sorting, we take scores and use those


### PR DESCRIPTION
Man, I forgot it in the commit message. I am rusty.
This fixes #3175.

The reasoning was sound. If we have tag sorting options and an alphabetical sorting setting in the "Tag Management", we shouldn't sort the tags *sometimes* and sometimes not in the char list.
Only exception is when using search, where the matching weights get applied to show the best matching tags at the top. I think that is fine.

### Changes
- Folders respect the chosen sorting of the "Tag Management"
- They will still always be displayed on top
- They will now not follow any chosen list sorting, so do not get changed based on alphabetical sorting of the char list

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
