### PR TITLE
Make `{{trim}}` macro actually trim whitespaces

### DIFF
--- a/public/scripts/macros.js
+++ b/public/scripts/macros.js
@@ -451,7 +451,7 @@ export function evaluateMacros(content, env, postProcessFn) {
         ...getInstructMacros(env),
         ...getVariableMacros(),
         { regex: /{{newline}}/gi, replace: () => '\n' },
-        { regex: /(?:\r?\n)*{{trim}}(?:\r?\n)*/gi, replace: () => '' },
+        { regex: /(?:\s)*{{trim}}(?:\s)*/gi, replace: () => '' },
         { regex: /{{noop}}/gi, replace: () => '' },
         { regex: /{{input}}/gi, replace: () => String($('#send_textarea').val()) },
     ];

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -4,7 +4,7 @@
 <ul>
     <li><tt>&lcub;&lcub;pipe&rcub;&rcub;</tt> – <span data-i18n="help_macros_1">only for slash command batching. Replaced with the returned result of the previous command.</span></li>
     <li><tt>&lcub;&lcub;newline&rcub;&rcub;</tt> – <span data-i18n="help_macros_2">just inserts a newline.</span></li>
-    <li><tt>&lcub;&lcub;trim&rcub;&rcub;</tt> – <span data-i18n="help_macros_3">trims newlines surrounding this macro.</span></li>
+    <li><tt>&lcub;&lcub;trim&rcub;&rcub;</tt> – <span data-i18n="help_macros_3">trims whitespaces (including newlines) surrounding this macro.</span></li>
     <li><tt>&lcub;&lcub;noop&rcub;&rcub;</tt> – <span data-i18n="help_macros_4">no operation, just an empty string.</span></li>
     <li><tt>&lcub;&lcub;original&rcub;&rcub;</tt> – <span data-i18n="help_macros_5">global prompts defined in API settings. Only valid in Advanced Definitions prompt overrides.</span></li>
     <li><tt>&lcub;&lcub;input&rcub;&rcub;</tt> – <span data-i18n="help_macros_6">the user input</span></li>


### PR DESCRIPTION
...as the name "trim" implies, for everyone who knows a bit about coding.

See also [String.prototype.trim()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim) and
![image](https://github.com/user-attachments/assets/5d1b10d3-caf7-4804-9ece-2ef740fe7b4e)


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
