### PR TITLE
Gemini Safety Filter

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -139,19 +139,19 @@ export const UNSAFE_EXTENSIONS = [
 export const GEMINI_SAFETY = [
     {
         category: 'HARM_CATEGORY_HARASSMENT',
-        threshold: 'OFF',
+        threshold: 'BLOCK_NONE',
     },
     {
         category: 'HARM_CATEGORY_HATE_SPEECH',
-        threshold: 'OFF',
+        threshold: 'BLOCK_NONE',
     },
     {
         category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-        threshold: 'OFF',
+        threshold: 'BLOCK_NONE',
     },
     {
         category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-        threshold: 'OFF',
+        threshold: 'BLOCK_NONE',
     },
     {
         category: 'HARM_CATEGORY_CIVIC_INTEGRITY',


### PR DESCRIPTION
Changing the thresholds from 'OFF' to 'BLOCK_NONE' dramatically decreased the rate in which Gemini models will block requests.

According to the Gemini documentation, invalid thresholds with set the threshold to a default value, which on some versions on Gemini sets filters to BLOCK_MOST. https://ai.google.dev/gemini-api/docs/safety-settings

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
