### PR TITLE
Add returnChunks and resultSize args to /db-search

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -1615,12 +1615,12 @@ jQuery(async () => {
         callback: async (args, query) => {
             const clamp = (v) => Number.isNaN(v) ? null : Math.min(1, Math.max(0, v));
             const threshold = clamp(Number(args?.threshold ?? settings.score_threshold));
-            const validateSize = (v) => Number.isNaN(v) || !Number.isInteger(v) || v < 1 ? null : v;
-            const resultSize = validateSize(Number(args?.resultSize)) ?? settings.chunk_count_db;
+            const validateCount = (v) => Number.isNaN(v) || !Number.isInteger(v) || v < 1 ? null : v;
+            const count = validateCount(Number(args?.count)) ?? settings.chunk_count_db;
             const source = String(args?.source ?? '');
             const attachments = source ? getDataBankAttachmentsForSource(source, false) : getDataBankAttachments(false);
             const collectionIds = await ingestDataBankAttachments(String(source));
-            const queryResults = await queryMultipleCollections(collectionIds, String(query), resultSize, threshold);
+            const queryResults = await queryMultipleCollections(collectionIds, String(query), count, threshold);
     
             // Get URLs
             const urls = Object
@@ -1651,7 +1651,7 @@ jQuery(async () => {
         helpString: 'Search the Data Bank for a specific query using vector similarity. Returns a list of file URLs with the most relevant content.',
         namedArgumentList: [
             new SlashCommandNamedArgument('threshold', 'Threshold for the similarity score in the [0, 1] range. Uses the global config value if not set.', ARGUMENT_TYPE.NUMBER, false, false, ''),
-            new SlashCommandNamedArgument('resultSize', 'Maximum number of query results to return.', ARGUMENT_TYPE.NUMBER, false, false, ''),
+            new SlashCommandNamedArgument('count', 'Maximum number of query results to return.', ARGUMENT_TYPE.NUMBER, false, false, ''),
             new SlashCommandNamedArgument('source', 'Optional filter for the attachments by source.', ARGUMENT_TYPE.STRING, false, false, '', ['global', 'character', 'chat']),
             SlashCommandNamedArgument.fromProps({
                 name: 'return',


### PR DESCRIPTION
First pull request I've ever done so excuse any mistakes;

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Adds two new arguments to /db-search
 - returnChunks: returns the actual chunk instead of a file pointer - defaults to false
 - resultSize: allows the command to take a custom topK - defaults to the standard set in the extension settings

Useful for situations when you have a large databank file and want to pull specific parts that fit the query out of it.

I've done testing with the below qr and it behaved as expected when provided correct/bad values. Not a versed dev so might've missed something though.

/input rows=3 okButton=Search |
/setvar key=CharacterDBinput |
/if left={{pipe}} right="" rule=neq else="/abort" "/echo Searching for {{getvar::CharacterDBinput}}..." |
/db-search returnChunks=true resultSize=1 {{getvar::CharacterDBinput}} |
/setvar key=CharacterDBresult |
/sys {{getvar::CharacterDBresult}}

