### PR TITLE
Show forwarded IP in whitelist denied message

### DIFF
--- a/src/middleware/whitelist.js
+++ b/src/middleware/whitelist.js
@@ -75,7 +75,7 @@ export default function whitelistMiddleware() {
             if (!noLogPaths.includes(req.path)) {
                 console.warn(
                     color.red(
-                        `Blocked connection from ${clientIp}; User Agent: ${userAgent}\n\tTo allow this connection, add its IP address to the whitelist or disable whitelist mode by editing config.yaml in the root directory of your SillyTavern installation.\n`,
+                        `Blocked connection from ${ipDetails}; User Agent: ${userAgent}\n\tTo allow this connection, add its IP address to the whitelist or disable whitelist mode by editing config.yaml in the root directory of your SillyTavern installation.\n`,
                     ),
                 );
             }


### PR DESCRIPTION
Show the forwarded IP address in the log when the IP is rejected due to the whitelist

## Checklist:

- [ X ] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
