### PR TITLE
Reasoning blocks auto-parsing

### DIFF
--- a/public/css/toggle-dependent.css
+++ b/public/css/toggle-dependent.css
@@ -472,6 +472,11 @@ label[for="trim_spaces"]:has(input:checked) i.warning {
     display: none;
 }
 
+label[for="trim_spaces"]:not(:has(input:checked)) small {
+    color: var(--warning);
+    opacity: 1;
+}
+
 #claude_function_prefill_warning {
     display: none;
     color: red;

--- a/public/index.html
+++ b/public/index.html
@@ -3791,6 +3791,12 @@
                                 <span data-i18n="Reasoning">Reasoning</span>
                             </h4>
                             <div>
+                                <label class="checkbox_label" for="reasoning_auto_parse" title="Automatically parse reasoning blocks from main content between the reasoning prefix/suffix. Both fields must be defined and non-empty." data-i18n="[title]reasoning_auto_parse">
+                                    <input id="reasoning_auto_parse" type="checkbox" />
+                                    <small data-i18n="Auto-Parse Reasoning">
+                                        Auto-Parse Reasoning
+                                    </small>
+                                </label>
                                 <label class="checkbox_label" for="reasoning_add_to_prompts" title="Add existing reasoning blocks to prompts. To add a new reasoning block, use the message edit menu." data-i18n="[title]reasoning_add_to_prompts">
                                     <input id="reasoning_add_to_prompts" type="checkbox" />
                                     <small data-i18n="Add Reasoning to Prompts">

--- a/public/script.js
+++ b/public/script.js
@@ -169,6 +169,7 @@ import {
     toggleDrawer,
     isElementInViewport,
     copyText,
+    escapeHtml,
 } from './scripts/utils.js';
 import { debounce_timeout } from './scripts/constants.js';
 
@@ -2066,6 +2067,17 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         mes = mes.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
     }
 
+    // Make sure reasoning strings are always shown, even if they include "<" or ">"
+    [power_user.reasoning.prefix, power_user.reasoning.suffix].forEach((reasoningString) => {
+        if (!reasoningString || !reasoningString.trim().length) {
+            return;
+        }
+        // Only replace the first occurrence of the reasoning string
+        if (mes.includes(reasoningString)) {
+            mes = mes.replace(reasoningString, escapeHtml(reasoningString));
+        }
+    });
+
     if (!isSystem) {
         // Save double quotes in tags as a special character to prevent them from being encoded
         if (!power_user.encode_tags) {
@@ -3208,7 +3220,7 @@ class StreamingProcessor {
             }
 
             if (this.reasoning) {
-                chat[messageId]['extra']['reasoning'] = this.reasoning;
+                chat[messageId]['extra']['reasoning'] = power_user.trim_spaces ? this.reasoning.trim() : this.reasoning;
                 if (this.messageReasoningDom instanceof HTMLElement) {
                     const formattedReasoning = messageFormatting(this.reasoning, '', false, false, messageId, {}, true);
                     this.messageReasoningDom.innerHTML = formattedReasoning;
@@ -4804,6 +4816,10 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
         messageChunk = cleanUpMessage(getMessage, isImpersonate, isContinue, false);
         reasoning = getRegexedString(reasoning, regex_placement.REASONING);
+
+        if (power_user.trim_spaces) {
+            reasoning = reasoning.trim();
+        }
 
         if (isContinue) {
             getMessage = continue_mag + getMessage;

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -254,6 +254,7 @@ let power_user = {
     },
 
     reasoning: {
+        auto_parse: false,
         add_to_prompts: false,
         prefix: '<think>\n',
         suffix: '\n</think>',

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -167,6 +167,36 @@ function registerReasoningSlashCommands() {
             return message.extra.reasoning;
         },
     }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'reasoning-parse',
+        returns: 'reasoning string',
+        helpString: t`Extracts the reasoning block from a string using the Reasoning Formatting settings.`,
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'input string',
+                typeList: ARGUMENT_TYPE.STRING,
+            }),
+        ],
+        callback: (_, value) => {
+            if (!value) {
+                return '';
+            }
+
+            if (!power_user.reasoning.prefix || !power_user.reasoning.suffix) {
+                toastr.warning(t`Both prefix and suffix must be set in the Reasoning Formatting settings.`);
+                return value.toString();
+            }
+
+            const parsedReasoning = parseReasoningFromString(value.toString());
+
+            if (!parsedReasoning) {
+                return '';
+            }
+
+            return getRegexedString(parsedReasoning.reasoning, regex_placement.REASONING);
+        },
+    }));
 }
 
 function registerReasoningMacros() {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -194,16 +194,16 @@ function registerReasoningSlashCommands() {
 
             if (!power_user.reasoning.prefix || !power_user.reasoning.suffix) {
                 toastr.warning(t`Both prefix and suffix must be set in the Reasoning Formatting settings.`);
-                return value.toString();
+                return String(value);
             }
 
-            const parsedReasoning = parseReasoningFromString(value.toString());
+            const parsedReasoning = parseReasoningFromString(String(value));
 
             if (!parsedReasoning) {
                 return '';
             }
 
-            const applyRegex = !isFalseBoolean(args.regex.toString());
+            const applyRegex = !isFalseBoolean(String(args.regex ?? ''));
             return applyRegex
                 ? getRegexedString(parsedReasoning.reasoning, regex_placement.REASONING)
                 : parsedReasoning.reasoning;

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -176,15 +176,16 @@ function registerReasoningSlashCommands() {
             SlashCommandNamedArgument.fromProps({
                 name: 'regex',
                 description: 'Whether to apply regex scripts to the reasoning content.',
-                typeList: ARGUMENT_TYPE.BOOLEAN,
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
                 defaultValue: 'true',
                 isRequired: false,
+                enumProvider: commonEnumProviders.boolean('trueFalse'),
             }),
         ],
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: 'input string',
-                typeList: ARGUMENT_TYPE.STRING,
+                typeList: [ARGUMENT_TYPE.STRING],
             }),
         ],
         callback: (args, value) => {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -311,13 +311,18 @@ function parseReasoningFromString(str) {
     }
 
     try {
-        let reasoning = '';
-
         const regex = new RegExp(`${escapeRegex(power_user.reasoning.prefix)}(.*?)${escapeRegex(power_user.reasoning.suffix)}`, 's');
-        const content = String(str).replace(regex, (_match, captureGroup) => {
-            reasoning = power_user.trim_spaces ? captureGroup.trim() : captureGroup;
+
+        let reasoning = '';
+        let content = String(str).replace(regex, (_match, captureGroup) => {
+            reasoning = captureGroup;
             return '';
         });
+
+        if (reasoning && power_user.trim_spaces) {
+            reasoning = reasoning.trim();
+            content = content.trim();
+        }
 
         return { reasoning, content };
     } catch (error) {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1,4 +1,4 @@
-import { chat, closeMessageEditor, saveChatConditional, saveSettingsDebounced, substituteParams, updateMessageBlock } from '../script.js';
+import { chat, closeMessageEditor, event_types, eventSource, saveChatConditional, saveSettingsDebounced, substituteParams, updateMessageBlock } from '../script.js';
 import { getRegexedString, regex_placement } from './extensions/regex/engine.js';
 import { t } from './i18n.js';
 import { MacrosParser } from './macros.js';
@@ -8,7 +8,7 @@ import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { commonEnumProviders } from './slash-commands/SlashCommandCommonEnumsProvider.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
-import { copyText } from './utils.js';
+import { copyText, escapeRegex } from './utils.js';
 
 /**
  * Gets a message from a jQuery element.
@@ -104,6 +104,12 @@ function loadReasoningSettings() {
     $('#reasoning_max_additions').val(power_user.reasoning.max_additions);
     $('#reasoning_max_additions').on('input', function () {
         power_user.reasoning.max_additions = Number($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#reasoning_auto_parse').prop('checked', power_user.reasoning.auto_parse);
+    $('#reasoning_auto_parse').on('change', function () {
+        power_user.reasoning.auto_parse = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 }
@@ -290,9 +296,94 @@ function setReasoningEventHandlers(){
     });
 }
 
+/**
+ * Parses reasoning from a string using the power user reasoning settings.
+ * @typedef {Object} ParsedReasoning
+ * @property {string} reasoning Reasoning block
+ * @property {string} content Message content
+ * @param {string} str Content of the message
+ * @returns {ParsedReasoning|null} Parsed reasoning block and message content
+ */
+function parseReasoningFromString(str) {
+    // Both prefix and suffix must be defined
+    if (!power_user.reasoning.prefix || !power_user.reasoning.suffix) {
+        return null;
+    }
+
+    try {
+        let reasoning = '';
+
+        const regex = new RegExp(`${escapeRegex(power_user.reasoning.prefix)}(.*?)${escapeRegex(power_user.reasoning.suffix)}`, 's');
+        const content = String(str).replace(regex, (_match, captureGroup) => {
+            reasoning = power_user.trim_spaces ? captureGroup.trim() : captureGroup;
+            return '';
+        });
+
+        return { reasoning, content };
+    } catch (error) {
+        console.error('[Reasoning] Error parsing reasoning block', error);
+        return null;
+    }
+}
+
+function registerReasoningAppEvents() {
+    eventSource.makeFirst(event_types.MESSAGE_RECEIVED, (/** @type {number} */ idx) => {
+        if (!power_user.reasoning.auto_parse) {
+            return;
+        }
+
+        console.debug('[Reasoning] Auto-parsing reasoning block for message', idx);
+        const message = chat[idx];
+
+        if (!message) {
+            console.warn('[Reasoning] Message not found', idx);
+            return null;
+        }
+
+        if (!message.mes || message.mes === '...') {
+            console.debug('[Reasoning] Message content is empty or a placeholder', idx);
+            return null;
+        }
+
+        const parsedReasoning = parseReasoningFromString(message.mes);
+
+        // No reasoning block found
+        if (!parsedReasoning) {
+            return;
+        }
+
+        // Make sure the message has an extra object
+        if (!message.extra || typeof message.extra !== 'object') {
+            message.extra = {};
+        }
+
+        const contentUpdated = !!parsedReasoning.reasoning || parsedReasoning.content !== message.mes;
+
+        // If reasoning was found, add it to the message
+        if (parsedReasoning.reasoning) {
+            message.extra.reasoning = parsedReasoning.reasoning;
+        }
+
+        // Update the message text if it was changed
+        if (parsedReasoning.content !== message.mes) {
+            message.mes = parsedReasoning.content;
+        }
+
+        // Find if a message already exists in DOM and must be updated
+        if (contentUpdated) {
+            const messageRendered = document.querySelector(`.mes[mesid="${idx}"]`) !== null;
+            if (messageRendered) {
+                console.debug('[Reasoning] Updating message block', idx);
+                updateMessageBlock(idx, message);
+            }
+        }
+    });
+}
+
 export function initReasoning() {
     loadReasoningSettings();
     setReasoningEventHandlers();
     registerReasoningSlashCommands();
     registerReasoningMacros();
+    registerReasoningAppEvents();
 }

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -313,13 +313,15 @@ function parseReasoningFromString(str) {
     try {
         const regex = new RegExp(`${escapeRegex(power_user.reasoning.prefix)}(.*?)${escapeRegex(power_user.reasoning.suffix)}`, 's');
 
+        let didReplace = false;
         let reasoning = '';
         let content = String(str).replace(regex, (_match, captureGroup) => {
+            didReplace = true;
             reasoning = captureGroup;
             return '';
         });
 
-        if (reasoning && power_user.trim_spaces) {
+        if (didReplace && power_user.trim_spaces) {
             reasoning = reasoning.trim();
             content = content.trim();
         }


### PR DESCRIPTION
Supersedes #3385

1. Add a toggle to auto-parse reasoning blocks using defined reasoning formatting settings (both suffix and prefix must be non-empty).
2. Makes sure reasoning blocks follow the "trim spaces" context preference.
3. Encodes HTML in reasoning strings if they are contained in messages to be rendered. This is to be able to show pseudo-XML <tags> even if the preference is NOT to view tags.

**Important:** to go easy on computational resources and not run regex replacement every frame, this DOES NOT work during the streaming, only after the streamed message has been fully received. 

Easily testable on newly added Perplexity sonar-reasoning models, but should work for every API source, including Text Completon.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
