### PR TITLE
Add command and profile for custom stop strings

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -30,6 +30,7 @@ const CC_COMMANDS = [
     'api-url',
     'model',
     'proxy',
+    'stop-strings',
 ];
 
 const TC_COMMANDS = [
@@ -43,6 +44,7 @@ const TC_COMMANDS = [
     'context',
     'instruct-state',
     'tokenizer',
+    'stop-strings',
 ];
 
 const FANCY_NAMES = {
@@ -57,6 +59,7 @@ const FANCY_NAMES = {
     'instruct': 'Instruct Template',
     'context': 'Context Template',
     'tokenizer': 'Tokenizer',
+    'stop-strings': 'Custom Stopping Strings',
 };
 
 /**
@@ -138,6 +141,7 @@ const profilesProvider = () => [
  * @property {string} [context] Context Template
  * @property {string} [instruct-state] Instruct Mode
  * @property {string} [tokenizer] Tokenizer
+ * @property {string} [stop-strings] Custom Stopping Strings
  * @property {string[]} [exclude] Commands to exclude
  */
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -4074,7 +4074,7 @@ $(document).ready(() => {
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'stop-strings',
-        aliases: ['stopping-strings'],
+        aliases: ['stopping-strings', 'custom-stopping-strings', 'custom-stop-strings'],
         helpString: `
             <div>
                 Sets a list of custom stopping strings. Gets the list if no value is provided.

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -4075,7 +4075,18 @@ $(document).ready(() => {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'stop-strings',
         aliases: ['stopping-strings'],
-        helpString: 'Sets a list of custom stopping strings. Gets the list if no value is provided.',
+        helpString: `
+            <div>
+                Sets a list of custom stopping strings. Gets the list if no value is provided.
+            </div>
+            <div>
+                <strong>Examples:</strong>
+            </div>
+            <ul>
+                <li>Value must be a JSON-serialized array: <pre><code class="language-stscript">/stop-strings ["goodbye", "farewell"]</code></pre></li>
+                <li>Pipe characters must be escaped with a backslash: <pre><code class="language-stscript">/stop-strings ["left\\|right"]</code></pre></li>
+            </ul>
+        `,
         returns: ARGUMENT_TYPE.LIST,
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -4072,4 +4072,34 @@ $(document).ready(() => {
         ],
         helpString: 'activates a movingUI preset by name',
     }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'stop-strings',
+        aliases: ['stopping-strings'],
+        helpString: 'Sets a list of custom stopping strings. Gets the list if no value is provided.',
+        returns: ARGUMENT_TYPE.LIST,
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'list of strings',
+                typeList: [ARGUMENT_TYPE.LIST],
+                acceptsMultiple: false,
+                isRequired: false,
+            }),
+        ],
+        callback: (_, value) => {
+            if (String(value ?? '').trim()) {
+                const parsedValue = ((x) => { try { return JSON.parse(x.toString()); } catch { return null; } })(value);
+                if (!parsedValue || !Array.isArray(parsedValue)) {
+                    throw new Error('Invalid list format. The value must be a JSON-serialized array of strings.');
+                }
+                parsedValue.forEach((item, index) => {
+                    parsedValue[index] = String(item);
+                });
+                power_user.custom_stopping_strings = JSON.stringify(parsedValue);
+                $('#custom_stopping_strings').val(power_user.custom_stopping_strings);
+                saveSettingsDebounced();
+            }
+
+            return power_user.custom_stopping_strings;
+        },
+    }));
 });


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Closes #3365

Added new `/stop-strings` command to get or set a list of stop strings. Made this command be used by the Connection Profiles.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
