### PR TITLE
fix: resolve URL duplication in AllTalk TTS audio output on V1 AllTalk

### DIFF
--- a/public/scripts/extensions/tts/alltalk.js
+++ b/public/scripts/extensions/tts/alltalk.js
@@ -262,13 +262,13 @@ class AllTalkTtsProvider {
         console.debug('AllTalkTTS: Settings loaded');
         try {
             // Check if TTS provider is ready
-            this.setupEventListeners();
-            this.updateLanguageDropdown();
             await this.checkReady();
             await this.updateSettingsFromServer(); // Fetch dynamic settings from the TTS server
             await this.fetchTtsVoiceObjects(); // Fetch voices only if service is ready
             await this.fetchRvcVoiceObjects(); // Fetch RVC voices
             this.updateNarratorVoicesDropdown();
+            this.updateLanguageDropdown();
+            this.setupEventListeners();
             this.applySettingsToHTML();
             updateStatus('Ready');
         } catch (error) {
@@ -388,7 +388,7 @@ class AllTalkTtsProvider {
     }
 
     async fetchRvcVoiceObjects() {
-        if (this.settings.server_version == 'v2') {
+        if (this.settings.server_version !== 'v1') {
             console.log('Skipping RVC voices fetch for V1 server');
             return [];
         }
@@ -1031,14 +1031,18 @@ class AllTalkTtsProvider {
                 console.error('fetchTtsGeneration Error Response Text:', errorText);
                 throw new Error(`HTTP ${response.status}: ${errorText}`);
             }
+
             const data = await response.json();
 
-            // Handle V1/V2 URL differences
-            const outputUrl = this.settings.server_version === 'v1'
-                ? data.output_file_url  // V1 returns full URL
-                : `${this.settings.provider_endpoint}${data.output_file_url}`; // V2 returns relative path
+            // V1 returns a complete URL, V2 returns a relative path
+            if (this.settings.server_version === 'v1') {
+                // V1: Use the complete URL directly from the response
+                return data.output_file_url;
+            } else {
+                // V2: Combine the endpoint with the relative path
+                return `${this.settings.provider_endpoint}${data.output_file_url}`;
+            }
 
-            return outputUrl;
         } catch (error) {
             console.error('[fetchTtsGeneration] Exception caught:', error);
             throw error;

--- a/public/scripts/extensions/tts/alltalk.js
+++ b/public/scripts/extensions/tts/alltalk.js
@@ -262,13 +262,13 @@ class AllTalkTtsProvider {
         console.debug('AllTalkTTS: Settings loaded');
         try {
             // Check if TTS provider is ready
+            this.setupEventListeners();
+            this.updateLanguageDropdown();
             await this.checkReady();
             await this.updateSettingsFromServer(); // Fetch dynamic settings from the TTS server
             await this.fetchTtsVoiceObjects(); // Fetch voices only if service is ready
             await this.fetchRvcVoiceObjects(); // Fetch RVC voices
             this.updateNarratorVoicesDropdown();
-            this.updateLanguageDropdown();
-            this.setupEventListeners();
             this.applySettingsToHTML();
             updateStatus('Ready');
         } catch (error) {
@@ -388,7 +388,7 @@ class AllTalkTtsProvider {
     }
 
     async fetchRvcVoiceObjects() {
-        if (this.settings.server_version !== 'v1') {
+        if (this.settings.server_version == 'v1') {
             console.log('Skipping RVC voices fetch for V1 server');
             return [];
         }


### PR DESCRIPTION
Fix URL concatenation issue where base URL was being duplicated in audio file paths. 

Updated handling of V1 (full URL) and V2 (relative path) API response formats to prevent `http://localhost:7851http://127.0.0.1:7851` type errors.

Re-corrected RVC version matching back to what is currently live on ST.

Es-linted 

Tested on AllTalk V1 and V2 servers multiple times.

<!-- Put X in the box below to confirm -->

## Checklist:

- [ x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
