### PR TITLE
fix: corrects the preset name and adds deepseek v2.5 hash.

### DIFF
--- a/public/scripts/chat-templates.js
+++ b/public/scripts/chat-templates.js
@@ -61,9 +61,14 @@ const hash_derivations = {
         'Tulu'
     ,
 
+    // DeepSeek V2.5
+    '54d400beedcd17f464e10063e0577f6f798fa896266a912d8a366f8a2fcc0bca':
+        'DeepSeek-V2.5'
+    ,
+
     // DeepSeek R1
     'b6835114b7303ddd78919a82e4d9f7d8c26ed0d7dfc36beeb12d524f6144eab1':
-        'DeepSeek-R1'
+        'DeepSeek-V2.5'
 };
 
 const substr_derivations = {


### PR DESCRIPTION
Fix for #3329.

I forgot to fix the name in the chat-template. I also checked the V2.5 template and it is slightly different, so I added that hash as well.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
