### PR TITLE
Add new gemini models and update the safety settings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3066,6 +3066,7 @@
                                 <h4 data-i18n="Google Model">Google Model</h4>
                                 <select id="model_google_select">
                                     <optgroup label="Primary">
+                                        <option value="gemini-2.0-flash">Gemini 2.0 Flash</option>
                                         <option value="gemini-1.5-pro">Gemini 1.5 Pro</option>
                                         <option value="gemini-1.5-flash">Gemini 1.5 Flash</option>
                                         <option value="gemini-1.0-pro">Gemini 1.0 Pro (Deprecated)</option>
@@ -3074,6 +3075,11 @@
                                         <option value="gemini-1.0-ultra-latest">Gemini 1.0 Ultra</option>
                                     </optgroup>
                                     <optgroup label="Subversions">
+                                        <option value="gemini-2.0-pro-exp">Gemini 2.0 Pro Experimental</option>
+                                        <option value="gemini-2.0-pro-exp-02-05">Gemini 2.0 Pro Experimental 2025-02-05</option>
+                                        <option value="gemini-2.0-flash-lite-preview">Gemini 2.0 Flash-Lite Preview</option>
+                                        <option value="gemini-2.0-flash-lite-preview-02-05">Gemini 2.0 Flash-Lite Preview 2025-02-05</option>
+                                        <option value="gemini-2.0-flash-001">Gemini 2.0 Flash [001]</option>
                                         <option value="gemini-2.0-flash-thinking-exp">Gemini 2.0 Flash Thinking Experimental</option>
                                         <option value="gemini-2.0-flash-thinking-exp-01-21">Gemini 2.0 Flash Thinking Experimental 2025-01-21</option>
                                         <option value="gemini-2.0-flash-thinking-exp-1219">Gemini 2.0 Flash Thinking Experimental 2024-12-19</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -53,6 +53,12 @@
                         <option data-type="anthropic" value="claude-3-opus-20240229">claude-3-opus-20240229</option>
                         <option data-type="anthropic" value="claude-3-sonnet-20240229">claude-3-sonnet-20240229</option>
                         <option data-type="anthropic" value="claude-3-haiku-20240307">claude-3-haiku-20240307</option>
+                        <option data-type="google" value="gemini-2.0-pro-exp">gemini-2.0-pro-exp</option>
+                        <option data-type="google" value="gemini-2.0-pro-exp-02-05">gemini-2.0-pro-exp-02-05</option>
+                        <option data-type="google" value="gemini-2.0-flash-lite-preview">gemini-2.0-flash-lite-preview</option>
+                        <option data-type="google" value="gemini-2.0-flash-lite-preview-02-05">gemini-2.0-flash-lite-preview-02-05</option>
+                        <option data-type="google" value="gemini-2.0-flash">gemini-2.0-flash</option>
+                        <option data-type="google" value="gemini-2.0-flash-001">gemini-2.0-flash-001</option>
                         <option data-type="google" value="gemini-2.0-flash-exp">gemini-2.0-flash-exp</option>
                         <option data-type="google" value="gemini-2.0-flash-thinking-exp">gemini-2.0-flash-thinking-exp</option>
                         <option data-type="google" value="gemini-2.0-flash-thinking-exp-01-21">gemini-2.0-flash-thinking-exp-01-21</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4239,9 +4239,9 @@ async function onModelChange() {
             $('#openai_max_context').attr('max', max_2mil);
         } else if (value.includes('gemini-exp-1114') || value.includes('gemini-exp-1121') || value.includes('gemini-2.0-flash-thinking-exp-1219')) {
             $('#openai_max_context').attr('max', max_32k);
-        } else if (value.includes('gemini-1.5-pro') || value.includes('gemini-exp-1206')) {
+        } else if (value.includes('gemini-1.5-pro') || value.includes('gemini-exp-1206') || value.includes('gemini-2.0-pro')) {
             $('#openai_max_context').attr('max', max_2mil);
-        } else if (value.includes('gemini-1.5-flash') || value.includes('gemini-2.0-flash-exp') || value.includes('gemini-2.0-flash-thinking-exp')) {
+        } else if (value.includes('gemini-1.5-flash') || value.includes('gemini-2.0-flash')) {
             $('#openai_max_context').attr('max', max_1mil);
         } else if (value.includes('gemini-1.0-pro') || value === 'gemini-pro') {
             $('#openai_max_context').attr('max', max_32k);
@@ -4934,6 +4934,12 @@ export function isImageInliningSupported() {
     // gultra just isn't being offered as multimodal, thanks google.
     const visionSupportedModels = [
         'gpt-4-vision',
+        'gemini-2.0-pro-exp',
+        'gemini-2.0-pro-exp-02-05',
+        'gemini-2.0-flash-lite-preview',
+        'gemini-2.0-flash-lite-preview-02-05',
+        'gemini-2.0-flash',
+        'gemini-2.0-flash-001',
         'gemini-2.0-flash-thinking-exp-1219',
         'gemini-2.0-flash-thinking-exp-01-21',
         'gemini-2.0-flash-thinking-exp',

--- a/src/constants.js
+++ b/src/constants.js
@@ -139,19 +139,19 @@ export const UNSAFE_EXTENSIONS = [
 export const GEMINI_SAFETY = [
     {
         category: 'HARM_CATEGORY_HARASSMENT',
-        threshold: 'BLOCK_NONE',
+        threshold: 'OFF',
     },
     {
         category: 'HARM_CATEGORY_HATE_SPEECH',
-        threshold: 'BLOCK_NONE',
+        threshold: 'OFF',
     },
     {
         category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-        threshold: 'BLOCK_NONE',
+        threshold: 'OFF',
     },
     {
         category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-        threshold: 'BLOCK_NONE',
+        threshold: 'OFF',
     },
     {
         category: 'HARM_CATEGORY_CIVIC_INTEGRITY',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -316,9 +316,15 @@ async function sendMakerSuiteRequest(request, response) {
         const prompt = convertGooglePrompt(request.body.messages, model, should_use_system_prompt, getPromptNames(request));
         let safetySettings = GEMINI_SAFETY;
 
-        if (model.includes('gemini-2.0-flash-exp')) {
+        // These old models do not support setting the threshold to OFF at all.
+        if (['gemini-1.5-pro-001', 'gemini-1.5-flash-001', 'gemini-1.0-pro-001'].includes(model)) {
+            safetySettings = GEMINI_SAFETY.map(setting => ({ ...setting, threshold: 'BLOCK_NONE' }));
+        }
+        // Interestingly, Gemini 2.0 Flash does support setting the threshold for HARM_CATEGORY_CIVIC_INTEGRITY to OFF.
+        else if (['gemini-2.0-flash', 'gemini-2.0-flash-001', 'gemini-2.0-flash-exp'].includes(model)) {
             safetySettings = GEMINI_SAFETY.map(setting => ({ ...setting, threshold: 'OFF' }));
         }
+        // Most of the other models allow for setting the threshold of filters, except for HARM_CATEGORY_CIVIC_INTEGRITY, to OFF.
 
         let body = {
             contents: prompt.contents,

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -360,6 +360,12 @@ export function convertCohereMessages(messages, names) {
  */
 export function convertGooglePrompt(messages, model, useSysPrompt, names) {
     const visionSupportedModels = [
+        'gemini-2.0-pro-exp',
+        'gemini-2.0-pro-exp-02-05',
+        'gemini-2.0-flash-lite-preview',
+        'gemini-2.0-flash-lite-preview-02-05',
+        'gemini-2.0-flash',
+        'gemini-2.0-flash-001',
         'gemini-2.0-flash-thinking-exp',
         'gemini-2.0-flash-thinking-exp-01-21',
         'gemini-2.0-flash-thinking-exp-1219',


### PR DESCRIPTION
# Add New Gemini Models (Feb 2025)

Added the new Gemini models that Google released on Feb 5th:
- `gemini-2.0-flash`
- `gemini-2.0-flash-001` 
- `gemini-2.0-flash-lite-preview`
- `gemini-2.0-flash-lite-preview-02-05`
- `gemini-2.0-pro-exp`
- `gemini-2.0-pro-exp-02-05`

Also fixed my previous oversight - updated the `visionSupportedModels` in `public/scripts/openai.js` this time 😅

## Safety Settings Update

After some testing, I found that some older models do not support setting `threshold` to `OFF` and only allow `BLOCK_NONE`:
- `gemini-1.5-pro-001`
- `gemini-1.5-flash-001`
- `gemini-1.0-pro-001`

However, `gemini-2.0-flash` models can have all thresholds set to `OFF`:
- `gemini-2.0-flash` 
- `gemini-2.0-flash-001`
- `gemini-2.0-flash-exp`  

For the other models, setting all thresholds to `OFF` will result in an error:
```json
{
  "error": {
    "code": 400,
    "message": "HARM_CATEGORY_CIVIC_INTEGRITY threshold cannot be 5",
    "status": "INVALID_ARGUMENT"
  }
}
```

Therefore, I updated the default `GEMINI_SAFETY` settings to:
```javascript
{
    category: 'HARM_CATEGORY_HARASSMENT',
    threshold: 'OFF',
},
{
    category: 'HARM_CATEGORY_HATE_SPEECH',
    threshold: 'OFF',
},
{
    category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
    threshold: 'OFF',
},
{
    category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
    threshold: 'OFF',
},
{
    category: 'HARM_CATEGORY_CIVIC_INTEGRITY',
    threshold: 'BLOCK_NONE',
},
```

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
