### PR TITLE
Feature: Add configurable X-Real-IP header support for rate limiting

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -85,6 +85,11 @@ cookieSecret: ''
 disableCsrfProtection: false
 # Disable startup security checks - NOT RECOMMENDED
 securityOverride: false
+# -- RATE LIMITING CONFIGURATION --
+rateLimiting:
+  # Use X-Real-IP or X-Forwarded-For header instead of socket IP for rate limiting
+  # Enable this if you're behind a reverse proxy
+  preferRealIpHeader: false
 # -- ADVANCED CONFIGURATION --
 # Open the browser automatically
 autorun: true

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -87,8 +87,8 @@ disableCsrfProtection: false
 securityOverride: false
 # -- RATE LIMITING CONFIGURATION --
 rateLimiting:
-  # Use X-Real-IP or X-Forwarded-For header instead of socket IP for rate limiting
-  # Enable this if you're behind a reverse proxy
+  # Use X-Real-IP header instead of socket IP for rate limiting
+  # Only enable this if you are using a properly configured reverse proxy (like Nginx/traefik/Caddy)
   preferRealIpHeader: false
 # -- ADVANCED CONFIGURATION --
 # Open the browser automatically

--- a/src/endpoints/users-public.js
+++ b/src/endpoints/users-public.js
@@ -3,11 +3,12 @@ import crypto from 'node:crypto';
 import storage from 'node-persist';
 import express from 'express';
 import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
-import { jsonParser, getIpFromRequest } from '../express-common.js';
+import { jsonParser, getIpFromRequest, getRealIpFromHeader } from '../express-common.js';
 import { color, Cache, getConfigValue } from '../util.js';
 import { KEY_PREFIX, getUserAvatar, toKey, getPasswordHash, getPasswordSalt } from '../users.js';
 
 const DISCREET_LOGIN = getConfigValue('enableDiscreetLogin', false);
+const PREFER_REAL_IP_HEADER = getConfigValue('rateLimiting.preferRealIpHeader', false);
 const MFA_CACHE = new Cache(5 * 60 * 1000);
 
 export const router = express.Router();
@@ -60,7 +61,7 @@ router.post('/login', jsonParser, async (request, response) => {
             return response.status(400).json({ error: 'Missing required fields' });
         }
 
-        const ip = getIpFromRequest(request);
+        const ip = PREFER_REAL_IP_HEADER ? getRealIpFromHeader(request) : getIpFromRequest(request);
         await loginLimiter.consume(ip);
 
         /** @type {import('../users.js').User} */
@@ -92,7 +93,7 @@ router.post('/login', jsonParser, async (request, response) => {
         return response.json({ handle: user.handle });
     } catch (error) {
         if (error instanceof RateLimiterRes) {
-            console.error('Login failed: Rate limited from', getIpFromRequest(request));
+            console.error('Login failed: Rate limited from', PREFER_REAL_IP_HEADER ? getRealIpFromHeader(request) : getIpFromRequest(request));
             return response.status(429).send({ error: 'Too many attempts. Try again later or recover your password.' });
         }
 
@@ -108,7 +109,7 @@ router.post('/recover-step1', jsonParser, async (request, response) => {
             return response.status(400).json({ error: 'Missing required fields' });
         }
 
-        const ip = getIpFromRequest(request);
+        const ip = PREFER_REAL_IP_HEADER ? getRealIpFromHeader(request) : getIpFromRequest(request);
         await recoverLimiter.consume(ip);
 
         /** @type {import('../users.js').User} */
@@ -132,7 +133,7 @@ router.post('/recover-step1', jsonParser, async (request, response) => {
         return response.sendStatus(204);
     } catch (error) {
         if (error instanceof RateLimiterRes) {
-            console.error('Recover step 1 failed: Rate limited from', getIpFromRequest(request));
+            console.error('Recover step 1 failed: Rate limited from', PREFER_REAL_IP_HEADER ? getRealIpFromHeader(request) : getIpFromRequest(request));
             return response.status(429).send({ error: 'Too many attempts. Try again later or contact your admin.' });
         }
 
@@ -150,7 +151,7 @@ router.post('/recover-step2', jsonParser, async (request, response) => {
 
         /** @type {import('../users.js').User} */
         const user = await storage.getItem(toKey(request.body.handle));
-        const ip = getIpFromRequest(request);
+        const ip = PREFER_REAL_IP_HEADER ? getRealIpFromHeader(request) : getIpFromRequest(request);
 
         if (!user) {
             console.error('Recover step 2 failed: User', request.body.handle, 'not found');
@@ -186,7 +187,7 @@ router.post('/recover-step2', jsonParser, async (request, response) => {
         return response.sendStatus(204);
     } catch (error) {
         if (error instanceof RateLimiterRes) {
-            console.error('Recover step 2 failed: Rate limited from', getIpFromRequest(request));
+            console.error('Recover step 2 failed: Rate limited from', PREFER_REAL_IP_HEADER ? getRealIpFromHeader(request) : getIpFromRequest(request));
             return response.status(429).send({ error: 'Too many attempts. Try again later or contact your admin.' });
         }
 

--- a/src/express-common.js
+++ b/src/express-common.js
@@ -25,3 +25,17 @@ export function getIpFromRequest(req) {
     }
     return clientIp;
 }
+
+/**
+ * Gets the IP address of the client when behind reverse proxy using x-real-ip header, falls back to socket remote address.
+ * This function should be used when the application is running behind a reverse proxy (e.g., Nginx, Apache, Caddy...).
+ * @param {import('express').Request} req Request object
+ * @returns {string} IP address of the client
+ */
+export function getRealIpFromHeader(req) {
+    if (req.headers['x-real-ip']) {
+        return req.headers['x-real-ip'].toString();
+    }
+
+    return getIpFromRequest(req);
+}

--- a/src/express-common.js
+++ b/src/express-common.js
@@ -11,10 +11,17 @@ export const urlencodedParser = express.urlencoded({ extended: true, limit: '200
  * @returns {string} IP address of the client
  */
 export function getIpFromRequest(req) {
+    // First check X-Real-IP header
+    if (req.headers['x-real-ip']) {
+        return req.headers['x-real-ip'].toString();
+    }
+
+    // Fall back to socket remote address
     let clientIp = req.socket.remoteAddress;
     if (!clientIp) {
         return 'unknown';
     }
+
     let ip = ipaddr.parse(clientIp);
     // Check if the IP address is IPv4-mapped IPv6 address
     if (ip.kind() === 'ipv6' && ip instanceof ipaddr.IPv6 && ip.isIPv4MappedAddress()) {

--- a/src/express-common.js
+++ b/src/express-common.js
@@ -28,7 +28,7 @@ export function getIpFromRequest(req) {
 
 /**
  * Gets the IP address of the client when behind reverse proxy using x-real-ip header, falls back to socket remote address.
- * This function should be used when the application is running behind a reverse proxy (e.g., Nginx, Apache, Caddy...).
+ * This function should be used when the application is running behind a reverse proxy (e.g., Nginx, traefik, Caddy...).
  * @param {import('express').Request} req Request object
  * @returns {string} IP address of the client
  */

--- a/src/express-common.js
+++ b/src/express-common.js
@@ -11,17 +11,10 @@ export const urlencodedParser = express.urlencoded({ extended: true, limit: '200
  * @returns {string} IP address of the client
  */
 export function getIpFromRequest(req) {
-    // First check X-Real-IP header
-    if (req.headers['x-real-ip']) {
-        return req.headers['x-real-ip'].toString();
-    }
-
-    // Fall back to socket remote address
     let clientIp = req.socket.remoteAddress;
     if (!clientIp) {
         return 'unknown';
     }
-
     let ip = ipaddr.parse(clientIp);
     // Check if the IP address is IPv4-mapped IPv6 address
     if (ip.kind() === 'ipv6' && ip instanceof ipaddr.IPv6 && ip.isIPv4MappedAddress()) {

--- a/src/middleware/whitelist.js
+++ b/src/middleware/whitelist.js
@@ -4,12 +4,11 @@ import process from 'node:process';
 import Handlebars from 'handlebars';
 import ipMatching from 'ip-matching';
 
-import { getIpFromRequest, getRealIpFromHeader } from '../express-common.js';
+import { getIpFromRequest } from '../express-common.js';
 import { color, getConfigValue, safeReadFileSync } from '../util.js';
 
 const whitelistPath = path.join(process.cwd(), './whitelist.txt');
 const enableForwardedWhitelist = getConfigValue('enableForwardedWhitelist', false);
-const preferRealIpHeader = getConfigValue('rateLimiting.preferRealIpHeader', false);
 let whitelist = getConfigValue('whitelist', []);
 let knownIPs = new Set();
 
@@ -59,7 +58,7 @@ export default function whitelistMiddleware(whitelistMode, listen) {
     );
 
     return function (req, res, next) {
-        const clientIp = preferRealIpHeader && !whitelistMode ? getRealIpFromHeader(req) : getIpFromRequest(req);
+        const clientIp = getIpFromRequest(req);
         const forwardedIp = getForwardedIp(req);
         const userAgent = req.headers['user-agent'];
 

--- a/src/middleware/whitelist.js
+++ b/src/middleware/whitelist.js
@@ -31,6 +31,11 @@ function getForwardedIp(req) {
         return undefined;
     }
 
+    // Check if X-Real-IP is available
+    if (req.headers['x-real-ip']) {
+        return req.headers['x-real-ip'].toString();
+    }
+
     // Check for X-Forwarded-For and parse if available
     if (req.headers['x-forwarded-for']) {
         const ipList = req.headers['x-forwarded-for'].toString().split(',').map(ip => ip.trim());

--- a/src/middleware/whitelist.js
+++ b/src/middleware/whitelist.js
@@ -31,11 +31,6 @@ function getForwardedIp(req) {
         return undefined;
     }
 
-    // Check if X-Real-IP is available
-    if (req.headers['x-real-ip']) {
-        return req.headers['x-real-ip'].toString();
-    }
-
     // Check for X-Forwarded-For and parse if available
     if (req.headers['x-forwarded-for']) {
         const ipList = req.headers['x-forwarded-for'].toString().split(',').map(ip => ip.trim());

--- a/src/middleware/whitelist.js
+++ b/src/middleware/whitelist.js
@@ -4,11 +4,12 @@ import process from 'node:process';
 import Handlebars from 'handlebars';
 import ipMatching from 'ip-matching';
 
-import { getIpFromRequest } from '../express-common.js';
+import { getIpFromRequest, getRealIpFromHeader } from '../express-common.js';
 import { color, getConfigValue, safeReadFileSync } from '../util.js';
 
 const whitelistPath = path.join(process.cwd(), './whitelist.txt');
 const enableForwardedWhitelist = getConfigValue('enableForwardedWhitelist', false);
+const preferRealIpHeader = getConfigValue('rateLimiting.preferRealIpHeader', false);
 let whitelist = getConfigValue('whitelist', []);
 let knownIPs = new Set();
 
@@ -58,7 +59,7 @@ export default function whitelistMiddleware(whitelistMode, listen) {
     );
 
     return function (req, res, next) {
-        const clientIp = getIpFromRequest(req);
+        const clientIp = preferRealIpHeader && !whitelistMode ? getRealIpFromHeader(req) : getIpFromRequest(req);
         const forwardedIp = getForwardedIp(req);
         const userAgent = req.headers['user-agent'];
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

---

### Why is this change needed?
When running SillyTavern behind a reverse proxy (like Nginx, Traefik, or Caddy), the application sees the proxy's IP address instead of the actual client IP for rate limiting. 
This can cause issues where all users behind the same proxy share the same rate limit quota.

### What did you do to achieve this?

#### Changes

1. In `config.yaml`:
- Added new `rateLimiting` configuration section
- Introduced `preferRealIpHeader` option (default: false) to enable X-Real-IP header usage

2. In `src/express-common.js`:
- Added new `getRealIpFromHeader` function to handle X-Real-IP header parsing
- Maintains fallback to socket IP if header is not present

3. In `src/endpoints/users-public.js`:
- Implemented configurable IP resolution using `getIpAddress` helper
- Updated all rate limiting checks to use the new IP resolution method


### How would a reviewer test the change?


#### With reverse proxy and correctly set X-Real-IP to the correct Client ip (remote_addr, CF-Connecting-IP)

1. Test Rate Limiting:
   - Set `rateLimiting.preferRealIpHeader: true` in config
   - Attempt multiple rapid login failed attempts
   - Verify rate limiting works per actual client IP, not proxy IP
   - Verify rate limiting works when user forge a fake X-Real-IP header

2. Check Logging:
   - Verify correct client IPs appear in rate limiting logs
   - Confirm error messages show actual client IP instead of proxy IP

---

Related Issue: #3503 