### PR TITLE
Adds /member-get via enhancing findGroupMemberId

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -292,10 +292,11 @@ export function getGroupNames() {
 
 /**
  * Finds the character ID for a group member.
- * @param {string} arg 0-based member index or character name
- * @returns {number} 0-based character ID
+ * @param {number|string} arg 0-based member index or character name
+ * @param {Boolean} full Whether to return a key-value object containing extra data
+ * @returns {number|Object} 0-based character ID or key-value object if full is true
  */
-export function findGroupMemberId(arg) {
+export function findGroupMemberId(arg, full) {
     arg = arg?.trim();
 
     if (!arg) {
@@ -311,15 +312,19 @@ export function findGroupMemberId(arg) {
     }
 
     const index = parseInt(arg);
-    const searchByName = isNaN(index);
+    const searchByString = isNaN(index);
 
-    if (searchByName) {
-        const memberNames = group.members.map(x => ({ name: characters.find(y => y.avatar === x)?.name, index: characters.findIndex(y => y.avatar === x) }));
-        const fuse = new Fuse(memberNames, { keys: ['name'] });
+    if (searchByString) {
+        const memberNames = group.members.map(x => ({
+            avatar: x,
+            name: characters.find(y => y.avatar === x)?.name,
+            index: characters.findIndex(y => y.avatar === x),
+        }));
+        const fuse = new Fuse(memberNames, { keys: ['avatar', 'name'] });
         const result = fuse.search(arg);
 
         if (!result.length) {
-            console.warn(`WARN: No group member found with name ${arg}`);
+            console.warn(`WARN: No group member found using string ${arg}`);
             return;
         }
 
@@ -330,9 +335,11 @@ export function findGroupMemberId(arg) {
             return;
         }
 
-        console.log(`Triggering group member ${chid} (${arg}) from search result`, result[0]);
-        return chid;
-    } else {
+        console.log(`Targeting group member ${chid} (${arg}) from search result`, result[0]);
+
+        return !full ? chid : { ...{ id: chid }, ...result[0].item };
+    }
+    else {
         const memberAvatar = group.members[index];
 
         if (memberAvatar === undefined) {
@@ -347,8 +354,14 @@ export function findGroupMemberId(arg) {
             return;
         }
 
-        console.log(`Triggering group member ${memberAvatar} at index ${index}`);
-        return chid;
+        console.log(`Targeting group member ${memberAvatar} at index ${index}`);
+
+        return !full ? chid : {
+            id: chid,
+            avatar: memberAvatar,
+            name: characters.find(y => y.avatar === memberAvatar)?.name,
+            index: index,
+        };
     }
 }
 

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -296,7 +296,7 @@ export function getGroupNames() {
  * @param {Boolean} full Whether to return a key-value object containing extra data
  * @returns {number|Object} 0-based character ID or key-value object if full is true
  */
-export function findGroupMemberId(arg, full) {
+export function findGroupMemberId(arg, full = false) {
     arg = arg?.trim();
 
     if (!arg) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -736,16 +736,18 @@ export function initDefaultSlashCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'member-get',
         aliases: ['getmember', 'memberget'],
-        callback: (async ({field}, arg) => {
+        callback: (async ({field = 'name'}, arg) => {
             if (!selected_group) {
                 toastr.warning('Cannot run /member-get command outside of a group chat.');
                 return '';
             }
-            if (field === undefined) {
-                throw new Error('\'/member-get field=\' argument required!');
+            if (field === '') {
+                toastr.warning('\'/member-get field=\' argument required!');
+                return '';
             }
             if (!['name', 'index', 'id', 'avatar'].includes(field)) {
-                throw new Error(`Invalid '/member-get field=' argument '${field}' specified!`);
+                toastr.warning('\'/member-get field=\' argument required!');
+                return '';
             }
             const isId = !isNaN(parseInt(arg));
             const groupMember = findGroupMemberId(arg, true);
@@ -761,6 +763,7 @@ export function initDefaultSlashCommands() {
                 description: 'Whether to retrieve the name, index, id, or avatar.',
                 typeList: [ARGUMENT_TYPE.STRING],
                 isRequired: true,
+                defaultValue: 'name',
                 enumList: ['name', 'index', 'id', 'avatar'],
             }),
         ],

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -843,7 +843,8 @@ export function initDefaultSlashCommands() {
         helpString: 'Moves a group member down in the group chat list.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'peek',
+        name: 'member-peek',
+        aliases: ['peek', 'memberpeek', 'peekmember'],
         callback: peekCallback,
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
@@ -3047,7 +3048,7 @@ function performGroupMemberAction(chid, action) {
 
 async function disableGroupMemberCallback(_, arg) {
     if (!selected_group) {
-        toastr.warning('Cannot run /disable command outside of a group chat.');
+        toastr.warning('Cannot run /member-disable command outside of a group chat.');
         return '';
     }
 
@@ -3064,7 +3065,7 @@ async function disableGroupMemberCallback(_, arg) {
 
 async function enableGroupMemberCallback(_, arg) {
     if (!selected_group) {
-        toastr.warning('Cannot run /enable command outside of a group chat.');
+        toastr.warning('Cannot run /member-enable command outside of a group chat.');
         return '';
     }
 
@@ -3115,12 +3116,12 @@ async function moveGroupMemberDownCallback(_, arg) {
 
 async function peekCallback(_, arg) {
     if (!selected_group) {
-        toastr.warning('Cannot run /peek command outside of a group chat.');
+        toastr.warning('Cannot run /member-peek command outside of a group chat.');
         return '';
     }
 
     if (is_group_generating) {
-        toastr.warning('Cannot run /peek command while the group reply is generating.');
+        toastr.warning('Cannot run /member-peek command while the group reply is generating.');
         return '';
     }
 
@@ -3137,7 +3138,7 @@ async function peekCallback(_, arg) {
 
 async function removeGroupMemberCallback(_, arg) {
     if (!selected_group) {
-        toastr.warning('Cannot run /memberremove command outside of a group chat.');
+        toastr.warning('Cannot run /member-remove command outside of a group chat.');
         return '';
     }
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -734,6 +734,47 @@ export function initDefaultSlashCommands() {
         helpString: 'Unhides a message from the prompt.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'member-get',
+        aliases: ['getmember', 'memberget'],
+        callback: (async ({field}, arg) => {
+            if (!selected_group) {
+                toastr.warning('Cannot run /member-get command outside of a group chat.');
+                return '';
+            }
+            if (field === undefined) {
+                throw new Error('\'/member-get field=\' argument required!');
+            }
+            if (!['name', 'index', 'id', 'avatar'].includes(field)) {
+                throw new Error(`Invalid '/member-get field=' argument '${field}' specified!`);
+            }
+            const isId = !isNaN(parseInt(arg));
+            const groupMember = findGroupMemberId(arg, true);
+            if (!groupMember) {
+                toastr.warn(`No group member found using ${isId?'id':'string'} ${arg}`);
+                return '';
+            }
+            return groupMember[field];
+        }),
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'field',
+                description: 'Whether to retrieve the name, index, id, or avatar.',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumList: ['name', 'index', 'id', 'avatar'],
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'member index (starts with 0), name, or avatar',
+                typeList: [ARGUMENT_TYPE.NUMBER, ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: commonEnumProviders.groupMembers(),
+            }),
+        ],
+        helpString: 'Retrieves a group member\'s name, index, id, or avatar.',
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'member-disable',
         callback: disableGroupMemberCallback,
         aliases: ['disable', 'disablemember', 'memberdisable'],

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -736,7 +736,7 @@ export function initDefaultSlashCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'member-get',
         aliases: ['getmember', 'memberget'],
-        callback: (async ({field = 'name'}, arg) => {
+        callback: (async ({ field = 'name' }, arg) => {
             if (!selected_group) {
                 toastr.warning('Cannot run /member-get command outside of a group chat.');
                 return '';
@@ -745,6 +745,8 @@ export function initDefaultSlashCommands() {
                 toastr.warning('\'/member-get field=\' argument required!');
                 return '';
             }
+            field = field.toString();
+            arg = arg.toString();
             if (!['name', 'index', 'id', 'avatar'].includes(field)) {
                 toastr.warning('\'/member-get field=\' argument required!');
                 return '';
@@ -752,7 +754,7 @@ export function initDefaultSlashCommands() {
             const isId = !isNaN(parseInt(arg));
             const groupMember = findGroupMemberId(arg, true);
             if (!groupMember) {
-                toastr.warn(`No group member found using ${isId?'id':'string'} ${arg}`);
+                toastr.warn(`No group member found using ${isId ? 'id' : 'string'} ${arg}`);
                 return '';
             }
             return groupMember[field];
@@ -764,7 +766,12 @@ export function initDefaultSlashCommands() {
                 typeList: [ARGUMENT_TYPE.STRING],
                 isRequired: true,
                 defaultValue: 'name',
-                enumList: ['name', 'index', 'id', 'avatar'],
+                enumList: [
+                    new SlashCommandEnumValue('name', 'Character name'),
+                    new SlashCommandEnumValue('index', 'Group member index'),
+                    new SlashCommandEnumValue('avatar', 'Character avatar'),
+                    new SlashCommandEnumValue('id', 'Character index'),
+                ],
             }),
         ],
         unnamedArgumentList: [

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3081,7 +3081,7 @@ async function enableGroupMemberCallback(_, arg) {
 
 async function moveGroupMemberUpCallback(_, arg) {
     if (!selected_group) {
-        toastr.warning('Cannot run /memberup command outside of a group chat.');
+        toastr.warning('Cannot run /member-up command outside of a group chat.');
         return '';
     }
 
@@ -3098,7 +3098,7 @@ async function moveGroupMemberUpCallback(_, arg) {
 
 async function moveGroupMemberDownCallback(_, arg) {
     if (!selected_group) {
-        toastr.warning('Cannot run /memberdown command outside of a group chat.');
+        toastr.warning('Cannot run /member-down command outside of a group chat.');
         return '';
     }
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

I gave `findGroupMemberId` a `full` parameter to retrieve a dict with all the relevant group member data. It can also match by avatar now.

`/member-get` uses the enhanced command to retrieve the requested field. You can technically retrieve the name field using the character's name, but that would make you a very silly person and I would recommend you upgrade to VerysillyTavern.

Also some fixes to certain `/member-*` commands to use their new command names in the warnings, and a rename of `/peek` to `/member-peek` (with `/peek` being an alias) for consistency.