### PR TITLE
Correct skipping RVC on AllTalk V1 Server

### DIFF
--- a/public/scripts/extensions/tts/alltalk.js
+++ b/public/scripts/extensions/tts/alltalk.js
@@ -388,7 +388,7 @@ class AllTalkTtsProvider {
     }
 
     async fetchRvcVoiceObjects() {
-        if (this.settings.server_version !== 'v2') {
+        if (this.settings.server_version !== 'v1') {
             console.log('Skipping RVC voices fetch for V1 server');
             return [];
         }

--- a/public/scripts/extensions/tts/alltalk.js
+++ b/public/scripts/extensions/tts/alltalk.js
@@ -388,7 +388,7 @@ class AllTalkTtsProvider {
     }
 
     async fetchRvcVoiceObjects() {
-        if (this.settings.server_version !== 'v1') {
+        if (this.settings.server_version == 'v2') {
             console.log('Skipping RVC voices fetch for V1 server');
             return [];
         }


### PR DESCRIPTION
Silly bug that caused the extension when used with the legacy V1 AllTalk server, would cause it to skip downloading Narrator voices.

Literally changed "v2" to "v1" on line 391

No other changes.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X ] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Happy New Year by the way!

Thanks
