### PR TITLE
adding event after loading more messages in chat

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -443,6 +443,7 @@ export const event_types = {
     MESSAGE_DELETED: 'message_deleted',
     MESSAGE_UPDATED: 'message_updated',
     MESSAGE_FILE_EMBEDDED: 'message_file_embedded',
+    MORE_MESSAGES_LOADED: 'more_messages_loaded',
     IMPERSONATE_READY: 'impersonate_ready',
     CHAT_CHANGED: 'chat_id_changed',
     GENERATION_AFTER_COMMANDS: 'GENERATION_AFTER_COMMANDS',
@@ -1859,6 +1860,8 @@ export function showMoreMessages(messagesToLoad = null) {
         const newHeight = $('#chat').prop('scrollHeight');
         $('#chat').scrollTop(newHeight - prevHeight);
     }
+
+    eventSource.emit(event_types.MORE_MESSAGES_LOADED)
 }
 
 export async function printMessages() {

--- a/public/script.js
+++ b/public/script.js
@@ -1861,7 +1861,7 @@ export async function showMoreMessages(messagesToLoad = null) {
         $('#chat').scrollTop(newHeight - prevHeight);
     }
 
-    await eventSource.emit(event_types.MORE_MESSAGES_LOADED)
+    await eventSource.emit(event_types.MORE_MESSAGES_LOADED);
 }
 
 export async function printMessages() {

--- a/public/script.js
+++ b/public/script.js
@@ -1830,7 +1830,7 @@ export async function replaceCurrentChat() {
     }
 }
 
-export function showMoreMessages(messagesToLoad = null) {
+export async function showMoreMessages(messagesToLoad = null) {
     const firstDisplayedMesId = $('#chat').children('.mes').first().attr('mesid');
     let messageId = Number(firstDisplayedMesId);
     let count = messagesToLoad || power_user.chat_truncation || Number.MAX_SAFE_INTEGER;
@@ -1861,7 +1861,7 @@ export function showMoreMessages(messagesToLoad = null) {
         $('#chat').scrollTop(newHeight - prevHeight);
     }
 
-    eventSource.emit(event_types.MORE_MESSAGES_LOADED)
+    await eventSource.emit(event_types.MORE_MESSAGES_LOADED)
 }
 
 export async function printMessages() {
@@ -11468,8 +11468,8 @@ jQuery(async function () {
         $('#avatar-and-name-block').slideToggle();
     });
 
-    $(document).on('mouseup touchend', '#show_more_messages', () => {
-        showMoreMessages();
+    $(document).on('mouseup touchend', '#show_more_messages', async function () {
+        await showMoreMessages();
     });
 
     $(document).on('click', '.open_characters_library', async function () {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -2534,7 +2534,7 @@ async function loadUntilMesId(mesId) {
     let target;
 
     while (getFirstDisplayedMessageId() > mesId && getFirstDisplayedMessageId() !== 0) {
-        showMoreMessages();
+        await showMoreMessages();
         await delay(1);
         target = $('#chat').find(`.mes[mesid=${mesId}]`);
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1968,8 +1968,8 @@ export function initDefaultSlashCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'chat-render',
         helpString: 'Renders a specified number of messages into the chat window. Displays all messages if no argument is provided.',
-        callback: (args, number) => {
-            showMoreMessages(number && !isNaN(Number(number)) ? Number(number) : Number.MAX_SAFE_INTEGER);
+        callback: async (args, number) => {
+            await showMoreMessages(number && !isNaN(Number(number)) ? Number(number) : Number.MAX_SAFE_INTEGER);
             if (isTrueBoolean(String(args?.scroll ?? ''))) {
                 $('#chat').scrollTop(0);
             }


### PR DESCRIPTION
#### Description
Simple change to emit a new event `MORE_MESSAGES_LOADED` after loading additional chat messages.

#### Reason
I am building an extension which modifies the visuals of messages, and I needed to know when more messages are shown in the chat in order to update them.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
