### PR TITLE
Fix hidden reasoning models blocking auto-parsing from working

### DIFF
--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -338,14 +338,15 @@ export class ReasoningHandler {
             return mesChanged;
         }
 
-        if (this.state === ReasoningState.None) {
+        if (this.state === ReasoningState.None || this.#isHiddenReasoningModel) {
             // If streamed message starts with the opening, cut it out and put all inside reasoning
             if (message.mes.startsWith(power_user.reasoning.prefix) && message.mes.length > power_user.reasoning.prefix.length) {
                 this.#isParsingReasoning = true;
 
                 // Manually set starting state here, as we might already have received the ending suffix
                 this.state = ReasoningState.Thinking;
-                this.startTime = this.initialTime;
+                this.startTime = this.startTime ?? this.initialTime;
+                this.endTime = null;
             }
         }
 


### PR DESCRIPTION
Not considering whether it is actually a good idea to tell a model that already does internal reasoning to output reasoning via the reasoning blocks/parsing, this should work.

This fix keeps the existing functionality intact, not really changing much.

Before, the auto parse only checked for the reasoning prefix when the ReasoningHandler didn't have a state - which was already set to "Hidden" for the hidden reasoning models.
Now the check will also allow checking on prefix when the model is defines via `isHiddenReasoningModel`.

The rest of the requirements are still there.

Minor additional change is to keep the start time when one already exists and reset the end time, so that the parsing after hidden reasoning will calculate the whole timespan of both for the reasoning duration.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=ViaxRQ3zThA).
