### PR TITLE
Fix tts.skip_tags's regex to match newlines

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -466,7 +466,7 @@ async function processTtsQueue() {
     }
 
     if (extension_settings.tts.skip_tags) {
-        text = text.replace(/<.*?>.*?<\/.*?>/g, '').trim();
+        text = text.replace(/<.*?>[\s\S]*?<\/.*?>/g, '').trim();
     }
 
     if (!extension_settings.tts.pass_asterisks) {


### PR DESCRIPTION
### What is the reason for a change?
The `extension_settings.tts.skip_tags` setting is meant to skip sending tags and their content to the TTS API provider. The original regular expression (`/<.*?>.*?<\/.*?>/g`) tries to match content inside tags using `.*?`. Unfortunately, Javascript's engine does *not* match newlines on the "." without the /s flag. So for example, the regex fails to remove the tags from DeepSeek R1's output before sending it to the TTS provider. This will either generate a TTS of the entire content (including tags) or cause an error due to its length. eg.
```
<think>
{reasoning_content}
</think>
```
### What did you do to achieve this?
The /s flag was added in ES2018 and has [~96% user support](https://caniuse.com/mdn-javascript_builtins_regexp_dotall). However, to ensure maximum compatibility, the regex has been changed to `[\s\S]+?` (`/<.*?>[\s\S]*?<\/.*?>/g`). This gives similar performance and matches all content within a tag, as the original regex intended. The other options involve capture groups like `(?:.|\s)` or `(.|\s)` end up catastrophically backtracking on large texts. Using `[\s\S]` does not have this issue.

### How would a reviewer test the change?
After turning on the skip tags setting in the TTS extension, tests should include:
1. Text without any tags
  a. *Expected Result:* Output is the same as input 
3. Text with inline tags (no newlines) eg. `<tag>Text</tag>`
  a. *Expected Result:* Output has tags removed
4. Text with tags whose content spans multiple lines
  a. *Expected Result:* Output has tags removed

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
