### PR TITLE
Smaller improvements and fixes to the reasoning UI

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2276,10 +2276,12 @@ function getMessageFromTemplate({
  * @param {number} messageId Message ID
  * @param {object} message Message object
  */
-export function updateMessageBlock(messageId, message) {
+export function updateMessageBlock(messageId, message, { rerenderMessage = true } = {}) {
     const messageElement = $(`#chat [mesid="${messageId}"]`);
-    const text = message?.extra?.display_text ?? message.mes;
-    messageElement.find('.mes_text').html(messageFormatting(text, message.name, message.is_system, message.is_user, messageId, {}, false));
+    if (rerenderMessage) {
+        const text = message?.extra?.display_text ?? message.mes;
+        messageElement.find('.mes_text').html(messageFormatting(text, message.name, message.is_system, message.is_user, messageId, {}, false));
+    }
     messageElement.find('.mes_reasoning').html(messageFormatting(message.extra?.reasoning ?? '', '', false, false, messageId, {}, true));
     messageElement.toggleClass('reasoning', !!message.extra?.reasoning);
     addCopyToCodeBlocks(messageElement);

--- a/public/script.js
+++ b/public/script.js
@@ -2275,6 +2275,8 @@ function getMessageFromTemplate({
  * Re-renders a message block with updated content.
  * @param {number} messageId Message ID
  * @param {object} message Message object
+ * @param {object} [options={}] Optional arguments
+ * @param {boolean} [options.rerenderMessage=true] Whether to re-render the message content (inside <c>.mes_text</c>)
  */
 export function updateMessageBlock(messageId, message, { rerenderMessage = true } = {}) {
     const messageElement = $(`#chat [mesid="${messageId}"]`);

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -54,8 +54,6 @@ export function extractReasoningFromData(data) {
             break;
 
         case 'openai':
-            if (!oai_settings.show_thoughts) break;
-
             switch (oai_settings.chat_completion_source) {
                 case chat_completion_sources.DEEPSEEK:
                     return data?.choices?.[0]?.message?.reasoning_content ?? '';

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -401,7 +401,7 @@ function setReasoningEventHandlers() {
     });
 
     $(document).on('click', '.mes_edit_add_reasoning', async function () {
-        const { message, messageId } = getMessageFromJquery(this);
+        const { message, messageId, messageBlock } = getMessageFromJquery(this);
         if (!message?.extra) {
             return;
         }
@@ -412,7 +412,8 @@ function setReasoningEventHandlers() {
         }
 
         message.extra.reasoning = PromptReasoning.REASONING_PLACEHOLDER;
-        updateMessageBlock(messageId, message);
+        updateMessageBlock(messageId, message, { rerenderMessage: false });
+        messageBlock.find('.mes_reasoning_edit').trigger('click');
         await saveChatConditional();
     });
 
@@ -426,13 +427,15 @@ function setReasoningEventHandlers() {
             return;
         }
 
-        const { message, messageId } = getMessageFromJquery(this);
+        const { message, messageId, messageBlock } = getMessageFromJquery(this);
         if (!message?.extra) {
             return;
         }
         message.extra.reasoning = '';
         await saveChatConditional();
         updateMessageBlock(messageId, message);
+        const textarea = messageBlock.find('.reasoning_edit_textarea');
+        textarea.remove();
     });
 
     $(document).on('pointerup', '.mes_reasoning_copy', async function () {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1,13 +1,18 @@
-import { chat, closeMessageEditor, event_types, eventSource, saveChatConditional, saveSettingsDebounced, substituteParams, updateMessageBlock } from '../script.js';
+import {
+    moment,
+} from '../lib.js';
+import { chat, closeMessageEditor, event_types, eventSource, main_api, saveChatConditional, saveSettingsDebounced, substituteParams, updateMessageBlock } from '../script.js';
 import { getRegexedString, regex_placement } from './extensions/regex/engine.js';
-import { t } from './i18n.js';
+import { getCurrentLocale, t } from './i18n.js';
 import { MacrosParser } from './macros.js';
+import { chat_completion_sources, oai_settings } from './openai.js';
 import { Popup } from './popup.js';
 import { power_user } from './power-user.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { commonEnumProviders } from './slash-commands/SlashCommandCommonEnumsProvider.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
+import { textgen_types, textgenerationwebui_settings } from './textgen-settings.js';
 import { copyText, escapeRegex, isFalseBoolean } from './utils.js';
 
 /**
@@ -32,6 +37,55 @@ function toggleReasoningAutoExpand() {
             block.open = power_user.reasoning.auto_expand;
         }
     });
+}
+
+/**
+ * Extracts the reasoning from the response data.
+ * @param {object} data Response data
+ * @returns {string} Extracted reasoning
+ */
+export function extractReasoningFromData(data) {
+    switch (main_api) {
+        case 'textgenerationwebui':
+            switch (textgenerationwebui_settings.type) {
+                case textgen_types.OPENROUTER:
+                    return data?.choices?.[0]?.reasoning ?? '';
+            }
+            break;
+
+        case 'openai':
+            if (!oai_settings.show_thoughts) break;
+
+            switch (oai_settings.chat_completion_source) {
+                case chat_completion_sources.DEEPSEEK:
+                    return data?.choices?.[0]?.message?.reasoning_content ?? '';
+                case chat_completion_sources.OPENROUTER:
+                    return data?.choices?.[0]?.message?.reasoning ?? '';
+                case chat_completion_sources.MAKERSUITE:
+                    return data?.responseContent?.parts?.filter(part => part.thought)?.map(part => part.text)?.join('\n\n') ?? '';
+            }
+            break;
+    }
+
+    return '';
+}
+
+/**
+ * Updates the Reasoning controls
+ * @param {HTMLElement} element The element to update
+ * @param {number?} duration The duration of the reasoning in milliseconds
+ * @param {object} [options={}] Options for the function
+ * @param {boolean} [options.forceEnd=false] If true, there will be no "Thinking..." when no duration exists
+ */
+export function updateReasoningTimeUI(element, duration, { forceEnd = false } = {}) {
+    if (duration) {
+        const durationStr = moment.duration(duration).locale(getCurrentLocale()).humanize({ s: 50, ss: 9 });
+        element.textContent = t`Thought for ${durationStr}`;
+    } else if (forceEnd) {
+        element.textContent = t`Thought for some time`;
+    } else {
+        element.textContent = t`Thinking...`;
+    }
 }
 
 /**
@@ -247,6 +301,29 @@ function registerReasoningMacros() {
 }
 
 function setReasoningEventHandlers() {
+    $(document).on('click', '.mes_reasoning_summary', function () {
+        // If you toggle summary header while editing reasoning, yup - we just cancel it
+        $(this).closest('.mes').find('.mes_reasoning_edit_cancel:visible').trigger('click');
+    });
+
+    $(document).on('click', '.mes_reasoning_details', function (e) {
+        if (!e.target.closest('.mes_reasoning_actions') && !e.target.closest('.mes_reasoning_header')) {
+            e.preventDefault();
+        }
+    });
+
+    $(document).on('click', '.mes_reasoning_header', function () {
+        // If we are in message edit mode and reasoning area is closed, a click opens and edits it
+        const mes = $(this).closest('.mes');
+        const mesEditArea = mes.find('#curEditTextarea');
+        if (mesEditArea.length) {
+            const summary = $(mes).find('.mes_reasoning_summary');
+            if (!summary.attr('open')) {
+                summary.find('.mes_reasoning_edit').trigger('click');
+            }
+        }
+    });
+
     $(document).on('click', '.mes_reasoning_copy', (e) => {
         e.stopPropagation();
         e.preventDefault();

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -80,7 +80,8 @@ export function extractReasoningFromData(data) {
 export function updateReasoningTimeUI(element, duration, { forceEnd = false } = {}) {
     if (duration) {
         const durationStr = moment.duration(duration).locale(getCurrentLocale()).humanize({ s: 50, ss: 9 });
-        element.textContent = t`Thought for ${durationStr}`;
+        const secondsStr = moment.duration(duration).asSeconds();
+        element.innerHTML = t`Thought for <span title="${secondsStr} seconds">${durationStr}</span>`;
     } else if (forceEnd) {
         element.textContent = t`Thought for some time`;
     } else {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -54,6 +54,8 @@ export function extractReasoningFromData(data) {
             break;
 
         case 'openai':
+            if (!oai_settings.show_thoughts) break;
+
             switch (oai_settings.chat_completion_source) {
                 case chat_completion_sources.DEEPSEEK:
                     return data?.choices?.[0]?.message?.reasoning_content ?? '';

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -302,11 +302,6 @@ function registerReasoningMacros() {
 }
 
 function setReasoningEventHandlers() {
-    $(document).on('click', '.mes_reasoning_summary', function () {
-        // If you toggle summary header while editing reasoning, yup - we just cancel it
-        $(this).closest('.mes').find('.mes_reasoning_edit_cancel:visible').trigger('click');
-    });
-
     $(document).on('click', '.mes_reasoning_details', function (e) {
         if (!e.target.closest('.mes_reasoning_actions') && !e.target.closest('.mes_reasoning_header')) {
             e.preventDefault();

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -79,7 +79,7 @@ export function extractReasoningFromData(data) {
  */
 export function updateReasoningTimeUI(element, duration, { forceEnd = false } = {}) {
     if (duration) {
-        const durationStr = moment.duration(duration).locale(getCurrentLocale()).humanize({ s: 50, ss: 9 });
+        const durationStr = moment.duration(duration).locale(getCurrentLocale()).humanize({ s: 50, ss: 3 });
         const secondsStr = moment.duration(duration).asSeconds();
         element.innerHTML = t`Thought for <span title="${secondsStr} seconds">${durationStr}</span>`;
     } else if (forceEnd) {

--- a/public/style.css
+++ b/public/style.css
@@ -388,7 +388,7 @@ input[type='checkbox']:focus-visible {
     margin: 0.5em 2px;
     padding: 7px 14px;
     padding-right: calc(0.7em + 14px);
-    border-radius: 10px;
+    border-radius: 5px;
     background-color: var(--grey30);
     font-size: calc(var(--mainFontSize) * 0.9);
     align-items: baseline;


### PR DESCRIPTION
Fixed multiple smaller issues with the reasoning UI. Made some smaller tweaks.

> [!IMPORTANT]
> **Changed reasoning header block radius from `10px` to `5px` to be more pleasing to the eyes. Because it felt so wrong.** 

### Changes / Additions
- Added reasoning time in seconds on hover (useful if the time ins in minutes)
- Moved reasoning-only functions from `script.js` to `reasoning.js` for a bit more clean code

### Fixes
- Fixes adding reasoning block on message re-rendering message as a message, removing the edit textbox
- When adding reasoning block, it should be editable right away
- On reasoning delete, remove reasoning textarea, so it does not appear with the old text if you add the reasoning block again - for whatever reason

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).

## Copilot
This pull request includes several changes to `public/script.js`, `public/scripts/reasoning.js`, and `public/style.css` to improve the handling of reasoning data and UI elements. The most important changes involve refactoring reasoning extraction and updating functions, as well as modifying event handlers for better user interaction.

### Reasoning Data Handling Improvements:
* Moved `extractReasoningFromData` and `updateReasoningTimeUI` functions from `public/script.js` to `public/scripts/reasoning.js` for better modularity and maintainability. [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L272-R272) [[2]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627R42-R91)

### Event Handlers and UI Updates:
* Added new event handlers for reasoning elements, including click events for `.mes_reasoning_summary`, `.mes_reasoning_details`, and `.mes_reasoning_header` to improve user interaction when editing reasoning. [[1]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627R305-R327) [[2]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L326-R404)
* Updated the `updateMessageBlock` function to accept an additional `rerenderMessage` parameter for conditional re-rendering of message content. [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L2279-R2284) [[2]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L337-R416)

### Style Adjustments:
* Changed the border-radius of buttons in `public/style.css` from 10px to 5px for a more consistent design. (~ DON'T DO THIS TO ME, COPILOT)