### PR TITLE
Add o1 to vision-supported models

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4967,6 +4967,8 @@ export function isImageInliningSupported() {
         'gpt-4-turbo',
         'gpt-4o',
         'gpt-4o-mini',
+        'o1',
+        'o1-2024-12-17',
         'chatgpt-4o-latest',
         'yi-vision',
         'pixtral-latest',


### PR DESCRIPTION
Slipped my mind when I added o1 to the supported OpenAI models. The main o1 does support vision since release, so we can just add that.
o3-mini, o1-mini and o1-preview still don't support it. Tested them all.

![image](https://github.com/user-attachments/assets/76dfe7f2-6099-4537-9a67-e19686759fd0)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
