### PR TITLE
Assorted summary improvements

### DIFF
--- a/public/scripts/extensions/memory/settings.html
+++ b/public/scripts/extensions/memory/settings.html
@@ -10,16 +10,18 @@
         <div class="inline-drawer-content">
             <div id="summaryExtensionDrawerContents">
                 <label for="summary_source" data-i18n="ext_sum_with">Summarize with:</label>
-                <select id="summary_source">
+                <select id="summary_source" class="text_pole">
                     <option value="main" data-i18n="ext_sum_main_api">Main API</option>
                     <option value="extras">Extras API (deprecated)</option>
                     <option value="webllm" data-i18n="ext_sum_webllm">WebLLM Extension</option>
                 </select><br>
 
                 <div class="flex-container justifyspacebetween alignitemscenter">
-                    <span class="flex1" data-i18n="ext_sum_current_summary">Current summary:</span>
-                    <div id="memory_restore" class="menu_button flex1 margin0" data-i18n="[title]ext_sum_restore_tip" title="Restore a previous summary; use repeatedly to clear summarization state for this chat.">
-                        <span data-i18n="ext_sum_restore_previous">Restore Previous</span>
+                    <span data-i18n="ext_sum_current_summary">Current summary:</span>
+                    <i class="editor_maximize fa-solid fa-maximize right_menu_button" data-for="memory_contents" title="Expand the editor" data-i18n="[title]Expand the editor"></i>
+                    <span class="flex1">&nbsp;</span>
+                    <div id="memory_restore" class="menu_button margin0" data-i18n="[title]ext_sum_restore_tip" title="Restore a previous summary; use repeatedly to clear summarization state for this chat.">
+                        <small data-i18n="ext_sum_restore_previous">Restore Previous</small>
                     </div>
                 </div>
 

--- a/public/scripts/extensions/memory/style.css
+++ b/public/scripts/extensions/memory/style.css
@@ -12,11 +12,6 @@
     width: max-content;
 }
 
-#memory_settings textarea {
-    font-size: calc(var(--mainFontSize) * 0.9);
-    line-height: 1.2;
-}
-
 label[for="memory_frozen"],
 label[for="memory_skipWIAN"] {
     display: flex;

--- a/public/scripts/extensions/memory/style.css
+++ b/public/scripts/extensions/memory/style.css
@@ -3,6 +3,15 @@
     flex-direction: column;
 }
 
+#memory_contents {
+    field-sizing: content;
+    max-height: 50dvh;
+}
+
+#memory_restore {
+    width: max-content;
+}
+
 #memory_settings textarea {
     font-size: calc(var(--mainFontSize) * 0.9);
     line-height: 1.2;
@@ -34,4 +43,10 @@ label[for="memory_frozen"] input {
     display: flex;
     flex-direction: column;
     row-gap: 5px;
+}
+
+#summaryExtensionPopout {
+    display: flex;
+    flex-direction: column;
+    padding-top: 25px;
 }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Fixed previous summary sometimes not being restored on chat change by decoupling chat changed event handler from message update events.
2. Fixed popup summary not being scrollable when the height overflows the screen.
3. Fixed source-specific controls not being updated when the source is switched in popout.
4. Fixed event off/on handler types mismatch on controls setup.
5. Adds an ability to generate summary for neutral chat (Assistant).
6. Adds "expand editor" button for summary and dynamic height for summary content for supported browsers.
7. Removes unneeded memoization of last chat/group/character id. This is now fully covered by the event handling.
8. Updates message edit summarization handler to use MESSAGE_UPDATED event (when the edit was rendered).
9. Fixes a couple of tiny type errors.
10. Other, almost unnoticable, stylistic updates.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
