### PR TITLE
Emit event after loading message history

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1977,12 +1977,12 @@
                                             </span>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="makersuite">
+                                    <div class="range-block" data-source="makersuite,deepseek">
                                         <label for="openai_show_thoughts" class="checkbox_label widthFreeExpand">
                                             <input id="openai_show_thoughts" type="checkbox" />
                                             <span>
                                                 <span data-i18n="Show model thoughts">Show model thoughts</span>
-                                                <i class="opacity50p fa-solid fa-circle-info" title="Gemini 2.0 Thinking"></i>
+                                                <i class="opacity50p fa-solid fa-circle-info" title="Gemini 2.0 Thinking / DeepSeek Reasoner"></i>
                                             </span>
                                         </label>
                                         <div class="toggle-description justifyLeft marginBot5">
@@ -3209,6 +3209,7 @@
                                 <select id="model_deepseek_select">
                                     <option value="deepseek-chat">deepseek-chat</option>
                                     <option value="deepseek-coder">deepseek-coder</option>
+                                    <option value="deepseek-reasoner">deepseek-reasoner</option>
                                 </select>
                             </div>
                         </div>

--- a/public/script.js
+++ b/public/script.js
@@ -5655,20 +5655,31 @@ function extractMessageFromData(data) {
         return data;
     }
 
-    switch (main_api) {
-        case 'kobold':
-            return data.results[0].text;
-        case 'koboldhorde':
-            return data.text;
-        case 'textgenerationwebui':
-            return data.choices?.[0]?.text ?? data.content ?? data.response ?? '';
-        case 'novel':
-            return data.output;
-        case 'openai':
-            return data?.choices?.[0]?.message?.content ?? data?.choices?.[0]?.text ?? data?.text ?? data?.message?.content?.[0]?.text ?? data?.message?.tool_plan ?? '';
-        default:
-            return '';
+    function getTextContext() {
+        switch (main_api) {
+            case 'kobold':
+                return data.results[0].text;
+            case 'koboldhorde':
+                return data.text;
+            case 'textgenerationwebui':
+                return data.choices?.[0]?.text ?? data.content ?? data.response ?? '';
+            case 'novel':
+                return data.output;
+            case 'openai':
+                return data?.choices?.[0]?.message?.content ?? data?.choices?.[0]?.text ?? data?.text ?? data?.message?.content?.[0]?.text ?? data?.message?.tool_plan ?? '';
+            default:
+                return '';
+        }
     }
+
+    const content = getTextContext();
+
+    if (main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK && oai_settings.show_thoughts) {
+        const thoughts = data?.choices?.[0]?.message?.reasoning_content ?? '';
+        return [thoughts, content].filter(x => x).join('\n\n');
+    }
+
+    return content;
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -443,6 +443,7 @@ export const event_types = {
     MESSAGE_DELETED: 'message_deleted',
     MESSAGE_UPDATED: 'message_updated',
     MESSAGE_FILE_EMBEDDED: 'message_file_embedded',
+    MORE_MESSAGES_LOADED: 'more_messages_loaded',
     IMPERSONATE_READY: 'impersonate_ready',
     CHAT_CHANGED: 'chat_id_changed',
     GENERATION_AFTER_COMMANDS: 'GENERATION_AFTER_COMMANDS',
@@ -1859,6 +1860,8 @@ export function showMoreMessages(messagesToLoad = null) {
         const newHeight = $('#chat').prop('scrollHeight');
         $('#chat').scrollTop(newHeight - prevHeight);
     }
+
+    eventSource.emit(event_types.MORE_MESSAGES_LOADED)
 }
 
 export async function printMessages() {

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -81,6 +81,7 @@ import { t } from './i18n.js';
 
 export {
     selected_group,
+    openGroupId,
     is_group_automode_enabled,
     hideMutedSprites,
     is_group_generating,

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2030,6 +2030,16 @@ async function sendOpenAIRequest(type, messages, signal) {
     // https://api-docs.deepseek.com/api/create-chat-completion
     if (isDeepSeek) {
         generate_data.top_p = generate_data.top_p || Number.EPSILON;
+
+        if (generate_data.model.endsWith('-reasoner')) {
+            delete generate_data.top_p;
+            delete generate_data.temperature;
+            delete generate_data.frequency_penalty;
+            delete generate_data.presence_penalty;
+            delete generate_data.top_logprobs;
+            delete generate_data.logprobs;
+            delete generate_data.logit_bias;
+        }
     }
 
     if ((isOAI || isOpenRouter || isMistral || isCustom || isCohere || isNano) && oai_settings.seed >= 0) {
@@ -2085,6 +2095,7 @@ async function sendOpenAIRequest(type, messages, signal) {
             let text = '';
             const swipes = [];
             const toolCalls = [];
+            const state = {};
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) return;
@@ -2095,9 +2106,9 @@ async function sendOpenAIRequest(type, messages, signal) {
 
                 if (Array.isArray(parsed?.choices) && parsed?.choices?.[0]?.index > 0) {
                     const swipeIndex = parsed.choices[0].index - 1;
-                    swipes[swipeIndex] = (swipes[swipeIndex] || '') + getStreamingReply(parsed);
+                    swipes[swipeIndex] = (swipes[swipeIndex] || '') + getStreamingReply(parsed, state);
                 } else {
-                    text += getStreamingReply(parsed);
+                    text += getStreamingReply(parsed, state);
                 }
 
                 ToolManager.parseToolCalls(toolCalls, parsed);
@@ -2129,14 +2140,27 @@ async function sendOpenAIRequest(type, messages, signal) {
     }
 }
 
-function getStreamingReply(data) {
+/**
+ * Extracts the reply from the response data from a chat completions-like source
+ * @param {object} data Response data from the chat completions-like source
+ * @param {object} state Additional state to keep track of
+ * @returns {string} The reply extracted from the response data
+ */
+function getStreamingReply(data, state) {
     if (oai_settings.chat_completion_source === chat_completion_sources.CLAUDE) {
         return data?.delta?.text || '';
     } else if (oai_settings.chat_completion_source === chat_completion_sources.MAKERSUITE) {
         return data?.candidates?.[0]?.content?.parts?.filter(x => oai_settings.show_thoughts || !x.thought)?.map(x => x.text)?.filter(x => x)?.join('\n\n') || '';
     } else if (oai_settings.chat_completion_source === chat_completion_sources.COHERE) {
         return data?.delta?.message?.content?.text || data?.delta?.message?.tool_plan || '';
-    } else {
+    } else if (oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
+        const hadThoughts = state.hadThoughts;
+        const thoughts = data.choices?.filter(x => oai_settings.show_thoughts || !x?.delta?.reasoning_content)?.[0]?.delta?.reasoning_content || '';
+        const content = data.choices?.[0]?.delta?.content || '';
+        state.hadThoughts = !!thoughts;
+        const separator = hadThoughts && !thoughts ? '\n\n' : '';
+        return [thoughts, separator, content].filter(x => x).join('\n\n');
+    } else  {
         return data.choices?.[0]?.delta?.content ?? data.choices?.[0]?.message?.content ?? data.choices?.[0]?.text ?? '';
     }
 }
@@ -4488,7 +4512,7 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
         if (oai_settings.max_context_unlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
-        } else if (oai_settings.deepseek_model == 'deepseek-chat') {
+        } else if (['deepseek-reasoner', 'deepseek-chat'].includes(oai_settings.deepseek_model)) {
             $('#openai_max_context').attr('max', max_64k);
         } else if (oai_settings.deepseek_model == 'deepseek-coder') {
             $('#openai_max_context').attr('max', max_16k);

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -220,6 +220,21 @@ async function* parseStreamData(json) {
                 }
                 return;
             }
+            else if (typeof json.choices[0].delta.reasoning_content === 'string' && json.choices[0].delta.reasoning_content.length > 0) {
+                for (let j = 0; j < json.choices[0].delta.reasoning_content.length; j++) {
+                    const str = json.choices[0].delta.reasoning_content[j];
+                    const isLastSymbol = j === json.choices[0].delta.reasoning_content.length - 1;
+                    const choiceClone = structuredClone(json.choices[0]);
+                    choiceClone.delta.reasoning_content = str;
+                    choiceClone.delta.content = isLastSymbol ? choiceClone.delta.content : '';
+                    const choices = [choiceClone];
+                    yield {
+                        data: { ...json, choices },
+                        chunk: str,
+                    };
+                }
+                return;
+            }
             else if (typeof json.choices[0].delta.content === 'string' && json.choices[0].delta.content.length > 0) {
                 for (let j = 0; j < json.choices[0].delta.content.length; j++) {
                     const str = json.choices[0].delta.content[j];


### PR DESCRIPTION
#### Description
Simple change to emit a new event `MORE_MESSAGES_LOADED` after loading additional chat messages.

#### Reason
I am building an extension which modifies the visuals of messages, and I needed to know when more messages are shown in the chat in order to update them.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
