### PR TITLE
QR Set buttons for rename and duplicate

### DIFF
--- a/public/scripts/extensions/quick-reply/html/settings.html
+++ b/public/scripts/extensions/quick-reply/html/settings.html
@@ -51,6 +51,7 @@
 						<div class="qr--add menu_button menu_button_icon fa-solid fa-file-import" id="qr--set-import" title="Import quick reply set"></div>
 						<input type="file" id="qr--set-importFile" accept=".json" hidden>
 						<div class="qr--add menu_button menu_button_icon fa-solid fa-file-export" id="qr--set-export" title="Export quick reply set"></div>
+                        <div class="qr-add menu_button menu_button_icon fa-solid fa-paste" id="qr--set-duplicate" title="Duplicate quick reply set"></div>
 						<div class="qr--del menu_button menu_button_icon fa-solid fa-trash redWarningBG" id="qr--set-delete" title="Delete quick reply set"></div>
 					</div>
 				</div>

--- a/public/scripts/extensions/quick-reply/html/settings.html
+++ b/public/scripts/extensions/quick-reply/html/settings.html
@@ -46,6 +46,7 @@
 					<div class="qr--title" data-i18n="Edit Quick Replies">Edit Quick Replies</div>
 					<div class="qr--actions">
 						<select id="qr--set" class="text_pole"></select>
+						<div class="qr--add menu_button menu_button_icon fa-solid fa-pencil" id="qr--set-rename" title="Rename quick reply set"></div>
 						<div class="qr--add menu_button menu_button_icon fa-solid fa-plus" id="qr--set-new" title="Create new quick reply set"></div>
 						<div class="qr--add menu_button menu_button_icon fa-solid fa-file-import" id="qr--set-import" title="Import quick reply set"></div>
 						<input type="file" id="qr--set-importFile" accept=".json" hidden>

--- a/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
@@ -317,15 +317,7 @@ export class SettingsUi {
             this.currentQrSet.name = newName;
             await this.currentQrSet.save();
 
-            // Update the option in all select dropdowns
-            /** @type {NodeListOf<HTMLOptionElement>} */
-            const options = this.dom.querySelectorAll(`#qr--set option[value="${oldName}"], select.qr--set option[value="${oldName}"]`);
-            options.forEach(option => {
-                option.value = newName;
-                option.textContent = newName;
-            });
-
-            // Update in in both set lists
+            // Update it in both set lists
             this.settings.config.setList.forEach(set => {
                 if (set.set.name === oldName) {
                     set.set.name = newName;
@@ -336,9 +328,19 @@ export class SettingsUi {
                     set.set.name = newName;
                 }
             });
-
             this.settings.save();
+
+            // Update the option in the current selected QR dropdown. All others will be refreshed via the prepare calls below.
+            /** @type {HTMLOptionElement} */
+            const option = this.currentSet.querySelector(`#qr--set option[value="${oldName}"]`);
+            option.value = newName;
+            option.textContent = newName;
+
             this.currentSet.value = newName;
+            this.onQrSetChange();
+            this.prepareGlobalSetList();
+            this.prepareChatSetList();
+
             console.info(`Quick Reply Set renamed from ""${oldName}" to "${newName}".`);
         }
     }

--- a/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
@@ -1,4 +1,4 @@
-import { callPopup } from '../../../../../script.js';
+import { Popup } from '../../../../popup.js';
 import { getSortableDelay } from '../../../../utils.js';
 import { log, warn } from '../../index.js';
 import { QuickReply } from '../QuickReply.js';
@@ -280,7 +280,7 @@ export class SettingsUi {
     }
 
     async deleteQrSet() {
-        const confirmed = await callPopup(`Are you sure you want to delete the Quick Reply Set "${this.currentQrSet.name}"?<br>This cannot be undone.`, 'confirm');
+        const confirmed = await Popup.show.confirm('Delete Quick Reply Set', `Are you sure you want to delete the Quick Reply Set "${this.currentQrSet.name}"?<br>This cannot be undone.`);
         if (confirmed) {
             await this.doDeleteQrSet(this.currentQrSet);
             this.rerender();
@@ -305,7 +305,7 @@ export class SettingsUi {
     }
 
     async renameQrSet() {
-        const newName = await callPopup('Enter new name for the Quick Reply Set:', 'input');
+        const newName = await Popup.show.input('Rename Quick Reply Set', 'Enter a new name:', this.currentQrSet.name);
         if (newName && newName.length > 0) {
             const existingSet = QuickReplySet.get(newName);
             if (existingSet) {
@@ -343,11 +343,11 @@ export class SettingsUi {
     }
 
     async addQrSet() {
-        const name = await callPopup('Quick Reply Set Name:', 'input');
+        const name = await Popup.show.input('Create a new World Info', 'Enter a name for the new Quick Reply Set:');
         if (name && name.length > 0) {
             const oldQrs = QuickReplySet.get(name);
             if (oldQrs) {
-                const replace = await callPopup(`A Quick Reply Set named "${name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`, 'confirm');
+                const replace = Popup.show.confirm('Replace existing World Info', `A Quick Reply Set named "${name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
                 if (replace) {
                     const idx = QuickReplySet.list.indexOf(oldQrs);
                     await this.doDeleteQrSet(oldQrs);
@@ -408,7 +408,7 @@ export class SettingsUi {
                 qrs.init();
                 const oldQrs = QuickReplySet.get(props.name);
                 if (oldQrs) {
-                    const replace = await callPopup(`A Quick Reply Set named "${qrs.name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`, 'confirm');
+                    const replace = Popup.show.confirm('Replace existing World Info', `A Quick Reply Set named "${name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
                     if (replace) {
                         const idx = QuickReplySet.list.indexOf(oldQrs);
                         await this.doDeleteQrSet(oldQrs);


### PR DESCRIPTION
Added two buttons to QR set editor to rename and duplicate a set. They follow the same style and functionality than WI rename/duplicate.

Also refactored all popups from that QR settings menu to the new ones.

Closes #2621

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
