### PR TITLE
[BUG] Wrong white list conditions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -80,6 +80,8 @@ body:
           required: true
         - label: I have checked the [docs](https://docs.sillytavern.app/) ![important](https://img.shields.io/badge/Important!-F6094E)
           required: true
+        - label: I confirm that my issue is not related to third-party content, unofficial extension or patch. If in doubt, check with a new [user account](https://docs.sillytavern.app/administration/multi-user/) and with extensions disabled
+          required: true
 
   - type: markdown
     attributes:


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

The judgment condition of the original code is wrong. If the whitelist contains the client IP but not the forwarding IP, or vice versa, 403 will be displayed.

```
function test() {
    const whitelist = ['172.124.0.1', '116.6.226.81']
    const whitelistMode = true
    const forwardedIp = '172.124.0.1'
    const clientIp = '116.6.226.82'

    
    if (
        whitelistMode === true &&
        (
            !whitelist.some(x => ipMatching.matches(clientIp, ipMatching.getMatch(x))) &&
            (!forwardedIp || !whitelist.some(x => ipMatching.matches(forwardedIp, ipMatching.getMatch(x))))
        )
    ) {
        console.log(1111);
    }


    if (whitelistMode === true && !whitelist.some(x => ipMatching.matches(clientIp, ipMatching.getMatch(x)))
        || forwardedIp && whitelistMode === true && !whitelist.some(x => ipMatching.matches(forwardedIp, ipMatching.getMatch(x)))
    ) {
        console.log(2222);
    }
}
test()
```