### PR TITLE
Update loader being removed correctly on manually forced transition duration

### DIFF
--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -33,14 +33,12 @@ export async function hideLoader() {
             cleanup();
             return;
         }
-
-
-
+ 
         // Check if transitions are enabled
         const transitionDuration = spinner[0] ? getComputedStyle(spinner[0]).transitionDuration : '0s';
         const hasTransitions = parseFloat(transitionDuration) > 0;
 
-       if (hasTransitions) {
+        if (hasTransitions) {
             Promise.race([
                 new Promise((r) => setTimeout(r, 500)), // Fallback timeout
                 new Promise((r) => spinner.one('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', r)),
@@ -55,14 +53,14 @@ export async function hideLoader() {
             // If it's present, we remove it once and then it's gone.
             yoinkPreloader();
 
-        loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE)
-            .catch((err) => console.error('Error completing loaderPopup:', err))
-            .finally(() => {
-                loaderPopup = null;
-                resolve();
-            });
+            loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE)
+                .catch((err) => console.error('Error completing loaderPopup:', err))
+                .finally(() => {
+                    loaderPopup = null;
+                    resolve();
+                });
         }
-        
+
         // Apply the styles
         spinner.css({
             'filter': 'blur(15px)',

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -37,7 +37,7 @@ export async function hideLoader() {
 
         // Check if transitions are disabled by comparing computed style
         const transitionDuration = getComputedStyle(spinner[0]).transitionDuration;
-        const hasTransitions = parseInt(transitionDuration) > 0;
+        const hasTransitions = parseFloat(transitionDuration) > 0;
 
         if (hasTransitions) {
             // Spinner blurs/fades out

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -54,13 +54,7 @@ export async function hideLoader() {
             // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
             // If it's present, we remove it once and then it's gone.
             yoinkPreloader();
-            
-        // Apply the styles
-        spinner.css({
-            'filter': 'blur(15px)',
-            'opacity': '0',
-        });
-            
+
         loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE)
             .catch((err) => console.error('Error completing loaderPopup:', err))
             .finally(() => {
@@ -68,6 +62,12 @@ export async function hideLoader() {
                 resolve();
             });
         }
+        
+        // Apply the styles
+        spinner.css({
+            'filter': 'blur(15px)',
+            'opacity': '0',
+        });
     });
 }
 

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -37,7 +37,7 @@ export async function hideLoader() {
 
         // Check if transitions are disabled by comparing computed style
         const transitionDuration = getComputedStyle(spinner[0]).transitionDuration;
-        const hasTransitions = transitionDuration !== '0s' && transitionDuration !== '0';
+        const hasTransitions = parseInt(transitionDuration) > 0;
 
         if (hasTransitions) {
             // Spinner blurs/fades out

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -44,21 +44,16 @@ export async function hideLoader() {
         const transitionDuration = spinner[0] ? getComputedStyle(spinner[0]).transitionDuration : '0s';
         const hasTransitions = parseFloat(transitionDuration) > 0;
 
-        let transitionTimeout;
-        if (hasTransitions) {
-            spinner.one('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', () => {
-                clearTimeout(transitionTimeout);
-                cleanup();
-            });
-
-            // Fallback: Ensure cleanup happens even if transition event is missed
-            transitionTimeout = setTimeout(cleanup, 500);
+       if (hasTransitions) {
+            Promise.race([
+                new Promise((r) => setTimeout(r, 500)), // Fallback timeout
+                new Promise((r) => spinner.one('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', r)),
+            ]).finally(cleanup);
         } else {
             cleanup();
         }
 
         function cleanup() {
-            clearTimeout(transitionTimeout);
             $('#loader').remove();
             // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
             // If it's present, we remove it once and then it's gone.

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -34,11 +34,7 @@ export async function hideLoader() {
             return;
         }
 
-        // Apply the styles
-        spinner.css({
-            'filter': 'blur(15px)',
-            'opacity': '0',
-        });
+
 
         // Check if transitions are enabled
         const transitionDuration = spinner[0] ? getComputedStyle(spinner[0]).transitionDuration : '0s';
@@ -58,13 +54,19 @@ export async function hideLoader() {
             // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
             // If it's present, we remove it once and then it's gone.
             yoinkPreloader();
-
-            loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE)
-                .catch((err) => console.error('Error completing loaderPopup:', err))
-                .finally(() => {
-                    loaderPopup = null;
-                    resolve();
-                });
+            
+        // Apply the styles
+        spinner.css({
+            'filter': 'blur(15px)',
+            'opacity': '0',
+        });
+            
+        loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE)
+            .catch((err) => console.error('Error completing loaderPopup:', err))
+            .finally(() => {
+                loaderPopup = null;
+                resolve();
+            });
         }
     });
 }

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -27,24 +27,36 @@ export async function hideLoader() {
     }
 
     return new Promise((resolve) => {
-        // Spinner blurs/fades out
-        $('#load-spinner').on('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function () {
+        const spinner = $('#load-spinner');
+        
+        // Apply the styles
+        spinner.css({
+            'filter': 'blur(15px)',
+            'opacity': '0',
+        });
+
+        // Check if transitions are disabled by comparing computed style
+        const transitionDuration = getComputedStyle(spinner[0]).transitionDuration;
+        const hasTransitions = transitionDuration !== '0s' && transitionDuration !== '0';
+
+        if (hasTransitions) {
+            // Spinner blurs/fades out
+            spinner.one('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', cleanup);
+        } else {
+            // No transitions - clean up immediately
+            cleanup();
+        }
+
+        function cleanup() {
             $('#loader').remove();
             // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
             // If it's present, we remove it once and then it's gone.
             yoinkPreloader();
-
             loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE).then(() => {
                 loaderPopup = null;
                 resolve();
             });
-        });
-
-        $('#load-spinner')
-            .css({
-                'filter': 'blur(15px)',
-                'opacity': '0',
-            });
+        }
     });
 }
 


### PR DESCRIPTION
Preventing user custom css (transition-duration: 0) to not load a page.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
