### PR TITLE
Feature: Allow user to configure an address to listen to

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -7,8 +7,9 @@ cardsCacheCapacity: 100
 # Listen for incoming connections
 listen: false
 # Listen on a specific address, supports IPv4 and IPv6
-listenAddressIPv6: [::]
-listenAddressIPv4: 0.0.0.0
+listenAddress:
+  ipv4: 0.0.0.0
+  ipv6: [::]
 # Enables IPv6 and/or IPv4 protocols. Need to have at least one enabled!
 # - Use option "auto" to automatically detect support
 # - Use true or false (no qoutes) to enable or disable each protocol

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -7,7 +7,7 @@ cardsCacheCapacity: 100
 # Listen for incoming connections
 listen: false
 # Listen on a specific address, supports IPv4 and IPv6
-listenAddress: 127.0.0.1
+listenAddress: 0.0.0.0
 # Enables IPv6 and/or IPv4 protocols. Need to have at least one enabled!
 # - Use option "auto" to automatically detect support
 # - Use true or false (no qoutes) to enable or disable each protocol

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -7,7 +7,8 @@ cardsCacheCapacity: 100
 # Listen for incoming connections
 listen: false
 # Listen on a specific address, supports IPv4 and IPv6
-listenAddress: 0.0.0.0
+listenAddressIPv6: [::]
+listenAddressIPv4: 0.0.0.0
 # Enables IPv6 and/or IPv4 protocols. Need to have at least one enabled!
 # - Use option "auto" to automatically detect support
 # - Use true or false (no qoutes) to enable or disable each protocol

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -9,7 +9,7 @@ listen: false
 # Listen on a specific address, supports IPv4 and IPv6
 listenAddress:
   ipv4: 0.0.0.0
-  ipv6: [::]
+  ipv6: '[::]'
 # Enables IPv6 and/or IPv4 protocols. Need to have at least one enabled!
 # - Use option "auto" to automatically detect support
 # - Use true or false (no qoutes) to enable or disable each protocol

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -6,6 +6,8 @@ cardsCacheCapacity: 100
 # -- SERVER CONFIGURATION --
 # Listen for incoming connections
 listen: false
+# Listen on a specific address, supports IPv4 and IPv6
+listenAddress: 127.0.0.1
 # Enables IPv6 and/or IPv4 protocols. Need to have at least one enabled!
 # - Use option "auto" to automatically detect support
 # - Use true or false (no qoutes) to enable or disable each protocol

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
                 "html-entities": "^2.5.2",
                 "iconv-lite": "^0.6.3",
                 "ip-matching": "^2.1.2",
+                "ip-regex": "^5.0.0",
                 "ipaddr.js": "^2.0.1",
                 "jimp": "^0.22.10",
                 "localforage": "^1.10.0",
@@ -4627,6 +4628,18 @@
             "resolved": "https://registry.npmjs.org/ip-matching/-/ip-matching-2.1.2.tgz",
             "integrity": "sha512-/ok+VhKMasgR5gvTRViwRFQfc0qYt9Vdowg6TO4/pFlDCob5ZjGPkwuOoQVCd5OrMm20zqh+1vA8KLJZTeWudg==",
             "license": "LGPL-3.0-only"
+        },
+        "node_modules/ip-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+            "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/ipaddr.js": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "version": "1.12.11",
     "scripts": {
         "start": "node server.js",
+        "debug": "node server.js --inspect",
         "start:deno": "deno run --allow-run --allow-net --allow-read --allow-write --allow-sys --allow-env server.js",
         "start:bun": "bun server.js",
         "start:no-csrf": "node server.js --disableCsrf",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "html-entities": "^2.5.2",
         "iconv-lite": "^0.6.3",
         "ip-matching": "^2.1.2",
+        "ip-regex": "^5.0.0",
         "ipaddr.js": "^2.0.1",
         "jimp": "^0.22.10",
         "localforage": "^1.10.0",

--- a/server.js
+++ b/server.js
@@ -266,9 +266,9 @@ const autorun = (cliArguments.autorun ?? getConfigValue('autorun', DEFAULT_AUTOR
 /** @type {boolean} */
 const listen = cliArguments.listen ?? getConfigValue('listen', DEFAULT_LISTEN);
 /** @type {string} */
-const listenAddressIPv6 = cliArguments.listenAddressIPv6 ?? getConfigValue('listenAddressIPv6', DEFAULT_LISTEN_ADDRESS_IPV6);
+const listenAddressIPv6 = cliArguments.listenAddressIPv6 ?? getConfigValue('listenAddress.ipv6', DEFAULT_LISTEN_ADDRESS_IPV6);
 /** @type {string} */
-const listenAddressIPv4 = cliArguments.listenAddressIPv4 ?? getConfigValue('listenAddressIPv4', DEFAULT_LISTEN_ADDRESS_IPV4);
+const listenAddressIPv4 = cliArguments.listenAddressIPv4 ?? getConfigValue('listenAddress.ipv4', DEFAULT_LISTEN_ADDRESS_IPV4);
 /** @type {boolean} */
 const enableCorsProxy = cliArguments.corsProxy ?? getConfigValue('enableCorsProxy', DEFAULT_CORS_PROXY);
 const enableWhitelist = cliArguments.whitelist ?? getConfigValue('whitelistMode', DEFAULT_WHITELIST);

--- a/server.js
+++ b/server.js
@@ -852,22 +852,15 @@ const postSetupTasks = async function (v6Failed, v4Failed, useIPv6, useIPv4) {
     const plainGoToLog = removeColorFormatting(goToLog);
 
     console.log(logListen);
+    if (listen) {
+        console.log();
+        console.log('To limit connections to internal localhost only ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false".');
+        console.log('Check the "access.log" file in the SillyTavern directory to inspect incoming connections.');
+    }
     console.log('\n' + getSeparator(plainGoToLog.length) + '\n');
     console.log(goToLog);
     console.log('\n' + getSeparator(plainGoToLog.length) + '\n');
 
-    if (listen) {
-        const logAddress = ipRegex.v6({ exact: true }).test(listenAddressIPv6)
-            ? listenAddressIPv6
-            : ipRegex.v4({ exact: true }).test(listenAddressIPv4)
-                ? listenAddressIPv4
-                : null;
-        console.log(
-            logAddress
-                ? `SillyTavern is listening on the address ${logAddress}. If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n`
-                : '[::] or 0.0.0.0 means SillyTavern is listening on all network interfaces (Wi-Fi, LAN, localhost). If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n',
-        );
-    }
 
     if (basicAuthMode) {
         if (perUserBasicAuth && !enableAccounts) {

--- a/server.js
+++ b/server.js
@@ -942,19 +942,6 @@ function logSecurityAlert(message) {
 }
 
 /**
- * Prints a warning message
- * @param {string} message The warning message to print
- * @returns {void}
- */
-function logSecurityWarning(message) {
-    if (basicAuthMode || enableWhitelist) return; // safe!
-    console.error(color.yellow(message));
-    if (getConfigValue('securityOverride', false)) {
-        console.warn(color.red('Security has been overridden. If it\'s not a trusted network, change the settings.'));
-    }
-}
-
-/**
  * Handles the case where the server failed to start on one or both protocols.
  * @param {boolean} v6Failed If the server failed to start on IPv6
  * @param {boolean} v4Failed If the server failed to start on IPv4

--- a/server.js
+++ b/server.js
@@ -716,7 +716,7 @@ app.use('/api/azure', azureRouter);
 const ipv6_regex = /^(?:(?:[a-fA-F\d]{1,4}:){7}(?:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){6}(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){5}(?::(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,2}|:)|(?:[a-fA-F\d]{1,4}:){4}(?:(?::[a-fA-F\d]{1,4}){0,1}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,3}|:)|(?:[a-fA-F\d]{1,4}:){3}(?:(?::[a-fA-F\d]{1,4}){0,2}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,4}|:)|(?:[a-fA-F\d]{1,4}:){2}(?:(?::[a-fA-F\d]{1,4}){0,3}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,5}|:)|(?:[a-fA-F\d]{1,4}:){1}(?:(?::[a-fA-F\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,6}|:)|(?::(?:(?::[a-fA-F\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,7}|:)))(?:%[0-9a-zA-Z]{1,})?$/m;
 const tavernUrlV6 = new URL(
     (cliArguments.ssl ? 'https://' : 'http://') +
-    (listen ? (ipv6_regex.test(listenAddress) ? listenAddress : '[::]') : '[::1]') +
+    (listen ? (ipv6_regex.test(listenAddress) ? `[${listenAddress}]` : '[::]') : '[::1]') +
     (':' + server_port),
 );
 
@@ -789,8 +789,12 @@ const preSetupTasks = async function () {
  */
 async function getAutorunHostname(useIPv6, useIPv4) {
     if (autorunHostname === 'auto') {
-        if (listen && (ipv4_regex.test(listenAddress) || ipv6_regex.test(listenAddress))) {
-            return listenAddress;
+        if (listen) {
+            if (ipv4_regex.test(listenAddress)) {
+                return listenAddress;
+            } else if (ipv6_regex.test(listenAddress)) {
+                return `[${listenAddress}]`;
+            }
         }
 
         let localhostResolve = await canResolve('localhost', useIPv6, useIPv4);
@@ -855,9 +859,13 @@ const postSetupTasks = async function (v6Failed, v4Failed, useIPv6, useIPv4) {
     console.log('\n' + getSeparator(plainGoToLog.length) + '\n');
 
     if (listen) {
-        if (ipv4_regex.test(listenAddress) || ipv6_regex.test(listenAddress)) {
+        if (ipv4_regex.test(listenAddress)) {
             console.log(
                 `SillyTavern is listening on the address ${listenAddress}. If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n`,
+            );
+        } else if (ipv6_regex.test(listenAddress)) {
+            console.log(
+                `SillyTavern is listening on the address [${listenAddress}]. If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n`,
             );
         } else {
             console.log(

--- a/server.js
+++ b/server.js
@@ -857,19 +857,16 @@ const postSetupTasks = async function (v6Failed, v4Failed, useIPv6, useIPv4) {
     console.log('\n' + getSeparator(plainGoToLog.length) + '\n');
 
     if (listen) {
-        if (ipRegex.v6({ exact: true }).test(listenAddressIPv6)) {
-            console.log(
-                `SillyTavern is listening on the address ${listenAddressIPv6}. If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n`,
-            );
-        } else if (ipRegex.v4({ exact: true }).test(listenAddressIPv4)) {
-            console.log(
-                `SillyTavern is listening on the address ${listenAddressIPv4}. If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n`,
-            );
-        } else {
-            console.log(
-                '[::] or 0.0.0.0 means SillyTavern is listening on all network interfaces (Wi-Fi, LAN, localhost). If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n',
-            );
-        }
+        const logAddress = ipRegex.v6({ exact: true }).test(listenAddressIPv6)
+            ? listenAddressIPv6
+            : ipRegex.v4({ exact: true }).test(listenAddressIPv4)
+                ? listenAddressIPv4
+                : null;
+        console.log(
+            logAddress
+                ? `SillyTavern is listening on the address ${logAddress}. If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n`
+                : '[::] or 0.0.0.0 means SillyTavern is listening on all network interfaces (Wi-Fi, LAN, localhost). If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n',
+        );
     }
 
     if (basicAuthMode) {

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ import bodyParser from 'body-parser';
 
 // net related library imports
 import fetch from 'node-fetch';
+import ipRegex from 'ip-regex';
 
 // Unrestrict console logs display limit
 util.inspect.defaultOptions.maxArrayLength = null;
@@ -713,17 +714,15 @@ app.use('/api/backends/scale-alt', scaleAltRouter);
 app.use('/api/speech', speechRouter);
 app.use('/api/azure', azureRouter);
 
-const ipv6_regex = /^(?:(?:[a-fA-F\d]{1,4}:){7}(?:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){6}(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){5}(?::(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,2}|:)|(?:[a-fA-F\d]{1,4}:){4}(?:(?::[a-fA-F\d]{1,4}){0,1}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,3}|:)|(?:[a-fA-F\d]{1,4}:){3}(?:(?::[a-fA-F\d]{1,4}){0,2}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,4}|:)|(?:[a-fA-F\d]{1,4}:){2}(?:(?::[a-fA-F\d]{1,4}){0,3}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,5}|:)|(?:[a-fA-F\d]{1,4}:){1}(?:(?::[a-fA-F\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,6}|:)|(?::(?:(?::[a-fA-F\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,7}|:)))(?:%[0-9a-zA-Z]{1,})?$/m;
 const tavernUrlV6 = new URL(
     (cliArguments.ssl ? 'https://' : 'http://') +
-    (listen ? (ipv6_regex.test(listenAddress) ? `[${listenAddress}]` : '[::]') : '[::1]') +
+    (listen ? (ipRegex.v6({ exact: true }).test(listenAddress) ? `[${listenAddress}]` : '[::]') : '[::1]') +
     (':' + server_port),
 );
 
-const ipv4_regex = /^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$/m;
 const tavernUrl = new URL(
     (cliArguments.ssl ? 'https://' : 'http://') +
-    (listen ? (ipv4_regex.test(listenAddress) ? listenAddress : '0.0.0.0') : '127.0.0.1') +
+    (listen ? (ipRegex.v4({ exact: true }).test(listenAddress) ? listenAddress : '0.0.0.0') : '127.0.0.1') +
     (':' + server_port),
 );
 
@@ -790,9 +789,9 @@ const preSetupTasks = async function () {
 async function getAutorunHostname(useIPv6, useIPv4) {
     if (autorunHostname === 'auto') {
         if (listen) {
-            if (ipv4_regex.test(listenAddress)) {
+            if (ipRegex.v4({ exact: true }).test(listenAddress)) {
                 return listenAddress;
-            } else if (ipv6_regex.test(listenAddress)) {
+            } else if (ipRegex.v6({ exact: true }).test(listenAddress)) {
                 return `[${listenAddress}]`;
             }
         }
@@ -859,11 +858,11 @@ const postSetupTasks = async function (v6Failed, v4Failed, useIPv6, useIPv4) {
     console.log('\n' + getSeparator(plainGoToLog.length) + '\n');
 
     if (listen) {
-        if (ipv4_regex.test(listenAddress)) {
+        if (ipRegex.v4({ exact: true }).test(listenAddress)) {
             console.log(
                 `SillyTavern is listening on the address ${listenAddress}. If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n`,
             );
-        } else if (ipv6_regex.test(listenAddress)) {
+        } else if (ipRegex.v6({ exact: true }).test(listenAddress)) {
             console.log(
                 `SillyTavern is listening on the address [${listenAddress}]. If you want to limit it only to internal localhost ([::1] or 127.0.0.1), change the setting in config.yaml to "listen: false". Check "access.log" file in the SillyTavern directory if you want to inspect incoming connections.\n`,
             );

--- a/server.js
+++ b/server.js
@@ -795,14 +795,6 @@ const preSetupTasks = async function () {
  */
 async function getAutorunHostname(useIPv6, useIPv4) {
     if (autorunHostname === 'auto') {
-        if (listen) {
-            if (ipRegex.v6({ exact: true }).test(listenAddressIPv6)) {
-                return listenAddressIPv6;
-            } else if (ipRegex.v4({ exact: true }).test(listenAddressIPv4)) {
-                return listenAddressIPv4;
-            }
-        }
-
         let localhostResolve = await canResolve('localhost', useIPv6, useIPv4);
 
         if (useIPv6 && useIPv4) {


### PR DESCRIPTION
This PR allows users to configure a new field in the config.yaml named listenAddress. This can be either an IPv4 or IPv6 address. When listen is true and a valid address is given, SillyTavern will listen on that address instead of all. A non-compliant or an empty value will be rejected and default to either 0.0.0.0 or [::], based on previous behavior when listen was set to true.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
