### PR TITLE
Fix auto expand on thinking during new message

### DIFF
--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -216,7 +216,7 @@ export class ReasoningHandler {
 
         this.updateDom(messageId);
 
-        if (power_user.reasoning.auto_expand) {
+        if (power_user.reasoning.auto_expand && this.state !== ReasoningState.Hidden) {
             this.messageReasoningDetailsDom.open = true;
         }
     }

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -215,6 +215,10 @@ export class ReasoningHandler {
         }
 
         this.updateDom(messageId);
+
+        if (power_user.reasoning.auto_expand) {
+            this.messageReasoningDetailsDom.open = true;
+        }
     }
 
     /**


### PR DESCRIPTION
Small fix, but quite important.
When "Auto-Expand" is being toggled, new swipes on a message with a currently hidden reasoning will **not** automatically show the reasoning expanded and processed.

This PR fixes this, by changing every init of an unknown message to be automatically expanded when set up, when the Auto-Expand toggle is actice.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
