### PR TITLE
Search term search will show empty folders too

### DIFF
--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -196,9 +196,10 @@ function filterByTagState(entities, { globalDisplayFilters = false, subForEntity
                 return false;
             }
 
-            // Hide folders that have 0 visible sub entities after the first filtering round
+            // Hide folders that have 0 visible sub entities after the first filtering round, unless we are inside a search via search term.
+            // Then we want to display folders that mach too, even if the chars inside don't match the search.
             if (entity.type === 'tag') {
-                return entity.entities.length > 0;
+                return entity.entities.length > 0 || entitiesFilter.getFilterData(FILTER_TYPES.SEARCH);
             }
 
             return true;


### PR DESCRIPTION
A small fix that I found annoying, until I realized I had accidently turned off "Advanced Character Search".
If that setting is on, it doesn't matter, as tags on the chars themselves also make the char match.
But without it, searching for a tag name that is a valid folder in your char list will hide the folder, unless the char also has that tag in its name.

Changed it to show empty folders if a a search term is applied.

#### Changes
- Char list did hide folders with 0 sub entities inside. This also applied to any search being done. Now when searching, if a tag/folder matches, it is shown, even if the chars inside don't match. Before that, it was not possible to "search" for tags without the "Advanced Character Search" enabled

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
