### PR TITLE
Add thinkingConfig to Gemini thinking models 

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -323,6 +323,13 @@ async function sendMakerSuiteRequest(request, response) {
             generationConfig: generationConfig,
         };
 
+        const isThinking = model.includes('thinking');
+        if (isThinking) {
+            body.generationConfig.thinkingConfig = {
+                includeThoughts: showThoughts,
+            };
+        }
+
         if (should_use_system_prompt) {
             body.systemInstruction = prompt.system_instruction;
         }
@@ -384,10 +391,6 @@ async function sendMakerSuiteRequest(request, response) {
 
             const responseContent = candidates[0].content ?? candidates[0].output;
             console.log('Google AI Studio response:', responseContent);
-
-            if (Array.isArray(responseContent?.parts) && isThinking && !showThoughts) {
-                responseContent.parts = responseContent.parts.filter(part => !part.thought);
-            }
 
             const responseText = typeof responseContent === 'string' ? responseContent : responseContent?.parts?.map(part => part.text)?.join('\n\n');
             if (!responseText) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Fix: Handle Gemini API changes for CoT and model compatibility

**Issues:**

*   Google's Gemini API now requires `thinkingConfig` in `generationConfig` to get CoT responses from Thinking models.
*   Sending `thinkingConfig` to non-reasoning models now throws a `400 INVALID_ARGUMENT` error:
    ```json
    {
        "error": {
            "code": 400,
            "message": "thinking_config is not supported.",
            "status": "INVALID_ARGUMENT"
        }
    }
    ```
*   Old CoT filtering code is now redundant.

**Changes:**

*   Added `thinkingConfig` to `generationConfig` for Gemini Thinking models in `getGeminiBody`, respecting the `showThoughts` switch. This ensures CoT is returned only when both the model supports it and the switch is on.
*   Removed the now-unnecessary CoT filtering code.

This ensures consistent CoT display for Gemini Thinking models with models like DeepSeek R1.