### PR TITLE
Minor fix: quick-reply/style.css menu

### DIFF
--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -173,7 +173,7 @@
 .ctx-menu {
   position: absolute;
   overflow: hidden auto;
-  max-height: 50dvh;
+  max-height: 75dvh;
   padding: 5px;
 }
 .ctx-menu .ctx-item .qr--hidden {
@@ -206,6 +206,9 @@
 @media screen and (max-width: 1000px) {
   .ctx-blocker {
     position: absolute;
+  }
+  .ctx-menu {
+    max-height: 65dvh;
   }
   .list-group .list-group-item.ctx-item {
     padding: 5px;

--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -172,7 +172,9 @@
 }
 .ctx-menu {
   position: absolute;
-  overflow: visible;
+  overflow: hidden auto;
+  max-height: 50dvh;
+  padding: 5px;
 }
 .ctx-menu .ctx-item .qr--hidden {
     display: none;
@@ -206,7 +208,7 @@
     position: absolute;
   }
   .list-group .list-group-item.ctx-item {
-    padding: 1em;
+    padding: 5px;
   }
 }
 #qr--settings .qr--head {

--- a/public/scripts/extensions/quick-reply/style.less
+++ b/public/scripts/extensions/quick-reply/style.less
@@ -173,7 +173,9 @@
 
 .ctx-menu {
     position: absolute;
-    overflow: visible;
+    overflow: hidden auto;
+    max-height: 75dvh;
+    padding: 5px;
 }
 
 .ctx-menu .ctx-item .qr--hidden {
@@ -215,8 +217,12 @@
         position: absolute;
     }
 
+    .ctx-menu {
+        max-height: 65dvh;
+    }
+    
     .list-group .list-group-item.ctx-item {
-        padding: 1em;
+        padding: 5px;
     }
 }
 


### PR DESCRIPTION
## Checklist:
- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
- - -
- Added max height and enabled scrolling for better usability
- Improved appearance on mobile devices (reduced excessive padding)

I've noticed some users mentioning that the Quick Reply menu sometimes becomes too long or misaligned.
These adjustments might help improve the experience.

<img width="1677" alt="截圖 2025-01-25 下午5 59 36" src="https://github.com/user-attachments/assets/74639580-ea3d-42d1-8321-8b6a776fbc45" />