### PR TITLE
await GENERATE_BEFORE_COMBINE_PROMPTS

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4497,7 +4497,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     // For prompt bit itemization
     let mesSendString = '';
 
-    function getCombinedPrompt(isNegative) {
+    async function getCombinedPrompt(isNegative) {
         // Only return if the guidance scale doesn't exist or the value is 1
         // Also don't return if constructing the neutral prompt
         if (isNegative && !useCfgPrompt) {
@@ -4606,13 +4606,13 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         };
 
         // Before returning the combined prompt, give available context related information to all subscribers.
-        eventSource.emitAndWait(event_types.GENERATE_BEFORE_COMBINE_PROMPTS, data);
+        await eventSource.emit(event_types.GENERATE_BEFORE_COMBINE_PROMPTS, data);
 
         // If one or multiple subscribers return a value, forfeit the responsibillity of flattening the context.
         return !data.combinedPrompt ? combine() : data.combinedPrompt;
     }
 
-    let finalPrompt = getCombinedPrompt(false);
+    let finalPrompt = await getCombinedPrompt(false);
 
     const eventData = { prompt: finalPrompt, dryRun: dryRun };
     await eventSource.emit(event_types.GENERATE_AFTER_COMBINE_PROMPTS, eventData);
@@ -4646,7 +4646,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             }
             break;
         case 'textgenerationwebui': {
-            const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale, negativePrompt: getCombinedPrompt(true) } : null;
+            const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale, negativePrompt: await getCombinedPrompt(true) } : null;
             generate_data = getTextGenGenerationData(finalPrompt, maxLength, isImpersonate, isContinue, cfgValues, type);
             break;
         }


### PR DESCRIPTION
### Description
This change changes the event `GENERATE_BEFORE_COMBINE_PROMPTS` to await an `emit()` instead of just using `emitAndWait()` as it was previously.

### Reason
I found that this event would not properly wait for callbacks to finish before performing the generation, which was unexpected as all the other events do this properly. Looking into it, I found that this event was using `emitAndWait()` unlike all the other generation events. Changing this to await a regular `emit()` call fixed the behavior, and it now properly waits for callbacks as expected.

As an example use-case, I needed to perform a background generation immediately before a message was received using the most recent message as context. Before this change, the regular generation would unexpectedly occur first, followed by the generation scheduled by the callback to this event. After this change, it behaves as expected with my background generation going before the regular generation.

### Notes
I am unsure why this event was using `emitAndWait()` to begin with, but I have not observed any negative side effects of this change as of yet. I [asked about it](https://discord.com/channels/1100685673633153084/1100820587586273343/1336034798577385639) in the discord there were no immediate objections.

I have been using this change with my current setup, using text completion with a local model. I have not tested with any other APIs.

### To test
You can test the change by calling a long-running function on the event. Without this change, the generation does not wait for the callback to finish before running. With this change, it properly waits just like the other generation events.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
