### PR TITLE
Fix auto expand on thinking during new message (v2.1)

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5930,6 +5930,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
             chat[chat.length - 1]['extra']['api'] = getGeneratingApi();
             chat[chat.length - 1]['extra']['model'] = getGeneratingModel();
             chat[chat.length - 1]['extra']['reasoning'] = reasoning;
+            chat[chat.length - 1]['extra']['reasoning_duration'] = null;
             if (power_user.message_token_count_enabled) {
                 const tokenCountText = (reasoning || '') + chat[chat.length - 1]['mes'];
                 chat[chat.length - 1]['extra']['token_count'] = await getTokenCountAsync(tokenCountText, 0);
@@ -5952,6 +5953,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
         chat[chat.length - 1]['extra']['api'] = getGeneratingApi();
         chat[chat.length - 1]['extra']['model'] = getGeneratingModel();
         chat[chat.length - 1]['extra']['reasoning'] = reasoning;
+        chat[chat.length - 1]['extra']['reasoning_duration'] = null;
         if (power_user.message_token_count_enabled) {
             const tokenCountText = (reasoning || '') + chat[chat.length - 1]['mes'];
             chat[chat.length - 1]['extra']['token_count'] = await getTokenCountAsync(tokenCountText, 0);
@@ -5971,6 +5973,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
         chat[chat.length - 1]['extra']['api'] = getGeneratingApi();
         chat[chat.length - 1]['extra']['model'] = getGeneratingModel();
         chat[chat.length - 1]['extra']['reasoning'] += reasoning;
+        // We don't know if the reasoning duration extended, so we don't update it here on purpose.
         if (power_user.message_token_count_enabled) {
             const tokenCountText = (reasoning || '') + chat[chat.length - 1]['mes'];
             chat[chat.length - 1]['extra']['token_count'] = await getTokenCountAsync(tokenCountText, 0);
@@ -5990,6 +5993,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
         chat[chat.length - 1]['extra']['api'] = getGeneratingApi();
         chat[chat.length - 1]['extra']['model'] = getGeneratingModel();
         chat[chat.length - 1]['extra']['reasoning'] = reasoning;
+        chat[chat.length - 1]['extra']['reasoning_duration'] = null;
         if (power_user.trim_spaces) {
             getMessage = getMessage.trim();
         }


### PR DESCRIPTION
Continuation of #3480.
Fixing this **again**, hopefully for good now.

Good that you mentioned it might fuck up hidden thinking being un-opened, but I should've tested the changes after again....
Because this *small fix* broke the auto-expand for streamed messages **again**.

Reason for this is simple. For whatever reason, swiping does **not** correctly update the extras data before the `addOneMessage` is getting called.
The `reasoning_duration` is being stuck on the old value, so the first render **after** the init will mark this as a hidden reasoning block (no reasoning text, but reasoning duration), which will remove the "open" attribute. Once the reasoning actually streams in, it stays closed then.
Setting this to hidden was wrong and the issue.

I could've either switched from reading extras directly in `initHandleMessage` to reading the extras object from the relevant `swipes_info` of the current message (which I considered ugly), or I'd have to reset the reasoning duration manually too like the reasoning text itself was reset on the `saveReply`. I did the latter.
Couldn't find any other issues, so I think this is good to go.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=vDWlhQjGjoc).
