### PR TITLE
Decrease TTS generation delay by splitting a message on a new line

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -120,7 +120,7 @@ async function onNarrateOneMessage() {
     }
 
     resetTtsPlayback();
-    splitMessageAndAddToTtsJobQueue(message);
+    processAndQueueTtsMessage(message);
     moduleWorker();
 }
 
@@ -147,7 +147,7 @@ async function onNarrateText(args, text) {
     }
 
     resetTtsPlayback();
-    splitMessageAndAddToTtsJobQueue({ mes: text, name: name });
+    processAndQueueTtsMessage({ mes: text, name: name });
     await moduleWorker();
 
     // Return back to the chat voices
@@ -227,7 +227,12 @@ function isTtsProcessing() {
  * @param {string} message.name - The name associated with the message.
  * @returns {void}
  */
-function splitMessageAndAddToTtsJobQueue(message) {
+function processAndQueueTtsMessage(message) {
+    if (!extension_settings.tts.narrate_by_paragraphs) {
+        ttsJobQueue.push(message);
+        return;
+    }
+
     const lines = message.mes.split("\n");
 
     for (let i = 0; i < lines.length; i++) {
@@ -375,7 +380,7 @@ function onAudioControlClicked() {
         talkingAnimation(false);
     } else {
         // Default play behavior if not processing or playing is to play the last message.
-        splitMessageAndAddToTtsJobQueue(context.chat[context.chat.length - 1]);
+        processAndQueueTtsMessage(context.chat[context.chat.length - 1]);
     }
     updateUiAudioPlayState();
 }
@@ -594,6 +599,7 @@ function loadSettings() {
     $('#tts_narrate_quoted').prop('checked', extension_settings.tts.narrate_quoted_only);
     $('#tts_auto_generation').prop('checked', extension_settings.tts.auto_generation);
     $('#tts_periodic_auto_generation').prop('checked', extension_settings.tts.periodic_auto_generation);
+    $('#tts_narrate_by_paragraphs').prop('checked', extension_settings.tts.narrate_by_paragraphs);
     $('#tts_narrate_translated_only').prop('checked', extension_settings.tts.narrate_translated_only);
     $('#tts_narrate_user').prop('checked', extension_settings.tts.narrate_user);
     $('#tts_pass_asterisks').prop('checked', extension_settings.tts.pass_asterisks);
@@ -660,6 +666,11 @@ function onAutoGenerationClick() {
 
 function onPeriodicAutoGenerationClick() {
     extension_settings.tts.periodic_auto_generation = !!$('#tts_periodic_auto_generation').prop('checked');
+    saveSettingsDebounced();
+}
+
+function onNarrateByParagraphsClick() {
+    extension_settings.tts.narrate_by_paragraphs = !!$('#tts_narrate_by_paragraphs').prop('checked');
     saveSettingsDebounced();
 }
 
@@ -841,7 +852,12 @@ async function onMessageEvent(messageId, lastCharIndex) {
     lastChatId = context.chatId;
 
     console.debug(`Adding message from ${message.name} for TTS processing: "${message.mes}"`);
-    splitMessageAndAddToTtsJobQueue(message);
+
+    if (extension_settings.tts.periodic_auto_generation) {
+        ttsJobQueue.push(message);
+    } else {
+        processAndQueueTtsMessage(message);
+    }
 }
 
 async function onMessageDeleted() {
@@ -1181,6 +1197,7 @@ jQuery(async function () {
         $('#tts_pass_asterisks').on('click', onPassAsterisksClick);
         $('#tts_auto_generation').on('click', onAutoGenerationClick);
         $('#tts_periodic_auto_generation').on('click', onPeriodicAutoGenerationClick);
+        $('#tts_narrate_by_paragraphs').on('click', onNarrateByParagraphsClick);
         $('#tts_narrate_user').on('click', onNarrateUserClick);
 
         $('#playback_rate').on('input', function () {

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -233,7 +233,7 @@ function processAndQueueTtsMessage(message) {
         return;
     }
 
-    const lines = message.mes.split("\n");
+    const lines = message.mes.split('\n');
 
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
@@ -245,7 +245,7 @@ function processAndQueueTtsMessage(message) {
         ttsJobQueue.push(
             Object.assign({}, message, {
                 mes: line,
-            })
+            }),
         );
     }
 }

--- a/public/scripts/extensions/tts/settings.html
+++ b/public/scripts/extensions/tts/settings.html
@@ -30,6 +30,10 @@
                     <input type="checkbox" id="tts_periodic_auto_generation">
                     <small data-i18n="Narrate by paragraphs (when streaming)">Narrate by paragraphs (when streaming)</small>
                 </label>
+                <label class="checkbox_label" for="tts_narrate_by_paragraphs">
+                    <input type="checkbox" id="tts_narrate_by_paragraphs">
+                    <small data-i18n="Narrate by paragraphs (when not streaming)">Narrate by paragraphs (when not streaming)</small>
+                </label>
                 <label class="checkbox_label" for="tts_narrate_quoted">
                     <input type="checkbox" id="tts_narrate_quoted">
                     <small data-i18n="Only narrate quotes">Only narrate "quotes"</small>


### PR DESCRIPTION
The change should greatly decrease the delay before a narration starts especially for long paragraphs typically found in a first message in a character's card or any other subsequent long messages.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
