### PR TITLE
exporting openGroupId from group-chats.js

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -81,6 +81,7 @@ import { t } from './i18n.js';
 
 export {
     selected_group,
+    openGroupId,
     is_group_automode_enabled,
     hideMutedSprites,
     is_group_generating,


### PR DESCRIPTION
#### Description
 Very simple one-line change exporting the `openGroupId` variable in `group-chats.js`.

#### Reason
 I needed to access this variable while making an extension in order to detect which group chat is currently being edited, not just which group chat is currently selected. The selected and edited group chat are almost always the same except when creating a new group chat, in which case `openGroupId` is undefined.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
