### PR TITLE
Add new Gemini thinking model and its alias

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3062,7 +3062,9 @@
                                         <option value="gemini-1.0-ultra-latest">Gemini 1.0 Ultra</option>
                                     </optgroup>
                                     <optgroup label="Subversions">
-                                        <option value="gemini-2.0-flash-thinking-exp-1219">Gemini 2.0 Flash Thinking Experimental</option>
+                                        <option value="gemini-2.0-flash-thinking-exp">Gemini 2.0 Flash Thinking Experimental</option>
+                                        <option value="gemini-2.0-flash-thinking-exp-01-21">Gemini 2.0 Flash Thinking Experimental 2025-01-21</option>
+                                        <option value="gemini-2.0-flash-thinking-exp-1219">Gemini 2.0 Flash Thinking Experimental 2024-12-19</option>
                                         <option value="gemini-2.0-flash-exp">Gemini 2.0 Flash Experimental</option>
                                         <option value="gemini-exp-1114">Gemini Experimental 2024-11-14</option>
                                         <option value="gemini-exp-1121">Gemini Experimental 2024-11-21</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -54,6 +54,8 @@
                         <option data-type="anthropic" value="claude-3-sonnet-20240229">claude-3-sonnet-20240229</option>
                         <option data-type="anthropic" value="claude-3-haiku-20240307">claude-3-haiku-20240307</option>
                         <option data-type="google" value="gemini-2.0-flash-exp">gemini-2.0-flash-exp</option>
+                        <option data-type="google" value="gemini-2.0-flash-thinking-exp">gemini-2.0-flash-thinking-exp</option>
+                        <option data-type="google" value="gemini-2.0-flash-thinking-exp-01-21">gemini-2.0-flash-thinking-exp-01-21</option>
                         <option data-type="google" value="gemini-2.0-flash-thinking-exp-1219">gemini-2.0-flash-thinking-exp-1219</option>
                         <option data-type="google" value="gemini-1.5-flash">gemini-1.5-flash</option>
                         <option data-type="google" value="gemini-1.5-flash-latest">gemini-1.5-flash-latest</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4228,7 +4228,7 @@ async function onModelChange() {
             $('#openai_max_context').attr('max', max_32k);
         } else if (value.includes('gemini-1.5-pro') || value.includes('gemini-exp-1206')) {
             $('#openai_max_context').attr('max', max_2mil);
-        } else if (value.includes('gemini-1.5-flash') || value.includes('gemini-2.0-flash-exp')) {
+        } else if (value.includes('gemini-1.5-flash') || value.includes('gemini-2.0-flash-exp') || value.includes('gemini-2.0-flash-thinking-exp')) {
             $('#openai_max_context').attr('max', max_1mil);
         } else if (value.includes('gemini-1.0-pro') || value === 'gemini-pro') {
             $('#openai_max_context').attr('max', max_32k);

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -360,6 +360,8 @@ export function convertCohereMessages(messages, names) {
  */
 export function convertGooglePrompt(messages, model, useSysPrompt, names) {
     const visionSupportedModels = [
+        'gemini-2.0-flash-thinking-exp',
+        'gemini-2.0-flash-thinking-exp-01-21',
         'gemini-2.0-flash-thinking-exp-1219',
         'gemini-2.0-flash-exp',
         'gemini-1.5-flash',


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

I've added the new `gemini-2.0-flash-thinking-exp-01-21` model and its corresponding alias `gemini-2.0-flash-thinking-exp` (pointing to the latest version) based on Pull request #3229. Clarified its Vision capabilities and context window (1M tokens). The existing logic regarding the use of system prompts from #3229 remains applicable, therefore no changes were needed in that aspect.

However, I'm uncertain whether we should update the context window settings for legacy experimental models in `public/scripts/openai.js`. These older experimental models are now deprecated and currently aliased to newer experimental models (as evidenced by the [models endpoint](https://generativelanguage.googleapis.com/v1beta/models) response and [Gemini documentation](https://ai.google.dev/gemini-api/docs/models/experimental-models)):
- `gemini-exp-1114` and `gemini-exp-1121` now point to `gemini-exp-1206` with 2M token context
- `gemini-2.0-flash-thinking-exp-1219` points to `gemini-2.0-flash-thinking-exp-01-21` with 1M token context