### PR TITLE
Fix syncing swipe data on reasoning parse & utility function to sync swipe data

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6120,7 +6120,7 @@ export function syncMesToSwipe(messageId = null) {
     }
 
     const targetSwipeInfo = targetMessage.swipe_info[targetMessage.swipe_id];
-    if (!targetSwipeInfo || typeof targetSwipeInfo !== 'object') {
+    if (typeof targetSwipeInfo !== 'object') {
         return false;
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -6436,6 +6436,7 @@ export function saveChatDebounced() {
     if (chatSaveTimeout) {
         console.debug('Clearing chat save timeout');
         clearTimeout(chatSaveTimeout);
+        chatSaveTimeout = null;
     }
 
     chatSaveTimeout = setTimeout(async () => {
@@ -6452,7 +6453,7 @@ export function saveChatDebounced() {
         console.debug('Chat save timeout triggered');
         await saveChatConditional();
         console.debug('Chat saved');
-    }, 1000);
+    }, DEFAULT_SAVE_EDIT_TIMEOUT);
 }
 
 export async function saveChat(chatName, withMetadata, mesId) {
@@ -8067,6 +8068,12 @@ export async function saveChatConditional() {
     }
 
     try {
+        if (chatSaveTimeout) {
+            console.debug('Debounced chat save canceled');
+            clearTimeout(chatSaveTimeout);
+            chatSaveTimeout = null;
+        }
+
         isChatSaving = true;
 
         if (selected_group) {

--- a/public/script.js
+++ b/public/script.js
@@ -6099,7 +6099,7 @@ export function syncMesToSwipe(messageId = null) {
     }
 
     const targetMessageId = messageId ?? chat.length - 1;
-    if (chat.length > targetMessageId) {
+    if (chat.length > targetMessageId || targetMessageId < 0) {
         console.warn(`[syncMesToSwipe] Invalid message ID: ${messageId}`);
         return false;
     }
@@ -6120,7 +6120,7 @@ export function syncMesToSwipe(messageId = null) {
     }
 
     const targetSwipeInfo = targetMessage.swipe_info[targetMessage.swipe_id];
-    if (typeof targetSwipeInfo !== 'object') {
+    if (!targetSwipeInfo || typeof targetSwipeInfo !== 'object') {
         return false;
     }
 

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1048,7 +1048,7 @@ function registerReasoningAppEvents() {
 
         if (contentUpdated) {
             syncMesToSwipe();
-            await saveChatConditional();
+            saveChatDebounced();
 
             // Find if a message already exists in DOM and must be updated
             const messageRendered = document.querySelector(`.mes[mesid="${idx}"]`) !== null;

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1048,6 +1048,7 @@ function registerReasoningAppEvents() {
 
         if (contentUpdated) {
             syncMesToSwipe();
+            saveChatDebounced();
 
             // Find if a message already exists in DOM and must be updated
             const messageRendered = document.querySelector(`.mes[mesid="${idx}"]`) !== null;

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -998,7 +998,7 @@ function parseReasoningFromString(str, { strict = true } = {}) {
 }
 
 function registerReasoningAppEvents() {
-    const eventHandler = async (/** @type {number} */ idx) => {
+    const eventHandler = (/** @type {number} */ idx) => {
         if (!power_user.reasoning.auto_parse) {
             return;
         }

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1,7 +1,7 @@
 import {
     moment,
 } from '../lib.js';
-import { chat, closeMessageEditor, event_types, eventSource, main_api, messageFormatting, saveChatConditional, saveChatDebounced, saveSettingsDebounced, substituteParams, updateMessageBlock } from '../script.js';
+import { chat, closeMessageEditor, event_types, eventSource, main_api, messageFormatting, saveChatConditional, saveChatDebounced, saveSettingsDebounced, substituteParams, syncMesToSwipe, updateMessageBlock } from '../script.js';
 import { getRegexedString, regex_placement } from './extensions/regex/engine.js';
 import { getCurrentLocale, t, translate } from './i18n.js';
 import { MacrosParser } from './macros.js';
@@ -1046,8 +1046,10 @@ function registerReasoningAppEvents() {
             message.mes = parsedReasoning.content;
         }
 
-        // Find if a message already exists in DOM and must be updated
         if (contentUpdated) {
+            syncMesToSwipe();
+
+            // Find if a message already exists in DOM and must be updated
             const messageRendered = document.querySelector(`.mes[mesid="${idx}"]`) !== null;
             if (messageRendered) {
                 console.debug('[Reasoning] Updating message block', idx);

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -998,7 +998,7 @@ function parseReasoningFromString(str, { strict = true } = {}) {
 }
 
 function registerReasoningAppEvents() {
-    const eventHandler = (/** @type {number} */ idx) => {
+    const eventHandler = async (/** @type {number} */ idx) => {
         if (!power_user.reasoning.auto_parse) {
             return;
         }
@@ -1048,7 +1048,7 @@ function registerReasoningAppEvents() {
 
         if (contentUpdated) {
             syncMesToSwipe();
-            saveChatDebounced();
+            await saveChatConditional();
 
             // Find if a message already exists in DOM and must be updated
             const messageRendered = document.querySelector(`.mes[mesid="${idx}"]`) !== null;

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -42,7 +42,7 @@ import {
     showMoreMessages,
     stopGeneration,
     substituteParams,
-    syncCurrentSwipeInfoExtras,
+    syncMesToSwipe,
     system_avatar,
     system_message_types,
     this_chid,
@@ -2921,7 +2921,7 @@ async function addSwipeCallback(args, value) {
 
     if (isTrueBoolean(args.switch)) {
         // Make sure ad-hoc changes to extras are saved before swiping away
-        syncCurrentSwipeInfoExtras();
+        syncMesToSwipe();
         lastMessage.swipe_id = newSwipeId;
         lastMessage.mes = lastMessage.swipes[newSwipeId];
         lastMessage.extra = structuredClone(lastMessage.swipe_info?.[newSwipeId]?.extra ?? lastMessage.extra ?? {});


### PR DESCRIPTION
Too often it was hard to decide when and what to sync to swipes data. Sometimes it happened automatically, sometimes it didn't. We even had recent fixes, that added the base function here that I reworked.
Not really feasible to rework all of swipes or rethink the process, but let's provide an exported function you can use that just updates all swipe-relevant data and saves.

This was mostly done because I noticed on checking #3507 that there is a high chance on streaming events reasoning would be parsed **after** the swipes data was already synced and filled. Which was too late, unless you update it again.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=ViaxRQ3zThA).
