### PR TITLE
Add cache buster middleware to clear browser cache on server restart

### DIFF
--- a/server.js
+++ b/server.js
@@ -60,6 +60,7 @@ import basicAuthMiddleware from './src/middleware/basicAuth.js';
 import whitelistMiddleware from './src/middleware/whitelist.js';
 import multerMonkeyPatch from './src/middleware/multerMonkeyPatch.js';
 import initRequestProxy from './src/request-proxy.js';
+import getCacheBusterMiddleware from './src/middleware/cacheBuster.js';
 import {
     getVersion,
     getConfigValue,
@@ -515,7 +516,7 @@ if (!disableCsrf) {
 
 // Static files
 // Host index page
-app.get('/', (request, response) => {
+app.get('/', getCacheBusterMiddleware(), (request, response) => {
     if (shouldRedirectToLogin(request)) {
         const query = request.url.split('?')[1];
         const redirectUrl = query ? `/login?${query}` : '/login';

--- a/src/middleware/cacheBuster.js
+++ b/src/middleware/cacheBuster.js
@@ -1,0 +1,22 @@
+/**
+ * Middleware to bust the browser cache for the current user.
+ * @returns {import('express').RequestHandler}
+ */
+export default function getCacheBusterMiddleware() {
+    /**
+     * @type {Set<string>} Handles that have already been busted.
+     */
+    const handles = new Set();
+
+    return (request, response, next) => {
+        const handle = request.user?.profile?.handle;
+
+        if (!handle || handles.has(handle)) {
+            return next();
+        }
+
+        handles.add(handle);
+        response.setHeader('Clear-Site-Data', '"cache"');
+        next();
+    };
+}

--- a/src/middleware/cacheBuster.js
+++ b/src/middleware/cacheBuster.js
@@ -1,21 +1,27 @@
+import crypto from 'node:crypto';
+import { DEFAULT_USER } from '../constants.js';
+
 /**
  * Middleware to bust the browser cache for the current user.
  * @returns {import('express').RequestHandler}
  */
 export default function getCacheBusterMiddleware() {
     /**
-     * @type {Set<string>} Handles that have already been busted.
+     * @type {Set<string>} Handles/User-Agents that have already been busted.
      */
-    const handles = new Set();
+    const keys = new Set();
 
     return (request, response, next) => {
-        const handle = request.user?.profile?.handle;
+        const handle = request.user?.profile?.handle || DEFAULT_USER.handle;
+        const userAgent = request.headers['user-agent'] || '';
+        const hash = crypto.createHash('sha256').update(userAgent).digest('hex');
+        const key = `${handle}-${hash}`;
 
-        if (!handle || handles.has(handle)) {
+        if (keys.has(key)) {
             return next();
         }
 
-        handles.add(handle);
+        keys.add(key);
         response.setHeader('Clear-Site-Data', '"cache"');
         next();
     };


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

On every server restart, when the user first accesses index.html page, the browser cache will be forced to clear (using '[Clear-Site-Data](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data)' header). 

This MIGHT be a proper fix for #3479, but since iOS can only access remote instances and the header requires HTTPS to work, it's likely to do nothing.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
