### PR TITLE
Optimize Dockerfile to use `apk add` with `--no-cache`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:lts-alpine3.19
 ARG APP_HOME=/home/node/app
 
 # Install system dependencies
-RUN apk add gcompat tini git
+RUN apk add --no-cache gcompat tini git
 
 # Create app directory
 WORKDIR ${APP_HOME}


### PR DESCRIPTION
Using the `apk add` command with the `--no-cache` parameter for package installation will prevent the package index from being cached and reduce the image size.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
