### PR TITLE
Fix `{{firstIncludedMessageId}}` to not rely on DOM

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5429,20 +5429,24 @@ async function promptItemize(itemizedPrompts, requestedMesId) {
     await popup.show();
 }
 
-function setInContextMessages(lastmsg, type) {
+function setInContextMessages(msgInContextCount, type) {
     $('#chat .mes').removeClass('lastInContext');
 
     if (type === 'swipe' || type === 'regenerate' || type === 'continue') {
-        lastmsg++;
+        msgInContextCount++;
     }
 
-    const lastMessageBlock = $('#chat .mes:not([is_system="true"])').eq(-lastmsg);
+    const lastMessageBlock = $('#chat .mes:not([is_system="true"])').eq(-msgInContextCount);
     lastMessageBlock.addClass('lastInContext');
 
     if (lastMessageBlock.length === 0) {
         const firstMessageId = getFirstDisplayedMessageId();
         $(`#chat .mes[mesid="${firstMessageId}"`).addClass('lastInContext');
     }
+
+    const lastMessageId = Math.max(0, chat.length - msgInContextCount);
+    chat_metadata['lastInContextMessageId'] = lastMessageId;
+    saveMetadataDebounced();
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -5444,9 +5444,9 @@ function setInContextMessages(msgInContextCount, type) {
         $(`#chat .mes[mesid="${firstMessageId}"`).addClass('lastInContext');
     }
 
+    // Update last id to chat. No metadata save on purpose, gets hopefully saved via another call
     const lastMessageId = Math.max(0, chat.length - msgInContextCount);
     chat_metadata['lastInContextMessageId'] = lastMessageId;
-    saveMetadataDebounced();
 }
 
 /**

--- a/public/scripts/macros.js
+++ b/public/scripts/macros.js
@@ -202,13 +202,7 @@ export function getLastMessageId({ exclude_swipe_in_propress = true, filter = nu
  * @returns {number|null} The ID of the first message in the context
  */
 function getFirstIncludedMessageId() {
-    const index = Number(document.querySelector('.lastInContext')?.getAttribute('mesid'));
-
-    if (!isNaN(index) && index >= 0) {
-        return index;
-    }
-
-    return null;
+    return chat_metadata['lastInContextMessageId'];
 }
 
 /**

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -28,7 +28,7 @@
     <li><tt>&lcub;&lcub;lastUserMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_lastUser">the text of the latest user chat message.</span></li>
     <li><tt>&lcub;&lcub;lastCharMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_lastChar">the text of the latest character chat message.</span></li>
     <li><tt>&lcub;&lcub;lastMessageId&rcub;&rcub;</tt> – <span data-i18n="help_macros_21">index # of the latest chat message. Useful for slash command batching.</span></li>
-    <li><tt>&lcub;&lcub;firstIncludedMessageId&rcub;&rcub;</tt> – <span data-i18n="help_macros_22">the ID of the first message included in the context. Requires generation to be ran at least once in the current session.</span></li>
+    <li><tt>&lcub;&lcub;firstIncludedMessageId&rcub;&rcub;</tt> – <span data-i18n="help_macros_22">the ID of the first message included in the context. Requires generation to be run at least once in the current session. Will only be updated on generation.</span></li>
     <li><tt>&lcub;&lcub;firstDisplayedMessageId&rcub;&rcub;</tt> – <span data-i18n="help_macros_firstDisplayedMessageId">the ID of the first message loaded into the visible chat.</span></li>
     <li><tt>&lcub;&lcub;currentSwipeId&rcub;&rcub;</tt> – <span data-i18n="help_macros_23">the 1-based ID of the current swipe in the last chat message. Empty string if the last message is user or prompt-hidden.</span></li>
     <li><tt>&lcub;&lcub;lastSwipeId&rcub;&rcub;</tt> – <span data-i18n="help_macros_24">the number of swipes in the last chat message. Empty string if the last message is user or prompt-hidden.</span></li>


### PR DESCRIPTION
Up until now, the `{{firstIncludedMessageId}}` macro relied on searching the DOM for the actual CSS class applied for the context line. Bad design, as the actual message was maybe not display, with display X messages enabled.

Fixes #3281

#### Changes
- Use `setInContextMessages()` that sets the context line on generation to also update a chat metadata field
- Utilize that field inside the macro
- Update docs to clarify that this will only show the mesid that was relevant during last generation

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
