### PR TITLE
Update reasoning block coloring to CSS vars

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -55,8 +55,9 @@
     --interactable-outline-color: var(--white100);
     --interactable-outline-color-faint: var(--white20a);
 
-    --reasoning-mix-rate: 50%;
-    --reasoning-mix-color: var(--grey30);
+    --reasoning-body-color: var(--SmartThemeEmColor);
+    --reasoning-em-color: color-mix(in srgb, var(--SmartThemeEmColor) 67%, var(--SmartThemeBlurTintColor) 33%);
+    --reasoning-saturation: 0.5;
 
 
     /*Default Theme, will be changed by ToolCool Color Picker*/
@@ -351,13 +352,13 @@ input[type='checkbox']:focus-visible {
 
 .mes_reasoning {
     display: block;
-    border-left: 2px solid var(--SmartThemeEmColor);
+    border-left: 2px solid var(--reasoning-body-color);
     border-radius: 2px;
     padding: 5px;
     padding-left: 14px;
     margin-bottom: 0.5em;
     overflow-y: auto;
-    color: color-mix(in srgb, var(--SmartThemeBodyColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
+    color: hsl(from var(--reasoning-body-color) h calc(s * var(--reasoning-saturation)) l);
 }
 
 .mes_reasoning_details {
@@ -457,7 +458,7 @@ input[type='checkbox']:focus-visible {
 }
 .mes_reasoning i,
 .mes_reasoning em {
-    color: color-mix(in srgb, var(--SmartThemeEmColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
+    color: hsl(from var(--reasoning-em-color) h calc(s * var(--reasoning-saturation)) l);
 }
 
 .mes_text q i,
@@ -466,21 +467,21 @@ input[type='checkbox']:focus-visible {
 }
 .mes_reasoning q i,
 .mes_reasoning q em {
-    color: color-mix(in srgb, var(--SmartThemeQuoteColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
+    color: hsl(from var(--SmartThemeQuoteColor) h calc(s * var(--reasoning-saturation)) l);
 }
 
 .mes_text u {
     color: var(--SmartThemeUnderlineColor);
 }
 .mes_reasoning u {
-    color: color-mix(in srgb, var(--SmartThemeUnderlineColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
+    color: hsl(from var(--SmartThemeUnderlineColor) h calc(s * var(--reasoning-saturation)) l);
 }
 
 .mes_text q {
     color: var(--SmartThemeQuoteColor);
 }
 .mes_reasoning q {
-    color: color-mix(in srgb, var(--SmartThemeQuoteColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
+    color: hsl(from var(--SmartThemeQuoteColor) h calc(s * var(--reasoning-saturation)) l);
 }
 
 .mes_text font[color] em,

--- a/public/style.css
+++ b/public/style.css
@@ -55,6 +55,9 @@
     --interactable-outline-color: var(--white100);
     --interactable-outline-color-faint: var(--white20a);
 
+    --reasoning-mix-rate: 50%;
+    --reasoning-mix-color: var(--grey30);
+
 
     /*Default Theme, will be changed by ToolCool Color Picker*/
     --SmartThemeBodyColor: rgb(220, 220, 210);
@@ -354,7 +357,7 @@ input[type='checkbox']:focus-visible {
     padding-left: 14px;
     margin-bottom: 0.5em;
     overflow-y: auto;
-    color: var(--SmartThemeEmColor);
+    color: color-mix(in srgb, var(--SmartThemeBodyColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
 }
 
 .mes_reasoning_details {
@@ -372,18 +375,6 @@ input[type='checkbox']:focus-visible {
 
 .mes_reasoning *:last-child {
     margin-bottom: 0;
-}
-
-.mes_reasoning em,
-.mes_reasoning i,
-.mes_reasoning u,
-.mes_reasoning q,
-.mes_reasoning blockquote {
-    filter: saturate(0.5);
-}
-
-.mes_reasoning_details .mes_reasoning em {
-    color: color-mix(in srgb, var(--SmartThemeEmColor) 67%, var(--SmartThemeBlurTintColor) 33%);
 }
 
 .mes_reasoning_header_block {
@@ -461,25 +452,35 @@ input[type='checkbox']:focus-visible {
 }
 
 .mes_text i,
-.mes_text em,
+.mes_text em {
+    color: var(--SmartThemeEmColor);
+}
 .mes_reasoning i,
 .mes_reasoning em {
-    color: var(--SmartThemeEmColor);
+    color: color-mix(in srgb, var(--SmartThemeEmColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
 }
 
 .mes_text q i,
 .mes_text q em {
     color: inherit;
 }
-
-.mes_text u,
-.mes_reasoning u {
-    color: var(--SmartThemeUnderlineColor);
+.mes_reasoning q i,
+.mes_reasoning q em {
+    color: color-mix(in srgb, var(--SmartThemeQuoteColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
 }
 
-.mes_text q,
-.mes_reasoning q {
+.mes_text u {
+    color: var(--SmartThemeUnderlineColor);
+}
+.mes_reasoning u {
+    color: color-mix(in srgb, var(--SmartThemeUnderlineColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
+}
+
+.mes_text q {
     color: var(--SmartThemeQuoteColor);
+}
+.mes_reasoning q {
+    color: color-mix(in srgb, var(--SmartThemeQuoteColor) var(--reasoning-mix-rate), var(--reasoning-mix-color));
 }
 
 .mes_text font[color] em,


### PR DESCRIPTION
Changed reasoning block coloring from `filter: saturate(50%)` to using `hsl` and CSS variables to do the actual saturation.

This will fix images, smiley and co from being desaturated when being in the reasoning block.

The colors are changeable via CSS, and follow the theme. three new values were added:

- `--reasoning-saturation`
  Defines the base saturation level of the original colors. Set to `0.5` by default.
- `--reasoning-body-color`
  Overrides the main body color of the reasoning block (also coloring the left bar/border highlighting the reasoning block)
  This mainly exists because default body color is usually white, not being able to be saturated. Set to `--SmartThemeEmColor` by default.
- `--reasoning-em-color`
  Because the main reasoning color is the default em color, this is a separate variable, defining reasoning em. Same as before this PR, it's a color-mix of the original em and the tint color. Didn't have a better idea.

The coloring is **exactly** like before, just more easily CSS-changeable now, and images, smileys blah work now.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=ViaxRQ3zThA).
