### PR TITLE
added templates for description+persona insertion

### DIFF
--- a/default/content/presets/openai/Default.json
+++ b/default/content/presets/openai/Default.json
@@ -41,6 +41,8 @@
     "wi_format": "{0}",
     "scenario_format": "{{scenario}}",
     "personality_format": "{{personality}}",
+    "description_format": "{{description}}",
+    "persona_format": "{{persona}}",
     "group_nudge_prompt": "[Write the next reply only as {{char}}.]",
     "stream_openai": true,
     "prompts": [

--- a/public/index.html
+++ b/public/index.html
@@ -730,7 +730,7 @@
                                             <input type="range" id="top_k_openai" name="volume" min="0" max="500" step="1">
                                         </div>
                                         <div class="range-block-counter">
-                                            <input type="number" min="0" max="500" step="1" data-for="top_k_openai" id="top_k_counter_openai">
+                                            <input type="number" min="0" max="200" step="1" data-for="top_k_openai" id="top_k_counter_openai">
                                         </div>
                                     </div>
                                 </div>
@@ -860,6 +860,34 @@
                                             </div>
                                             <div class="wide100p">
                                                 <textarea id="scenario_format_textarea" class="text_pole textarea_compact autoSetHeight" rows="3" placeholder="&mdash;"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="range-block m-t-1">
+                                            <div class="range-block-title openai_restorable">
+                                                <span data-i18n="Persona Format Template">Persona format template</span>
+                                                <div id="persona_format_restore" data-i18n="[title]Restore default format" title="Restore default format" class="right_menu_button">
+                                                    <div class="fa-solid fa-clock-rotate-left"></div>
+                                                </div>
+                                            </div>
+                                            <div class="toggle-description justifyLeft">
+                                                <span data-i18n="scenario_format_template_part_1">Use</span> <code>{{persona}}</code> <span data-i18n="scenario_format_template_part_2">to mark a place where the content is inserted.</span>
+                                            </div>
+                                            <div class="wide100p">
+                                                <textarea id="persona_format_textarea" class="text_pole textarea_compact autoSetHeight" rows="3" placeholder="&mdash;"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="range-block m-t-1">
+                                            <div class="range-block-title openai_restorable">
+                                                <span data-i18n="Description Format Template">Description format template</span>
+                                                <div id="description_format_restore" data-i18n="[title]Restore default format" title="Restore default format" class="right_menu_button">
+                                                    <div class="fa-solid fa-clock-rotate-left"></div>
+                                                </div>
+                                            </div>
+                                            <div class="toggle-description justifyLeft">
+                                                <span data-i18n="scenario_format_template_part_1">Use</span> <code>{{description}}</code> <span data-i18n="scenario_format_template_part_2">to mark a place where the content is inserted.</span>
+                                            </div>
+                                            <div class="wide100p">
+                                                <textarea id="description_format_textarea" class="text_pole textarea_compact autoSetHeight" rows="3" placeholder="&mdash;"></textarea>
                                             </div>
                                         </div>
                                         <div class="range-block m-t-1">


### PR DESCRIPTION
I was tired of having to create new prompts just to format {{persona}} and {{description}} with templates in the same manner that you can format the insertion of {{personality}} and {{scenario}}. I'd like to do this with the example messages as well, but they're much more complicated.

I have tested it and it works as expected, allowing you to do things like <description>{{description}}</description> without having to make two additional prompts. Makes for less work, as there is no need to turn off the additional formatting toggles if you have no persona. Also reduces cluttering up the preset with things that only exist for formatting purposes.

This is my first time contributing anything or editing something other than a bash script so let me know if everything has been done appropriately.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

