### PR TITLE
Fixed featherless.ai models display and filters

### DIFF
--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -383,7 +383,7 @@ export async function loadFeatherlessModels(data) {
 
                     const dateAddedDiv = document.createElement('div');
                     dateAddedDiv.classList.add('model-date-added');
-                    dateAddedDiv.textContent = `Added On: ${new Date(model.updated_at).toLocaleDateString()}`;
+                    dateAddedDiv.textContent = `Added On: ${new Date(model.created * 1000).toLocaleDateString()}`;
 
                     detailsContainer.appendChild(modelClassDiv);
                     detailsContainer.appendChild(contextLengthDiv);
@@ -502,9 +502,9 @@ export async function loadFeatherlessModels(data) {
         } else if (selectedSortOrder === 'desc') {
             filteredModels.sort((a, b) => b.id.localeCompare(a.id));
         } else if (selectedSortOrder === 'date_asc') {
-            filteredModels.sort((a, b) => a.updated_at.localeCompare(b.updated_at));
+            filteredModels.sort((a, b) => a.created - b.created);
         } else if (selectedSortOrder === 'date_desc') {
-            filteredModels.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+            filteredModels.sort((a, b) => b.created - a.created);
         }
 
         setupPagination(filteredModels, Number(localStorage.getItem(storageKey)) || perPage, featherlessCurrentPage);

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -472,6 +472,7 @@ export async function loadFeatherlessModels(data) {
             featherlessTop = await fetchFeatherlessStats();
         }
         const featherlessIds = featherlessTop.map(stat => stat.id);
+
         if (selectedCategory === 'New') {
             featherlessNew = await fetchFeatherlessNew();
         }
@@ -493,7 +494,7 @@ export async function loadFeatherlessModels(data) {
                 return matchesSearch && matchesClass && matchesNew;
             }
             else {
-                return matchesSearch;
+                return matchesSearch && matchesClass;
             }
         });
 
@@ -528,7 +529,7 @@ async function fetchFeatherlessStats() {
 }
 
 async function fetchFeatherlessNew() {
-    const response = await fetch('https://api.featherless.ai/feather/models?sort=-created_at&perPage=10');
+    const response = await fetch('https://api.featherless.ai/feather/models?sort=-created_at&perPage=20');
     const data = await response.json();
     return data.items;
 }

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -319,8 +319,6 @@ export async function loadFeatherlessModels(data) {
         return;
     }
 
-    // Sort the data by model id (default A-Z)
-    data.sort((a, b) => a.id.localeCompare(b.id));
     originalModels = data;  // Store the original data for search
     featherlessModels = data;
 
@@ -334,10 +332,8 @@ export async function loadFeatherlessModels(data) {
     // Retrieve the stored number of items per page or default to 10
     const perPage = Number(localStorage.getItem(storageKey)) || 10;
 
-    // Initialize pagination with the full set of models
-    const currentModelIndex = data.findIndex(x => x.id === textgen_settings.featherless_model);
-    featherlessCurrentPage = currentModelIndex >= 0 ? (currentModelIndex / perPage) + 1 : 1;
-    setupPagination(originalModels, perPage);
+    // Initialize pagination
+    applyFiltersAndSort();
 
     // Function to set up pagination (also used for filtered results)
     function setupPagination(models, perPage, pageNumber = featherlessCurrentPage) {
@@ -507,6 +503,9 @@ export async function loadFeatherlessModels(data) {
         } else if (selectedSortOrder === 'date_desc') {
             filteredModels.sort((a, b) => b.created - a.created);
         }
+
+        const currentModelIndex = filteredModels.findIndex(x => x.id === textgen_settings.featherless_model);
+        featherlessCurrentPage = currentModelIndex >= 0 ? (currentModelIndex / perPage) + 1 : 1;
 
         setupPagination(filteredModels, Number(localStorage.getItem(storageKey)) || perPage, featherlessCurrentPage);
     }


### PR DESCRIPTION
Some minor fixes for the featherless.ai models display and filters.

* Fixed the added on date
* Fixed the sort by date
* Fixed the model class filter
* Modified the number of new models to fetch to correspond to the number displayed on their website (10 -> 20)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
