### PR TITLE
Allow zoomed in images in chat to be closed by clicking outside

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -585,10 +585,12 @@ async function enlargeMessageImage() {
     const imgHolder = document.createElement('div');
     imgHolder.classList.add('img_enlarged_holder');
     imgHolder.append(img);
-    const imgContainer = $('<div><pre><code></code></pre></div>');
+    const imgContainer = $('<div><pre><code class="img_enlarged_title"></code></code></pre></div>');
     imgContainer.prepend(imgHolder);
     imgContainer.addClass('img_enlarged_container');
-    imgContainer.find('code').addClass('txt').text(title);
+
+    const codeTitle = imgContainer.find('.img_enlarged_title');
+    codeTitle.addClass('txt').text(title);
     const titleEmpty = !title || title.trim().length === 0;
     imgContainer.find('pre').toggle(!titleEmpty);
     addCopyToCodeBlocks(imgContainer);
@@ -598,9 +600,17 @@ async function enlargeMessageImage() {
     popup.dlg.style.width = 'unset';
     popup.dlg.style.height = 'unset';
 
-    img.addEventListener('click', () => {
+    img.addEventListener('click', event => {
         const shouldZoom = !img.classList.contains('zoomed');
         img.classList.toggle('zoomed', shouldZoom);
+        event.stopPropagation();
+    });
+    codeTitle[0]?.addEventListener('click', event => {
+        event.stopPropagation();
+    });
+
+    popup.dlg.addEventListener('click', event => {
+        popup.completeCancelled();
     });
 
     await popup.show();

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -585,7 +585,7 @@ async function enlargeMessageImage() {
     const imgHolder = document.createElement('div');
     imgHolder.classList.add('img_enlarged_holder');
     imgHolder.append(img);
-    const imgContainer = $('<div><pre><code class="img_enlarged_title"></code></code></pre></div>');
+    const imgContainer = $('<div><pre><code class="img_enlarged_title"></code></pre></div>');
     imgContainer.prepend(imgHolder);
     imgContainer.addClass('img_enlarged_container');
 

--- a/public/style.css
+++ b/public/style.css
@@ -4799,7 +4799,7 @@ body:not(.sd) .mes_img_swipes {
 
 .img_enlarged {
     object-fit: contain;
-    width: 100%;
+    max-width: 100%;
     height: 100%;
     cursor: zoom-in
 }


### PR DESCRIPTION
Further improvements to #2410.
I usually don't like when websites have zoom-in images and then don't fucking close when you click to the empty space next to it.
Don't know why I missed that back then, but I think this is nicer.

#### Changes
- Add event listener to close image enlarge popup when clicked outside of image or description
- Change img div to not be width:100% by default, was useless and just confusing when you could click next to the image and it zoomed in

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
