### PR TITLE
Fix searxng search preferences.

### DIFF
--- a/src/endpoints/search.js
+++ b/src/endpoints/search.js
@@ -190,13 +190,13 @@ router.post('/searxng', jsonParser, async (request, response) => {
         const searchUrl = new URL('/search', baseUrl);
         const searchParams = new URLSearchParams();
         searchParams.append('q', query);
-        if (preferences) {
-            searchParams.append('preferences', preferences);
-        }
         if (categories) {
             searchParams.append('categories', categories);
         }
         searchUrl.search = searchParams.toString();
+        if (preferences) {
+            searchUrl.search = `${searchUrl.search}&${preferences}`;
+        }
 
         const searchResult = await fetch(searchUrl, { headers: visitHeaders });
 


### PR DESCRIPTION
Maybe add examples for preferences to the document later? As there is '!' and ':' syntax for searxng and it's confusing.
Also, I would suggest merging the categories into the preferences or splitting the preferences into each parameter. https://github.com/SillyTavern/SillyTavern/commit/72e1dcb3f9667cba0e512016f86eab172cc96469

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
