### PR TITLE
Move webpack cache to data root

### DIFF
--- a/docker/build-lib.js
+++ b/docker/build-lib.js
@@ -1,4 +1,4 @@
 import getWebpackServeMiddleware from '../src/middleware/webpack-serve.js';
 
 const middleware = getWebpackServeMiddleware();
-await middleware.runWebpackCompiler();
+await middleware.runWebpackCompiler(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
                 "ip-matching": "^2.1.2",
                 "ip-regex": "^5.0.0",
                 "ipaddr.js": "^2.0.1",
+                "is-docker": "^3.0.0",
                 "jimp": "^0.22.10",
                 "localforage": "^1.10.0",
                 "lodash": "^4.17.21",
@@ -4649,15 +4650,15 @@
             "license": "MIT"
         },
         "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
             },
             "engines": {
-                "node": ">=8"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4732,6 +4733,21 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-wsl/node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/isarray": {
@@ -5513,6 +5529,21 @@
             },
             "engines": {
                 "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/open/node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "ip-matching": "^2.1.2",
         "ip-regex": "^5.0.0",
         "ipaddr.js": "^2.0.1",
+        "is-docker": "^3.0.0",
         "jimp": "^0.22.10",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",

--- a/src/middleware/webpack-serve.js
+++ b/src/middleware/webpack-serve.js
@@ -1,11 +1,8 @@
 import path from 'node:path';
 import webpack from 'webpack';
-import { publicLibConfig } from '../../webpack.config.js';
+import getPublicLibConfig from '../../webpack.config.js';
 
 export default function getWebpackServeMiddleware() {
-    const outputPath = publicLibConfig.output?.path;
-    const outputFile = publicLibConfig.output?.filename;
-
     /**
      * A very spartan recreation of webpack-dev-middleware.
      * @param {import('express').Request} req Request object.
@@ -14,6 +11,10 @@ export default function getWebpackServeMiddleware() {
      * @type {import('express').RequestHandler}
      */
     function devMiddleware(req, res, next) {
+        const publicLibConfig = getPublicLibConfig();
+        const outputPath = publicLibConfig.output?.path;
+        const outputFile = publicLibConfig.output?.filename;
+
         if (req.method === 'GET' && path.parse(req.path).base === outputFile) {
             return res.sendFile(outputFile, { root: outputPath });
         }
@@ -23,9 +24,11 @@ export default function getWebpackServeMiddleware() {
 
     /**
      * Wait until Webpack is done compiling.
+     * @param {boolean} [forceDist=false] Whether to force the use the /dist folder.
      * @returns {Promise<void>}
      */
-    devMiddleware.runWebpackCompiler = () => {
+    devMiddleware.runWebpackCompiler = (forceDist = false) => {
+        const publicLibConfig = getPublicLibConfig(forceDist);
         const compiler = webpack(publicLibConfig);
 
         return new Promise((resolve) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,30 +1,43 @@
 import process from 'node:process';
 import path from 'node:path';
-import os from 'node:os';
 import isDocker from 'is-docker';
 
 /**
  * Get the Webpack configuration for the public/lib.js file.
+ * 1. Docker has got cache and the output file pre-baked.
+ * 2. Non-Docker environments use the global DATA_ROOT variable to determine the cache and output directories.
  * @param {boolean} forceDist Whether to force the use the /dist folder.
  * @returns {import('webpack').Configuration}
+ * @throws {Error} If the DATA_ROOT variable is not set.
  * */
 export default function getPublicLibConfig(forceDist = false) {
     function getCacheDirectory() {
-        // Docker got cache pre-baked into the image.
         if (forceDist || isDocker()) {
             return path.resolve(process.cwd(), 'dist/webpack');
         }
 
-        // Data root is set (should be the case 99.99% of the time).
         if (typeof globalThis.DATA_ROOT === 'string') {
-            return path.resolve(globalThis.DATA_ROOT, '_cache', 'webpack');
+            return path.resolve(globalThis.DATA_ROOT, '_webpack', 'cache');
         }
 
-        // Fallback to the system temp directory.
-        return path.resolve(os.tmpdir(), 'webpack');
+        throw new Error('DATA_ROOT variable is not set.');
+    }
+
+    function getOutputDirectory() {
+        if (forceDist || isDocker()) {
+            return path.resolve(process.cwd(), 'dist');
+        }
+
+        if (typeof globalThis.DATA_ROOT === 'string') {
+            return path.resolve(globalThis.DATA_ROOT, '_webpack', 'output');
+        }
+
+        throw new Error('DATA_ROOT variable is not set.');
     }
 
     const cacheDirectory = getCacheDirectory();
+    const outputDirectory = getOutputDirectory();
+
     return {
         mode: 'production',
         entry: './public/lib.js',
@@ -51,7 +64,7 @@ export default function getPublicLibConfig(forceDist = false) {
             hints: false,
         },
         output: {
-            path: path.resolve(process.cwd(), 'dist'),
+            path: outputDirectory,
             filename: 'lib.js',
             libraryTarget: 'module',
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,35 +1,59 @@
 import process from 'node:process';
 import path from 'node:path';
+import os from 'node:os';
+import isDocker from 'is-docker';
 
-/** @type {import('webpack').Configuration} */
-export const publicLibConfig = {
-    mode: 'production',
-    entry: './public/lib.js',
-    cache: {
-        type: 'filesystem',
-        cacheDirectory: path.resolve(process.cwd(), 'dist/webpack'),
-        store: 'pack',
-        compression: 'gzip',
-    },
-    devtool: false,
-    watch: false,
-    module: {},
-    stats: {
-        preset: 'minimal',
-        assets: false,
-        modules: false,
-        colors: true,
-        timings: true,
-    },
-    experiments: {
-        outputModule: true,
-    },
-    performance: {
-        hints: false,
-    },
-    output: {
-        path: path.resolve(process.cwd(), 'dist'),
-        filename: 'lib.js',
-        libraryTarget: 'module',
-    },
-};
+/**
+ * Get the Webpack configuration for the public/lib.js file.
+ * @param {boolean} forceDist Whether to force the use the /dist folder.
+ * @returns {import('webpack').Configuration}
+ * */
+export default function getPublicLibConfig(forceDist = false) {
+    function getCacheDirectory() {
+        // Docker got cache pre-baked into the image.
+        if (forceDist || isDocker()) {
+            return path.resolve(process.cwd(), 'dist/webpack');
+        }
+
+        // Data root is set (should be the case 99.99% of the time).
+        if (typeof globalThis.DATA_ROOT === 'string') {
+            return path.resolve(globalThis.DATA_ROOT, '_cache', 'webpack');
+        }
+
+        // Fallback to the system temp directory.
+        return path.resolve(os.tmpdir(), 'webpack');
+    }
+
+    const cacheDirectory = getCacheDirectory();
+    return {
+        mode: 'production',
+        entry: './public/lib.js',
+        cache: {
+            type: 'filesystem',
+            cacheDirectory: cacheDirectory,
+            store: 'pack',
+            compression: 'gzip',
+        },
+        devtool: false,
+        watch: false,
+        module: {},
+        stats: {
+            preset: 'minimal',
+            assets: false,
+            modules: false,
+            colors: true,
+            timings: true,
+        },
+        experiments: {
+            outputModule: true,
+        },
+        performance: {
+            hints: false,
+        },
+        output: {
+            path: path.resolve(process.cwd(), 'dist'),
+            filename: 'lib.js',
+            libraryTarget: 'module',
+        },
+    };
+}


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Another small step toward #3453. Can be reviewed independently from #3499.

1. Webpack cache and output for regular installs will be collected in `/data/_webpack/`.
2. This doesn't change the cache path for Docker. Webpack run results are baked into the container image.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
