### PR TITLE
OpenAI "Reasoning Effort" for o1/o3-mini + oai models restructured

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1995,6 +1995,18 @@
                                             </span>
                                         </div>
                                     </div>
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai">
+                                        <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Currently supported values are low, medium, and high.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.">
+                                            <label for="openai_reasoning_effort" data-i18n="Reasoning Effort">
+                                                Reasoning Effort
+                                            </label>
+                                            <select id="openai_reasoning_effort">
+                                                <option data-i18n="openai_reasoning_effort_low" value="low">Low</option>
+                                                <option data-i18n="openai_reasoning_effort_medium" value="medium">Medium</option>
+                                                <option data-i18n="openai_reasoning_effort_high" value="high">High</option>
+                                            </select>
+                                        </div>
+                                    </div>
                                     <div class="range-block" data-source="claude">
                                         <div class="wide100p">
                                             <div class="flex-container alignItemsCenter">

--- a/public/index.html
+++ b/public/index.html
@@ -2858,17 +2858,12 @@
                                         <option value="gpt-4-0314">gpt-4-0314 (2023)</option>
                                     </optgroup>
                                     <optgroup label="GPT-3.5 Turbo">
-                                        <option value="gpt-3.5-turbo-0125">gpt-3.5-turbo-0125 (2024)</option>
                                         <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
+                                        <option value="gpt-3.5-turbo-0125">gpt-3.5-turbo-0125 (2024)</option>
                                         <option value="gpt-3.5-turbo-1106">gpt-3.5-turbo-1106 (2023)</option>
                                         <option value="gpt-3.5-turbo-instruct">gpt-3.5-turbo-instruct</option>
                                     </optgroup>
                                     <optgroup label="Other">
-                                        <option value="omni-moderation-latest">omni-moderation-latest</option>
-                                        <option value="omni-moderation-2024-09-26">omni-moderation-2024-09-26</option>
-                                        <option value="text-moderation-latest">text-moderation-latest</option>
-                                        <option value="text-moderation-stable">text-moderation-stable</option>
-                                        <option value="text-moderation-007">text-moderation-007</option>
                                         <option value="babbage-002">babbage-002</option>
                                         <option value="davinci-002">davinci-002</option>
                                     </optgroup>

--- a/public/index.html
+++ b/public/index.html
@@ -2821,27 +2821,6 @@
                             <div>
                                 <h4 data-i18n="OpenAI Model">OpenAI Model</h4>
                                 <select id="model_openai_select">
-                                    <optgroup label="GPT-3.5 Turbo">
-                                        <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
-                                        <option value="gpt-3.5-turbo-0125">gpt-3.5-turbo-0125 (2024)</option>
-                                        <option value="gpt-3.5-turbo-1106">gpt-3.5-turbo-1106 (2023)</option>
-                                        <option value="gpt-3.5-turbo-0613">gpt-3.5-turbo-0613 (2023)</option>
-                                        <option value="gpt-3.5-turbo-0301">gpt-3.5-turbo-0301 (2023)</option>
-                                        <option value="gpt-3.5-turbo-16k">gpt-3.5-turbo-16k</option>
-                                        <option value="gpt-3.5-turbo-16k-0613">gpt-3.5-turbo-16k-0613 (2023)</option>
-                                    </optgroup>
-                                    <optgroup label="GPT-3.5 Turbo Instruct">
-                                        <option value="gpt-3.5-turbo-instruct">gpt-3.5-turbo-instruct</option>
-                                        <option value="gpt-3.5-turbo-instruct-0914">gpt-3.5-turbo-instruct-0914</option>
-                                    </optgroup>
-                                    <optgroup label="GPT-4">
-                                        <option value="gpt-4">gpt-4</option>
-                                        <option value="gpt-4-0613">gpt-4-0613 (2023)</option>
-                                        <option value="gpt-4-0314">gpt-4-0314 (2023)</option>
-                                        <option value="gpt-4-32k">gpt-4-32k</option>
-                                        <option value="gpt-4-32k-0613">gpt-4-32k-0613 (2023)</option>
-                                        <option value="gpt-4-32k-0314">gpt-4-32k-0314 (2023)</option>
-                                    </optgroup>
                                     <optgroup label="GPT-4o">
                                         <option value="gpt-4o">gpt-4o</option>
                                         <option value="gpt-4o-2024-11-20">gpt-4o-2024-11-20</option>
@@ -2849,33 +2828,49 @@
                                         <option value="gpt-4o-2024-05-13">gpt-4o-2024-05-13</option>
                                         <option value="chatgpt-4o-latest">chatgpt-4o-latest</option>
                                     </optgroup>
-                                    <optgroup label="gpt-4o-mini">
+                                    <optgroup label="GPT-4o mini">
                                         <option value="gpt-4o-mini">gpt-4o-mini</option>
-                                        <option value="gpt-4o-mini-2024-07-18">gpt-4o-mini-2024-07-18</option>
+                                        <option value="gpt-4o-2024-11-20">gpt-4o-2024-11-20</option>
+                                        <option value="gpt-4o-2024-08-06">gpt-4o-2024-08-06</option>
+                                        <option value="gpt-4o-2024-05-13">gpt-4o-2024-05-13</option>
+                                        <option value="chatgpt-4o-latest">chatgpt-4o-latest</option>
                                     </optgroup>
-                                    <optgroup label="GPT-4 Turbo">
-                                        <option value="gpt-4-turbo">gpt-4-turbo</option>
-                                        <option value="gpt-4-turbo-2024-04-09">gpt-4-turbo-2024-04-09</option>
-                                        <option value="gpt-4-turbo-preview">gpt-4-turbo-preview</option>
-                                        <option value="gpt-4-vision-preview">gpt-4-vision-preview</option>
-                                        <option value="gpt-4-0125-preview">gpt-4-0125-preview (2024)</option>
-                                        <option value="gpt-4-1106-preview">gpt-4-1106-preview (2023)</option>
-                                    </optgroup>
-                                    <optgroup label="o1">
-                                        <option value="o1-preview">o1-preview</option>
+                                    <optgroup label="o1 and o1-mini">
+                                        <option value="o1">o1</option>
+                                        <option value="o1-2024-12-17">o1-2024-12-17</option>
                                         <option value="o1-mini">o1-mini</option>
+                                        <option value="o1-mini-2024-09-12">o1-mini-2024-09-12</option>
+                                        <option value="o1-preview">o1-preview</option>
+                                        <option value="o1-preview-2024-09-12">o1-preview-2024-09-12</option>
                                     </optgroup>
                                     <optgroup label="o3">
                                         <option value="o3-mini">o3-mini</option>
                                         <option value="o3-mini-2025-01-31">o3-mini-2025-01-31</option>
                                     </optgroup>
+                                    <optgroup label="GPT-4 Turbo and GPT-4">
+                                        <option value="gpt-4-turbo">gpt-4-turbo</option>
+                                        <option value="gpt-4-turbo-2024-04-09">gpt-4-turbo-2024-04-09</option>
+                                        <option value="gpt-4-turbo-preview">gpt-4-turbo-preview</option>
+                                        <option value="gpt-4-0125-preview">gpt-4-0125-preview (2024)</option>
+                                        <option value="gpt-4-1106-preview">gpt-4-1106-preview (2023)</option>
+                                        <option value="gpt-4">gpt-4</option>
+                                        <option value="gpt-4-0613">gpt-4-0613 (2023)</option>
+                                        <option value="gpt-4-0314">gpt-4-0314 (2023)</option>
+                                    </optgroup>
+                                    <optgroup label="GPT-3.5 Turbo">
+                                        <option value="gpt-3.5-turbo-0125">gpt-3.5-turbo-0125 (2024)</option>
+                                        <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
+                                        <option value="gpt-3.5-turbo-1106">gpt-3.5-turbo-1106 (2023)</option>
+                                        <option value="gpt-3.5-turbo-instruct">gpt-3.5-turbo-instruct</option>
+                                    </optgroup>
                                     <optgroup label="Other">
-                                        <option value="text-davinci-003">text-davinci-003</option>
-                                        <option value="text-davinci-002">text-davinci-002</option>
-                                        <option value="text-curie-001">text-curie-001</option>
-                                        <option value="text-babbage-001">text-babbage-001</option>
-                                        <option value="text-ada-001">text-ada-001</option>
-                                        <option value="code-davinci-002">code-davinci-002</option>
+                                        <option value="omni-moderation-latest">omni-moderation-latest</option>
+                                        <option value="omni-moderation-2024-09-26">omni-moderation-2024-09-26</option>
+                                        <option value="text-moderation-latest">text-moderation-latest</option>
+                                        <option value="text-moderation-stable">text-moderation-stable</option>
+                                        <option value="text-moderation-007">text-moderation-007</option>
+                                        <option value="babbage-002">babbage-002</option>
+                                        <option value="davinci-002">davinci-002</option>
                                     </optgroup>
                                     <optgroup id="openai_external_category" label="External">
                                     </optgroup>

--- a/public/index.html
+++ b/public/index.html
@@ -1957,14 +1957,16 @@
                                             <span data-i18n="image_inlining_hint_3">menu to attach an image file to the chat.</span>
                                         </div>
                                         <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom">
-                                            <label for="openai_inline_image_quality" data-i18n="Inline Image Quality">
-                                                Inline Image Quality
-                                            </label>
-                                            <select id="openai_inline_image_quality">
-                                                <option data-i18n="openai_inline_image_quality_auto" value="auto">Auto</option>
-                                                <option data-i18n="openai_inline_image_quality_low" value="low">Low</option>
-                                                <option data-i18n="openai_inline_image_quality_high" value="high">High</option>
-                                            </select>
+                                            <div class="flex-container oneline-dropdown">
+                                                <label for="openai_inline_image_quality" data-i18n="Inline Image Quality">
+                                                    Inline Image Quality
+                                                </label>
+                                                <select id="openai_inline_image_quality">
+                                                    <option data-i18n="openai_inline_image_quality_auto" value="auto">Auto</option>
+                                                    <option data-i18n="openai_inline_image_quality_low" value="low">Low</option>
+                                                    <option data-i18n="openai_inline_image_quality_high" value="high">High</option>
+                                                </select>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="range-block" data-source="makersuite">
@@ -1995,7 +1997,7 @@
                                             </span>
                                         </div>
                                     </div>
-                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai">
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom">
                                         <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Currently supported values are low, medium, and high.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.">
                                             <label for="openai_reasoning_effort" data-i18n="Reasoning Effort">
                                                 Reasoning Effort

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3518,6 +3518,7 @@ async function saveOpenAIPreset(name, settings, triggerUi = true) {
         continue_postfix: settings.continue_postfix,
         function_calling: settings.function_calling,
         show_thoughts: settings.show_thoughts,
+        reasoning_effort: settings.reasoning_effort,
         seed: settings.seed,
         n: settings.n,
     };

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -299,6 +299,7 @@ const default_settings = {
     continue_postfix: continue_postfix_types.SPACE,
     custom_prompt_post_processing: custom_prompt_post_processing_types.NONE,
     show_thoughts: true,
+    reasoning_effort: 'medium',
     seed: -1,
     n: 1,
 };
@@ -378,6 +379,7 @@ const oai_settings = {
     continue_postfix: continue_postfix_types.SPACE,
     custom_prompt_post_processing: custom_prompt_post_processing_types.NONE,
     show_thoughts: true,
+    reasoning_effort: 'medium',
     seed: -1,
     n: 1,
 };
@@ -1912,6 +1914,7 @@ async function sendOpenAIRequest(type, messages, signal) {
         'char_name': name2,
         'group_names': getGroupNames(),
         'include_reasoning': Boolean(oai_settings.show_thoughts),
+        'reasoning_effort': String(oai_settings.reasoning_effort),
     };
 
     // Empty array will produce a validation error
@@ -3122,6 +3125,7 @@ function loadOpenAISettings(data, settings) {
     oai_settings.inline_image_quality = settings.inline_image_quality ?? default_settings.inline_image_quality;
     oai_settings.bypass_status_check = settings.bypass_status_check ?? default_settings.bypass_status_check;
     oai_settings.show_thoughts = settings.show_thoughts ?? default_settings.show_thoughts;
+    oai_settings.reasoning_effort = settings.reasoning_effort ?? default_settings.reasoning_effort;
     oai_settings.seed = settings.seed ?? default_settings.seed;
     oai_settings.n = settings.n ?? default_settings.n;
 
@@ -3250,6 +3254,9 @@ function loadOpenAISettings(data, settings) {
     $('#seed_openai').val(oai_settings.seed);
     $('#n_openai').val(oai_settings.n);
     $('#openai_show_thoughts').prop('checked', oai_settings.show_thoughts);
+
+    $('#openai_reasoning_effort').val(oai_settings.reasoning_effort);
+    $(`#openai_reasoning_effort option[value="${oai_settings.reasoning_effort}"]`).prop('selected', true);
 
     if (settings.reverse_proxy !== undefined) oai_settings.reverse_proxy = settings.reverse_proxy;
     $('#openai_reverse_proxy').val(oai_settings.reverse_proxy);
@@ -3969,6 +3976,7 @@ function onSettingsPresetChange() {
         continue_postfix: ['#continue_postfix', 'continue_postfix', false],
         function_calling: ['#openai_function_calling', 'function_calling', true],
         show_thoughts: ['#openai_show_thoughts', 'show_thoughts', true],
+        reasoning_effort: ['#openai_reasoning_effort', 'reasoning_effort', false],
         seed: ['#seed_openai', 'seed', false],
         n: ['#n_openai', 'n', false],
     };
@@ -5507,6 +5515,11 @@ export function initOpenAI() {
 
     $('#openai_show_thoughts').on('input', function () {
         oai_settings.show_thoughts = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#openai_reasoning_effort').on('input', function () {
+        oai_settings.reasoning_effort = String($(this).val());
         saveSettingsDebounced();
     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -5914,3 +5914,15 @@ body:not(.movingUI) .drawer-content.maximized {
 .mes_text div[data-type="assistant_note"]:has(.assistant_note_export)>div:not(.assistant_note_export) {
     flex: 1;
 }
+
+.oneline-dropdown label {
+    margin-top: 3px;
+    margin-bottom: 5px;
+    flex-grow: 1;
+    text-align: left;
+}
+
+.oneline-dropdown select {
+    min-width: fit-content;
+    width: 40%;
+}

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -967,11 +967,6 @@ router.post('/generate', jsonParser, function (request, response) {
         if (getConfigValue('openai.randomizeUserId', false)) {
             bodyParams['user'] = uuidv4();
         }
-
-        // A few of OpenAIs reasoning models support reasoning effort
-        if (['o1', 'o3-mini', 'o3-mini-2025-01-31'].includes(request.body.model)) {
-            bodyParams['reasoning_effort'] = request.body.reasoning_effort;
-        }
     } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.OPENROUTER) {
         apiUrl = 'https://openrouter.ai/api/v1';
         apiKey = readSecret(request.user.directories, SECRET_KEYS.OPENROUTER);
@@ -1027,11 +1022,6 @@ router.post('/generate', jsonParser, function (request, response) {
             bodyParams.logprobs = true;
         }
 
-        // A few of OpenAIs reasoning models support reasoning effort
-        if (['o1', 'o3-mini', 'o3-mini-2025-01-31'].includes(request.body.model)) {
-            bodyParams['reasoning_effort'] = request.body.reasoning_effort;
-        }
-
         mergeObjectWithYaml(bodyParams, request.body.custom_include_body);
         mergeObjectWithYaml(headers, request.body.custom_include_headers);
 
@@ -1071,6 +1061,13 @@ router.post('/generate', jsonParser, function (request, response) {
     } else {
         console.warn('This chat completion source is not supported yet.');
         return response.status(400).send({ error: true });
+    }
+
+    // A few of OpenAIs reasoning models support reasoning effort
+    if ([CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.OPENAI].includes(request.body.chat_completion_source)) {
+        if (['o1', 'o3-mini', 'o3-mini-2025-01-31'].includes(request.body.model)) {
+            bodyParams['reasoning_effort'] = request.body.reasoning_effort;
+        }
     }
 
     if (!apiKey && !request.body.reverse_proxy && request.body.chat_completion_source !== CHAT_COMPLETION_SOURCES.CUSTOM) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -967,6 +967,11 @@ router.post('/generate', jsonParser, function (request, response) {
         if (getConfigValue('openai.randomizeUserId', false)) {
             bodyParams['user'] = uuidv4();
         }
+
+        // A few of OpenAIs reasoning models support reasoning effort
+        if (['o1', 'o3-mini', 'o3-mini-2025-01-31'].includes(request.body.model)) {
+            bodyParams['reasoning_effort'] = request.body.reasoning_effort;
+        }
     } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.OPENROUTER) {
         apiUrl = 'https://openrouter.ai/api/v1';
         apiKey = readSecret(request.user.directories, SECRET_KEYS.OPENROUTER);

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1027,6 +1027,11 @@ router.post('/generate', jsonParser, function (request, response) {
             bodyParams.logprobs = true;
         }
 
+        // A few of OpenAIs reasoning models support reasoning effort
+        if (['o1', 'o3-mini', 'o3-mini-2025-01-31'].includes(request.body.model)) {
+            bodyParams['reasoning_effort'] = request.body.reasoning_effort;
+        }
+
         mergeObjectWithYaml(bodyParams, request.body.custom_include_body);
         mergeObjectWithYaml(headers, request.body.custom_include_headers);
 


### PR DESCRIPTION
#### Reasoning Effort parameter
It's hard to confirm that it works, because ya know... OpenAI does not expose thoughts.
But it seems to work. I also got it to fail for all models who don't support it - that's how I got the model list.
oai docs say only o1. But actually "o3-mini" supports it too - while the o1-preview and o1-mini do not support it.
https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort

This parameter is currently only available for OpenAI. I did not hide it for non-reasoning models, as... we don't do that with other parameters either that don't work for some models. So I thought it's more consistent like this.

Deepseek has in their documentation that they are adding reasoning_effort soon. We can update the control and backend for deepseek then.
https://api-docs.deepseek.com/guides/reasoning_model

I don't know anything about OpenRouter.

#### OpenAI model list restructure
I also restructured the existing model list. We were missing some pretty important models (`o1`, duh?) and others weren't even available anymore.
I followed the exact same order they have on their model list. Should make it easier for cross-checking. Also is a more sensible approach to sort them in a way you have the models at top that you'd likely use most.
https://platform.openai.com/docs/models

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
