### PR TITLE
[RFC WIP] Improve reasoning editing UI

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -10723,6 +10723,9 @@ jQuery(async function () {
             this_edit_mes_id = edit_mes_id;
 
             var text = chat[edit_mes_id]['mes'];
+
+            text = new PromptReasoning().addToMessage(text, chat[edit_mes_id].extra?.reasoning ?? '', true);
+
             if (chat[edit_mes_id]['is_user']) {
                 this_edit_mes_chname = name1;
             } else if (chat[edit_mes_id]['force_avatar']) {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -218,7 +218,7 @@ function registerReasoningMacros() {
     MacrosParser.registerMacro('reasoningSeparator', () => power_user.reasoning.separator, t`Reasoning Separator`);
 }
 
-function setReasoningEventHandlers(){
+function setReasoningEventHandlers() {
     $(document).on('click', '.mes_reasoning_copy', (e) => {
         e.stopPropagation();
         e.preventDefault();
@@ -377,7 +377,7 @@ function parseReasoningFromString(str) {
 }
 
 function registerReasoningAppEvents() {
-    eventSource.makeFirst(event_types.MESSAGE_RECEIVED, (/** @type {number} */ idx) => {
+    function handleEvent(/** @type {number} */ idx) {
         if (!power_user.reasoning.auto_parse) {
             return;
         }
@@ -427,7 +427,10 @@ function registerReasoningAppEvents() {
                 updateMessageBlock(idx, message);
             }
         }
-    });
+    };
+
+    eventSource.makeFirst(event_types.MESSAGE_RECEIVED, handleEvent);
+    eventSource.makeFirst(event_types.MESSAGE_EDITED, handleEvent);
 }
 
 export function initReasoning() {


### PR DESCRIPTION
Reasoning can be edited jointly with the message content.
This UI is much closer to the experience of #3352, and supersedes #3352.

RFC for the UI change.
Soft-depends on #3395 (can be tested without).

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
