### PR TITLE
Fix: Ensure "OFF" safety settings are applied to gemini-2.0-flash-exp for unfiltered responses

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -308,11 +308,18 @@ async function sendMakerSuiteRequest(request, response) {
         ) && request.body.use_makersuite_sysprompt;
 
         const prompt = convertGooglePrompt(request.body.messages, model, should_use_system_prompt, getPromptNames(request));
+        let safetySettings = GEMINI_SAFETY;
+        
+        if (model.includes('gemini-2.0-flash-exp')) {
+            safetySettings = GEMINI_SAFETY.map(setting => ({ ...setting, threshold: 'OFF' }));
+        }
+
         let body = {
             contents: prompt.contents,
-            safetySettings: GEMINI_SAFETY,
+            safetySettings: safetySettings,
             generationConfig: generationConfig,
         };
+
 
         if (should_use_system_prompt) {
             body.system_instruction = prompt.system_instruction;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -309,7 +309,7 @@ async function sendMakerSuiteRequest(request, response) {
 
         const prompt = convertGooglePrompt(request.body.messages, model, should_use_system_prompt, getPromptNames(request));
         let safetySettings = GEMINI_SAFETY;
-        
+
         if (model.includes('gemini-2.0-flash-exp')) {
             safetySettings = GEMINI_SAFETY.map(setting => ({ ...setting, threshold: 'OFF' }));
         }
@@ -319,7 +319,6 @@ async function sendMakerSuiteRequest(request, response) {
             safetySettings: safetySettings,
             generationConfig: generationConfig,
         };
-
 
         if (should_use_system_prompt) {
             body.system_instruction = prompt.system_instruction;


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

I'm sorry. I was sleepy and accidentally forked only the release branch and made a PR. This is a code modification proposal for the issue content of the Gemini 2.0 flash model.

