### PR TITLE
Add a [Create an Assistant] button on the splash screen

### DIFF
--- a/public/locales/ar-sa.json
+++ b/public/locales/ar-sa.json
@@ -1439,5 +1439,8 @@
     "Still have questions?": "هل ما زالت لديك اسئلة؟",
     "Join the SillyTavern Discord": "انضم إلى ديسكورد SillyTavern",
     "Post a GitHub issue": "نشر مشكلة على GitHub",
-    "Contact the developers": "الاتصال بالمطورين"
+    "Contact the developers": "الاتصال بالمطورين",
+    "Alternatively,": "بدلاً من ذلك,",
+    "Create a new Assistant": "إنشاء مساعد جديد",
+    "Unable to create assistant.": "غير قادر على إنشاء مساعد"
 }

--- a/public/locales/de-de.json
+++ b/public/locales/de-de.json
@@ -1439,5 +1439,8 @@
     "Still have questions?": "Hast du immer noch Fragen?",
     "Join the SillyTavern Discord": "Trete dem SillyTavern Discord bei",
     "Post a GitHub issue": "Veröffentliche ein GitHub-Problem",
-    "Contact the developers": "Kontaktiere die Entwickler"
+    "Contact the developers": "Kontaktiere die Entwickler",
+    "Alternatively,": "Alternativ,",
+    "Create a new Assistant": "Erstellen Sie einen neuen Assistenten",
+    "Unable to create assistant.": "Assistent konnte nicht erstellt werden."
 }

--- a/public/locales/es-es.json
+++ b/public/locales/es-es.json
@@ -1546,5 +1546,8 @@
     "Toggles sharing world tint with character sprites (This will override Character Tint)": "Alterna el tinte mundial compartido con los sprites de personajes (esto anulará el tinte de personajes)",
     "Sets the expression of the user sprite": "Establece la expresión del sprite de usuario",
     "Sets the user sprite set to use for the user sprite": "Establece el conjunto de sprites de usuario para usar en el sprite de usuario",
-    "Toggles the user sprite on the VN UI": "Alterna el sprite de usuario en la interfaz VN"
+    "Toggles the user sprite on the VN UI": "Alterna el sprite de usuario en la interfaz VN",
+    "Alternatively,": "Alternativamente,",
+    "Create a new Assistant": "Crear un nuevo asistente",
+    "Unable to create assistant.": "No se puede crear asistente."
 }

--- a/public/locales/fr-fr.json
+++ b/public/locales/fr-fr.json
@@ -2050,5 +2050,8 @@
     "System Prompt Name": "Nom du prompt système:",
     "Instruct Mode": "Mode Instruction:",
     "Save and Update": "Sauvegarder et mettre à jour",
-    "Don't ask again for this URL": "Ne plus demander pour cette URL"
+    "Don't ask again for this URL": "Ne plus demander pour cette URL",
+    "Alternatively,": "Alternativement,",
+    "Create a new Assistant": "Créer un nouvel assistant",
+    "Unable to create assistant.": "Impossible de créer l'assistant."
 }

--- a/public/locales/is-is.json
+++ b/public/locales/is-is.json
@@ -1439,5 +1439,8 @@
     "Still have questions?": "Ertu enn með spurningar?",
     "Join the SillyTavern Discord": "Skráðu þig í SillyTavern Discord",
     "Post a GitHub issue": "Senda inn GitHub málefni",
-    "Contact the developers": "Hafa samband við þróunaraðila"
+    "Contact the developers": "Hafa samband við þróunaraðila",
+    "Alternatively,": "Að öðrum kosti,",
+    "Create a new Assistant": "Búðu til nýjan aðstoðarmann",
+    "Unable to create assistant.": "Ekki tókst að búa til aðstoðarmann."
 }

--- a/public/locales/it-it.json
+++ b/public/locales/it-it.json
@@ -1439,5 +1439,8 @@
     "Still have questions?": "Hai ancora domande?",
     "Join the SillyTavern Discord": "Unisciti al SillyTavern Discord",
     "Post a GitHub issue": "Pubblica un problema su GitHub",
-    "Contact the developers": "Contatta gli sviluppatori"
+    "Contact the developers": "Contatta gli sviluppatori",
+    "Alternatively,": "In alternativa,",
+    "Create a new Assistant": "Crea un nuovo assistente",
+    "Unable to create assistant.": "Impossibile creare l'assistente."
 }

--- a/public/locales/ja-jp.json
+++ b/public/locales/ja-jp.json
@@ -1444,5 +1444,8 @@
     "Contact the developers": "開発者に連絡",
     "Stop Inspecting": "検査を停止",
     "Inspect Prompts": "プロンプトを検査",
-    "Toggle prompt inspection": "プロンプト検査の切り替え"
+    "Toggle prompt inspection": "プロンプト検査の切り替え",
+    "Alternatively,": "あるいは、",
+    "Create a new Assistant": "新しいアシスタントを作成する",
+    "Unable to create assistant.": "アシスタントを作成できません。"
 }

--- a/public/locales/ko-kr.json
+++ b/public/locales/ko-kr.json
@@ -1622,5 +1622,8 @@
     "to install additional features.": "으로 가세요.",
     "Master Import": "마스터 불러오기",
     "Master Export": "마스터 내보내기",
-    "Chat Quick Reply Sets": "채팅 빠른 답장 세트들"
+    "Chat Quick Reply Sets": "채팅 빠른 답장 세트들",
+    "Alternatively,": "대안적으로,",
+    "Create a new Assistant": "새 어시스턴트 만들기",
+    "Unable to create assistant.": "어시스턴트를 생성할 수 없습니다."
 }

--- a/public/locales/nl-nl.json
+++ b/public/locales/nl-nl.json
@@ -1439,5 +1439,8 @@
     "Still have questions?": "Heb je nog vragen?",
     "Join the SillyTavern Discord": "Word lid van de SillyTavern Discord",
     "Post a GitHub issue": "Plaats een GitHub-probleem",
-    "Contact the developers": "Neem contact op met de ontwikkelaars"
+    "Contact the developers": "Neem contact op met de ontwikkelaars",
+    "Alternatively,": "Alternatief,",
+    "Create a new Assistant": "Maak een nieuwe assistent",
+    "Unable to create assistant.": "Kan assistent niet maken."
 }

--- a/public/locales/pt-pt.json
+++ b/public/locales/pt-pt.json
@@ -1439,5 +1439,8 @@
     "Still have questions?": "Ainda tem perguntas?",
     "Join the SillyTavern Discord": "Junte-se ao Discord do SillyTavern",
     "Post a GitHub issue": "Publicar um problema no GitHub",
-    "Contact the developers": "Contatar os desenvolvedores"
+    "Contact the developers": "Contatar os desenvolvedores",
+    "Alternatively,": "Alternativamente,",
+    "Create a new Assistant": "Crie um novo Assistente",
+    "Unable to create assistant.": "Não foi possível criar o assistente."
 }

--- a/public/locales/ru-ru.json
+++ b/public/locales/ru-ru.json
@@ -2144,5 +2144,8 @@
     "Not connected to the API!": "Нет соединения с API!",
     "ext_type_system": "Это комплектное расширение. Его нельзя удалить, а обновляется оно вместе со всей системой.",
     "Update all": "Обновить все",
-    "Close": "Закрыть"
+    "Close": "Закрыть",
+    "Alternatively,": "Альтернативно,",
+    "Create a new Assistant": "Создать нового помощника",
+    "Unable to create assistant.": "Не удалось создать помощника."
 }

--- a/public/locales/uk-ua.json
+++ b/public/locales/uk-ua.json
@@ -1439,5 +1439,8 @@
     "Still have questions?": "Все ще є питання?",
     "Join the SillyTavern Discord": "Приєднуйтесь до SillyTavern Discord",
     "Post a GitHub issue": "Опублікуйте проблему на GitHub",
-    "Contact the developers": "Зв'яжіться з розробниками"
+    "Contact the developers": "Зв'яжіться з розробниками",
+    "Alternatively,": "Альтернативно,",
+    "Create a new Assistant": "Створіть нового помічника",
+    "Unable to create assistant.": "Не вдалося створити помічника."
 }

--- a/public/locales/vi-vn.json
+++ b/public/locales/vi-vn.json
@@ -1439,5 +1439,8 @@
     "Still have questions?": "Bạn còn thắc mắc?",
     "Join the SillyTavern Discord": "Tham gia Kênh Discord của SillyTavern",
     "Post a GitHub issue": "Đăng một vấn đề trên GitHub",
-    "Contact the developers": "Liên hệ với Devs"
+    "Contact the developers": "Liên hệ với Devs",
+    "Alternatively,": "Ngoài ra,",
+    "Create a new Assistant": "Tạo Trợ lý mới",
+    "Unable to create assistant.": "Không thể tạo trợ lý."
 }

--- a/public/locales/zh-cn.json
+++ b/public/locales/zh-cn.json
@@ -2048,5 +2048,8 @@
     "Title/Memo": "标题（备忘）",
     "Strategy": "触发策略",
     "Position": "插入位置",
-    "Trigger %": "触发概率%"
+    "Trigger %": "触发概率%",
+    "Alternatively,": "或者，",
+    "Create a new Assistant": "创建新助理",
+    "Unable to create assistant.": "无法创建助手。"
 }

--- a/public/locales/zh-tw.json
+++ b/public/locales/zh-tw.json
@@ -2452,5 +2452,8 @@
     "Modules provided by your Extras API:": "由您的 Extras API 提供的模組：",
     "Not connected to the API!": "未連線到 API！",
     "ext_type_system": "這是內建的擴充功能，無法刪除，且會跟隨系統更新。",
-    "Valid": "已驗證"
+    "Valid": "已驗證",
+    "Alternatively,": "或者，",
+    "Create a new Assistant": "建立新助理",
+    "Unable to create assistant.": "無法創建助手。"
 }

--- a/public/script.js
+++ b/public/script.js
@@ -269,7 +269,7 @@ import { initBulkEdit } from './scripts/bulk-edit.js';
 import { deriveTemplatesFromChatTemplate } from './scripts/chat-templates.js';
 import { getContext } from './scripts/st-context.js';
 import { initReasoning, PromptReasoning } from './scripts/reasoning.js';
-
+import { prepareCreateAssistant } from './scripts/prepare-create-assistant.js';
 // API OBJECT FOR EXTERNAL WIRING
 globalThis.SillyTavern = {
     libs,
@@ -11559,4 +11559,6 @@ jQuery(async function () {
     });
 
     initCustomSelectedSamplers();
+
+    prepareCreateAssistant();
 });

--- a/public/scripts/prepare-create-assistant.js
+++ b/public/scripts/prepare-create-assistant.js
@@ -68,16 +68,14 @@ async function createAssistant() {
 
         await sleep(0);
 
-        if ([characterNameInput, saveCharacterButton].every(Boolean)) {
-            characterNameInput.value = ASSISTANT_NAME;
-            firstMessageTextarea.value = 'Hello! I am your assistant. How can I help you today?';
+        characterNameInput.value = ASSISTANT_NAME;
+        firstMessageTextarea.value = 'Hello! I am your assistant. How can I help you today?';
 
-            await sleep(0);
+        await sleep(0);
 
-            saveCharacterButton.click();
+        saveCharacterButton.click();
 
-            await sleep(100);
-        }
+        await sleep(100);
     } catch (error) {
         console.error('Unable to create assistant.', error);
         toastr.error(t`Unable to create assistant.`, t`Error`, { timeOut: 0, extendedTimeOut: 0, preventDuplicates: true });

--- a/public/scripts/prepare-create-assistant.js
+++ b/public/scripts/prepare-create-assistant.js
@@ -2,6 +2,8 @@ import { t } from './i18n.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { getContext } from './st-context.js';
 
+const ASSISTANT_NAME = 'Assistant';
+
 /**
  * @desc Prepare the create assistant button.
  * @returns {void}
@@ -38,7 +40,7 @@ function sleep(ms) {
 function assistantAlreadyExists() {
     const { characters } = getContext();
 
-    return characters.some(character => character.name === 'Assistant');
+    return characters.some(character => character.name === ASSISTANT_NAME);
 }
 
 /**
@@ -46,7 +48,7 @@ function assistantAlreadyExists() {
  * @returns {Promise<void>}
  */
 async function chatWithAssistant() {
-    SlashCommandParser.commands.char.callback({ _scope: null, _abortController: null }, 'Assistant');
+    SlashCommandParser.commands.char.callback({ _scope: null, _abortController: null }, ASSISTANT_NAME);
 }
 
 /**
@@ -67,7 +69,7 @@ async function createAssistant() {
         await sleep(0);
 
         if ([characterNameInput, saveCharacterButton].every(Boolean)) {
-            characterNameInput.value = 'Assistant';
+            characterNameInput.value = ASSISTANT_NAME;
             firstMessageTextarea.value = 'Hello! I am your assistant. How can I help you today?';
 
             await sleep(0);

--- a/public/scripts/prepare-create-assistant.js
+++ b/public/scripts/prepare-create-assistant.js
@@ -1,0 +1,84 @@
+import { t } from './i18n.js';
+import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
+import { getContext } from './st-context.js';
+
+/**
+ * @desc Prepare the create assistant button.
+ * @returns {void}
+ */
+export function prepareCreateAssistant() {
+    const createAssistantBtn = document.querySelector('[data-which="create-assistant-btn"]');
+
+    if (createAssistantBtn) {
+        createAssistantBtn.addEventListener('click', async () => {
+            if (assistantAlreadyExists()) {
+                chatWithAssistant();
+            } else {
+                await createAssistant();
+                chatWithAssistant();
+            }
+        });
+    }
+}
+
+// region Helpers
+/**
+ * @desc Sleep for a given number of milliseconds.
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * @desc Check if the assistant already exists.
+ * @returns {boolean}
+ */
+function assistantAlreadyExists() {
+    const { characters } = getContext();
+
+    return characters.some(character => character.name === 'Assistant');
+}
+
+/**
+ * @desc Chat with the assistant.
+ * @returns {Promise<void>}
+ */
+async function chatWithAssistant() {
+    SlashCommandParser.commands.char.callback({ _scope: null, _abortController: null }, 'Assistant');
+}
+
+/**
+ * @desc Create the assistant.
+ * @returns {Promise<void>}
+ */
+async function createAssistant() {
+    try {
+        const characterManagementButton = document.querySelector('#rightNavDrawerIcon');
+        const createCharacterButton = document.querySelector('#rm_button_create');
+        const characterNameInput = document.querySelector('#character_name_pole');
+        const firstMessageTextarea = document.querySelector('#firstmessage_textarea');
+        const saveCharacterButton = document.querySelector('#create_button_label');
+
+        characterManagementButton.click();
+        createCharacterButton.click();
+
+        await sleep(0);
+
+        if ([characterNameInput, saveCharacterButton].every(Boolean)) {
+            characterNameInput.value = 'Assistant';
+            firstMessageTextarea.value = 'Hello! I am your assistant. How can I help you today?';
+
+            await sleep(0);
+
+            saveCharacterButton.click();
+
+            await sleep(100);
+        }
+    } catch (error) {
+        console.error('Unable to create assistant.', error);
+        toastr.error(t`Unable to create assistant.`, t`Error`, { timeOut: 0, extendedTimeOut: 0, preventDuplicates: true });
+    }
+}
+// endregion

--- a/public/scripts/templates/welcome.html
+++ b/public/scripts/templates/welcome.html
@@ -24,6 +24,11 @@
             <span data-i18n="Character Management">Character Management</span>
         </button>
         <span data-i18n="and pick a character."> and pick a character.</span>
+        <span data-i18n="Alternatively,">Alternatively,</span>
+        <button class="menu_button menu_button_icon inline-flex" data-which="create-assistant-btn">
+            <i class="fa-solid fa-user-plus"></i>
+            <span data-i18n="Create a new Assistant">Create a new Assistant</span>
+        </button>
     </li>
 </ol>
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/f439bd46-3f9d-4316-bcd3-307b09b74147



<!-- Put X in the box below to confirm -->

## Checklist:

- [ X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Questions:

### What is the reason for the change?

* In the Discord chat (in #code-contributions), a discussion occurred between Ross and some others about improving the flow for new users.
* One idea was to have a button for fast-tracking a chat with an Assistant.
* This was determined to be a good first issue to work on.

### What did you do to achieve this?

* On the splash screen, there is now a button that can be clicked to either a) create a new character called "Assistant" and open the chat, or b) open a chat with the existing "Assistant" character.

### How would a reviewer test the change?

1. Open ST and make sure you don't have a character called Assistant.
2. On the splash screen, press the [Create an Assistant] button.
3. A character called Assistant should be created and the chat should open to them.
4. Hard-refresh the page.
5. Click the [Create an Assistant] button again.
6. No new Assistant should be made, but the chat should be open.


