### PR TITLE
Add 'return' and 'strict' to `/reasoning-parse`, and make all reasoning parsing strict by default

### DIFF
--- a/public/scripts/slash-commands/SlashCommandCommonEnumsProvider.js
+++ b/public/scripts/slash-commands/SlashCommandCommonEnumsProvider.js
@@ -34,6 +34,7 @@ export const enumIcons = {
     preset: '⚙️',
     file: '📄',
     message: '💬',
+    reasoning: '💡',
     voice: '🎤',
     server: '🖥️',
     popup: '🗔',


### PR DESCRIPTION
- Add 'return' arg to `/reasoning-parse` to decide whether to return the reasoning, or the content without reasoning. Defaulting to reasoning.
- Add 'strict' arg to `/reasoning-parse` to decide whether the reasoning block has to be at the beginning of the provided message or not. Defaulting to true.
- Update parsing of all reasoning (even the auto parse one) to be strict by default - meaning the regex block has to be at the beginning (excluding whitespaces)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=B5nim_i_PiM).
