### PR TITLE
Show forwarded IP in whitelist denied message

### DIFF
--- a/src/middleware/whitelist.js
+++ b/src/middleware/whitelist.js
@@ -86,7 +86,7 @@ export default function whitelistMiddleware(whitelistMode, listen) {
                 : clientIp;
             console.warn(
                 color.red(
-                    `Blocked connection from ${clientIp}; User Agent: ${userAgent}\n\tTo allow this connection, add its IP address to the whitelist or disable whitelist mode by editing config.yaml in the root directory of your SillyTavern installation.\n`,
+                    `Blocked connection from ${ipDetails}; User Agent: ${userAgent}\n\tTo allow this connection, add its IP address to the whitelist or disable whitelist mode by editing config.yaml in the root directory of your SillyTavern installation.\n`,
                 ),
             );
             return res.status(403).send(forbiddenWebpage({ ipDetails }));


### PR DESCRIPTION
Show the forwarded IP address in the log when whitelist denies access.

I spent quite a long time trying to fix some nginx headers that weren't broken because I couldn't see the forwarded IP

## Checklist:

- [X ] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
