### PR TITLE
add killswitch for textgen banned token/strings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1621,10 +1621,23 @@
                                     </div>
                                     <div data-tg-type-mode="except" data-tg-type="generic" id="banned_tokens_block_ooba" class="wide100p">
                                         <hr class="width100p">
-                                        <h4 class="range-block-title justifyCenter">
-                                            <span data-i18n="Banned Tokens">Banned Tokens/Strings</span>
-                                            <div class="margin5 fa-solid fa-circle-info opacity50p " data-i18n="[title]LLaMA / Mistral / Yi models only" title="Enter sequences you don't want to appear in the output.&#13;Unquoted text will be tokenized in the back end and banned as tokens.&#13;[token ids] will be banned as-is.&#13;Most tokens have a leading space. Use token counter (with the correct tokenizer selected first!) if you are unsure.&#13;Enclose text in double quotes to ban the entire string as a set.&#13;Quoted Strings and [Token ids] must be on their own line."></div>
-                                        </h4>
+
+                                        <span class="flex-container flexnowrap">
+
+
+                                            <h4 class="range-block-title justifyCenter flex-container">
+                                                <label id="bannedStringsKillSwitch_label" for="bannedStringsKillSwitch_textgenerationwebui" class="checkbox_label">
+                                                    <input id="bannedStringsKillSwitch_textgenerationwebui" type="checkbox" style="display:none;" />
+                                                    <small><i class="fa-solid fa-power-off menu_button margin0"></i></small>
+                                                </label>
+                                                <span data-i18n="Banned Tokens">
+
+                                                    Banned Tokens/Strings
+                                                </span>
+                                                <div class="margin5 fa-solid fa-circle-info opacity50p " data-i18n="[title]LLaMA / Mistral / Yi models only" title="Enter sequences you don't want to appear in the output.&#13;Unquoted text will be tokenized in the back end and banned as tokens.&#13;[token ids] will be banned as-is.&#13;Most tokens have a leading space. Use token counter (with the correct tokenizer selected first!) if you are unsure.&#13;Enclose text in double quotes to ban the entire string as a set.&#13;Quoted Strings and [Token ids] must be on their own line."></div>
+                                            </h4>
+
+                                        </span>
                                         <div class="wide100p">
                                             <textarea id="banned_tokens_textgenerationwebui" class="text_pole textarea_compact" name="banned_tokens_textgenerationwebui" rows="3" data-i18n="[placeholder]Example: some text [42, 69, 1337]" placeholder='some text as tokens&#10;[420, 69, 1337]&#10;"Some verbatim string"'></textarea>
                                         </div>

--- a/public/style.css
+++ b/public/style.css
@@ -2816,7 +2816,8 @@ select option:not(:checked) {
 }
 
 #instruct_enabled_label .menu_button:not(.toggleEnabled),
-#sysprompt_enabled_label .menu_button:not(.toggleEnabled) {
+#sysprompt_enabled_label .menu_button:not(.toggleEnabled),
+#bannedStringsKillSwitch_label .menu_button:not(.toggleEnabled) {
     color: Red;
 }
 


### PR DESCRIPTION
A simple toggle to send banned strings or not on textgen requests. 

Removes the tedium of clearing the textbox if you want to test a model's behavior without banned strings.

Code mostly ripped from `instruct_enabled` toggle implementation.