### PR TITLE
Make DeepSeek API reasoning output/prefill compatible with other APIs

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5680,7 +5680,9 @@ function extractMessageFromData(data) {
 
     if (main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK && oai_settings.show_thoughts) {
         const thoughts = data?.choices?.[0]?.message?.reasoning_content ?? '';
-        return [thoughts, content].filter(x => x).join('\n\n');
+        const thinkingBegin = thoughts ? '<think>\n' : '';
+        const thinkingEnd = thoughts ? '\n</think>\n\n' : '';
+        return [thinkingBegin, thoughts, thinkingEnd, content].filter(x => x).join('');
     }
 
     return content;

--- a/public/script.js
+++ b/public/script.js
@@ -5680,8 +5680,8 @@ function extractMessageFromData(data) {
 
     if (main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK && oai_settings.show_thoughts) {
         const thoughts = data?.choices?.[0]?.message?.reasoning_content ?? '';
-        const thinkingBegin = thoughts ? '<think>\n' : '';
-        const thinkingEnd = thoughts ? '\n</think>\n\n' : '';
+        const thinkingBegin = thoughts ? power_user.thinking_begin : '';
+        const thinkingEnd = thoughts ? power_user.thinking_end : '';
         return [thinkingBegin, thoughts, thinkingEnd, content].filter(x => x).join('');
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -4740,7 +4740,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         }
 
         //const getData = await response.json();
-        let getMessage = extractMessageFromData(data);
+        let getMessage = extractMessageFromData(data, isContinue);
         let title = extractTitleFromData(data);
         kobold_horde_model = title;
 
@@ -5652,9 +5652,10 @@ function parseAndSaveLogprobs(data, continueFrom) {
 /**
  * Extracts the message from the response data.
  * @param {object} data Response data
+ * @param {boolean} isContinue Whether the generation was a continuation.
  * @returns {string} Extracted message
  */
-function extractMessageFromData(data) {
+function extractMessageFromData(data, isContinue = false) {
     if (typeof data === 'string') {
         return data;
     }
@@ -5678,11 +5679,11 @@ function extractMessageFromData(data) {
 
     const content = getTextContext();
 
-    if (main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK && oai_settings.show_thoughts) {
-        const thoughts = data?.choices?.[0]?.message?.reasoning_content ?? '';
-        const thinkingBegin = thoughts ? power_user.thinking_begin : '';
-        const thinkingEnd = thoughts ? power_user.thinking_end : '';
-        return [thinkingBegin, thoughts, thinkingEnd, content].filter(x => x).join('');
+    if (main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
+        const thoughts = oai_settings.show_thoughts ? data?.choices?.[0]?.message?.reasoning_content ?? null : null;
+        const thinkingBegin = !isContinue && thoughts !== null ? power_user.thinking_begin : '';
+        const thinkingEnd = thoughts !== null ? power_user.thinking_end : '';
+        return [thinkingBegin, thoughts ?? '', thinkingEnd, content].filter(x => x).join('');
     }
 
     return content;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2158,9 +2158,10 @@ function getStreamingReply(data, state) {
         const thoughts = data.choices?.filter(x => oai_settings.show_thoughts || !x?.delta?.reasoning_content)?.[0]?.delta?.reasoning_content || '';
         const content = data.choices?.[0]?.delta?.content || '';
         state.hadThoughts = !!thoughts;
-        const separator = hadThoughts && !thoughts ? '\n\n' : '';
-        return [thoughts, separator, content].filter(x => x).join('\n\n');
-    } else  {
+        const thinkingBegin = !hadThoughts && thoughts ? '<think>\n' : '';
+        const thinkingEnd = hadThoughts && !thoughts ? '\n</think>\n\n' : '';
+        return [thinkingBegin, thoughts, thinkingEnd, content].filter(x => x).join('');
+    } else {
         return data.choices?.[0]?.delta?.content ?? data.choices?.[0]?.message?.content ?? data.choices?.[0]?.text ?? '';
     }
 }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2039,6 +2039,14 @@ async function sendOpenAIRequest(type, messages, signal) {
             delete generate_data.top_logprobs;
             delete generate_data.logprobs;
             delete generate_data.logit_bias;
+
+            const lastMessage = messages[messages.length - 1];
+            if (lastMessage?.role === 'assistant' && lastMessage.content.startsWith(power_user.thinking_begin)) {
+                const parts = lastMessage.content.slice(power_user.thinking_begin.length).split(power_user.thinking_end);
+                lastMessage.reasoning_content = parts[0];
+                lastMessage.content = parts.slice(1).join(power_user.thinking_end);
+                generate_data.is_thinking = parts.length === 1;
+            }
         }
     }
 
@@ -2095,7 +2103,9 @@ async function sendOpenAIRequest(type, messages, signal) {
             let text = '';
             const swipes = [];
             const toolCalls = [];
-            const state = {};
+            const state = {
+                isThinking: !!generate_data.is_thinking,
+            };
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) return;
@@ -2154,13 +2164,12 @@ function getStreamingReply(data, state) {
     } else if (oai_settings.chat_completion_source === chat_completion_sources.COHERE) {
         return data?.delta?.message?.content?.text || data?.delta?.message?.tool_plan || '';
     } else if (oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
-        const hadThoughts = state.hadThoughts;
-        const thoughts = data.choices?.filter(x => oai_settings.show_thoughts || !x?.delta?.reasoning_content)?.[0]?.delta?.reasoning_content || '';
+        const thoughts = oai_settings.show_thoughts ? data.choices?.[0]?.delta?.reasoning_content ?? null : null;
+        const thinkingBegin = !state.isThinking && thoughts !== null ? power_user.thinking_begin : '';
+        const thinkingEnd = state.isThinking && thoughts === null ? power_user.thinking_end : '';
         const content = data.choices?.[0]?.delta?.content || '';
-        state.hadThoughts = !!thoughts;
-        const thinkingBegin = !hadThoughts && thoughts ? power_user.thinking_begin : '';
-        const thinkingEnd = hadThoughts && !thoughts ? power_user.thinking_end : '';
-        return [thinkingBegin, thoughts, thinkingEnd, content].filter(x => x).join('');
+        state.isThinking = thoughts !== null;
+        return [thinkingBegin, thoughts ?? '', thinkingEnd, content].filter(x => x).join('');
     } else {
         return data.choices?.[0]?.delta?.content ?? data.choices?.[0]?.message?.content ?? data.choices?.[0]?.text ?? '';
     }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2158,8 +2158,8 @@ function getStreamingReply(data, state) {
         const thoughts = data.choices?.filter(x => oai_settings.show_thoughts || !x?.delta?.reasoning_content)?.[0]?.delta?.reasoning_content || '';
         const content = data.choices?.[0]?.delta?.content || '';
         state.hadThoughts = !!thoughts;
-        const thinkingBegin = !hadThoughts && thoughts ? '<think>\n' : '';
-        const thinkingEnd = hadThoughts && !thoughts ? '\n</think>\n\n' : '';
+        const thinkingBegin = !hadThoughts && thoughts ? power_user.thinking_begin : '';
+        const thinkingEnd = hadThoughts && !thoughts ? power_user.thinking_end : '';
         return [thinkingBegin, thoughts, thinkingEnd, content].filter(x => x).join('');
     } else {
         return data.choices?.[0]?.delta?.content ?? data.choices?.[0]?.message?.content ?? data.choices?.[0]?.text ?? '';

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -120,6 +120,8 @@ let power_user = {
     always_force_name2: false,
     user_prompt_bias: '',
     show_user_prompt_bias: true,
+    thinking_begin: '<think>\n',
+    thinking_end: '\n</think>\n\n',
     auto_continue: {
         enabled: false,
         allow_chat_completions: false,


### PR DESCRIPTION
DeepSeek API returns outputs with separate `content` and `reasoning_content` fields for the R1 model, while the underlying model output (returned by other APIs) follows this format:
```
<think>
{reasoning_content}
</think>

{content}
```

This PR makes the official API's output to align with the format above, so we can use both the official API and other APIs seamlessly. This formatting is also convenient for regex usage.
Also, the `reasoning_content` can also be prefilled using the chat prefix completion API (undocumented?). So I also implemented that.

Note: `<think>` and `</think>` are special tokens (128798 and 128799), but the official API maps these tokens to different strings  `<｜begin▁of▁thinking｜>` and `<｜end▁of▁thinking｜>`. As long as messages are properly formatted and no thinking tags except in the last message, the difference shouldn't be observable.

Implementation note: `reasoning_content` (or `thoughts`) being `null` and `""` are different. An empty `reasoning_content` may occur at the start of streaming, or when the reasoning ended immediately after the given prefix.

For testing, combinations are:
- Prefix state:
  - No prefill
  - Prefill with incomplete reasoning: `{thinking_begin}{prefill}`
  - Prefill with completed reasoning: `{thinking_begin}{reasoning}{thinking_end}{prefill}`
- Streaming on/off
- Show model thoughts on/off

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
