### PR TITLE
Vectors: Don't use headers for source-specific fields in requests

### DIFF
--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -132,35 +132,35 @@ function getSourceSettings(source, request) {
     switch (source) {
         case 'togetherai':
             return {
-                model: String(request.headers['x-togetherai-model']),
+                model: String(request.body.model),
             };
         case 'openai':
             return {
-                model: String(request.headers['x-openai-model']),
+                model: String(request.body.model),
             };
         case 'cohere':
             return {
-                model: String(request.headers['x-cohere-model']),
+                model: String(request.body.model),
             };
         case 'llamacpp':
             return {
-                apiUrl: String(request.headers['x-llamacpp-url']),
+                apiUrl: String(request.body.apiUrl),
             };
         case 'vllm':
             return {
-                apiUrl: String(request.headers['x-vllm-url']),
-                model: String(request.headers['x-vllm-model']),
+                apiUrl: String(request.body.apiUrl),
+                model: String(request.body.model),
             };
         case 'ollama':
             return {
-                apiUrl: String(request.headers['x-ollama-url']),
-                model: String(request.headers['x-ollama-model']),
-                keep: Boolean(request.headers['x-ollama-keep']),
+                apiUrl: String(request.body.apiUrl),
+                model: String(request.body.model),
+                keep: Boolean(request.body.keep),
             };
         case 'extras':
             return {
-                extrasUrl: String(request.headers['x-extras-url']),
-                extrasKey: String(request.headers['x-extras-key']),
+                extrasUrl: String(request.body.extrasUrl),
+                extrasKey: String(request.body.extrasKey),
             };
         case 'transformers':
             return {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

I don't remember why it's using headers for passing data to backend, but it's dumb and likely shouldn't be doing that. So it's using request body JSON as it should now.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
