### PR TITLE
Fix top_k text value not being able to go up to 500, like the slider does

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -730,7 +730,7 @@
                                             <input type="range" id="top_k_openai" name="volume" min="0" max="500" step="1">
                                         </div>
                                         <div class="range-block-counter">
-                                            <input type="number" min="0" max="200" step="1" data-for="top_k_openai" id="top_k_counter_openai">
+                                            <input type="number" min="0" max="500" step="1" data-for="top_k_openai" id="top_k_counter_openai">
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
hey there i had noticed, you were not able to type into the top k value without getting a error: invalid value must be between 0 and 200, even though the max is 500 when moving the bar (also moving the bar does not produce the error) so i wanted to fix it.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
