### PR TITLE
Save chat for WI scan before running extension interceptors

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3882,6 +3882,8 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
     // Determine token limit
     let this_max_context = getMaxContextSize();
+    // Save chat for WI scan before running extension interceptors
+    const chatForWI = coreChat.map(x => world_info_include_names ? `${x.name}: ${x.mes}` : x.mes).reverse();
 
     if (!dryRun) {
         console.debug('Running extension interceptors');
@@ -3973,7 +3975,6 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     // Add WI to prompt (and also inject WI to AN value via hijack)
     // Make quiet prompt available for WIAN
     setExtensionPrompt('QUIET_PROMPT', quiet_prompt || '', extension_prompt_types.IN_PROMPT, 0, true);
-    const chatForWI = coreChat.map(x => world_info_include_names ? `${x.name}: ${x.mes}` : x.mes).reverse();
     const { worldInfoString, worldInfoBefore, worldInfoAfter, worldInfoExamples, worldInfoDepth } = await getWorldInfoPrompt(chatForWI, this_max_context, dryRun);
     setExtensionPrompt('QUIET_PROMPT', '', extension_prompt_types.IN_PROMPT, 0, true);
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Per numerous Giglio's struggles...

Extension interceptors can mutate the chat copy used for prompt building by appending/removing messages. This has a negative effect on WI timed effects which expect discreet changes made to the chat to work, i.e. the chat should be advancing for the timed effect not to be reset.

This fixates `chatForWI` variable by creating it before the running interceptors. Vector storage / message limits / etc. won't be able to affect the WI scanning by modifying the chat anymore, which I think is acceptable and more predictable. Prompt regex and message file embeds would still be affecting the scan though.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
