### PR TITLE
Constrict scrolling to lower dynamic formarea in alternate greetings popup

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -5738,12 +5738,12 @@ body:not(.movingUI) .drawer-content.maximized {
 
 /* Constrict the scroll of alternate greetings to only the dynamic form section */
 .alternate_grettings {
-	display: grid;
-	grid-template-rows: auto auto auto 1fr;
-	max-height: 100%;
-	overflow: hidden;
+    display: grid;
+    grid-template-rows: auto auto auto 1fr;
+    max-height: 100%;
+    overflow: hidden;
 }
 
 .alternate_greetings_list {
-	overflow-y: scroll;
+    overflow-y: scroll;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -5735,3 +5735,15 @@ body:not(.movingUI) .drawer-content.maximized {
     }
 
 }
+
+/* Constrict the scroll of alternate greetings to only the dynamic form section */
+.alternate_grettings {
+	display: grid;
+	grid-template-rows: auto auto auto 1fr;
+	max-height: 100%;
+	overflow: hidden;
+}
+
+.alternate_greetings_list {
+	overflow-y: scroll;
+}


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Character greetings

The topmost area (title, info, "Add" button) shouldn't scroll upwards out of the screen.

- Confined the scrollable area to the dynamic form elements (a few styles added)

## Screenshot

Screenshot showing the contents scrolled down, but the topmost area is still on screen:

![402352216-ce3b839d-8887-45b8-8668-eb8e0de9eccc](https://github.com/user-attachments/assets/0485fe7a-f755-4280-ad28-7ed137d0bdde)

