### PR TITLE
Add missing o3-mini model selector labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2854,8 +2854,8 @@
                                         <option value="o1-mini">o1-mini</option>
                                     </optgroup>
                                     <optgroup label="o3">
-                                        <option value="o3-mini"></option>
-                                        <option value="o3-mini-2025-01-31"></option>
+                                        <option value="o3-mini">o3-mini</option>
+                                        <option value="o3-mini-2025-01-31">o3-mini-2025-01-31</option>
                                     </optgroup>
                                     <optgroup label="Other">
                                         <option value="text-davinci-003">text-davinci-003</option>


### PR DESCRIPTION
## Description

o3-mini options in the model selector dropdown are not shown (see below).

![image](https://github.com/user-attachments/assets/afa7be27-a7b0-4626-92ad-2542c5564ee8)

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
