### PR TITLE
fix: adjust safetySettings handling for legacy Gemini models

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -318,7 +318,7 @@ async function sendMakerSuiteRequest(request, response) {
         let safetySettings = GEMINI_SAFETY;
 
         // These old models do not support setting the threshold to OFF at all.
-        if (['gemini-1.5-pro-001', 'gemini-1.5-flash-001', 'gemini-1.0-pro-001'].includes(model)) {
+        if (['gemini-1.5-pro-001', 'gemini-1.5-flash-001', 'gemini-1.5-flash-8b-exp-0827', 'gemini-1.5-flash-8b-exp-0924', 'gemini-pro', 'gemini-1.0-pro', 'gemini-1.0-pro-001'].includes(model)) {
             safetySettings = GEMINI_SAFETY.map(setting => ({ ...setting, threshold: 'BLOCK_NONE' }));
         }
         // Interestingly, Gemini 2.0 Flash does support setting the threshold for HARM_CATEGORY_CIVIC_INTEGRITY to OFF.


### PR DESCRIPTION
Add validation logic for these legacy and experimental Gemini models, according to #3434 :

- gemini-1.5-flash-8b-exp-0827
- gemini-1.5-flash-8b-exp-0924
- gemini-pro
- gemini-1.0-pro

Since Gemini 1.0 Pro is scheduled for removal on Feb. 15, `gemini-1.0-pro-latest` is already returning 404 errors, unlike the Latest stable `gemini-1.0-pro` and the stable `gemini-1.0-pro-001`. Therefore, no additional handling is required.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
