### PR TITLE
Character import speedup by delaying tag import

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -8865,19 +8865,18 @@ export async function processDroppedFiles(files, data = new Map()) {
         }
     }
 
-    await ImportCharactersTags(avatarFileNames);
+    await importCharactersTags(avatarFileNames);
 }
 
 /**
  * Imports tags for the given characters
  * @param {string[]} avatarFileNames character avatar filenames whose tags are to import
  */
-async function ImportCharactersTags(avatarFileNames) {
+async function importCharactersTags(avatarFileNames) {
     await getCharacters();
-    const currentContext = getContext();
     for (let i = 0; i < avatarFileNames.length; i++) {
         if (power_user.tag_import_setting !== tag_import_setting.NONE) {
-            const importedCharacter = currentContext.characters.find(character => character.avatar === avatarFileNames[i]);
+            const importedCharacter = characters.find(character => character.avatar === avatarFileNames[i]);
             await importTags(importedCharacter);
         }
     }
@@ -8935,7 +8934,7 @@ async function importCharacter(file, {preserveFileName = '', importTags = false}
         select_rm_info('char_import', data.file_name, oldSelectedChar);
         let avatarFileName = `${data.file_name}.png`;
         if (importTags) {
-            ImportCharactersTags([avatarFileName])
+            await importCharactersTags([avatarFileName])
         }
         return avatarFileName;
     }
@@ -10823,7 +10822,7 @@ jQuery(async function () {
                 avatarFileNames.push(avatarFileName);
             }
         }
-        await ImportCharactersTags(avatarFileNames);
+        await importCharactersTags(avatarFileNames);
     });
 
     $('#export_button').on('click', function () {

--- a/public/script.js
+++ b/public/script.js
@@ -8856,8 +8856,8 @@ export async function processDroppedFiles(files, data = new Map()) {
         const extension = file.name.split('.').pop().toLowerCase();
         if (allowedMimeTypes.some(x => file.type.startsWith(x)) || allowedExtensions.includes(extension)) {
             const preservedName = data instanceof Map && data.get(file);
-            const avatarFileName = await importCharacter(file, {preserveFileName: preservedName});
-            if (avatarFileName !== undefined){
+            const avatarFileName = await importCharacter(file, { preserveFileName: preservedName });
+            if (avatarFileName !== undefined) {
                 avatarFileNames.push(avatarFileName);
             }
         } else {
@@ -8865,7 +8865,7 @@ export async function processDroppedFiles(files, data = new Map()) {
         }
     }
 
-    if (avatarFileNames.length > 0){
+    if (avatarFileNames.length > 0) {
         await importCharactersTags(avatarFileNames);
         selectImportedChar(avatarFileNames[avatarFileNames.length - 1]);
     }
@@ -8905,7 +8905,7 @@ function selectImportedChar(charId) {
  * @param {Boolean} [options.importTags=false] Whether to import tags
  * @returns {Promise<string>}
  */
-async function importCharacter(file, {preserveFileName = '', importTags = false} = {}) {
+async function importCharacter(file, { preserveFileName = '', importTags = false } = {}) {
     if (is_group_generating || is_send_press) {
         toastr.error(t`Cannot import characters while generating. Stop the request and try again.`, t`Import aborted`);
         throw new Error('Cannot import character while generating');
@@ -10830,12 +10830,12 @@ jQuery(async function () {
         const avatarFileNames = [];
         for (const file of e.target.files) {
             const avatarFileName = await importCharacter(file);
-            if (avatarFileName !== undefined){
+            if (avatarFileName !== undefined) {
                 avatarFileNames.push(avatarFileName);
             }
         }
 
-        if (avatarFileNames.length > 0){
+        if (avatarFileNames.length > 0) {
             await importCharactersTags(avatarFileNames);
             selectImportedChar(avatarFileNames[avatarFileNames.length - 1]);
         }


### PR DESCRIPTION
This PR significantly improves the speed of character bulk imports when dealing with a large number of characters by delaying tag import, partially addressing #2952.
Tag import requires fetching all characters via `getCharacters()`, which becomes expensive as the number of characters increases. 
Tag import is currently done after each character import, causing as many calls to `getCharacters()` as the number of characters imported.
When importing multiple characters, the import phase can be done after the character import, requiring only a single complete character update at the end.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
