### PR TITLE
Generic generate methods

### DIFF
--- a/default/content/presets/openai/Default.json
+++ b/default/content/presets/openai/Default.json
@@ -28,7 +28,6 @@
     "wrap_in_quotes": false,
     "names_behavior": 0,
     "send_if_empty": "",
-    "jailbreak_system": false,
     "impersonation_prompt": "[Write your next reply from the point of view of {{user}}, using the chat history so far as a guideline for the writing style of {{user}}. Don't write as {{char}} or system. Don't describe actions of {{char}}.]",
     "new_chat_prompt": "[Start a new Chat]",
     "new_group_chat_prompt": "[Start a new group chat. Group members: {{group}}]",

--- a/default/content/settings.json
+++ b/default/content/settings.json
@@ -626,7 +626,6 @@
         "ai21_model": "jamba-1.5-large",
         "windowai_model": "",
         "openrouter_model": "OR_Website",
-        "jailbreak_system": true,
         "reverse_proxy": "",
         "chat_completion_source": "openai",
         "max_context_unlocked": false,

--- a/public/script.js
+++ b/public/script.js
@@ -5643,7 +5643,7 @@ export async function sendStreamingRequest(type, data) {
  * @returns {string} Generation URL
  * @throws {Error} If the API is unknown
  */
-function getGenerateUrl(api) {
+export function getGenerateUrl(api) {
     switch (api) {
         case 'kobold':
             return '/api/backends/kobold/generate';

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -1,5 +1,5 @@
 import { getPresetManager } from "./preset-manager.js";
-import { getGenerateUrl, getRequestHeaders } from "../script.js";
+import { extractMessageFromData, getGenerateUrl, getRequestHeaders } from "../script.js";
 import { getTextGenServer } from "./textgen-settings.js";
 
 // #region Type Definitions
@@ -18,6 +18,8 @@ import { getTextGenServer } from "./textgen-settings.js";
  * Creates & sends a text completion request. Streaming is not supported.
  */
 export class TextCompletionService {
+    static TYPE = 'textgenerationwebui';
+
     /**
      * @param {TextCompletionRequest} custom
      * @returns {TextCompletionPayload}
@@ -39,9 +41,12 @@ export class TextCompletionService {
     /**
      * Sends a text completion request to the specified server
      * @param {TextCompletionPayload} data Request data
+     * @param {boolean?} extractData Extract message from the response. Default true
+     * @returns {Promise<string | any>} Extracted data or the raw response
+     * @throws {Error}
      */
-    static async sendRequest(data) {
-        const response = await fetch(getGenerateUrl('textgenerationwebui'), {
+    static async sendRequest(data, extractData = true) {
+        const response = await fetch(getGenerateUrl(this.TYPE), {
             method: 'POST',
             headers: getRequestHeaders(),
             cache: 'no-cache',
@@ -53,17 +58,19 @@ export class TextCompletionService {
             throw await response.json();
         }
 
-        return await response.json();
+        const json = await response.json();
+        return extractData ? extractMessageFromData(json, this.TYPE) : json;
     }
 
     /**
      * @param {string} presetName
      * @param {TextCompletionRequest} custom
-     * @returns {Promise<any | null>}
+     * @param {boolean?} extractData Extract message from the response. Default true
+     * @returns {Promise<string | any>} Extracted data or the raw response
      * @throws {Error}
      */
-    static async sendRequestWithPreset(presetName, custom) {
-        const presetManager = getPresetManager('textgenerationwebui');
+    static async sendRequestWithPreset(presetName, custom, extractData = true) {
+        const presetManager = getPresetManager(this.TYPE);
         if (!presetManager) {
             throw new Error('Preset manager not found');
         }
@@ -75,7 +82,7 @@ export class TextCompletionService {
 
         const data = this.createRequestData({ ...preset, ...custom });
 
-        return await this.sendRequest(data);
+        return await this.sendRequest(data, extractData);
     }
 }
 
@@ -83,6 +90,8 @@ export class TextCompletionService {
  * Creates & sends a chat completion request. Streaming is not supported.
  */
 export class ChatCompletionService {
+    static TYPE = 'openai';
+
     /**
      * @param {ChatCompletionPayload} custom
      * @returns {ChatCompletionPayload}
@@ -102,8 +111,11 @@ export class ChatCompletionService {
     /**
      * Sends a chat completion request
      * @param {ChatCompletionPayload} data Request data
+     * @param {boolean?} extractData Extract message from the response. Default true
+     * @returns {Promise<string | any>} Extracted data or the raw response
+     * @throws {Error}
      */
-    static async sendRequest(data) {
+    static async sendRequest(data, extractData = true) {
         const response = await fetch('/api/backends/chat-completions/generate', {
             method: 'POST',
             headers: getRequestHeaders(),
@@ -116,17 +128,19 @@ export class ChatCompletionService {
             throw await response.json();
         }
 
-        return await response.json();
+        const json = await response.json();
+        return extractData ? extractMessageFromData(json, this.TYPE) : json;
     }
 
     /**
      * @param {string} presetName
      * @param {ChatCompletionPayload} custom
-     * @returns {Promise<any | null>}
+     * @param {boolean} extractData Extract message from the response. Default true
+     * @returns {Promise<string | any>} Extracted data or the raw response
      * @throws {Error}
      */
-    static async sendRequestWithPreset(presetName, custom) {
-        const presetManager = getPresetManager('openai');
+    static async sendRequestWithPreset(presetName, custom, extractData = true) {
+        const presetManager = getPresetManager(this.TYPE);
         if (!presetManager) {
             throw new Error('Preset manager not found');
         }
@@ -138,6 +152,6 @@ export class ChatCompletionService {
 
         const data = this.createRequestData({ ...preset, ...custom });
 
-        return await this.sendRequest(data);
+        return await this.sendRequest(data, extractData);
     }
 }

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -4,35 +4,19 @@ import { getTextGenServer } from './textgen-settings.js';
 
 // #region Type Definitions
 /**
- * @typedef {{
- *   prompt: string,
- *   max_tokens: number,
- *   model?: string,
- *   api_type: string,
- *   api_server?: string,
- *   temperature?: number,
- *   [key: string]: any
- * }} TextCompletionRequest
+ * @typedef {Object} TextCompletionRequestBase
  * @property {string} prompt - The text prompt for completion
  * @property {number} max_tokens - Maximum number of tokens to generate
  * @property {string} [model] - Optional model name
  * @property {string} api_type - Type of API to use
  * @property {string} [api_server] - Optional API server URL
  * @property {number} [temperature] - Optional temperature parameter
- * @property {any} [key] - Any additional properties
  */
 
+/** @typedef {Record<string, any> & TextCompletionRequestBase} TextCompletionRequest */
+
 /**
- * @typedef {{
- *   prompt: string,
- *   max_tokens: number,
- *   max_new_tokens: number,
- *   model?: string,
- *   api_type: string,
- *   api_server: string,
- *   temperature?: number,
- *   [key: string]: any
- * }} TextCompletionPayload
+ * @typedef {Object} TextCompletionPayloadBase
  * @property {string} prompt - The text prompt for completion
  * @property {number} max_tokens - Maximum number of tokens to generate
  * @property {number} max_new_tokens - Alias for max_tokens
@@ -40,34 +24,26 @@ import { getTextGenServer } from './textgen-settings.js';
  * @property {string} api_type - Type of API to use
  * @property {string} api_server - API server URL
  * @property {number} [temperature] - Optional temperature parameter
- * @property {any} [key] - Any additional properties
  */
 
+/** @typedef {Record<string, any> & TextCompletionPayloadBase} TextCompletionPayload */
+
 /**
- * @typedef {{
- *   role: string,
- *   content: string
- * }} ChatCompletionMessage
+ * @typedef {Object} ChatCompletionMessage
  * @property {string} role - The role of the message author (e.g., "user", "assistant", "system")
  * @property {string} content - The content of the message
  */
 
 /**
- * @typedef {{
- *   messages: ChatCompletionMessage[],
- *   model?: string,
- *   chat_completion_source: string,
- *   max_tokens: number,
- *   temperature?: number,
- *   [key: string]: any
- * }} ChatCompletionPayload
+ * @typedef {Object} ChatCompletionPayloadBase
  * @property {ChatCompletionMessage[]} messages - Array of chat messages
  * @property {string} [model] - Optional model name to use for completion
  * @property {string} chat_completion_source - Source provider for chat completion
  * @property {number} max_tokens - Maximum number of tokens to generate
- * @property {number} [temperature] - Optional temperature parameter
- * @property {any} [key] - Any additional properties
+ * @property {number} [temperature] - Optional temperature parameter for response randomness
  */
+
+/** @typedef {Record<string, any> & ChatCompletionPayloadBase} ChatCompletionPayload */
 // #endregion
 
 /**

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -1,16 +1,44 @@
-import { getPresetManager } from "./preset-manager.js";
-import { getGenerateUrl, getRequestHeaders } from "../script.js";
-import { getTextGenServer } from "./textgen-settings.js";
+import { getPresetManager } from './preset-manager.js';
+import { getGenerateUrl, getRequestHeaders } from '../script.js';
+import { getTextGenServer } from './textgen-settings.js';
 
 // #region Type Definitions
 /**
- * @typedef {{prompt: string, max_tokens: number, model?: string, api_type: string, api_server?: string, temperature?: number, [key: string]: any}} TextCompletionRequest
- * @typedef {{prompt: string, max_tokens: number, max_new_tokens: number, model?: string, api_type: string, api_server: string, temperature?: number, [key: string]: any}} TextCompletionPayload
+ * @typedef {{[key: string]: any}} TextCompletionRequest
+ * @property {string} prompt - The text prompt for completion
+ * @property {number} max_tokens - Maximum number of tokens to generate
+ * @property {string} [model] - Optional model name
+ * @property {string} api_type - Type of API to use
+ * @property {string} [api_server] - Optional API server URL
+ * @property {number} [temperature] - Optional temperature parameter
  */
 
 /**
- * @typedef {{role: string, content: string}} ChatCompletionMessage
- * @typedef {{messages: ChatCompletionMessage[], model?: string, chat_completion_source: string, max_tokens: number, temperature?: number, [key: string]: any}} ChatCompletionPayload
+ * @typedef {{[key: string]: any}} TextCompletionPayload
+ * @property {string} prompt - The text prompt for completion
+ * @property {number} max_tokens - Maximum number of tokens to generate
+ * @property {number} max_new_tokens - Alias for max_tokens
+ * @property {string} [model] - Optional model name
+ * @property {string} api_type - Type of API to use
+ * @property {string} api_server - API server URL
+ * @property {number} [temperature] - Optional temperature parameter
+ */
+
+/**
+ * @typedef {Object} ChatCompletionMessage
+ * @property {string} role - The role of the message author (e.g., "user", "assistant", "system")
+ * @property {string} content - The content of the message
+ */
+
+/**
+ * @typedef {Object} ChatCompletionPayload
+ * @property {ChatCompletionMessage[]} messages - Array of chat messages
+ * @property {string} [model] - Optional model name to use for completion
+ * @property {string} chat_completion_source - Source provider for chat completion
+ * @property {number} max_tokens - Maximum number of tokens to generate
+ * @property {number} [temperature] - Optional temperature parameter for response randomness
+ * @property {boolean} [stream] - Whether to stream the response (false by default)
+ * @property {any} [key] - Any additional properties
  */
 // #endregion
 

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -4,17 +4,35 @@ import { getTextGenServer } from './textgen-settings.js';
 
 // #region Type Definitions
 /**
- * @typedef {{[key: string]: any}} TextCompletionRequest
+ * @typedef {{
+ *   prompt: string,
+ *   max_tokens: number,
+ *   model?: string,
+ *   api_type: string,
+ *   api_server?: string,
+ *   temperature?: number,
+ *   [key: string]: any
+ * }} TextCompletionRequest
  * @property {string} prompt - The text prompt for completion
  * @property {number} max_tokens - Maximum number of tokens to generate
  * @property {string} [model] - Optional model name
  * @property {string} api_type - Type of API to use
  * @property {string} [api_server] - Optional API server URL
  * @property {number} [temperature] - Optional temperature parameter
+ * @property {any} [key] - Any additional properties
  */
 
 /**
- * @typedef {{[key: string]: any}} TextCompletionPayload
+ * @typedef {{
+ *   prompt: string,
+ *   max_tokens: number,
+ *   max_new_tokens: number,
+ *   model?: string,
+ *   api_type: string,
+ *   api_server: string,
+ *   temperature?: number,
+ *   [key: string]: any
+ * }} TextCompletionPayload
  * @property {string} prompt - The text prompt for completion
  * @property {number} max_tokens - Maximum number of tokens to generate
  * @property {number} max_new_tokens - Alias for max_tokens
@@ -22,22 +40,32 @@ import { getTextGenServer } from './textgen-settings.js';
  * @property {string} api_type - Type of API to use
  * @property {string} api_server - API server URL
  * @property {number} [temperature] - Optional temperature parameter
+ * @property {any} [key] - Any additional properties
  */
 
 /**
- * @typedef {Object} ChatCompletionMessage
+ * @typedef {{
+ *   role: string,
+ *   content: string
+ * }} ChatCompletionMessage
  * @property {string} role - The role of the message author (e.g., "user", "assistant", "system")
  * @property {string} content - The content of the message
  */
 
 /**
- * @typedef {Object} ChatCompletionPayload
+ * @typedef {{
+ *   messages: ChatCompletionMessage[],
+ *   model?: string,
+ *   chat_completion_source: string,
+ *   max_tokens: number,
+ *   temperature?: number,
+ *   [key: string]: any
+ * }} ChatCompletionPayload
  * @property {ChatCompletionMessage[]} messages - Array of chat messages
  * @property {string} [model] - Optional model name to use for completion
  * @property {string} chat_completion_source - Source provider for chat completion
  * @property {number} max_tokens - Maximum number of tokens to generate
- * @property {number} [temperature] - Optional temperature parameter for response randomness
- * @property {boolean} [stream] - Whether to stream the response (false by default)
+ * @property {number} [temperature] - Optional temperature parameter
  * @property {any} [key] - Any additional properties
  */
 // #endregion

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -1,6 +1,6 @@
 import { getPresetManager } from "./preset-manager.js";
 import { getGenerateUrl, getRequestHeaders } from "../script.js";
-import { DREAMGEN_SERVER, FEATHERLESS_SERVER, INFERMATICAI_SERVER, MANCER_SERVER, OPENROUTER_SERVER, textgen_types, textgenerationwebui_settings, TOGETHERAI_SERVER } from "./textgen-settings.js";
+import { getTextGenServer } from "./textgen-settings.js";
 
 // #region Type Definitions
 /**
@@ -14,31 +14,10 @@ import { DREAMGEN_SERVER, FEATHERLESS_SERVER, INFERMATICAI_SERVER, MANCER_SERVER
  */
 // #endregion
 
+/**
+ * Creates & sends a text completion request. Streaming is not supported.
+ */
 export class TextCompletionService {
-    /**
-     * Gets the API URL for the selected text generation type.
-     * @param {string} type
-     * @returns {string} API URL
-     */
-    static getApiUrl(type) {
-        switch (type) {
-            case textgen_types.FEATHERLESS:
-                return FEATHERLESS_SERVER;
-            case textgen_types.MANCER:
-                return MANCER_SERVER;
-            case textgen_types.TOGETHERAI:
-                return TOGETHERAI_SERVER;
-            case textgen_types.INFERMATICAI:
-                return INFERMATICAI_SERVER;
-            case textgen_types.DREAMGEN:
-                return DREAMGEN_SERVER;
-            case textgen_types.OPENROUTER:
-                return OPENROUTER_SERVER;
-            default:
-                return textgenerationwebui_settings.server_urls[type] ?? '';
-        }
-    }
-
     /**
      * @param {TextCompletionRequest} custom
      * @returns {TextCompletionPayload}
@@ -51,8 +30,9 @@ export class TextCompletionService {
             max_new_tokens: max_tokens,
             model,
             api_type,
-            api_server: api_server ?? this.getApiUrl(api_type),
+            api_server: api_server ?? getTextGenServer(api_type),
             temperature,
+            stream: false,
         };
     }
 
@@ -99,6 +79,9 @@ export class TextCompletionService {
     }
 }
 
+/**
+ * Creates & sends a chat completion request. Streaming is not supported.
+ */
 export class ChatCompletionService {
     /**
      * @param {ChatCompletionPayload} custom
@@ -112,6 +95,7 @@ export class ChatCompletionService {
             chat_completion_source,
             max_tokens,
             temperature,
+            stream: false,
         };
     }
 

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -1,0 +1,159 @@
+import { getPresetManager } from "./preset-manager.js";
+import { getGenerateUrl, getRequestHeaders } from "../script.js";
+import { DREAMGEN_SERVER, FEATHERLESS_SERVER, INFERMATICAI_SERVER, MANCER_SERVER, OPENROUTER_SERVER, textgen_types, textgenerationwebui_settings, TOGETHERAI_SERVER } from "./textgen-settings.js";
+
+// #region Type Definitions
+/**
+ * @typedef {{prompt: string, max_tokens: number, model?: string, api_type: string, api_server?: string, temperature?: number, [key: string]: any}} TextCompletionRequest
+ * @typedef {{prompt: string, max_tokens: number, max_new_tokens: number, model?: string, api_type: string, api_server: string, temperature?: number, [key: string]: any}} TextCompletionPayload
+ */
+
+/**
+ * @typedef {{role: string, content: string}} ChatCompletionMessage
+ * @typedef {{messages: ChatCompletionMessage[], model?: string, chat_completion_source: string, max_tokens: number, temperature?: number, [key: string]: any}} ChatCompletionPayload
+ */
+// #endregion
+
+export class TextCompletionService {
+    /**
+     * Gets the API URL for the selected text generation type.
+     * @param {string} type
+     * @returns {string} API URL
+     */
+    static getApiUrl(type) {
+        switch (type) {
+            case textgen_types.FEATHERLESS:
+                return FEATHERLESS_SERVER;
+            case textgen_types.MANCER:
+                return MANCER_SERVER;
+            case textgen_types.TOGETHERAI:
+                return TOGETHERAI_SERVER;
+            case textgen_types.INFERMATICAI:
+                return INFERMATICAI_SERVER;
+            case textgen_types.DREAMGEN:
+                return DREAMGEN_SERVER;
+            case textgen_types.OPENROUTER:
+                return OPENROUTER_SERVER;
+            default:
+                return textgenerationwebui_settings.server_urls[type] ?? '';
+        }
+    }
+
+    /**
+     * @param {TextCompletionRequest} custom
+     * @returns {TextCompletionPayload}
+     */
+    static createRequestData({ prompt, max_tokens, model, api_type, api_server, temperature, ...props }) {
+        return {
+            ...props,
+            prompt,
+            max_tokens,
+            max_new_tokens: max_tokens,
+            model,
+            api_type,
+            api_server: api_server ?? this.getApiUrl(api_type),
+            temperature,
+        };
+    }
+
+    /**
+     * Sends a text completion request to the specified server
+     * @param {TextCompletionPayload} data Request data
+     */
+    static async sendRequest(data) {
+        const response = await fetch(getGenerateUrl('textgenerationwebui'), {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            cache: 'no-cache',
+            body: JSON.stringify(data),
+            signal: new AbortController().signal,
+        });
+
+        if (!response.ok) {
+            throw await response.json();
+        }
+
+        return await response.json();
+    }
+
+    /**
+     * @param {string} presetName
+     * @param {TextCompletionRequest} custom
+     * @returns {Promise<any | null>}
+     * @throws {Error}
+     */
+    static async sendRequestWithPreset(presetName, custom) {
+        const presetManager = getPresetManager('textgenerationwebui');
+        if (!presetManager) {
+            throw new Error('Preset manager not found');
+        }
+
+        const preset = presetManager.getCompletionPresetByName(presetName);
+        if (!preset) {
+            throw new Error('Preset not found');
+        }
+
+        const data = this.createRequestData({ ...preset, ...custom });
+
+        return await this.sendRequest(data);
+    }
+}
+
+export class ChatCompletionService {
+    /**
+     * @param {ChatCompletionPayload} custom
+     * @returns {ChatCompletionPayload}
+     */
+    static createRequestData({ messages, model, chat_completion_source, max_tokens, temperature, ...props }) {
+        return {
+            ...props,
+            messages,
+            model,
+            chat_completion_source,
+            max_tokens,
+            temperature,
+        };
+    }
+
+    /**
+     * Sends a chat completion request
+     * @param {ChatCompletionPayload} data Request data
+     */
+    static async sendRequest(data) {
+        const response = await fetch('/api/backends/chat-completions/generate', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            cache: 'no-cache',
+            body: JSON.stringify(data),
+            signal: new AbortController().signal,
+        });
+
+        if (!response.ok) {
+            throw await response.json();
+        }
+
+        return await response.json();
+    }
+
+    /**
+     * @param {string} presetName
+     * @param {ChatCompletionPayload} custom
+     * @returns {Promise<any | null>}
+     * @throws {Error}
+     */
+    static async sendRequestWithPreset(presetName, custom) {
+        const presetManager = getPresetManager('openai');
+        if (!presetManager) {
+            throw new Error('Preset manager not found');
+        }
+
+        const preset = presetManager.getCompletionPresetByName(presetName);
+        if (!preset) {
+            throw new Error('Preset not found');
+        }
+
+        const data = this.createRequestData({ ...preset, ...custom });
+
+        return await this.sendRequest(data);
+    }
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -224,6 +224,88 @@ const sensitiveFields = [
     'custom_include_headers',
 ];
 
+/**
+ * preset_name -> [selector, setting_name, is_checkbox]
+ * @type {Record<string, [string, string, boolean]>}
+ */
+const settingsToUpdate = {
+    chat_completion_source: ['#chat_completion_source', 'chat_completion_source', false],
+    temperature: ['#temp_openai', 'temp_openai', false],
+    frequency_penalty: ['#freq_pen_openai', 'freq_pen_openai', false],
+    presence_penalty: ['#pres_pen_openai', 'pres_pen_openai', false],
+    top_p: ['#top_p_openai', 'top_p_openai', false],
+    top_k: ['#top_k_openai', 'top_k_openai', false],
+    top_a: ['#top_a_openai', 'top_a_openai', false],
+    min_p: ['#min_p_openai', 'min_p_openai', false],
+    repetition_penalty: ['#repetition_penalty_openai', 'repetition_penalty_openai', false],
+    max_context_unlocked: ['#oai_max_context_unlocked', 'max_context_unlocked', true],
+    openai_model: ['#model_openai_select', 'openai_model', false],
+    claude_model: ['#model_claude_select', 'claude_model', false],
+    windowai_model: ['#model_windowai_select', 'windowai_model', false],
+    openrouter_model: ['#model_openrouter_select', 'openrouter_model', false],
+    openrouter_use_fallback: ['#openrouter_use_fallback', 'openrouter_use_fallback', true],
+    openrouter_group_models: ['#openrouter_group_models', 'openrouter_group_models', false],
+    openrouter_sort_models: ['#openrouter_sort_models', 'openrouter_sort_models', false],
+    openrouter_providers: ['#openrouter_providers_chat', 'openrouter_providers', false],
+    openrouter_allow_fallbacks: ['#openrouter_allow_fallbacks', 'openrouter_allow_fallbacks', true],
+    openrouter_middleout: ['#openrouter_middleout', 'openrouter_middleout', false],
+    ai21_model: ['#model_ai21_select', 'ai21_model', false],
+    mistralai_model: ['#model_mistralai_select', 'mistralai_model', false],
+    cohere_model: ['#model_cohere_select', 'cohere_model', false],
+    perplexity_model: ['#model_perplexity_select', 'perplexity_model', false],
+    groq_model: ['#model_groq_select', 'groq_model', false],
+    nanogpt_model: ['#model_nanogpt_select', 'nanogpt_model', false],
+    deepseek_model: ['#model_deepseek_select', 'deepseek_model', false],
+    zerooneai_model: ['#model_01ai_select', 'zerooneai_model', false],
+    blockentropy_model: ['#model_blockentropy_select', 'blockentropy_model', false],
+    custom_model: ['#custom_model_id', 'custom_model', false],
+    custom_url: ['#custom_api_url_text', 'custom_url', false],
+    custom_include_body: ['#custom_include_body', 'custom_include_body', false],
+    custom_exclude_body: ['#custom_exclude_body', 'custom_exclude_body', false],
+    custom_include_headers: ['#custom_include_headers', 'custom_include_headers', false],
+    custom_prompt_post_processing: ['#custom_prompt_post_processing', 'custom_prompt_post_processing', false],
+    google_model: ['#model_google_select', 'google_model', false],
+    openai_max_context: ['#openai_max_context', 'openai_max_context', false],
+    openai_max_tokens: ['#openai_max_tokens', 'openai_max_tokens', false],
+    wrap_in_quotes: ['#wrap_in_quotes', 'wrap_in_quotes', true],
+    names_behavior: ['#names_behavior', 'names_behavior', false],
+    send_if_empty: ['#send_if_empty_textarea', 'send_if_empty', false],
+    impersonation_prompt: ['#impersonation_prompt_textarea', 'impersonation_prompt', false],
+    new_chat_prompt: ['#newchat_prompt_textarea', 'new_chat_prompt', false],
+    new_group_chat_prompt: ['#newgroupchat_prompt_textarea', 'new_group_chat_prompt', false],
+    new_example_chat_prompt: ['#newexamplechat_prompt_textarea', 'new_example_chat_prompt', false],
+    continue_nudge_prompt: ['#continue_nudge_prompt_textarea', 'continue_nudge_prompt', false],
+    bias_preset_selected: ['#openai_logit_bias_preset', 'bias_preset_selected', false],
+    reverse_proxy: ['#openai_reverse_proxy', 'reverse_proxy', false],
+    wi_format: ['#wi_format_textarea', 'wi_format', false],
+    scenario_format: ['#scenario_format_textarea', 'scenario_format', false],
+    personality_format: ['#personality_format_textarea', 'personality_format', false],
+    group_nudge_prompt: ['#group_nudge_prompt_textarea', 'group_nudge_prompt', false],
+    stream_openai: ['#stream_toggle', 'stream_openai', true],
+    prompts: ['', 'prompts', false],
+    prompt_order: ['', 'prompt_order', false],
+    api_url_scale: ['#api_url_scale', 'api_url_scale', false],
+    show_external_models: ['#openai_show_external_models', 'show_external_models', true],
+    proxy_password: ['#openai_proxy_password', 'proxy_password', false],
+    assistant_prefill: ['#claude_assistant_prefill', 'assistant_prefill', false],
+    assistant_impersonation: ['#claude_assistant_impersonation', 'assistant_impersonation', false],
+    claude_use_sysprompt: ['#claude_use_sysprompt', 'claude_use_sysprompt', true],
+    use_makersuite_sysprompt: ['#use_makersuite_sysprompt', 'use_makersuite_sysprompt', true],
+    use_alt_scale: ['#use_alt_scale', 'use_alt_scale', true],
+    squash_system_messages: ['#squash_system_messages', 'squash_system_messages', true],
+    image_inlining: ['#openai_image_inlining', 'image_inlining', true],
+    inline_image_quality: ['#openai_inline_image_quality', 'inline_image_quality', false],
+    continue_prefill: ['#continue_prefill', 'continue_prefill', true],
+    continue_postfix: ['#continue_postfix', 'continue_postfix', false],
+    function_calling: ['#openai_function_calling', 'function_calling', true],
+    show_thoughts: ['#openai_show_thoughts', 'show_thoughts', true],
+    reasoning_effort: ['#openai_reasoning_effort', 'reasoning_effort', false],
+    seed: ['#seed_openai', 'seed', false],
+    n: ['#n_openai', 'n', false],
+    jailbreak_system: ['#jailbreak_system', 'jailbreak_system', true],
+    bypass_status_check: ['#openai_bypass_status_check', 'bypass_status_check', true],
+};
+
 const default_settings = {
     preset_settings_openai: 'Default',
     temp_openai: 1.0,
@@ -399,13 +481,17 @@ export let openai_settings;
 /** @type {import('./PromptManager.js').PromptManager} */
 export let promptManager = null;
 
-async function validateReverseProxy() {
-    if (!oai_settings.reverse_proxy) {
+/**
+ * @param {string} reverseProxy If it's set, ignores active reverse proxy
+ */
+async function validateReverseProxy(reverseProxy = null) {
+    const activeReverseProxy = reverseProxy ?? oai_settings.reverse_proxy;
+    if (!activeReverseProxy) {
         return;
     }
 
     try {
-        new URL(oai_settings.reverse_proxy);
+        new URL(activeReverseProxy);
     }
     catch (err) {
         toastr.error(t`Entered reverse proxy address is not a valid URL`);
@@ -413,7 +499,7 @@ async function validateReverseProxy() {
         resultCheckStatus();
         throw err;
     }
-    const rememberKey = `Proxy_SkipConfirm_${getStringHash(oai_settings.reverse_proxy)}`;
+    const rememberKey = `Proxy_SkipConfirm_${getStringHash(activeReverseProxy)}`;
     const skipConfirm = accountStorage.getItem(rememberKey) === 'true';
 
     const confirmation = skipConfirm || await Popup.show.confirm(t`Connecting To Proxy`, await renderTemplateAsync('proxyConnectionWarning', { proxyURL: DOMPurify.sanitize(oai_settings.reverse_proxy) }));
@@ -1835,16 +1921,43 @@ async function sendAltScaleRequest(messages, logit_bias, signal, type) {
     return data.output;
 }
 
+export function presetToSettings(preset) {
+    let result = {};
+
+    // Add preset values.
+    for (const [key, value] of Object.entries(preset)) {
+        const settingToUpdate = settingsToUpdate[key];
+        if (!settingToUpdate) {
+            console.warn(`Unknown setting/preset name: ${key}`);
+            continue;
+        }
+
+        result[settingToUpdate[1]] = value;
+    }
+
+    // Merge with oai_settings
+    const resultKeys = new Set(Object.keys(result));
+    for (const [key, value] of Object.entries(oai_settings)) {
+        if (!resultKeys.has(key)) {
+            result[key] = value;
+        }
+    }
+
+    return result;
+}
+
 /**
  * Send a chat completion request to backend
  * @param {string} type (impersonate, quiet, continue, etc)
  * @param {Array} messages
  * @param {AbortSignal?} signal
+ * @param {{source?: string, preset?: object}} custom?
+ * @param {boolean} emitEvent
  * @returns {Promise<unknown>}
  * @throws {Error}
  */
 
-async function sendOpenAIRequest(type, messages, signal) {
+async function sendOpenAIRequest(type, messages, signal, { source, preset } = {}, emitEvent = true) {
     // Provide default abort signal
     if (!signal) {
         signal = new AbortController().signal;
@@ -1857,39 +1970,42 @@ async function sendOpenAIRequest(type, messages, signal) {
 
     messages = messages.filter(msg => msg && typeof msg === 'object');
 
+    const active_oai_settings = structuredClone(preset ? presetToSettings(preset) : oai_settings);
+    active_oai_settings.chat_completion_source = source ?? active_oai_settings.chat_completion_source;
+
     let logit_bias = {};
-    const isClaude = oai_settings.chat_completion_source == chat_completion_sources.CLAUDE;
-    const isOpenRouter = oai_settings.chat_completion_source == chat_completion_sources.OPENROUTER;
-    const isScale = oai_settings.chat_completion_source == chat_completion_sources.SCALE;
-    const isGoogle = oai_settings.chat_completion_source == chat_completion_sources.MAKERSUITE;
-    const isOAI = oai_settings.chat_completion_source == chat_completion_sources.OPENAI;
-    const isMistral = oai_settings.chat_completion_source == chat_completion_sources.MISTRALAI;
-    const isCustom = oai_settings.chat_completion_source == chat_completion_sources.CUSTOM;
-    const isCohere = oai_settings.chat_completion_source == chat_completion_sources.COHERE;
-    const isPerplexity = oai_settings.chat_completion_source == chat_completion_sources.PERPLEXITY;
-    const isGroq = oai_settings.chat_completion_source == chat_completion_sources.GROQ;
-    const is01AI = oai_settings.chat_completion_source == chat_completion_sources.ZEROONEAI;
-    const isNano = oai_settings.chat_completion_source == chat_completion_sources.NANOGPT;
-    const isDeepSeek = oai_settings.chat_completion_source == chat_completion_sources.DEEPSEEK;
-    const isTextCompletion = isOAI && textCompletionModels.includes(oai_settings.openai_model);
+    const isClaude = active_oai_settings.chat_completion_source == chat_completion_sources.CLAUDE;
+    const isOpenRouter = active_oai_settings.chat_completion_source == chat_completion_sources.OPENROUTER;
+    const isScale = active_oai_settings.chat_completion_source == chat_completion_sources.SCALE;
+    const isGoogle = active_oai_settings.chat_completion_source == chat_completion_sources.MAKERSUITE;
+    const isOAI = active_oai_settings.chat_completion_source == chat_completion_sources.OPENAI;
+    const isMistral = active_oai_settings.chat_completion_source == chat_completion_sources.MISTRALAI;
+    const isCustom = active_oai_settings.chat_completion_source == chat_completion_sources.CUSTOM;
+    const isCohere = active_oai_settings.chat_completion_source == chat_completion_sources.COHERE;
+    const isPerplexity = active_oai_settings.chat_completion_source == chat_completion_sources.PERPLEXITY;
+    const isGroq = active_oai_settings.chat_completion_source == chat_completion_sources.GROQ;
+    const is01AI = active_oai_settings.chat_completion_source == chat_completion_sources.ZEROONEAI;
+    const isNano = active_oai_settings.chat_completion_source == chat_completion_sources.NANOGPT;
+    const isDeepSeek = active_oai_settings.chat_completion_source == chat_completion_sources.DEEPSEEK;
+    const isTextCompletion = isOAI && textCompletionModels.includes(active_oai_settings.openai_model);
     const isQuiet = type === 'quiet';
     const isImpersonate = type === 'impersonate';
     const isContinue = type === 'continue';
-    const stream = oai_settings.stream_openai && !isQuiet && !isScale && !(isOAI && ['o1-2024-12-17', 'o1'].includes(oai_settings.openai_model));
+    const stream = active_oai_settings.stream_openai && !isQuiet && !isScale && !(isOAI && ['o1-2024-12-17', 'o1'].includes(active_oai_settings.openai_model));
     const useLogprobs = !!power_user.request_token_probabilities;
-    const canMultiSwipe = oai_settings.n > 1 && !isContinue && !isImpersonate && !isQuiet && (isOAI || isCustom);
+    const canMultiSwipe = active_oai_settings.n > 1 && !isContinue && !isImpersonate && !isQuiet && (isOAI || isCustom);
 
     // If we're using the window.ai extension, use that instead
     // Doesn't support logit bias yet
-    if (oai_settings.chat_completion_source == chat_completion_sources.WINDOWAI) {
+    if (active_oai_settings.chat_completion_source == chat_completion_sources.WINDOWAI) {
         return sendWindowAIRequest(messages, signal, stream);
     }
 
     const logitBiasSources = [chat_completion_sources.OPENAI, chat_completion_sources.OPENROUTER, chat_completion_sources.SCALE, chat_completion_sources.CUSTOM];
-    if (oai_settings.bias_preset_selected
-        && logitBiasSources.includes(oai_settings.chat_completion_source)
-        && Array.isArray(oai_settings.bias_presets[oai_settings.bias_preset_selected])
-        && oai_settings.bias_presets[oai_settings.bias_preset_selected].length) {
+    if (active_oai_settings.bias_preset_selected
+        && logitBiasSources.includes(active_oai_settings.chat_completion_source)
+        && Array.isArray(active_oai_settings.bias_presets[active_oai_settings.bias_preset_selected])
+        && active_oai_settings.bias_presets[active_oai_settings.bias_preset_selected].length) {
         logit_bias = biasCache || await calculateLogitBias();
         biasCache = logit_bias;
     }
@@ -1898,29 +2014,29 @@ async function sendOpenAIRequest(type, messages, signal) {
         logit_bias = undefined;
     }
 
-    if (isScale && oai_settings.use_alt_scale) {
+    if (isScale && active_oai_settings.use_alt_scale) {
         return sendAltScaleRequest(messages, logit_bias, signal, type);
     }
 
-    const model = getChatCompletionModel();
+    const model = getChatCompletionModel(active_oai_settings.chat_completion_source);
     const generate_data = {
         'messages': messages,
         'model': model,
-        'temperature': Number(oai_settings.temp_openai),
-        'frequency_penalty': Number(oai_settings.freq_pen_openai),
-        'presence_penalty': Number(oai_settings.pres_pen_openai),
-        'top_p': Number(oai_settings.top_p_openai),
-        'max_tokens': oai_settings.openai_max_tokens,
+        'temperature': Number(active_oai_settings.temp_openai),
+        'frequency_penalty': Number(active_oai_settings.freq_pen_openai),
+        'presence_penalty': Number(active_oai_settings.pres_pen_openai),
+        'top_p': Number(active_oai_settings.top_p_openai),
+        'max_tokens': active_oai_settings.openai_max_tokens,
         'stream': stream,
         'logit_bias': logit_bias,
         'stop': getCustomStoppingStrings(openai_max_stop_strings),
-        'chat_completion_source': oai_settings.chat_completion_source,
-        'n': canMultiSwipe ? oai_settings.n : undefined,
+        'chat_completion_source': active_oai_settings.chat_completion_source,
+        'n': canMultiSwipe ? active_oai_settings.n : undefined,
         'user_name': name1,
         'char_name': name2,
         'group_names': getGroupNames(),
-        'include_reasoning': Boolean(oai_settings.show_thoughts),
-        'reasoning_effort': String(oai_settings.reasoning_effort),
+        'include_reasoning': Boolean(active_oai_settings.show_thoughts),
+        'reasoning_effort': String(active_oai_settings.reasoning_effort),
     };
 
     if (!canMultiSwipe && ToolManager.canPerformToolCalls(type)) {
@@ -1933,10 +2049,10 @@ async function sendOpenAIRequest(type, messages, signal) {
     }
 
     // Proxy is only supported for Claude, OpenAI, Mistral, and Google MakerSuite
-    if (oai_settings.reverse_proxy && [chat_completion_sources.CLAUDE, chat_completion_sources.OPENAI, chat_completion_sources.MISTRALAI, chat_completion_sources.MAKERSUITE, chat_completion_sources.DEEPSEEK].includes(oai_settings.chat_completion_source)) {
-        await validateReverseProxy();
-        generate_data['reverse_proxy'] = oai_settings.reverse_proxy;
-        generate_data['proxy_password'] = oai_settings.proxy_password;
+    if (active_oai_settings.reverse_proxy && [chat_completion_sources.CLAUDE, chat_completion_sources.OPENAI, chat_completion_sources.MISTRALAI, chat_completion_sources.MAKERSUITE, chat_completion_sources.DEEPSEEK].includes(active_oai_settings.chat_completion_source)) {
+        await validateReverseProxy(active_oai_settings.reverse_proxy);
+        generate_data['reverse_proxy'] = active_oai_settings.reverse_proxy;
+        generate_data['proxy_password'] = active_oai_settings.proxy_password;
     }
 
     // Add logprobs request (currently OpenAI only, max 5 on their side)
@@ -1945,31 +2061,31 @@ async function sendOpenAIRequest(type, messages, signal) {
     }
 
     // Remove logit bias, logprobs and stop strings if it's not supported by the model
-    if (isOAI && oai_settings.openai_model.includes('vision') || isOpenRouter && oai_settings.openrouter_model.includes('vision')) {
+    if (isOAI && active_oai_settings.openai_model.includes('vision') || isOpenRouter && active_oai_settings.openrouter_model.includes('vision')) {
         delete generate_data.logit_bias;
         delete generate_data.stop;
         delete generate_data.logprobs;
     }
 
     if (isClaude) {
-        generate_data['top_k'] = Number(oai_settings.top_k_openai);
-        generate_data['claude_use_sysprompt'] = oai_settings.claude_use_sysprompt;
+        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
+        generate_data['claude_use_sysprompt'] = active_oai_settings.claude_use_sysprompt;
         generate_data['stop'] = getCustomStoppingStrings(); // Claude shouldn't have limits on stop strings.
         // Don't add a prefill on quiet gens (summarization) and when using continue prefill.
-        if (!isQuiet && !(isContinue && oai_settings.continue_prefill)) {
-            generate_data['assistant_prefill'] = isImpersonate ? substituteParams(oai_settings.assistant_impersonation) : substituteParams(oai_settings.assistant_prefill);
+        if (!isQuiet && !(isContinue && active_oai_settings.continue_prefill)) {
+            generate_data['assistant_prefill'] = isImpersonate ? substituteParams(active_oai_settings.assistant_impersonation) : substituteParams(active_oai_settings.assistant_prefill);
         }
     }
 
     if (isOpenRouter) {
-        generate_data['top_k'] = Number(oai_settings.top_k_openai);
-        generate_data['min_p'] = Number(oai_settings.min_p_openai);
-        generate_data['repetition_penalty'] = Number(oai_settings.repetition_penalty_openai);
-        generate_data['top_a'] = Number(oai_settings.top_a_openai);
-        generate_data['use_fallback'] = oai_settings.openrouter_use_fallback;
-        generate_data['provider'] = oai_settings.openrouter_providers;
-        generate_data['allow_fallbacks'] = oai_settings.openrouter_allow_fallbacks;
-        generate_data['middleout'] = oai_settings.openrouter_middleout;
+        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
+        generate_data['min_p'] = Number(active_oai_settings.min_p_openai);
+        generate_data['repetition_penalty'] = Number(active_oai_settings.repetition_penalty_openai);
+        generate_data['top_a'] = Number(active_oai_settings.top_a_openai);
+        generate_data['use_fallback'] = active_oai_settings.openrouter_use_fallback;
+        generate_data['provider'] = active_oai_settings.openrouter_providers;
+        generate_data['allow_fallbacks'] = active_oai_settings.openrouter_allow_fallbacks;
+        generate_data['middleout'] = active_oai_settings.openrouter_middleout;
 
         if (isTextCompletion) {
             generate_data['stop'] = getStoppingStrings(isImpersonate, isContinue);
@@ -1977,14 +2093,14 @@ async function sendOpenAIRequest(type, messages, signal) {
     }
 
     if (isScale) {
-        generate_data['api_url_scale'] = oai_settings.api_url_scale;
+        generate_data['api_url_scale'] = active_oai_settings.api_url_scale;
     }
 
     if (isGoogle) {
         const stopStringsLimit = 5;
-        generate_data['top_k'] = Number(oai_settings.top_k_openai);
+        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
         generate_data['stop'] = getCustomStoppingStrings(stopStringsLimit).slice(0, stopStringsLimit).filter(x => x.length >= 1 && x.length <= 16);
-        generate_data['use_makersuite_sysprompt'] = oai_settings.use_makersuite_sysprompt;
+        generate_data['use_makersuite_sysprompt'] = active_oai_settings.use_makersuite_sysprompt;
     }
 
     if (isMistral) {
@@ -1992,28 +2108,28 @@ async function sendOpenAIRequest(type, messages, signal) {
     }
 
     if (isCustom) {
-        generate_data['custom_url'] = oai_settings.custom_url;
-        generate_data['custom_include_body'] = oai_settings.custom_include_body;
-        generate_data['custom_exclude_body'] = oai_settings.custom_exclude_body;
-        generate_data['custom_include_headers'] = oai_settings.custom_include_headers;
-        generate_data['custom_prompt_post_processing'] = oai_settings.custom_prompt_post_processing;
+        generate_data['custom_url'] = active_oai_settings.custom_url;
+        generate_data['custom_include_body'] = active_oai_settings.custom_include_body;
+        generate_data['custom_exclude_body'] = active_oai_settings.custom_exclude_body;
+        generate_data['custom_include_headers'] = active_oai_settings.custom_include_headers;
+        generate_data['custom_prompt_post_processing'] = active_oai_settings.custom_prompt_post_processing;
     }
 
     if (isCohere) {
         // Clamp to 0.01 -> 0.99
-        generate_data['top_p'] = Math.min(Math.max(Number(oai_settings.top_p_openai), 0.01), 0.99);
-        generate_data['top_k'] = Number(oai_settings.top_k_openai);
+        generate_data['top_p'] = Math.min(Math.max(Number(active_oai_settings.top_p_openai), 0.01), 0.99);
+        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
         // Clamp to 0 -> 1
-        generate_data['frequency_penalty'] = Math.min(Math.max(Number(oai_settings.freq_pen_openai), 0), 1);
-        generate_data['presence_penalty'] = Math.min(Math.max(Number(oai_settings.pres_pen_openai), 0), 1);
+        generate_data['frequency_penalty'] = Math.min(Math.max(Number(active_oai_settings.freq_pen_openai), 0), 1);
+        generate_data['presence_penalty'] = Math.min(Math.max(Number(active_oai_settings.pres_pen_openai), 0), 1);
         generate_data['stop'] = getCustomStoppingStrings(5);
     }
 
     if (isPerplexity) {
-        generate_data['top_k'] = Number(oai_settings.top_k_openai);
+        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
         // Normalize values. 1 == disabled. 0 == is usual disabled state in OpenAI.
-        generate_data['frequency_penalty'] = Math.max(0, Number(oai_settings.freq_pen_openai)) + 1;
-        generate_data['presence_penalty'] = Number(oai_settings.pres_pen_openai);
+        generate_data['frequency_penalty'] = Math.max(0, Number(active_oai_settings.freq_pen_openai)) + 1;
+        generate_data['presence_penalty'] = Number(active_oai_settings.pres_pen_openai);
 
         // YEAH BRO JUST USE OPENAI CLIENT BRO
         delete generate_data['stop'];
@@ -2055,11 +2171,11 @@ async function sendOpenAIRequest(type, messages, signal) {
         }
     }
 
-    if ((isOAI || isOpenRouter || isMistral || isCustom || isCohere || isNano) && oai_settings.seed >= 0) {
-        generate_data['seed'] = oai_settings.seed;
+    if ((isOAI || isOpenRouter || isMistral || isCustom || isCohere || isNano) && active_oai_settings.seed >= 0) {
+        generate_data['seed'] = active_oai_settings.seed;
     }
 
-    if (isOAI && (oai_settings.openai_model.startsWith('o1') || oai_settings.openai_model.startsWith('o3'))) {
+    if (isOAI && (active_oai_settings.openai_model.startsWith('o1') || active_oai_settings.openai_model.startsWith('o3'))) {
         generate_data.messages.forEach((msg) => {
             if (msg.role === 'system') {
                 msg.role = 'user';
@@ -2080,7 +2196,9 @@ async function sendOpenAIRequest(type, messages, signal) {
         delete generate_data.logit_bias;
     }
 
-    await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);
+    if (emitEvent) {
+        await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);
+    }
 
     const generate_url = '/api/backends/chat-completions/generate';
     const response = await fetch(generate_url, {
@@ -3923,84 +4041,7 @@ async function onLogitBiasPresetDeleteClick() {
 
 // Load OpenAI preset settings
 function onSettingsPresetChange() {
-    const settingsToUpdate = {
-        chat_completion_source: ['#chat_completion_source', 'chat_completion_source', false],
-        temperature: ['#temp_openai', 'temp_openai', false],
-        frequency_penalty: ['#freq_pen_openai', 'freq_pen_openai', false],
-        presence_penalty: ['#pres_pen_openai', 'pres_pen_openai', false],
-        top_p: ['#top_p_openai', 'top_p_openai', false],
-        top_k: ['#top_k_openai', 'top_k_openai', false],
-        top_a: ['#top_a_openai', 'top_a_openai', false],
-        min_p: ['#min_p_openai', 'min_p_openai', false],
-        repetition_penalty: ['#repetition_penalty_openai', 'repetition_penalty_openai', false],
-        max_context_unlocked: ['#oai_max_context_unlocked', 'max_context_unlocked', true],
-        openai_model: ['#model_openai_select', 'openai_model', false],
-        claude_model: ['#model_claude_select', 'claude_model', false],
-        windowai_model: ['#model_windowai_select', 'windowai_model', false],
-        openrouter_model: ['#model_openrouter_select', 'openrouter_model', false],
-        openrouter_use_fallback: ['#openrouter_use_fallback', 'openrouter_use_fallback', true],
-        openrouter_group_models: ['#openrouter_group_models', 'openrouter_group_models', false],
-        openrouter_sort_models: ['#openrouter_sort_models', 'openrouter_sort_models', false],
-        openrouter_providers: ['#openrouter_providers_chat', 'openrouter_providers', false],
-        openrouter_allow_fallbacks: ['#openrouter_allow_fallbacks', 'openrouter_allow_fallbacks', true],
-        openrouter_middleout: ['#openrouter_middleout', 'openrouter_middleout', false],
-        ai21_model: ['#model_ai21_select', 'ai21_model', false],
-        mistralai_model: ['#model_mistralai_select', 'mistralai_model', false],
-        cohere_model: ['#model_cohere_select', 'cohere_model', false],
-        perplexity_model: ['#model_perplexity_select', 'perplexity_model', false],
-        groq_model: ['#model_groq_select', 'groq_model', false],
-        nanogpt_model: ['#model_nanogpt_select', 'nanogpt_model', false],
-        deepseek_model: ['#model_deepseek_select', 'deepseek_model', false],
-        zerooneai_model: ['#model_01ai_select', 'zerooneai_model', false],
-        blockentropy_model: ['#model_blockentropy_select', 'blockentropy_model', false],
-        custom_model: ['#custom_model_id', 'custom_model', false],
-        custom_url: ['#custom_api_url_text', 'custom_url', false],
-        custom_include_body: ['#custom_include_body', 'custom_include_body', false],
-        custom_exclude_body: ['#custom_exclude_body', 'custom_exclude_body', false],
-        custom_include_headers: ['#custom_include_headers', 'custom_include_headers', false],
-        custom_prompt_post_processing: ['#custom_prompt_post_processing', 'custom_prompt_post_processing', false],
-        google_model: ['#model_google_select', 'google_model', false],
-        openai_max_context: ['#openai_max_context', 'openai_max_context', false],
-        openai_max_tokens: ['#openai_max_tokens', 'openai_max_tokens', false],
-        wrap_in_quotes: ['#wrap_in_quotes', 'wrap_in_quotes', true],
-        names_behavior: ['#names_behavior', 'names_behavior', false],
-        send_if_empty: ['#send_if_empty_textarea', 'send_if_empty', false],
-        impersonation_prompt: ['#impersonation_prompt_textarea', 'impersonation_prompt', false],
-        new_chat_prompt: ['#newchat_prompt_textarea', 'new_chat_prompt', false],
-        new_group_chat_prompt: ['#newgroupchat_prompt_textarea', 'new_group_chat_prompt', false],
-        new_example_chat_prompt: ['#newexamplechat_prompt_textarea', 'new_example_chat_prompt', false],
-        continue_nudge_prompt: ['#continue_nudge_prompt_textarea', 'continue_nudge_prompt', false],
-        bias_preset_selected: ['#openai_logit_bias_preset', 'bias_preset_selected', false],
-        reverse_proxy: ['#openai_reverse_proxy', 'reverse_proxy', false],
-        wi_format: ['#wi_format_textarea', 'wi_format', false],
-        scenario_format: ['#scenario_format_textarea', 'scenario_format', false],
-        personality_format: ['#personality_format_textarea', 'personality_format', false],
-        group_nudge_prompt: ['#group_nudge_prompt_textarea', 'group_nudge_prompt', false],
-        stream_openai: ['#stream_toggle', 'stream_openai', true],
-        prompts: ['', 'prompts', false],
-        prompt_order: ['', 'prompt_order', false],
-        api_url_scale: ['#api_url_scale', 'api_url_scale', false],
-        show_external_models: ['#openai_show_external_models', 'show_external_models', true],
-        proxy_password: ['#openai_proxy_password', 'proxy_password', false],
-        assistant_prefill: ['#claude_assistant_prefill', 'assistant_prefill', false],
-        assistant_impersonation: ['#claude_assistant_impersonation', 'assistant_impersonation', false],
-        claude_use_sysprompt: ['#claude_use_sysprompt', 'claude_use_sysprompt', true],
-        use_makersuite_sysprompt: ['#use_makersuite_sysprompt', 'use_makersuite_sysprompt', true],
-        use_alt_scale: ['#use_alt_scale', 'use_alt_scale', true],
-        squash_system_messages: ['#squash_system_messages', 'squash_system_messages', true],
-        image_inlining: ['#openai_image_inlining', 'image_inlining', true],
-        inline_image_quality: ['#openai_inline_image_quality', 'inline_image_quality', false],
-        continue_prefill: ['#continue_prefill', 'continue_prefill', true],
-        continue_postfix: ['#continue_postfix', 'continue_postfix', false],
-        function_calling: ['#openai_function_calling', 'function_calling', true],
-        show_thoughts: ['#openai_show_thoughts', 'show_thoughts', true],
-        reasoning_effort: ['#openai_reasoning_effort', 'reasoning_effort', false],
-        seed: ['#seed_openai', 'seed', false],
-        n: ['#n_openai', 'n', false],
-    };
-
     const presetNameBefore = oai_settings.preset_settings_openai;
-
     const presetName = $('#settings_preset_openai').find(':selected').text();
     oai_settings.preset_settings_openai = presetName;
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1951,13 +1951,13 @@ export function presetToSettings(preset) {
  * @param {string} type (impersonate, quiet, continue, etc)
  * @param {Array} messages
  * @param {AbortSignal?} signal
- * @param {{source?: string, preset?: object}} custom?
+ * @param {{source?: string, preset?: object, model?: string}} custom?
  * @param {boolean} emitEvent
  * @returns {Promise<unknown>}
  * @throws {Error}
  */
 
-async function sendOpenAIRequest(type, messages, signal, { source, preset } = {}, emitEvent = true) {
+async function sendOpenAIRequest(type, messages, signal, { source, preset, model } = {}, emitEvent = true) {
     // Provide default abort signal
     if (!signal) {
         signal = new AbortController().signal;
@@ -2018,10 +2018,9 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset } = {}
         return sendAltScaleRequest(messages, logit_bias, signal, type);
     }
 
-    const model = getChatCompletionModel(active_oai_settings.chat_completion_source);
     const generate_data = {
         'messages': messages,
-        'model': model,
+        'model': model ?? getChatCompletionModel(active_oai_settings.chat_completion_source),
         'temperature': Number(active_oai_settings.temp_openai),
         'frequency_penalty': Number(active_oai_settings.freq_pen_openai),
         'presence_penalty': Number(active_oai_settings.pres_pen_openai),

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -478,17 +478,13 @@ export let openai_settings;
 /** @type {import('./PromptManager.js').PromptManager} */
 export let promptManager = null;
 
-/**
- * @param {string} reverseProxy If it's set, ignores active reverse proxy
- */
-async function validateReverseProxy(reverseProxy = null) {
-    const activeReverseProxy = reverseProxy ?? oai_settings.reverse_proxy;
-    if (!activeReverseProxy) {
+async function validateReverseProxy() {
+    if (!oai_settings.reverse_proxy) {
         return;
     }
 
     try {
-        new URL(activeReverseProxy);
+        new URL(oai_settings.reverse_proxy);
     }
     catch (err) {
         toastr.error(t`Entered reverse proxy address is not a valid URL`);
@@ -496,7 +492,7 @@ async function validateReverseProxy(reverseProxy = null) {
         resultCheckStatus();
         throw err;
     }
-    const rememberKey = `Proxy_SkipConfirm_${getStringHash(activeReverseProxy)}`;
+    const rememberKey = `Proxy_SkipConfirm_${getStringHash(oai_settings.reverse_proxy)}`;
     const skipConfirm = accountStorage.getItem(rememberKey) === 'true';
 
     const confirmation = skipConfirm || await Popup.show.confirm(t`Connecting To Proxy`, await renderTemplateAsync('proxyConnectionWarning', { proxyURL: DOMPurify.sanitize(oai_settings.reverse_proxy) }));
@@ -1918,42 +1914,16 @@ async function sendAltScaleRequest(messages, logit_bias, signal, type) {
     return data.output;
 }
 
-export function chatCompletionPresetToSettings(preset) {
-    let result = {};
-
-    // Add preset values.
-    for (const [key, value] of Object.entries(preset)) {
-        const settingToUpdate = settingsToUpdate[key];
-        if (!settingToUpdate) {
-            console.warn(`Unknown setting/preset name: ${key}`);
-            continue;
-        }
-
-        result[settingToUpdate[1]] = value;
-    }
-
-    // Merge with oai_settings
-    for (const [key, value] of Object.entries(oai_settings)) {
-        if (!Object.hasOwn(result, key)) {
-            result[key] = value;
-        }
-    }
-
-    return result;
-}
-
 /**
  * Send a chat completion request to backend
  * @param {string} type (impersonate, quiet, continue, etc)
  * @param {Array} messages
  * @param {AbortSignal?} signal
- * @param {{source?: string, preset?: object, model?: string}} custom?
- * @param {boolean} emitEvent
  * @returns {Promise<unknown>}
  * @throws {Error}
  */
 
-async function sendOpenAIRequest(type, messages, signal, { source, preset, model } = {}, emitEvent = true) {
+async function sendOpenAIRequest(type, messages, signal) {
     // Provide default abort signal
     if (!signal) {
         signal = new AbortController().signal;
@@ -1966,42 +1936,39 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
 
     messages = messages.filter(msg => msg && typeof msg === 'object');
 
-    const settings = structuredClone(preset ? chatCompletionPresetToSettings(preset) : oai_settings);
-    settings.chat_completion_source = source ?? settings.chat_completion_source;
-
     let logit_bias = {};
-    const isClaude = settings.chat_completion_source == chat_completion_sources.CLAUDE;
-    const isOpenRouter = settings.chat_completion_source == chat_completion_sources.OPENROUTER;
-    const isScale = settings.chat_completion_source == chat_completion_sources.SCALE;
-    const isGoogle = settings.chat_completion_source == chat_completion_sources.MAKERSUITE;
-    const isOAI = settings.chat_completion_source == chat_completion_sources.OPENAI;
-    const isMistral = settings.chat_completion_source == chat_completion_sources.MISTRALAI;
-    const isCustom = settings.chat_completion_source == chat_completion_sources.CUSTOM;
-    const isCohere = settings.chat_completion_source == chat_completion_sources.COHERE;
-    const isPerplexity = settings.chat_completion_source == chat_completion_sources.PERPLEXITY;
-    const isGroq = settings.chat_completion_source == chat_completion_sources.GROQ;
-    const is01AI = settings.chat_completion_source == chat_completion_sources.ZEROONEAI;
-    const isNano = settings.chat_completion_source == chat_completion_sources.NANOGPT;
-    const isDeepSeek = settings.chat_completion_source == chat_completion_sources.DEEPSEEK;
-    const isTextCompletion = isOAI && textCompletionModels.includes(settings.openai_model);
+    const isClaude = oai_settings.chat_completion_source == chat_completion_sources.CLAUDE;
+    const isOpenRouter = oai_settings.chat_completion_source == chat_completion_sources.OPENROUTER;
+    const isScale = oai_settings.chat_completion_source == chat_completion_sources.SCALE;
+    const isGoogle = oai_settings.chat_completion_source == chat_completion_sources.MAKERSUITE;
+    const isOAI = oai_settings.chat_completion_source == chat_completion_sources.OPENAI;
+    const isMistral = oai_settings.chat_completion_source == chat_completion_sources.MISTRALAI;
+    const isCustom = oai_settings.chat_completion_source == chat_completion_sources.CUSTOM;
+    const isCohere = oai_settings.chat_completion_source == chat_completion_sources.COHERE;
+    const isPerplexity = oai_settings.chat_completion_source == chat_completion_sources.PERPLEXITY;
+    const isGroq = oai_settings.chat_completion_source == chat_completion_sources.GROQ;
+    const is01AI = oai_settings.chat_completion_source == chat_completion_sources.ZEROONEAI;
+    const isNano = oai_settings.chat_completion_source == chat_completion_sources.NANOGPT;
+    const isDeepSeek = oai_settings.chat_completion_source == chat_completion_sources.DEEPSEEK;
+    const isTextCompletion = isOAI && textCompletionModels.includes(oai_settings.openai_model);
     const isQuiet = type === 'quiet';
     const isImpersonate = type === 'impersonate';
     const isContinue = type === 'continue';
-    const stream = settings.stream_openai && !isQuiet && !isScale && !(isOAI && ['o1-2024-12-17', 'o1'].includes(settings.openai_model));
+    const stream = oai_settings.stream_openai && !isQuiet && !isScale && !(isOAI && ['o1-2024-12-17', 'o1'].includes(oai_settings.openai_model));
     const useLogprobs = !!power_user.request_token_probabilities;
-    const canMultiSwipe = settings.n > 1 && !isContinue && !isImpersonate && !isQuiet && (isOAI || isCustom);
+    const canMultiSwipe = oai_settings.n > 1 && !isContinue && !isImpersonate && !isQuiet && (isOAI || isCustom);
 
     // If we're using the window.ai extension, use that instead
     // Doesn't support logit bias yet
-    if (settings.chat_completion_source == chat_completion_sources.WINDOWAI) {
+    if (oai_settings.chat_completion_source == chat_completion_sources.WINDOWAI) {
         return sendWindowAIRequest(messages, signal, stream);
     }
 
     const logitBiasSources = [chat_completion_sources.OPENAI, chat_completion_sources.OPENROUTER, chat_completion_sources.SCALE, chat_completion_sources.CUSTOM];
-    if (settings.bias_preset_selected
-        && logitBiasSources.includes(settings.chat_completion_source)
-        && Array.isArray(settings.bias_presets[settings.bias_preset_selected])
-        && settings.bias_presets[settings.bias_preset_selected].length) {
+    if (oai_settings.bias_preset_selected
+        && logitBiasSources.includes(oai_settings.chat_completion_source)
+        && Array.isArray(oai_settings.bias_presets[oai_settings.bias_preset_selected])
+        && oai_settings.bias_presets[oai_settings.bias_preset_selected].length) {
         logit_bias = biasCache || await calculateLogitBias();
         biasCache = logit_bias;
     }
@@ -2010,28 +1977,29 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
         logit_bias = undefined;
     }
 
-    if (isScale && settings.use_alt_scale) {
+    if (isScale && oai_settings.use_alt_scale) {
         return sendAltScaleRequest(messages, logit_bias, signal, type);
     }
 
+    const model = getChatCompletionModel();
     const generate_data = {
         'messages': messages,
-        'model': model ?? getChatCompletionModel(settings.chat_completion_source),
-        'temperature': Number(settings.temp_openai),
-        'frequency_penalty': Number(settings.freq_pen_openai),
-        'presence_penalty': Number(settings.pres_pen_openai),
-        'top_p': Number(settings.top_p_openai),
-        'max_tokens': settings.openai_max_tokens,
+        'model': model,
+        'temperature': Number(oai_settings.temp_openai),
+        'frequency_penalty': Number(oai_settings.freq_pen_openai),
+        'presence_penalty': Number(oai_settings.pres_pen_openai),
+        'top_p': Number(oai_settings.top_p_openai),
+        'max_tokens': oai_settings.openai_max_tokens,
         'stream': stream,
         'logit_bias': logit_bias,
         'stop': getCustomStoppingStrings(openai_max_stop_strings),
-        'chat_completion_source': settings.chat_completion_source,
-        'n': canMultiSwipe ? settings.n : undefined,
+        'chat_completion_source': oai_settings.chat_completion_source,
+        'n': canMultiSwipe ? oai_settings.n : undefined,
         'user_name': name1,
         'char_name': name2,
         'group_names': getGroupNames(),
-        'include_reasoning': Boolean(settings.show_thoughts),
-        'reasoning_effort': String(settings.reasoning_effort),
+        'include_reasoning': Boolean(oai_settings.show_thoughts),
+        'reasoning_effort': String(oai_settings.reasoning_effort),
     };
 
     if (!canMultiSwipe && ToolManager.canPerformToolCalls(type)) {
@@ -2044,10 +2012,10 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
     }
 
     // Proxy is only supported for Claude, OpenAI, Mistral, and Google MakerSuite
-    if (settings.reverse_proxy && [chat_completion_sources.CLAUDE, chat_completion_sources.OPENAI, chat_completion_sources.MISTRALAI, chat_completion_sources.MAKERSUITE, chat_completion_sources.DEEPSEEK].includes(settings.chat_completion_source)) {
-        await validateReverseProxy(settings.reverse_proxy);
-        generate_data['reverse_proxy'] = settings.reverse_proxy;
-        generate_data['proxy_password'] = settings.proxy_password;
+    if (oai_settings.reverse_proxy && [chat_completion_sources.CLAUDE, chat_completion_sources.OPENAI, chat_completion_sources.MISTRALAI, chat_completion_sources.MAKERSUITE, chat_completion_sources.DEEPSEEK].includes(oai_settings.chat_completion_source)) {
+        await validateReverseProxy();
+        generate_data['reverse_proxy'] = oai_settings.reverse_proxy;
+        generate_data['proxy_password'] = oai_settings.proxy_password;
     }
 
     // Add logprobs request (currently OpenAI only, max 5 on their side)
@@ -2056,31 +2024,31 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
     }
 
     // Remove logit bias, logprobs and stop strings if it's not supported by the model
-    if (isOAI && settings.openai_model.includes('vision') || isOpenRouter && settings.openrouter_model.includes('vision') || isOAI && settings.openai_model.includes('gpt-4.5-preview')) {
+    if (isOAI && oai_settings.openai_model.includes('vision') || isOpenRouter && oai_settings.openrouter_model.includes('vision') || isOAI && oai_settings.openai_model.includes('gpt-4.5-preview')) {
         delete generate_data.logit_bias;
         delete generate_data.stop;
         delete generate_data.logprobs;
     }
 
     if (isClaude) {
-        generate_data['top_k'] = Number(settings.top_k_openai);
-        generate_data['claude_use_sysprompt'] = settings.claude_use_sysprompt;
+        generate_data['top_k'] = Number(oai_settings.top_k_openai);
+        generate_data['claude_use_sysprompt'] = oai_settings.claude_use_sysprompt;
         generate_data['stop'] = getCustomStoppingStrings(); // Claude shouldn't have limits on stop strings.
         // Don't add a prefill on quiet gens (summarization) and when using continue prefill.
-        if (!isQuiet && !(isContinue && settings.continue_prefill)) {
-            generate_data['assistant_prefill'] = isImpersonate ? substituteParams(settings.assistant_impersonation) : substituteParams(settings.assistant_prefill);
+        if (!isQuiet && !(isContinue && oai_settings.continue_prefill)) {
+            generate_data['assistant_prefill'] = isImpersonate ? substituteParams(oai_settings.assistant_impersonation) : substituteParams(oai_settings.assistant_prefill);
         }
     }
 
     if (isOpenRouter) {
-        generate_data['top_k'] = Number(settings.top_k_openai);
-        generate_data['min_p'] = Number(settings.min_p_openai);
-        generate_data['repetition_penalty'] = Number(settings.repetition_penalty_openai);
-        generate_data['top_a'] = Number(settings.top_a_openai);
-        generate_data['use_fallback'] = settings.openrouter_use_fallback;
-        generate_data['provider'] = settings.openrouter_providers;
-        generate_data['allow_fallbacks'] = settings.openrouter_allow_fallbacks;
-        generate_data['middleout'] = settings.openrouter_middleout;
+        generate_data['top_k'] = Number(oai_settings.top_k_openai);
+        generate_data['min_p'] = Number(oai_settings.min_p_openai);
+        generate_data['repetition_penalty'] = Number(oai_settings.repetition_penalty_openai);
+        generate_data['top_a'] = Number(oai_settings.top_a_openai);
+        generate_data['use_fallback'] = oai_settings.openrouter_use_fallback;
+        generate_data['provider'] = oai_settings.openrouter_providers;
+        generate_data['allow_fallbacks'] = oai_settings.openrouter_allow_fallbacks;
+        generate_data['middleout'] = oai_settings.openrouter_middleout;
 
         if (isTextCompletion) {
             generate_data['stop'] = getStoppingStrings(isImpersonate, isContinue);
@@ -2088,14 +2056,14 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
     }
 
     if (isScale) {
-        generate_data['api_url_scale'] = settings.api_url_scale;
+        generate_data['api_url_scale'] = oai_settings.api_url_scale;
     }
 
     if (isGoogle) {
         const stopStringsLimit = 5;
-        generate_data['top_k'] = Number(settings.top_k_openai);
+        generate_data['top_k'] = Number(oai_settings.top_k_openai);
         generate_data['stop'] = getCustomStoppingStrings(stopStringsLimit).slice(0, stopStringsLimit).filter(x => x.length >= 1 && x.length <= 16);
-        generate_data['use_makersuite_sysprompt'] = settings.use_makersuite_sysprompt;
+        generate_data['use_makersuite_sysprompt'] = oai_settings.use_makersuite_sysprompt;
     }
 
     if (isMistral) {
@@ -2103,28 +2071,28 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
     }
 
     if (isCustom) {
-        generate_data['custom_url'] = settings.custom_url;
-        generate_data['custom_include_body'] = settings.custom_include_body;
-        generate_data['custom_exclude_body'] = settings.custom_exclude_body;
-        generate_data['custom_include_headers'] = settings.custom_include_headers;
-        generate_data['custom_prompt_post_processing'] = settings.custom_prompt_post_processing;
+        generate_data['custom_url'] = oai_settings.custom_url;
+        generate_data['custom_include_body'] = oai_settings.custom_include_body;
+        generate_data['custom_exclude_body'] = oai_settings.custom_exclude_body;
+        generate_data['custom_include_headers'] = oai_settings.custom_include_headers;
+        generate_data['custom_prompt_post_processing'] = oai_settings.custom_prompt_post_processing;
     }
 
     if (isCohere) {
         // Clamp to 0.01 -> 0.99
-        generate_data['top_p'] = Math.min(Math.max(Number(settings.top_p_openai), 0.01), 0.99);
-        generate_data['top_k'] = Number(settings.top_k_openai);
+        generate_data['top_p'] = Math.min(Math.max(Number(oai_settings.top_p_openai), 0.01), 0.99);
+        generate_data['top_k'] = Number(oai_settings.top_k_openai);
         // Clamp to 0 -> 1
-        generate_data['frequency_penalty'] = Math.min(Math.max(Number(settings.freq_pen_openai), 0), 1);
-        generate_data['presence_penalty'] = Math.min(Math.max(Number(settings.pres_pen_openai), 0), 1);
+        generate_data['frequency_penalty'] = Math.min(Math.max(Number(oai_settings.freq_pen_openai), 0), 1);
+        generate_data['presence_penalty'] = Math.min(Math.max(Number(oai_settings.pres_pen_openai), 0), 1);
         generate_data['stop'] = getCustomStoppingStrings(5);
     }
 
     if (isPerplexity) {
-        generate_data['top_k'] = Number(settings.top_k_openai);
+        generate_data['top_k'] = Number(oai_settings.top_k_openai);
         // Normalize values. 1 == disabled. 0 == is usual disabled state in OpenAI.
-        generate_data['frequency_penalty'] = Math.max(0, Number(settings.freq_pen_openai)) + 1;
-        generate_data['presence_penalty'] = Number(settings.pres_pen_openai);
+        generate_data['frequency_penalty'] = Math.max(0, Number(oai_settings.freq_pen_openai)) + 1;
+        generate_data['presence_penalty'] = Number(oai_settings.pres_pen_openai);
 
         // YEAH BRO JUST USE OPENAI CLIENT BRO
         delete generate_data['stop'];
@@ -2166,11 +2134,11 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
         }
     }
 
-    if ((isOAI || isOpenRouter || isMistral || isCustom || isCohere || isNano) && settings.seed >= 0) {
-        generate_data['seed'] = settings.seed;
+    if ((isOAI || isOpenRouter || isMistral || isCustom || isCohere || isNano) && oai_settings.seed >= 0) {
+        generate_data['seed'] = oai_settings.seed;
     }
 
-    if (isOAI && (settings.openai_model.startsWith('o1') || settings.openai_model.startsWith('o3'))) {
+    if (isOAI && (oai_settings.openai_model.startsWith('o1') || oai_settings.openai_model.startsWith('o3'))) {
         generate_data.messages.forEach((msg) => {
             if (msg.role === 'system') {
                 msg.role = 'user';
@@ -2191,9 +2159,7 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
         delete generate_data.logit_bias;
     }
 
-    if (emitEvent) {
-        await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);
-    }
+    await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);
 
     const generate_url = '/api/backends/chat-completions/generate';
     const response = await fetch(generate_url, {
@@ -4035,6 +4001,7 @@ async function onLogitBiasPresetDeleteClick() {
 // Load OpenAI preset settings
 function onSettingsPresetChange() {
     const presetNameBefore = oai_settings.preset_settings_openai;
+
     const presetName = $('#settings_preset_openai').find(':selected').text();
     oai_settings.preset_settings_openai = presetName;
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1969,42 +1969,42 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
 
     messages = messages.filter(msg => msg && typeof msg === 'object');
 
-    const active_oai_settings = structuredClone(preset ? presetToSettings(preset) : oai_settings);
-    active_oai_settings.chat_completion_source = source ?? active_oai_settings.chat_completion_source;
+    const settings = structuredClone(preset ? presetToSettings(preset) : oai_settings);
+    settings.chat_completion_source = source ?? settings.chat_completion_source;
 
     let logit_bias = {};
-    const isClaude = active_oai_settings.chat_completion_source == chat_completion_sources.CLAUDE;
-    const isOpenRouter = active_oai_settings.chat_completion_source == chat_completion_sources.OPENROUTER;
-    const isScale = active_oai_settings.chat_completion_source == chat_completion_sources.SCALE;
-    const isGoogle = active_oai_settings.chat_completion_source == chat_completion_sources.MAKERSUITE;
-    const isOAI = active_oai_settings.chat_completion_source == chat_completion_sources.OPENAI;
-    const isMistral = active_oai_settings.chat_completion_source == chat_completion_sources.MISTRALAI;
-    const isCustom = active_oai_settings.chat_completion_source == chat_completion_sources.CUSTOM;
-    const isCohere = active_oai_settings.chat_completion_source == chat_completion_sources.COHERE;
-    const isPerplexity = active_oai_settings.chat_completion_source == chat_completion_sources.PERPLEXITY;
-    const isGroq = active_oai_settings.chat_completion_source == chat_completion_sources.GROQ;
-    const is01AI = active_oai_settings.chat_completion_source == chat_completion_sources.ZEROONEAI;
-    const isNano = active_oai_settings.chat_completion_source == chat_completion_sources.NANOGPT;
-    const isDeepSeek = active_oai_settings.chat_completion_source == chat_completion_sources.DEEPSEEK;
-    const isTextCompletion = isOAI && textCompletionModels.includes(active_oai_settings.openai_model);
+    const isClaude = settings.chat_completion_source == chat_completion_sources.CLAUDE;
+    const isOpenRouter = settings.chat_completion_source == chat_completion_sources.OPENROUTER;
+    const isScale = settings.chat_completion_source == chat_completion_sources.SCALE;
+    const isGoogle = settings.chat_completion_source == chat_completion_sources.MAKERSUITE;
+    const isOAI = settings.chat_completion_source == chat_completion_sources.OPENAI;
+    const isMistral = settings.chat_completion_source == chat_completion_sources.MISTRALAI;
+    const isCustom = settings.chat_completion_source == chat_completion_sources.CUSTOM;
+    const isCohere = settings.chat_completion_source == chat_completion_sources.COHERE;
+    const isPerplexity = settings.chat_completion_source == chat_completion_sources.PERPLEXITY;
+    const isGroq = settings.chat_completion_source == chat_completion_sources.GROQ;
+    const is01AI = settings.chat_completion_source == chat_completion_sources.ZEROONEAI;
+    const isNano = settings.chat_completion_source == chat_completion_sources.NANOGPT;
+    const isDeepSeek = settings.chat_completion_source == chat_completion_sources.DEEPSEEK;
+    const isTextCompletion = isOAI && textCompletionModels.includes(settings.openai_model);
     const isQuiet = type === 'quiet';
     const isImpersonate = type === 'impersonate';
     const isContinue = type === 'continue';
-    const stream = active_oai_settings.stream_openai && !isQuiet && !isScale && !(isOAI && ['o1-2024-12-17', 'o1'].includes(active_oai_settings.openai_model));
+    const stream = settings.stream_openai && !isQuiet && !isScale && !(isOAI && ['o1-2024-12-17', 'o1'].includes(settings.openai_model));
     const useLogprobs = !!power_user.request_token_probabilities;
-    const canMultiSwipe = active_oai_settings.n > 1 && !isContinue && !isImpersonate && !isQuiet && (isOAI || isCustom);
+    const canMultiSwipe = settings.n > 1 && !isContinue && !isImpersonate && !isQuiet && (isOAI || isCustom);
 
     // If we're using the window.ai extension, use that instead
     // Doesn't support logit bias yet
-    if (active_oai_settings.chat_completion_source == chat_completion_sources.WINDOWAI) {
+    if (settings.chat_completion_source == chat_completion_sources.WINDOWAI) {
         return sendWindowAIRequest(messages, signal, stream);
     }
 
     const logitBiasSources = [chat_completion_sources.OPENAI, chat_completion_sources.OPENROUTER, chat_completion_sources.SCALE, chat_completion_sources.CUSTOM];
-    if (active_oai_settings.bias_preset_selected
-        && logitBiasSources.includes(active_oai_settings.chat_completion_source)
-        && Array.isArray(active_oai_settings.bias_presets[active_oai_settings.bias_preset_selected])
-        && active_oai_settings.bias_presets[active_oai_settings.bias_preset_selected].length) {
+    if (settings.bias_preset_selected
+        && logitBiasSources.includes(settings.chat_completion_source)
+        && Array.isArray(settings.bias_presets[settings.bias_preset_selected])
+        && settings.bias_presets[settings.bias_preset_selected].length) {
         logit_bias = biasCache || await calculateLogitBias();
         biasCache = logit_bias;
     }
@@ -2013,28 +2013,28 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
         logit_bias = undefined;
     }
 
-    if (isScale && active_oai_settings.use_alt_scale) {
+    if (isScale && settings.use_alt_scale) {
         return sendAltScaleRequest(messages, logit_bias, signal, type);
     }
 
     const generate_data = {
         'messages': messages,
-        'model': model ?? getChatCompletionModel(active_oai_settings.chat_completion_source),
-        'temperature': Number(active_oai_settings.temp_openai),
-        'frequency_penalty': Number(active_oai_settings.freq_pen_openai),
-        'presence_penalty': Number(active_oai_settings.pres_pen_openai),
-        'top_p': Number(active_oai_settings.top_p_openai),
-        'max_tokens': active_oai_settings.openai_max_tokens,
+        'model': model ?? getChatCompletionModel(settings.chat_completion_source),
+        'temperature': Number(settings.temp_openai),
+        'frequency_penalty': Number(settings.freq_pen_openai),
+        'presence_penalty': Number(settings.pres_pen_openai),
+        'top_p': Number(settings.top_p_openai),
+        'max_tokens': settings.openai_max_tokens,
         'stream': stream,
         'logit_bias': logit_bias,
         'stop': getCustomStoppingStrings(openai_max_stop_strings),
-        'chat_completion_source': active_oai_settings.chat_completion_source,
-        'n': canMultiSwipe ? active_oai_settings.n : undefined,
+        'chat_completion_source': settings.chat_completion_source,
+        'n': canMultiSwipe ? settings.n : undefined,
         'user_name': name1,
         'char_name': name2,
         'group_names': getGroupNames(),
-        'include_reasoning': Boolean(active_oai_settings.show_thoughts),
-        'reasoning_effort': String(active_oai_settings.reasoning_effort),
+        'include_reasoning': Boolean(settings.show_thoughts),
+        'reasoning_effort': String(settings.reasoning_effort),
     };
 
     if (!canMultiSwipe && ToolManager.canPerformToolCalls(type)) {
@@ -2047,10 +2047,10 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
     }
 
     // Proxy is only supported for Claude, OpenAI, Mistral, and Google MakerSuite
-    if (active_oai_settings.reverse_proxy && [chat_completion_sources.CLAUDE, chat_completion_sources.OPENAI, chat_completion_sources.MISTRALAI, chat_completion_sources.MAKERSUITE, chat_completion_sources.DEEPSEEK].includes(active_oai_settings.chat_completion_source)) {
-        await validateReverseProxy(active_oai_settings.reverse_proxy);
-        generate_data['reverse_proxy'] = active_oai_settings.reverse_proxy;
-        generate_data['proxy_password'] = active_oai_settings.proxy_password;
+    if (settings.reverse_proxy && [chat_completion_sources.CLAUDE, chat_completion_sources.OPENAI, chat_completion_sources.MISTRALAI, chat_completion_sources.MAKERSUITE, chat_completion_sources.DEEPSEEK].includes(settings.chat_completion_source)) {
+        await validateReverseProxy(settings.reverse_proxy);
+        generate_data['reverse_proxy'] = settings.reverse_proxy;
+        generate_data['proxy_password'] = settings.proxy_password;
     }
 
     // Add logprobs request (currently OpenAI only, max 5 on their side)
@@ -2059,31 +2059,31 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
     }
 
     // Remove logit bias, logprobs and stop strings if it's not supported by the model
-    if (isOAI && active_oai_settings.openai_model.includes('vision') || isOpenRouter && active_oai_settings.openrouter_model.includes('vision')) {
+    if (isOAI && settings.openai_model.includes('vision') || isOpenRouter && settings.openrouter_model.includes('vision')) {
         delete generate_data.logit_bias;
         delete generate_data.stop;
         delete generate_data.logprobs;
     }
 
     if (isClaude) {
-        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
-        generate_data['claude_use_sysprompt'] = active_oai_settings.claude_use_sysprompt;
+        generate_data['top_k'] = Number(settings.top_k_openai);
+        generate_data['claude_use_sysprompt'] = settings.claude_use_sysprompt;
         generate_data['stop'] = getCustomStoppingStrings(); // Claude shouldn't have limits on stop strings.
         // Don't add a prefill on quiet gens (summarization) and when using continue prefill.
-        if (!isQuiet && !(isContinue && active_oai_settings.continue_prefill)) {
-            generate_data['assistant_prefill'] = isImpersonate ? substituteParams(active_oai_settings.assistant_impersonation) : substituteParams(active_oai_settings.assistant_prefill);
+        if (!isQuiet && !(isContinue && settings.continue_prefill)) {
+            generate_data['assistant_prefill'] = isImpersonate ? substituteParams(settings.assistant_impersonation) : substituteParams(settings.assistant_prefill);
         }
     }
 
     if (isOpenRouter) {
-        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
-        generate_data['min_p'] = Number(active_oai_settings.min_p_openai);
-        generate_data['repetition_penalty'] = Number(active_oai_settings.repetition_penalty_openai);
-        generate_data['top_a'] = Number(active_oai_settings.top_a_openai);
-        generate_data['use_fallback'] = active_oai_settings.openrouter_use_fallback;
-        generate_data['provider'] = active_oai_settings.openrouter_providers;
-        generate_data['allow_fallbacks'] = active_oai_settings.openrouter_allow_fallbacks;
-        generate_data['middleout'] = active_oai_settings.openrouter_middleout;
+        generate_data['top_k'] = Number(settings.top_k_openai);
+        generate_data['min_p'] = Number(settings.min_p_openai);
+        generate_data['repetition_penalty'] = Number(settings.repetition_penalty_openai);
+        generate_data['top_a'] = Number(settings.top_a_openai);
+        generate_data['use_fallback'] = settings.openrouter_use_fallback;
+        generate_data['provider'] = settings.openrouter_providers;
+        generate_data['allow_fallbacks'] = settings.openrouter_allow_fallbacks;
+        generate_data['middleout'] = settings.openrouter_middleout;
 
         if (isTextCompletion) {
             generate_data['stop'] = getStoppingStrings(isImpersonate, isContinue);
@@ -2091,14 +2091,14 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
     }
 
     if (isScale) {
-        generate_data['api_url_scale'] = active_oai_settings.api_url_scale;
+        generate_data['api_url_scale'] = settings.api_url_scale;
     }
 
     if (isGoogle) {
         const stopStringsLimit = 5;
-        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
+        generate_data['top_k'] = Number(settings.top_k_openai);
         generate_data['stop'] = getCustomStoppingStrings(stopStringsLimit).slice(0, stopStringsLimit).filter(x => x.length >= 1 && x.length <= 16);
-        generate_data['use_makersuite_sysprompt'] = active_oai_settings.use_makersuite_sysprompt;
+        generate_data['use_makersuite_sysprompt'] = settings.use_makersuite_sysprompt;
     }
 
     if (isMistral) {
@@ -2106,28 +2106,28 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
     }
 
     if (isCustom) {
-        generate_data['custom_url'] = active_oai_settings.custom_url;
-        generate_data['custom_include_body'] = active_oai_settings.custom_include_body;
-        generate_data['custom_exclude_body'] = active_oai_settings.custom_exclude_body;
-        generate_data['custom_include_headers'] = active_oai_settings.custom_include_headers;
-        generate_data['custom_prompt_post_processing'] = active_oai_settings.custom_prompt_post_processing;
+        generate_data['custom_url'] = settings.custom_url;
+        generate_data['custom_include_body'] = settings.custom_include_body;
+        generate_data['custom_exclude_body'] = settings.custom_exclude_body;
+        generate_data['custom_include_headers'] = settings.custom_include_headers;
+        generate_data['custom_prompt_post_processing'] = settings.custom_prompt_post_processing;
     }
 
     if (isCohere) {
         // Clamp to 0.01 -> 0.99
-        generate_data['top_p'] = Math.min(Math.max(Number(active_oai_settings.top_p_openai), 0.01), 0.99);
-        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
+        generate_data['top_p'] = Math.min(Math.max(Number(settings.top_p_openai), 0.01), 0.99);
+        generate_data['top_k'] = Number(settings.top_k_openai);
         // Clamp to 0 -> 1
-        generate_data['frequency_penalty'] = Math.min(Math.max(Number(active_oai_settings.freq_pen_openai), 0), 1);
-        generate_data['presence_penalty'] = Math.min(Math.max(Number(active_oai_settings.pres_pen_openai), 0), 1);
+        generate_data['frequency_penalty'] = Math.min(Math.max(Number(settings.freq_pen_openai), 0), 1);
+        generate_data['presence_penalty'] = Math.min(Math.max(Number(settings.pres_pen_openai), 0), 1);
         generate_data['stop'] = getCustomStoppingStrings(5);
     }
 
     if (isPerplexity) {
-        generate_data['top_k'] = Number(active_oai_settings.top_k_openai);
+        generate_data['top_k'] = Number(settings.top_k_openai);
         // Normalize values. 1 == disabled. 0 == is usual disabled state in OpenAI.
-        generate_data['frequency_penalty'] = Math.max(0, Number(active_oai_settings.freq_pen_openai)) + 1;
-        generate_data['presence_penalty'] = Number(active_oai_settings.pres_pen_openai);
+        generate_data['frequency_penalty'] = Math.max(0, Number(settings.freq_pen_openai)) + 1;
+        generate_data['presence_penalty'] = Number(settings.pres_pen_openai);
 
         // YEAH BRO JUST USE OPENAI CLIENT BRO
         delete generate_data['stop'];
@@ -2169,11 +2169,11 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
         }
     }
 
-    if ((isOAI || isOpenRouter || isMistral || isCustom || isCohere || isNano) && active_oai_settings.seed >= 0) {
-        generate_data['seed'] = active_oai_settings.seed;
+    if ((isOAI || isOpenRouter || isMistral || isCustom || isCohere || isNano) && settings.seed >= 0) {
+        generate_data['seed'] = settings.seed;
     }
 
-    if (isOAI && (active_oai_settings.openai_model.startsWith('o1') || active_oai_settings.openai_model.startsWith('o3'))) {
+    if (isOAI && (settings.openai_model.startsWith('o1') || settings.openai_model.startsWith('o3'))) {
         generate_data.messages.forEach((msg) => {
             if (msg.role === 'system') {
                 msg.role = 'user';

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -228,7 +228,7 @@ const sensitiveFields = [
  * preset_name -> [selector, setting_name, is_checkbox]
  * @type {Record<string, [string, string, boolean]>}
  */
-const settingsToUpdate = {
+export const settingsToUpdate = {
     chat_completion_source: ['#chat_completion_source', 'chat_completion_source', false],
     temperature: ['#temp_openai', 'temp_openai', false],
     frequency_penalty: ['#freq_pen_openai', 'freq_pen_openai', false],

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1921,7 +1921,7 @@ async function sendAltScaleRequest(messages, logit_bias, signal, type) {
     return data.output;
 }
 
-export function presetToSettings(preset) {
+export function chatCompletionPresetToSettings(preset) {
     let result = {};
 
     // Add preset values.
@@ -1969,7 +1969,7 @@ async function sendOpenAIRequest(type, messages, signal, { source, preset, model
 
     messages = messages.filter(msg => msg && typeof msg === 'object');
 
-    const settings = structuredClone(preset ? presetToSettings(preset) : oai_settings);
+    const settings = structuredClone(preset ? chatCompletionPresetToSettings(preset) : oai_settings);
     settings.chat_completion_source = source ?? settings.chat_completion_source;
 
     let logit_bias = {};

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -302,7 +302,6 @@ const settingsToUpdate = {
     reasoning_effort: ['#openai_reasoning_effort', 'reasoning_effort', false],
     seed: ['#seed_openai', 'seed', false],
     n: ['#n_openai', 'n', false],
-    jailbreak_system: ['#jailbreak_system', 'jailbreak_system', true],
     bypass_status_check: ['#openai_bypass_status_check', 'bypass_status_check', true],
 };
 
@@ -359,7 +358,6 @@ const default_settings = {
     openrouter_providers: [],
     openrouter_allow_fallbacks: true,
     openrouter_middleout: openrouter_middleout_types.ON,
-    jailbreak_system: false,
     reverse_proxy: '',
     chat_completion_source: chat_completion_sources.OPENAI,
     max_context_unlocked: false,
@@ -439,7 +437,6 @@ const oai_settings = {
     openrouter_providers: [],
     openrouter_allow_fallbacks: true,
     openrouter_middleout: openrouter_middleout_types.ON,
-    jailbreak_system: false,
     reverse_proxy: '',
     chat_completion_source: chat_completion_sources.OPENAI,
     max_context_unlocked: false,
@@ -3335,7 +3332,6 @@ function loadOpenAISettings(data, settings) {
     $('#openai_max_tokens').val(oai_settings.openai_max_tokens);
 
     $('#wrap_in_quotes').prop('checked', oai_settings.wrap_in_quotes);
-    $('#jailbreak_system').prop('checked', oai_settings.jailbreak_system);
     $('#openai_show_external_models').prop('checked', oai_settings.show_external_models);
     $('#openai_external_category').toggle(oai_settings.show_external_models);
     $('#claude_use_sysprompt').prop('checked', oai_settings.claude_use_sysprompt);
@@ -3619,7 +3615,6 @@ async function saveOpenAIPreset(name, settings, triggerUi = true) {
         names_behavior: settings.names_behavior,
         send_if_empty: settings.send_if_empty,
         jailbreak_prompt: settings.jailbreak_prompt,
-        jailbreak_system: settings.jailbreak_system,
         impersonation_prompt: settings.impersonation_prompt,
         new_chat_prompt: settings.new_chat_prompt,
         new_group_chat_prompt: settings.new_group_chat_prompt,

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1936,9 +1936,8 @@ export function presetToSettings(preset) {
     }
 
     // Merge with oai_settings
-    const resultKeys = new Set(Object.keys(result));
     for (const [key, value] of Object.entries(oai_settings)) {
-        if (!resultKeys.has(key)) {
+        if (!Object.hasOwn(result, key)) {
             result[key] = value;
         }
     }

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -57,7 +57,7 @@ import { groups, openGroupChat, selected_group } from './group-chats.js';
 import { t, translate } from './i18n.js';
 import { hideLoader, showLoader } from './loader.js';
 import { MacrosParser } from './macros.js';
-import { getChatCompletionModel, oai_settings } from './openai.js';
+import { getChatCompletionModel, oai_settings, sendOpenAIRequest } from './openai.js';
 import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from './popup.js';
 import { power_user, registerDebugFunction } from './power-user.js';
 import { getPresetManager } from './preset-manager.js';
@@ -68,7 +68,7 @@ import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { tag_map, tags } from './tags.js';
-import { getTextGenServer, textgenerationwebui_settings } from './textgen-settings.js';
+import { getTextGenGenerationData, getTextGenServer, textgenerationwebui_settings } from './textgen-settings.js';
 import { tokenizers, getTextTokens, getTokenCount, getTokenCountAsync, getTokenizerModel } from './tokenizers.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
@@ -201,6 +201,8 @@ export function getContext() {
         extractMessageFromData,
         getPresetManager,
         getChatCompletionModel,
+        sendOpenAIRequest,
+        getTextGenGenerationData,
     };
 }
 

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -59,7 +59,7 @@ import { groups, openGroupChat, selected_group } from './group-chats.js';
 import { addLocaleData, getCurrentLocale, t, translate } from './i18n.js';
 import { hideLoader, showLoader } from './loader.js';
 import { MacrosParser } from './macros.js';
-import { getChatCompletionModel, oai_settings, sendOpenAIRequest } from './openai.js';
+import { getChatCompletionModel, oai_settings } from './openai.js';
 import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from './popup.js';
 import { power_user, registerDebugFunction } from './power-user.js';
 import { getPresetManager } from './preset-manager.js';
@@ -70,13 +70,14 @@ import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { tag_map, tags } from './tags.js';
-import { getTextGenGenerationData, getTextGenServer, textgenerationwebui_settings } from './textgen-settings.js';
+import { getTextGenServer, textgenerationwebui_settings } from './textgen-settings.js';
 import { tokenizers, getTextTokens, getTokenCount, getTokenCountAsync, getTokenizerModel } from './tokenizers.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { timestampToMoment, uuidv4 } from './utils.js';
 import { getGlobalVariable, getLocalVariable, setGlobalVariable, setLocalVariable } from './variables.js';
 import { convertCharacterBook, loadWorldInfo, saveWorldInfo, updateWorldInfoList } from './world-info.js';
+import { ChatCompletionService, TextCompletionService } from './custom-request.js';
 
 export function getContext() {
     return {
@@ -207,8 +208,8 @@ export function getContext() {
         getChatCompletionModel,
         printMessages,
         clearChat,
-        sendOpenAIRequest,
-        getTextGenGenerationData,
+        ChatCompletionService,
+        TextCompletionService,
     };
 }
 

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -128,7 +128,7 @@ export const SERVER_INPUTS = {
 };
 
 const KOBOLDCPP_ORDER = [6, 0, 1, 3, 4, 2, 5];
-const settings = {
+const textgenerationwebui_settings = {
     temp: 0.7,
     temperature_last: true,
     top_p: 0.5,
@@ -217,7 +217,7 @@ const settings = {
 };
 
 export {
-    settings as textgenerationwebui_settings,
+    textgenerationwebui_settings,
 };
 
 export let textgenerationwebui_banned_in_macros = [];
@@ -300,7 +300,7 @@ export const setting_names = [
 const DYNATEMP_BLOCK = document.getElementById('dynatemp_block_ooba');
 
 export function validateTextGenUrl() {
-    const selector = SERVER_INPUTS[settings.type];
+    const selector = SERVER_INPUTS[textgenerationwebui_settings.type];
 
     if (!selector) {
         return;
@@ -324,7 +324,7 @@ export function validateTextGenUrl() {
  * @returns {string} API URL
  */
 export function getTextGenServer(type = null) {
-    const selectedType = type ?? settings.type;
+    const selectedType = type ?? textgenerationwebui_settings.type;
     switch (selectedType) {
         case FEATHERLESS:
             return FEATHERLESS_SERVER;
@@ -339,7 +339,7 @@ export function getTextGenServer(type = null) {
         case OPENROUTER:
             return OPENROUTER_SERVER;
         default:
-            return settings.server_urls[selectedType] ?? '';
+            return textgenerationwebui_settings.server_urls[selectedType] ?? '';
     }
 }
 
@@ -350,7 +350,7 @@ async function selectPreset(name) {
         return;
     }
 
-    settings.preset = name;
+    textgenerationwebui_settings.preset = name;
     for (const name of setting_names) {
         const value = preset[name];
         setSettingByName(name, value, true);
@@ -364,7 +364,7 @@ async function selectPreset(name) {
 export function formatTextGenURL(value) {
     try {
         const noFormatTypes = [MANCER, TOGETHERAI, INFERMATICAI, DREAMGEN, OPENROUTER];
-        if (noFormatTypes.includes(settings.type)) {
+        if (noFormatTypes.includes(textgenerationwebui_settings.type)) {
             return value;
         }
 
@@ -381,7 +381,7 @@ function convertPresets(presets) {
 }
 
 function getTokenizerForTokenIds() {
-    if (power_user.tokenizer === tokenizers.API_CURRENT && TEXTGEN_TOKENIZERS.includes(settings.type)) {
+    if (power_user.tokenizer === tokenizers.API_CURRENT && TEXTGEN_TOKENIZERS.includes(textgenerationwebui_settings.type)) {
         return tokenizers.API_CURRENT;
     }
 
@@ -389,11 +389,11 @@ function getTokenizerForTokenIds() {
         return power_user.tokenizer;
     }
 
-    if (settings.type === OPENROUTER) {
+    if (textgenerationwebui_settings.type === OPENROUTER) {
         return getCurrentOpenRouterModelTokenizer();
     }
 
-    if (settings.type === DREAMGEN) {
+    if (textgenerationwebui_settings.type === DREAMGEN) {
         return getCurrentDreamGenModelTokenizer();
     }
 
@@ -406,8 +406,8 @@ function getTokenizerForTokenIds() {
  * @returns {TokenBanResult} String with comma-separated banned token IDs
  */
 function getCustomTokenBans(bannedTokens = null) {
-    const activeBannedTokens = bannedTokens ?? settings.banned_tokens;
-    if (!settings.send_banned_tokens || (!activeBannedTokens && !settings.global_banned_tokens && !textgenerationwebui_banned_in_macros.length)) {
+    const activeBannedTokens = bannedTokens ?? textgenerationwebui_settings.banned_tokens;
+    if (!textgenerationwebui_settings.send_banned_tokens || (!activeBannedTokens && !textgenerationwebui_settings.global_banned_tokens && !textgenerationwebui_banned_in_macros.length)) {
         return {
             banned_tokens: '',
             banned_strings: [],
@@ -419,7 +419,7 @@ function getCustomTokenBans(bannedTokens = null) {
     const banned_strings = [];
     const sequences = []
         .concat(activeBannedTokens.split('\n'))
-        .concat(settings.global_banned_tokens.split('\n'))
+        .concat(textgenerationwebui_settings.global_banned_tokens.split('\n'))
         .concat(textgenerationwebui_banned_in_macros)
         .filter(x => x.length > 0)
         .filter(onlyUnique);
@@ -474,7 +474,7 @@ function getCustomTokenBans(bannedTokens = null) {
 function toggleBannedStringsKillSwitch(isEnabled, title) {
     $('#send_banned_tokens_textgenerationwebui').prop('checked', isEnabled);
     $('#send_banned_tokens_label').find('.menu_button').toggleClass('toggleEnabled', isEnabled).prop('title', title);
-    settings.send_banned_tokens = isEnabled;
+    textgenerationwebui_settings.send_banned_tokens = isEnabled;
     saveSettingsDebounced();
 }
 
@@ -483,7 +483,7 @@ function toggleBannedStringsKillSwitch(isEnabled, title) {
  * @returns {object} Logit bias object
  */
 function calculateLogitBias() {
-    if (!Array.isArray(settings.logit_bias) || settings.logit_bias.length === 0) {
+    if (!Array.isArray(textgenerationwebui_settings.logit_bias) || textgenerationwebui_settings.logit_bias.length === 0) {
         return {};
     }
 
@@ -509,7 +509,7 @@ function calculateLogitBias() {
         return result;
     }
 
-    getLogitBiasListResult(settings.logit_bias, tokenizer, addBias);
+    getLogitBiasListResult(textgenerationwebui_settings.logit_bias, tokenizer, addBias);
 
     return result;
 }
@@ -517,25 +517,25 @@ function calculateLogitBias() {
 export function loadTextGenSettings(data, loadedSettings) {
     textgenerationwebui_presets = convertPresets(data.textgenerationwebui_presets);
     textgenerationwebui_preset_names = data.textgenerationwebui_preset_names ?? [];
-    Object.assign(settings, loadedSettings.textgenerationwebui_settings ?? {});
+    Object.assign(textgenerationwebui_settings, loadedSettings.textgenerationwebui_settings ?? {});
 
     if (loadedSettings.api_server_textgenerationwebui) {
         for (const type of Object.keys(SERVER_INPUTS)) {
-            settings.server_urls[type] = loadedSettings.api_server_textgenerationwebui;
+            textgenerationwebui_settings.server_urls[type] = loadedSettings.api_server_textgenerationwebui;
         }
         delete loadedSettings.api_server_textgenerationwebui;
     }
 
     for (const [type, selector] of Object.entries(SERVER_INPUTS)) {
         const control = $(selector);
-        control.val(settings.server_urls[type] ?? '').on('input', function () {
-            settings.server_urls[type] = String($(this).val()).trim();
+        control.val(textgenerationwebui_settings.server_urls[type] ?? '').on('input', function () {
+            textgenerationwebui_settings.server_urls[type] = String($(this).val()).trim();
             saveSettingsDebounced();
         });
     }
 
     if (loadedSettings.api_use_mancer_webui) {
-        settings.type = MANCER;
+        textgenerationwebui_settings.type = MANCER;
     }
 
     for (const name of textgenerationwebui_preset_names) {
@@ -545,20 +545,20 @@ export function loadTextGenSettings(data, loadedSettings) {
         $('#settings_preset_textgenerationwebui').append(option);
     }
 
-    if (settings.preset) {
-        $('#settings_preset_textgenerationwebui').val(settings.preset);
+    if (textgenerationwebui_settings.preset) {
+        $('#settings_preset_textgenerationwebui').val(textgenerationwebui_settings.preset);
     }
 
     for (const i of setting_names) {
-        const value = settings[i];
+        const value = textgenerationwebui_settings[i];
         setSettingByName(i, value);
     }
 
-    $('#textgen_type').val(settings.type);
-    $('#openrouter_providers_text').val(settings.openrouter_providers).trigger('change');
-    showTypeSpecificControls(settings.type);
+    $('#textgen_type').val(textgenerationwebui_settings.type);
+    $('#openrouter_providers_text').val(textgenerationwebui_settings.openrouter_providers).trigger('change');
+    showTypeSpecificControls(textgenerationwebui_settings.type);
     BIAS_CACHE.delete(BIAS_KEY);
-    displayLogitBias(settings.logit_bias, BIAS_KEY);
+    displayLogitBias(textgenerationwebui_settings.logit_bias, BIAS_KEY);
 
     registerDebugFunction('change-mancer-url', 'Change Mancer base URL', 'Change Mancer API server base URL', () => {
         const result = prompt(`Enter Mancer base URL\nDefault: ${MANCER_SERVER_DEFAULT}`, MANCER_SERVER);
@@ -635,15 +635,15 @@ jQuery(function () {
             $('#koboldcpp_order').children().each(function () {
                 order.push($(this).data('id'));
             });
-            settings.sampler_order = order;
-            console.log('Samplers reordered:', settings.sampler_order);
+            textgenerationwebui_settings.sampler_order = order;
+            console.log('Samplers reordered:', textgenerationwebui_settings.sampler_order);
             saveSettingsDebounced();
         },
     });
 
     $('#koboldcpp_default_order').on('click', function () {
-        settings.sampler_order = KOBOLDCPP_ORDER;
-        sortKoboldItemsByOrder(settings.sampler_order);
+        textgenerationwebui_settings.sampler_order = KOBOLDCPP_ORDER;
+        sortKoboldItemsByOrder(textgenerationwebui_settings.sampler_order);
         saveSettingsDebounced();
     });
 
@@ -654,16 +654,16 @@ jQuery(function () {
             $('#llamacpp_samplers_sortable').children().each(function () {
                 order.push($(this).data('name'));
             });
-            settings.samplers = order;
-            console.log('Samplers reordered:', settings.samplers);
+            textgenerationwebui_settings.samplers = order;
+            console.log('Samplers reordered:', textgenerationwebui_settings.samplers);
             saveSettingsDebounced();
         },
     });
 
     $('#llamacpp_samplers_default_order').on('click', function () {
         sortLlamacppItemsByOrder(LLAMACPP_DEFAULT_ORDER);
-        settings.samplers = LLAMACPP_DEFAULT_ORDER;
-        console.log('Default samplers order loaded:', settings.samplers);
+        textgenerationwebui_settings.samplers = LLAMACPP_DEFAULT_ORDER;
+        console.log('Default samplers order loaded:', textgenerationwebui_settings.samplers);
         saveSettingsDebounced();
     });
 
@@ -674,8 +674,8 @@ jQuery(function () {
             $('#sampler_priority_container').children().each(function () {
                 order.push($(this).data('name'));
             });
-            settings.sampler_priority = order;
-            console.log('Samplers reordered:', settings.sampler_priority);
+            textgenerationwebui_settings.sampler_priority = order;
+            console.log('Samplers reordered:', textgenerationwebui_settings.sampler_priority);
             saveSettingsDebounced();
         },
     });
@@ -687,8 +687,8 @@ jQuery(function () {
             $('#sampler_priority_container_aphrodite').children().each(function () {
                 order.push($(this).data('name'));
             });
-            settings.samplers_priorities = order;
-            console.log('Samplers reordered:', settings.samplers_priorities);
+            textgenerationwebui_settings.samplers_priorities = order;
+            console.log('Samplers reordered:', textgenerationwebui_settings.samplers_priorities);
             saveSettingsDebounced();
         },
     });
@@ -697,7 +697,7 @@ jQuery(function () {
         const json_schema_string = String($(this).val());
 
         try {
-            settings.json_schema = JSON.parse(json_schema_string || '{}');
+            textgenerationwebui_settings.json_schema = JSON.parse(json_schema_string || '{}');
         } catch {
             // Ignore errors from here
         }
@@ -706,38 +706,38 @@ jQuery(function () {
 
     $('#textgenerationwebui_default_order').on('click', function () {
         sortOobaItemsByOrder(OOBA_DEFAULT_ORDER);
-        settings.sampler_priority = OOBA_DEFAULT_ORDER;
-        console.log('Default samplers order loaded:', settings.sampler_priority);
+        textgenerationwebui_settings.sampler_priority = OOBA_DEFAULT_ORDER;
+        console.log('Default samplers order loaded:', textgenerationwebui_settings.sampler_priority);
         saveSettingsDebounced();
     });
 
     $('#aphrodite_default_order').on('click', function () {
         sortAphroditeItemsByOrder(APHRODITE_DEFAULT_ORDER);
-        settings.samplers_priorities = APHRODITE_DEFAULT_ORDER;
-        console.log('Default samplers order loaded:', settings.samplers_priorities);
+        textgenerationwebui_settings.samplers_priorities = APHRODITE_DEFAULT_ORDER;
+        console.log('Default samplers order loaded:', textgenerationwebui_settings.samplers_priorities);
         saveSettingsDebounced();
     });
 
     $('#textgen_type').on('change', function () {
         const type = String($(this).val());
-        settings.type = type;
+        textgenerationwebui_settings.type = type;
 
-        if ([VLLM, APHRODITE, INFERMATICAI].includes(settings.type)) {
+        if ([VLLM, APHRODITE, INFERMATICAI].includes(textgenerationwebui_settings.type)) {
             $('#mirostat_mode_textgenerationwebui').attr('step', 2); //Aphro disallows mode 1
             $('#do_sample_textgenerationwebui').prop('checked', true); //Aphro should always do sample; 'otherwise set temp to 0 to mimic no sample'
             $('#ban_eos_token_textgenerationwebui').prop('checked', false); //Aphro should not ban EOS, just ignore it; 'add token '2' to ban list do to this'
             //special handling for vLLM/Aphrodite topK -1 disable state
             $('#top_k_textgenerationwebui').attr('min', -1);
-            if ($('#top_k_textgenerationwebui').val() === '0' || settings['top_k'] === 0) {
-                settings['top_k'] = -1;
+            if ($('#top_k_textgenerationwebui').val() === '0' || textgenerationwebui_settings['top_k'] === 0) {
+                textgenerationwebui_settings['top_k'] = -1;
                 $('#top_k_textgenerationwebui').val('-1').trigger('input');
             }
         } else {
             $('#mirostat_mode_textgenerationwebui').attr('step', 1);
             //undo special vLLM/Aphrodite setup for topK
             $('#top_k_textgenerationwebui').attr('min', 0);
-            if ($('#top_k_textgenerationwebui').val() === '-1' || settings['top_k'] === -1) {
-                settings['top_k'] = 0;
+            if ($('#top_k_textgenerationwebui').val() === '-1' || textgenerationwebui_settings['top_k'] === -1) {
+                textgenerationwebui_settings['top_k'] = 0;
                 $('#top_k_textgenerationwebui').val('0').trigger('input');
             }
         }
@@ -748,7 +748,7 @@ jQuery(function () {
 
         $('#main_api').trigger('change');
 
-        if (!SERVER_INPUTS[type] || settings.server_urls[type]) {
+        if (!SERVER_INPUTS[type] || textgenerationwebui_settings.server_urls[type]) {
             $('#api_button_textgenerationwebui').trigger('click');
         }
 
@@ -763,7 +763,7 @@ jQuery(function () {
     $('#samplerResetButton').off('click').on('click', function () {
         const inputs = {
             'temp_textgenerationwebui': 1,
-            'top_k_textgenerationwebui': [INFERMATICAI, APHRODITE, VLLM].includes(settings.type) ? -1 : 0,
+            'top_k_textgenerationwebui': [INFERMATICAI, APHRODITE, VLLM].includes(textgenerationwebui_settings.type) ? -1 : 0,
             'top_p_textgenerationwebui': 1,
             'min_p_textgenerationwebui': 0,
             'rep_pen_textgenerationwebui': 1,
@@ -838,19 +838,19 @@ jQuery(function () {
 
             if (isCheckbox) {
                 const value = $(this).prop('checked');
-                settings[id] = value;
+                textgenerationwebui_settings[id] = value;
             }
             else if (isText) {
                 const value = $(this).val();
-                settings[id] = value;
+                textgenerationwebui_settings[id] = value;
             }
             else {
                 const value = Number($(this).val());
                 $(`#${id}_counter_textgenerationwebui`).val(value);
-                settings[id] = value;
+                textgenerationwebui_settings[id] = value;
                 //special handling for vLLM/Aphrodite using -1 as disabled instead of 0
-                if ($(this).attr('id') === 'top_k_textgenerationwebui' && [INFERMATICAI, APHRODITE, VLLM].includes(settings.type) && value === 0) {
-                    settings[id] = -1;
+                if ($(this).attr('id') === 'top_k_textgenerationwebui' && [INFERMATICAI, APHRODITE, VLLM].includes(textgenerationwebui_settings.type) && value === 0) {
+                    textgenerationwebui_settings[id] = -1;
                     $(this).val(-1);
                 }
             }
@@ -858,7 +858,7 @@ jQuery(function () {
         });
     }
 
-    $('#textgen_logit_bias_new_entry').on('click', () => createNewLogitBiasEntry(settings.logit_bias, BIAS_KEY));
+    $('#textgen_logit_bias_new_entry').on('click', () => createNewLogitBiasEntry(textgenerationwebui_settings.logit_bias, BIAS_KEY));
 
     $('#openrouter_providers_text').on('change', function () {
         const selectedProviders = $(this).val();
@@ -868,7 +868,7 @@ jQuery(function () {
             return;
         }
 
-        settings.openrouter_providers = selectedProviders;
+        textgenerationwebui_settings.openrouter_providers = selectedProviders;
 
         saveSettingsDebounced();
     });
@@ -922,7 +922,7 @@ function setSettingByName(setting, value, trigger) {
     if ('sampler_order' === setting) {
         value = Array.isArray(value) ? value : KOBOLDCPP_ORDER;
         sortKoboldItemsByOrder(value);
-        settings.sampler_order = value;
+        textgenerationwebui_settings.sampler_order = value;
         return;
     }
 
@@ -930,7 +930,7 @@ function setSettingByName(setting, value, trigger) {
         value = Array.isArray(value) ? value : OOBA_DEFAULT_ORDER;
         insertMissingArrayItems(OOBA_DEFAULT_ORDER, value);
         sortOobaItemsByOrder(value);
-        settings.sampler_priority = value;
+        textgenerationwebui_settings.sampler_priority = value;
         return;
     }
 
@@ -938,7 +938,7 @@ function setSettingByName(setting, value, trigger) {
         value = Array.isArray(value) ? value : APHRODITE_DEFAULT_ORDER;
         insertMissingArrayItems(APHRODITE_DEFAULT_ORDER, value);
         sortAphroditeItemsByOrder(value);
-        settings.samplers_priorities = value;
+        textgenerationwebui_settings.samplers_priorities = value;
         return;
     }
 
@@ -946,18 +946,18 @@ function setSettingByName(setting, value, trigger) {
         value = Array.isArray(value) ? value : LLAMACPP_DEFAULT_ORDER;
         insertMissingArrayItems(LLAMACPP_DEFAULT_ORDER, value);
         sortLlamacppItemsByOrder(value);
-        settings.samplers = value;
+        textgenerationwebui_settings.samplers = value;
         return;
     }
 
     if ('logit_bias' === setting) {
-        settings.logit_bias = Array.isArray(value) ? value : [];
+        textgenerationwebui_settings.logit_bias = Array.isArray(value) ? value : [];
         return;
     }
 
     if ('json_schema' === setting) {
-        settings.json_schema = value ?? {};
-        $('#tabby_json_schema').val(JSON.stringify(settings.json_schema, null, 2));
+        textgenerationwebui_settings.json_schema = value ?? {};
+        $('#tabby_json_schema').val(JSON.stringify(textgenerationwebui_settings.json_schema, null, 2));
         return;
     }
 
@@ -1065,7 +1065,7 @@ export function parseTextgenLogprobs(token, logprobs) {
         return null;
     }
 
-    switch (settings.type) {
+    switch (textgenerationwebui_settings.type) {
         case KOBOLDCPP:
         case TABBY:
         case VLLM:
@@ -1173,44 +1173,44 @@ function toIntArray(string) {
  * @returns {string | undefined}
  */
 export function getTextGenModel(type = null) {
-    switch (type ?? settings.type) {
+    switch (type ?? textgenerationwebui_settings.type) {
         case OOBA:
-            if (settings.custom_model) {
-                return settings.custom_model;
+            if (textgenerationwebui_settings.custom_model) {
+                return textgenerationwebui_settings.custom_model;
             }
             break;
         case GENERIC:
-            if (settings.generic_model) {
-                return settings.generic_model;
+            if (textgenerationwebui_settings.generic_model) {
+                return textgenerationwebui_settings.generic_model;
             }
             break;
         case MANCER:
-            return settings.mancer_model;
+            return textgenerationwebui_settings.mancer_model;
         case TOGETHERAI:
-            return settings.togetherai_model;
+            return textgenerationwebui_settings.togetherai_model;
         case INFERMATICAI:
-            return settings.infermaticai_model;
+            return textgenerationwebui_settings.infermaticai_model;
         case DREAMGEN:
-            return settings.dreamgen_model;
+            return textgenerationwebui_settings.dreamgen_model;
         case OPENROUTER:
-            return settings.openrouter_model;
+            return textgenerationwebui_settings.openrouter_model;
         case VLLM:
-            return settings.vllm_model;
+            return textgenerationwebui_settings.vllm_model;
         case APHRODITE:
-            return settings.aphrodite_model;
+            return textgenerationwebui_settings.aphrodite_model;
         case OLLAMA:
-            if (!settings.ollama_model) {
+            if (!textgenerationwebui_settings.ollama_model) {
                 toastr.error(t`No Ollama model selected.`, 'Text Completion API');
                 throw new Error('No Ollama model selected');
             }
-            return settings.ollama_model;
+            return textgenerationwebui_settings.ollama_model;
         case FEATHERLESS:
-            return settings.featherless_model;
+            return textgenerationwebui_settings.featherless_model;
         case HUGGINGFACE:
             return 'tgi';
         case TABBY:
-            if (settings.tabby_model) {
-                return settings.tabby_model;
+            if (textgenerationwebui_settings.tabby_model) {
+                return textgenerationwebui_settings.tabby_model;
             }
             break;
         default:
@@ -1221,7 +1221,7 @@ export function getTextGenModel(type = null) {
 }
 
 export function isJsonSchemaSupported() {
-    return [TABBY, LLAMACPP].includes(settings.type) && main_api === 'textgenerationwebui';
+    return [TABBY, LLAMACPP].includes(textgenerationwebui_settings.type) && main_api === 'textgenerationwebui';
 }
 
 /**
@@ -1231,8 +1231,8 @@ export function isJsonSchemaSupported() {
  * @returns {boolean}
  */
 function isDynamicTemperatureSupported(dynatemp = null, type = null) {
-    const selectedDynatemp = dynatemp ?? settings.dynatemp;
-    const selectedType = type ?? settings.type;
+    const selectedDynatemp = dynatemp ?? textgenerationwebui_settings.dynatemp;
+    const selectedType = type ?? textgenerationwebui_settings.type;
     return selectedDynatemp && DYNATEMP_BLOCK?.dataset?.tgType?.includes(selectedType);
 }
 
@@ -1242,7 +1242,7 @@ function isDynamicTemperatureSupported(dynatemp = null, type = null) {
  * @returns {number} Number of logprobs to request
  */
 export function getLogprobsNumber(type = null) {
-    const selectedType = type ?? settings.type;
+    const selectedType = type ?? textgenerationwebui_settings.type;
     if (selectedType === VLLM || selectedType === INFERMATICAI) {
         return 5;
     }
@@ -1293,7 +1293,7 @@ export function presetToSettings(preset) {
     }
 
     // Merge with settings
-    for (const [key, value] of Object.entries(settings)) {
+    for (const [key, value] of Object.entries(textgenerationwebui_settings)) {
         if (!Object.hasOwn(result, key)) {
             result[key] = value;
         }
@@ -1314,7 +1314,7 @@ export function presetToSettings(preset) {
  * @returns
  */
 export async function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type, { preset, model, textgen_type, api_url } = {}, emitEvent = true) {
-    const active_settings = structuredClone(preset ? presetToSettings(preset) : settings);
+    const active_settings = structuredClone(preset ? presetToSettings(preset) : textgenerationwebui_settings);
     active_settings.type = textgen_type ?? active_settings.type;
 
     const canMultiSwipe = !isContinue && !isImpersonate && type !== 'quiet';

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -402,12 +402,11 @@ function getTokenizerForTokenIds() {
 
 /**
  * @typedef {{banned_tokens: string, banned_strings: string[]}} TokenBanResult
- * @param {string} bannedTokens If it's set, ignores active banned tokens
+ * @param {object} textgenerationwebui_settings If it's set, ignores active settings
  * @returns {TokenBanResult} String with comma-separated banned token IDs
  */
-function getCustomTokenBans(bannedTokens = null) {
-    const activeBannedTokens = bannedTokens ?? textgenerationwebui_settings.banned_tokens;
-    if (!textgenerationwebui_settings.send_banned_tokens || (!activeBannedTokens && !textgenerationwebui_settings.global_banned_tokens && !textgenerationwebui_banned_in_macros.length)) {
+function getCustomTokenBans({ banned_tokens } = textgenerationwebui_settings) {
+    if (!textgenerationwebui_settings.send_banned_tokens || (!banned_tokens && !textgenerationwebui_settings.global_banned_tokens && !textgenerationwebui_banned_in_macros.length)) {
         return {
             banned_tokens: '',
             banned_strings: [],
@@ -415,10 +414,10 @@ function getCustomTokenBans(bannedTokens = null) {
     }
 
     const tokenizer = getTokenizerForTokenIds();
-    const banned_tokens = [];
+    const result_banned_tokens = [];
     const banned_strings = [];
     const sequences = []
-        .concat(activeBannedTokens.split('\n'))
+        .concat(banned_tokens.split('\n'))
         .concat(textgenerationwebui_settings.global_banned_tokens.split('\n'))
         .concat(textgenerationwebui_banned_in_macros)
         .filter(x => x.length > 0)
@@ -439,7 +438,7 @@ function getCustomTokenBans(bannedTokens = null) {
                 const tokens = JSON.parse(line);
 
                 if (Array.isArray(tokens) && tokens.every(t => Number.isInteger(t))) {
-                    banned_tokens.push(...tokens);
+                    result_banned_tokens.push(...tokens);
                 } else {
                     throw new Error('Not an array of integers');
                 }
@@ -453,7 +452,7 @@ function getCustomTokenBans(bannedTokens = null) {
         } else {
             try {
                 const tokens = getTextTokens(tokenizer, line);
-                banned_tokens.push(...tokens);
+                result_banned_tokens.push(...tokens);
             } catch {
                 console.log(`Could not tokenize raw text: ${line}`);
             }
@@ -461,7 +460,7 @@ function getCustomTokenBans(bannedTokens = null) {
     }
 
     return {
-        banned_tokens: banned_tokens.filter(onlyUnique).map(x => String(x)).join(','),
+        banned_tokens: result_banned_tokens.filter(onlyUnique).map(x => String(x)).join(','),
         banned_strings: banned_strings,
     };
 }
@@ -1278,7 +1277,7 @@ export function replaceMacrosInList(str) {
     }
 }
 
-export function presetToSettings(preset) {
+export function textCompletionPresetToSettings(preset) {
     let result = {};
 
     // Add preset values.
@@ -1314,170 +1313,170 @@ export function presetToSettings(preset) {
  * @returns
  */
 export async function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type, { preset, model, textgen_type, api_url } = {}, emitEvent = true) {
-    const active_settings = structuredClone(preset ? presetToSettings(preset) : textgenerationwebui_settings);
-    active_settings.type = textgen_type ?? active_settings.type;
+    const settings = structuredClone(preset ? textCompletionPresetToSettings(preset) : textgenerationwebui_settings);
+    settings.type = textgen_type ?? settings.type;
 
     const canMultiSwipe = !isContinue && !isImpersonate && type !== 'quiet';
-    const dynatemp = isDynamicTemperatureSupported(active_settings.dynatemp, active_settings.type);
-    const { banned_tokens, banned_strings } = getCustomTokenBans(active_settings.banned_tokens);
+    const dynatemp = isDynamicTemperatureSupported(settings.dynatemp, settings.type);
+    const { banned_tokens, banned_strings } = getCustomTokenBans(settings);
 
     let params = {
         'prompt': finalPrompt,
-        'model': model ?? getTextGenModel(active_settings.type),
+        'model': model ?? getTextGenModel(settings.type),
         'max_new_tokens': maxTokens,
         'max_tokens': maxTokens,
         'logprobs': power_user.request_token_probabilities ? getLogprobsNumber() : undefined,
-        'temperature': dynatemp ? (active_settings.min_temp + active_settings.max_temp) / 2 : active_settings.temp,
-        'top_p': active_settings.top_p,
-        'typical_p': active_settings.typical_p,
-        'typical': active_settings.typical_p,
-        'sampler_seed': active_settings.seed >= 0 ? active_settings.seed : undefined,
-        'min_p': active_settings.min_p,
-        'repetition_penalty': active_settings.rep_pen,
-        'frequency_penalty': active_settings.freq_pen,
-        'presence_penalty': active_settings.presence_pen,
-        'top_k': active_settings.top_k,
-        'skew': active_settings.skew,
-        'min_length': active_settings.type === OOBA ? active_settings.min_length : undefined,
-        'minimum_message_content_tokens': active_settings.type === DREAMGEN ? active_settings.min_length : undefined,
-        'min_tokens': active_settings.min_length,
-        'num_beams': active_settings.type === OOBA ? active_settings.num_beams : undefined,
-        'length_penalty': active_settings.type === OOBA ? active_settings.length_penalty : undefined,
-        'early_stopping': active_settings.type === OOBA ? active_settings.early_stopping : undefined,
-        'add_bos_token': active_settings.add_bos_token,
+        'temperature': dynatemp ? (settings.min_temp + settings.max_temp) / 2 : settings.temp,
+        'top_p': settings.top_p,
+        'typical_p': settings.typical_p,
+        'typical': settings.typical_p,
+        'sampler_seed': settings.seed >= 0 ? settings.seed : undefined,
+        'min_p': settings.min_p,
+        'repetition_penalty': settings.rep_pen,
+        'frequency_penalty': settings.freq_pen,
+        'presence_penalty': settings.presence_pen,
+        'top_k': settings.top_k,
+        'skew': settings.skew,
+        'min_length': settings.type === OOBA ? settings.min_length : undefined,
+        'minimum_message_content_tokens': settings.type === DREAMGEN ? settings.min_length : undefined,
+        'min_tokens': settings.min_length,
+        'num_beams': settings.type === OOBA ? settings.num_beams : undefined,
+        'length_penalty': settings.type === OOBA ? settings.length_penalty : undefined,
+        'early_stopping': settings.type === OOBA ? settings.early_stopping : undefined,
+        'add_bos_token': settings.add_bos_token,
         'dynamic_temperature': dynatemp ? true : undefined,
-        'dynatemp_low': dynatemp ? active_settings.min_temp : undefined,
-        'dynatemp_high': dynatemp ? active_settings.max_temp : undefined,
-        'dynatemp_range': dynatemp ? (active_settings.max_temp - active_settings.min_temp) / 2 : undefined,
-        'dynatemp_exponent': dynatemp ? active_settings.dynatemp_exponent : undefined,
-        'smoothing_factor': active_settings.smoothing_factor,
-        'smoothing_curve': active_settings.smoothing_curve,
-        'dry_allowed_length': active_settings.dry_allowed_length,
-        'dry_multiplier': active_settings.dry_multiplier,
-        'dry_base': active_settings.dry_base,
-        'dry_sequence_breakers': replaceMacrosInList(active_settings.dry_sequence_breakers),
-        'dry_penalty_last_n': active_settings.dry_penalty_last_n,
-        'max_tokens_second': active_settings.max_tokens_second,
-        'sampler_priority': active_settings.type === OOBA ? active_settings.sampler_priority : undefined,
-        'samplers': active_settings.type === LLAMACPP ? active_settings.samplers : undefined,
+        'dynatemp_low': dynatemp ? settings.min_temp : undefined,
+        'dynatemp_high': dynatemp ? settings.max_temp : undefined,
+        'dynatemp_range': dynatemp ? (settings.max_temp - settings.min_temp) / 2 : undefined,
+        'dynatemp_exponent': dynatemp ? settings.dynatemp_exponent : undefined,
+        'smoothing_factor': settings.smoothing_factor,
+        'smoothing_curve': settings.smoothing_curve,
+        'dry_allowed_length': settings.dry_allowed_length,
+        'dry_multiplier': settings.dry_multiplier,
+        'dry_base': settings.dry_base,
+        'dry_sequence_breakers': replaceMacrosInList(settings.dry_sequence_breakers),
+        'dry_penalty_last_n': settings.dry_penalty_last_n,
+        'max_tokens_second': settings.max_tokens_second,
+        'sampler_priority': settings.type === OOBA ? settings.sampler_priority : undefined,
+        'samplers': settings.type === LLAMACPP ? settings.samplers : undefined,
         'stopping_strings': getStoppingStrings(isImpersonate, isContinue),
         'stop': getStoppingStrings(isImpersonate, isContinue),
         'truncation_length': max_context,
-        'ban_eos_token': active_settings.ban_eos_token,
-        'skip_special_tokens': active_settings.skip_special_tokens,
-        'include_reasoning': active_settings.include_reasoning,
-        'top_a': active_settings.top_a,
-        'tfs': active_settings.tfs,
-        'epsilon_cutoff': [OOBA, MANCER].includes(active_settings.type) ? active_settings.epsilon_cutoff : undefined,
-        'eta_cutoff': [OOBA, MANCER].includes(active_settings.type) ? active_settings.eta_cutoff : undefined,
-        'mirostat_mode': active_settings.mirostat_mode,
-        'mirostat_tau': active_settings.mirostat_tau,
-        'mirostat_eta': active_settings.mirostat_eta,
-        'custom_token_bans': [APHRODITE, MANCER].includes(active_settings.type) ?
+        'ban_eos_token': settings.ban_eos_token,
+        'skip_special_tokens': settings.skip_special_tokens,
+        'include_reasoning': settings.include_reasoning,
+        'top_a': settings.top_a,
+        'tfs': settings.tfs,
+        'epsilon_cutoff': [OOBA, MANCER].includes(settings.type) ? settings.epsilon_cutoff : undefined,
+        'eta_cutoff': [OOBA, MANCER].includes(settings.type) ? settings.eta_cutoff : undefined,
+        'mirostat_mode': settings.mirostat_mode,
+        'mirostat_tau': settings.mirostat_tau,
+        'mirostat_eta': settings.mirostat_eta,
+        'custom_token_bans': [APHRODITE, MANCER].includes(settings.type) ?
             toIntArray(banned_tokens) :
             banned_tokens,
         'banned_strings': banned_strings,
-        'api_type': active_settings.type,
-        'api_server': api_url ?? getTextGenServer(active_settings.type),
-        'sampler_order': active_settings.type === textgen_types.KOBOLDCPP ? active_settings.sampler_order : undefined,
-        'xtc_threshold': active_settings.xtc_threshold,
-        'xtc_probability': active_settings.xtc_probability,
-        'nsigma': active_settings.nsigma,
+        'api_type': settings.type,
+        'api_server': api_url ?? getTextGenServer(settings.type),
+        'sampler_order': settings.type === textgen_types.KOBOLDCPP ? settings.sampler_order : undefined,
+        'xtc_threshold': settings.xtc_threshold,
+        'xtc_probability': settings.xtc_probability,
+        'nsigma': settings.nsigma,
     };
     const nonAphroditeParams = {
-        'rep_pen': active_settings.rep_pen,
-        'rep_pen_range': active_settings.rep_pen_range,
-        'repetition_decay': active_settings.type === TABBY ? active_settings.rep_pen_decay : undefined,
-        'repetition_penalty_range': active_settings.rep_pen_range,
-        'encoder_repetition_penalty': active_settings.type === OOBA ? active_settings.encoder_rep_pen : undefined,
-        'no_repeat_ngram_size': active_settings.type === OOBA ? active_settings.no_repeat_ngram_size : undefined,
-        'penalty_alpha': active_settings.type === OOBA ? active_settings.penalty_alpha : undefined,
-        'temperature_last': (active_settings.type === OOBA || active_settings.type === APHRODITE || active_settings.type == TABBY) ? active_settings.temperature_last : undefined,
-        'speculative_ngram': active_settings.type === TABBY ? active_settings.speculative_ngram : undefined,
-        'do_sample': active_settings.type === OOBA ? active_settings.do_sample : undefined,
-        'seed': active_settings.seed >= 0 ? active_settings.seed : undefined,
-        'guidance_scale': cfgValues?.guidanceScale?.value ?? active_settings.guidance_scale ?? 1,
-        'negative_prompt': cfgValues?.negativePrompt ?? substituteParams(active_settings.negative_prompt) ?? '',
-        'grammar_string': active_settings.grammar_string,
-        'json_schema': [TABBY, LLAMACPP].includes(active_settings.type) ? active_settings.json_schema : undefined,
+        'rep_pen': settings.rep_pen,
+        'rep_pen_range': settings.rep_pen_range,
+        'repetition_decay': settings.type === TABBY ? settings.rep_pen_decay : undefined,
+        'repetition_penalty_range': settings.rep_pen_range,
+        'encoder_repetition_penalty': settings.type === OOBA ? settings.encoder_rep_pen : undefined,
+        'no_repeat_ngram_size': settings.type === OOBA ? settings.no_repeat_ngram_size : undefined,
+        'penalty_alpha': settings.type === OOBA ? settings.penalty_alpha : undefined,
+        'temperature_last': (settings.type === OOBA || settings.type === APHRODITE || settings.type == TABBY) ? settings.temperature_last : undefined,
+        'speculative_ngram': settings.type === TABBY ? settings.speculative_ngram : undefined,
+        'do_sample': settings.type === OOBA ? settings.do_sample : undefined,
+        'seed': settings.seed >= 0 ? settings.seed : undefined,
+        'guidance_scale': cfgValues?.guidanceScale?.value ?? settings.guidance_scale ?? 1,
+        'negative_prompt': cfgValues?.negativePrompt ?? substituteParams(settings.negative_prompt) ?? '',
+        'grammar_string': settings.grammar_string,
+        'json_schema': [TABBY, LLAMACPP].includes(settings.type) ? settings.json_schema : undefined,
         // llama.cpp aliases. In case someone wants to use LM Studio as Text Completion API
-        'repeat_penalty': active_settings.rep_pen,
-        'tfs_z': active_settings.tfs,
-        'repeat_last_n': active_settings.rep_pen_range,
+        'repeat_penalty': settings.rep_pen,
+        'tfs_z': settings.tfs,
+        'repeat_last_n': settings.rep_pen_range,
         'n_predict': maxTokens,
         'num_predict': maxTokens,
         'num_ctx': max_context,
-        'mirostat': active_settings.mirostat_mode,
-        'ignore_eos': active_settings.ban_eos_token,
+        'mirostat': settings.mirostat_mode,
+        'ignore_eos': settings.ban_eos_token,
         'n_probs': power_user.request_token_probabilities ? 10 : undefined,
-        'rep_pen_slope': active_settings.rep_pen_slope,
+        'rep_pen_slope': settings.rep_pen_slope,
     };
     const vllmParams = {
-        'n': canMultiSwipe ? active_settings.n : 1,
-        'ignore_eos': active_settings.ignore_eos_token,
-        'spaces_between_special_tokens': active_settings.spaces_between_special_tokens,
-        'seed': active_settings.seed >= 0 ? active_settings.seed : undefined,
+        'n': canMultiSwipe ? settings.n : 1,
+        'ignore_eos': settings.ignore_eos_token,
+        'spaces_between_special_tokens': settings.spaces_between_special_tokens,
+        'seed': settings.seed >= 0 ? settings.seed : undefined,
     };
     const aphroditeParams = {
-        'n': canMultiSwipe ? active_settings.n : 1,
-        'frequency_penalty': active_settings.freq_pen,
-        'presence_penalty': active_settings.presence_pen,
-        'repetition_penalty': active_settings.rep_pen,
-        'seed': active_settings.seed >= 0 ? active_settings.seed : undefined,
+        'n': canMultiSwipe ? settings.n : 1,
+        'frequency_penalty': settings.freq_pen,
+        'presence_penalty': settings.presence_pen,
+        'repetition_penalty': settings.rep_pen,
+        'seed': settings.seed >= 0 ? settings.seed : undefined,
         'stop': getStoppingStrings(isImpersonate, isContinue),
-        'temperature': dynatemp ? (active_settings.min_temp + active_settings.max_temp) / 2 : active_settings.temp,
-        'temperature_last': active_settings.temperature_last,
-        'top_p': active_settings.top_p,
-        'top_k': active_settings.top_k,
-        'top_a': active_settings.top_a,
-        'min_p': active_settings.min_p,
-        'tfs': active_settings.tfs,
-        'eta_cutoff': active_settings.eta_cutoff,
-        'epsilon_cutoff': active_settings.epsilon_cutoff,
-        'typical_p': active_settings.typical_p,
-        'smoothing_factor': active_settings.smoothing_factor,
-        'smoothing_curve': active_settings.smoothing_curve,
-        'ignore_eos': active_settings.ignore_eos_token,
-        'min_tokens': active_settings.min_length,
-        'skip_special_tokens': active_settings.skip_special_tokens,
-        'spaces_between_special_tokens': active_settings.spaces_between_special_tokens,
-        'guided_grammar': active_settings.grammar_string,
-        'guided_json': active_settings.json_schema,
+        'temperature': dynatemp ? (settings.min_temp + settings.max_temp) / 2 : settings.temp,
+        'temperature_last': settings.temperature_last,
+        'top_p': settings.top_p,
+        'top_k': settings.top_k,
+        'top_a': settings.top_a,
+        'min_p': settings.min_p,
+        'tfs': settings.tfs,
+        'eta_cutoff': settings.eta_cutoff,
+        'epsilon_cutoff': settings.epsilon_cutoff,
+        'typical_p': settings.typical_p,
+        'smoothing_factor': settings.smoothing_factor,
+        'smoothing_curve': settings.smoothing_curve,
+        'ignore_eos': settings.ignore_eos_token,
+        'min_tokens': settings.min_length,
+        'skip_special_tokens': settings.skip_special_tokens,
+        'spaces_between_special_tokens': settings.spaces_between_special_tokens,
+        'guided_grammar': settings.grammar_string,
+        'guided_json': settings.json_schema,
         'early_stopping': false, // hacks
         'include_stop_str_in_output': false,
-        'dynatemp_min': dynatemp ? active_settings.min_temp : undefined,
-        'dynatemp_max': dynatemp ? active_settings.max_temp : undefined,
-        'dynatemp_exponent': dynatemp ? active_settings.dynatemp_exponent : undefined,
-        'xtc_threshold': active_settings.xtc_threshold,
-        'xtc_probability': active_settings.xtc_probability,
-        'nsigma': active_settings.nsigma,
+        'dynatemp_min': dynatemp ? settings.min_temp : undefined,
+        'dynatemp_max': dynatemp ? settings.max_temp : undefined,
+        'dynatemp_exponent': dynatemp ? settings.dynatemp_exponent : undefined,
+        'xtc_threshold': settings.xtc_threshold,
+        'xtc_probability': settings.xtc_probability,
+        'nsigma': settings.nsigma,
         'custom_token_bans': toIntArray(banned_tokens),
-        'no_repeat_ngram_size': active_settings.no_repeat_ngram_size,
-        'sampler_priority': active_settings.type === APHRODITE && !arraysEqual(
-            active_settings.samplers_priorities,
+        'no_repeat_ngram_size': settings.no_repeat_ngram_size,
+        'sampler_priority': settings.type === APHRODITE && !arraysEqual(
+            settings.samplers_priorities,
             APHRODITE_DEFAULT_ORDER)
-            ? active_settings.samplers_priorities
+            ? settings.samplers_priorities
             : undefined,
     };
 
-    if (active_settings.type === OPENROUTER) {
-        params.provider = active_settings.openrouter_providers;
-        params.allow_fallbacks = active_settings.openrouter_allow_fallbacks;
+    if (settings.type === OPENROUTER) {
+        params.provider = settings.openrouter_providers;
+        params.allow_fallbacks = settings.openrouter_allow_fallbacks;
     }
 
-    if (active_settings.type === KOBOLDCPP) {
-        params.grammar = active_settings.grammar_string;
+    if (settings.type === KOBOLDCPP) {
+        params.grammar = settings.grammar_string;
         params.trim_stop = true;
     }
 
-    if (active_settings.type === HUGGINGFACE) {
+    if (settings.type === HUGGINGFACE) {
         params.top_p = Math.min(Math.max(Number(params.top_p), 0.0), 0.999);
         params.stop = Array.isArray(params.stop) ? params.stop.slice(0, 4) : [];
-        nonAphroditeParams.seed = active_settings.seed >= 0 ? active_settings.seed : Math.floor(Math.random() * Math.pow(2, 32));
+        nonAphroditeParams.seed = settings.seed >= 0 ? settings.seed : Math.floor(Math.random() * Math.pow(2, 32));
     }
 
-    if (active_settings.type === MANCER) {
-        params.n = canMultiSwipe ? active_settings.n : 1;
+    if (settings.type === MANCER) {
+        params.n = canMultiSwipe ? settings.n : 1;
         params.epsilon_cutoff /= 1000;
         params.eta_cutoff /= 1000;
         params.dynatemp_mode = params.dynamic_temperature ? 1 : 0;
@@ -1487,11 +1486,11 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         delete params.dynatemp_high;
     }
 
-    if (active_settings.type === TABBY) {
-        params.n = canMultiSwipe ? active_settings.n : 1;
+    if (settings.type === TABBY) {
+        params.n = canMultiSwipe ? settings.n : 1;
     }
 
-    switch (active_settings.type) {
+    switch (settings.type) {
         case VLLM:
         case INFERMATICAI:
             params = Object.assign(params, vllmParams);
@@ -1507,13 +1506,13 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
             break;
     }
 
-    if (Array.isArray(active_settings.logit_bias) && active_settings.logit_bias.length) {
+    if (Array.isArray(settings.logit_bias) && settings.logit_bias.length) {
         const logitBias = BIAS_CACHE.get(BIAS_KEY) || calculateLogitBias();
         BIAS_CACHE.set(BIAS_KEY, logitBias);
         params.logit_bias = logitBias;
     }
 
-    if (active_settings.type === LLAMACPP || active_settings.type === OLLAMA) {
+    if (settings.type === LLAMACPP || settings.type === OLLAMA) {
         // Convert bias and token bans to array of arrays
         const logitBiasArray = (params.logit_bias && typeof params.logit_bias === 'object' && Object.keys(params.logit_bias).length > 0)
             ? Object.entries(params.logit_bias).map(([key, value]) => [Number(key), value])
@@ -1534,7 +1533,7 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         const llamaCppParams = {
             'logit_bias': logitBiasArray,
             // Conflicts with ooba's grammar_string
-            'grammar': active_settings.grammar_string,
+            'grammar': settings.grammar_string,
             'cache_prompt': true,
             'dry_sequence_breakers': sequenceBreakers,
         };
@@ -1549,7 +1548,7 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
     }
 
     // Grammar conflicts with with json_schema
-    if (active_settings.type === LLAMACPP) {
+    if (settings.type === LLAMACPP) {
         if (params.json_schema && Object.keys(params.json_schema).length > 0) {
             delete params.grammar_string;
             delete params.grammar;

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1293,9 +1293,8 @@ export function presetToSettings(preset) {
     }
 
     // Merge with settings
-    const resultKeys = new Set(Object.keys(result));
     for (const [key, value] of Object.entries(settings)) {
-        if (!resultKeys.has(key)) {
+        if (!Object.hasOwn(result, key)) {
             result[key] = value;
         }
     }

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -402,10 +402,12 @@ function getTokenizerForTokenIds() {
 
 /**
  * @typedef {{banned_tokens: string, banned_strings: string[]}} TokenBanResult
+ * @param {string} bannedTokens If it's set, ignores active banned tokens
  * @returns {TokenBanResult} String with comma-separated banned token IDs
  */
-function getCustomTokenBans() {
-    if (!settings.send_banned_tokens || (!settings.banned_tokens && !settings.global_banned_tokens && !textgenerationwebui_banned_in_macros.length)) {
+function getCustomTokenBans(bannedTokens = null) {
+    const activeBannedTokens = bannedTokens ?? settings.banned_tokens;
+    if (!settings.send_banned_tokens || (!activeBannedTokens && !settings.global_banned_tokens && !textgenerationwebui_banned_in_macros.length)) {
         return {
             banned_tokens: '',
             banned_strings: [],
@@ -416,7 +418,7 @@ function getCustomTokenBans() {
     const banned_tokens = [];
     const banned_strings = [];
     const sequences = []
-        .concat(settings.banned_tokens.split('\n'))
+        .concat(activeBannedTokens.split('\n'))
         .concat(settings.global_banned_tokens.split('\n'))
         .concat(textgenerationwebui_banned_in_macros)
         .filter(x => x.length > 0)
@@ -1165,8 +1167,13 @@ function toIntArray(string) {
     return string.split(',').map(x => parseInt(x)).filter(x => !isNaN(x));
 }
 
-export function getTextGenModel() {
-    switch (settings.type) {
+/**
+ * Returns the model to use based on the type
+ * @param {string} type If it's set, ignores active type
+ * @returns {string | undefined}
+ */
+export function getTextGenModel(type = null) {
+    switch (type ?? settings.type) {
         case OOBA:
             if (settings.custom_model) {
                 return settings.custom_model;
@@ -1217,8 +1224,16 @@ export function isJsonSchemaSupported() {
     return [TABBY, LLAMACPP].includes(settings.type) && main_api === 'textgenerationwebui';
 }
 
-function isDynamicTemperatureSupported() {
-    return settings.dynatemp && DYNATEMP_BLOCK?.dataset?.tgType?.includes(settings.type);
+/**
+ * Checks if dynamic temperature is supported for the selected type.
+ * @param {boolean} dynatemp If it's set, ignores active dynatemp
+ * @param {string} type If it's set, ignores active type
+ * @returns {boolean}
+ */
+function isDynamicTemperatureSupported(dynatemp = null, type = null) {
+    const selectedDynatemp = dynatemp ?? settings.dynatemp;
+    const selectedType = type ?? settings.type;
+    return selectedDynatemp && DYNATEMP_BLOCK?.dataset?.tgType?.includes(selectedType);
 }
 
 /**
@@ -1263,168 +1278,207 @@ export function replaceMacrosInList(str) {
     }
 }
 
-export async function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type) {
+export function presetToSettings(preset) {
+    let result = {};
+
+    // Add preset values.
+    for (const [key, value] of Object.entries(preset)) {
+        const isSettingExist = setting_names.includes(key);
+        if (!isSettingExist) {
+            console.warn(`Unknown setting/preset name: ${key}`);
+            continue;
+        }
+
+        result[key] = value;
+    }
+
+    // Merge with settings
+    const resultKeys = new Set(Object.keys(result));
+    for (const [key, value] of Object.entries(settings)) {
+        if (!resultKeys.has(key)) {
+            result[key] = value;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * @param {string} finalPrompt
+ * @param {number} maxTokens
+ * @param {boolean} isImpersonate
+ * @param {boolean} isContinue
+ * @param {object} cfgValues
+ * @param {string} type inpersonate, continue, etc.
+ * @param {{preset?: object, model?: string, textgen_type?: string, api_url?: string}} custom
+ * @param {boolean} emitEvent
+ * @returns
+ */
+export async function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type, { preset, model, textgen_type, api_url } = {}, emitEvent = true) {
+    const active_settings = structuredClone(preset ? presetToSettings(preset) : settings);
+    active_settings.type = textgen_type ?? active_settings.type;
+
     const canMultiSwipe = !isContinue && !isImpersonate && type !== 'quiet';
-    const dynatemp = isDynamicTemperatureSupported();
-    const { banned_tokens, banned_strings } = getCustomTokenBans();
+    const dynatemp = isDynamicTemperatureSupported(active_settings.dynatemp, active_settings.type);
+    const { banned_tokens, banned_strings } = getCustomTokenBans(active_settings.banned_tokens);
 
     let params = {
         'prompt': finalPrompt,
-        'model': getTextGenModel(),
+        'model': model ?? getTextGenModel(active_settings.type),
         'max_new_tokens': maxTokens,
         'max_tokens': maxTokens,
         'logprobs': power_user.request_token_probabilities ? getLogprobsNumber() : undefined,
-        'temperature': dynatemp ? (settings.min_temp + settings.max_temp) / 2 : settings.temp,
-        'top_p': settings.top_p,
-        'typical_p': settings.typical_p,
-        'typical': settings.typical_p,
-        'sampler_seed': settings.seed >= 0 ? settings.seed : undefined,
-        'min_p': settings.min_p,
-        'repetition_penalty': settings.rep_pen,
-        'frequency_penalty': settings.freq_pen,
-        'presence_penalty': settings.presence_pen,
-        'top_k': settings.top_k,
-        'skew': settings.skew,
-        'min_length': settings.type === OOBA ? settings.min_length : undefined,
-        'minimum_message_content_tokens': settings.type === DREAMGEN ? settings.min_length : undefined,
-        'min_tokens': settings.min_length,
-        'num_beams': settings.type === OOBA ? settings.num_beams : undefined,
-        'length_penalty': settings.type === OOBA ? settings.length_penalty : undefined,
-        'early_stopping': settings.type === OOBA ? settings.early_stopping : undefined,
-        'add_bos_token': settings.add_bos_token,
+        'temperature': dynatemp ? (active_settings.min_temp + active_settings.max_temp) / 2 : active_settings.temp,
+        'top_p': active_settings.top_p,
+        'typical_p': active_settings.typical_p,
+        'typical': active_settings.typical_p,
+        'sampler_seed': active_settings.seed >= 0 ? active_settings.seed : undefined,
+        'min_p': active_settings.min_p,
+        'repetition_penalty': active_settings.rep_pen,
+        'frequency_penalty': active_settings.freq_pen,
+        'presence_penalty': active_settings.presence_pen,
+        'top_k': active_settings.top_k,
+        'skew': active_settings.skew,
+        'min_length': active_settings.type === OOBA ? active_settings.min_length : undefined,
+        'minimum_message_content_tokens': active_settings.type === DREAMGEN ? active_settings.min_length : undefined,
+        'min_tokens': active_settings.min_length,
+        'num_beams': active_settings.type === OOBA ? active_settings.num_beams : undefined,
+        'length_penalty': active_settings.type === OOBA ? active_settings.length_penalty : undefined,
+        'early_stopping': active_settings.type === OOBA ? active_settings.early_stopping : undefined,
+        'add_bos_token': active_settings.add_bos_token,
         'dynamic_temperature': dynatemp ? true : undefined,
-        'dynatemp_low': dynatemp ? settings.min_temp : undefined,
-        'dynatemp_high': dynatemp ? settings.max_temp : undefined,
-        'dynatemp_range': dynatemp ? (settings.max_temp - settings.min_temp) / 2 : undefined,
-        'dynatemp_exponent': dynatemp ? settings.dynatemp_exponent : undefined,
-        'smoothing_factor': settings.smoothing_factor,
-        'smoothing_curve': settings.smoothing_curve,
-        'dry_allowed_length': settings.dry_allowed_length,
-        'dry_multiplier': settings.dry_multiplier,
-        'dry_base': settings.dry_base,
-        'dry_sequence_breakers': replaceMacrosInList(settings.dry_sequence_breakers),
-        'dry_penalty_last_n': settings.dry_penalty_last_n,
-        'max_tokens_second': settings.max_tokens_second,
-        'sampler_priority': settings.type === OOBA ? settings.sampler_priority : undefined,
-        'samplers': settings.type === LLAMACPP ? settings.samplers : undefined,
+        'dynatemp_low': dynatemp ? active_settings.min_temp : undefined,
+        'dynatemp_high': dynatemp ? active_settings.max_temp : undefined,
+        'dynatemp_range': dynatemp ? (active_settings.max_temp - active_settings.min_temp) / 2 : undefined,
+        'dynatemp_exponent': dynatemp ? active_settings.dynatemp_exponent : undefined,
+        'smoothing_factor': active_settings.smoothing_factor,
+        'smoothing_curve': active_settings.smoothing_curve,
+        'dry_allowed_length': active_settings.dry_allowed_length,
+        'dry_multiplier': active_settings.dry_multiplier,
+        'dry_base': active_settings.dry_base,
+        'dry_sequence_breakers': replaceMacrosInList(active_settings.dry_sequence_breakers),
+        'dry_penalty_last_n': active_settings.dry_penalty_last_n,
+        'max_tokens_second': active_settings.max_tokens_second,
+        'sampler_priority': active_settings.type === OOBA ? active_settings.sampler_priority : undefined,
+        'samplers': active_settings.type === LLAMACPP ? active_settings.samplers : undefined,
         'stopping_strings': getStoppingStrings(isImpersonate, isContinue),
         'stop': getStoppingStrings(isImpersonate, isContinue),
         'truncation_length': max_context,
-        'ban_eos_token': settings.ban_eos_token,
-        'skip_special_tokens': settings.skip_special_tokens,
-        'include_reasoning': settings.include_reasoning,
-        'top_a': settings.top_a,
-        'tfs': settings.tfs,
-        'epsilon_cutoff': [OOBA, MANCER].includes(settings.type) ? settings.epsilon_cutoff : undefined,
-        'eta_cutoff': [OOBA, MANCER].includes(settings.type) ? settings.eta_cutoff : undefined,
-        'mirostat_mode': settings.mirostat_mode,
-        'mirostat_tau': settings.mirostat_tau,
-        'mirostat_eta': settings.mirostat_eta,
-        'custom_token_bans': [APHRODITE, MANCER].includes(settings.type) ?
+        'ban_eos_token': active_settings.ban_eos_token,
+        'skip_special_tokens': active_settings.skip_special_tokens,
+        'include_reasoning': active_settings.include_reasoning,
+        'top_a': active_settings.top_a,
+        'tfs': active_settings.tfs,
+        'epsilon_cutoff': [OOBA, MANCER].includes(active_settings.type) ? active_settings.epsilon_cutoff : undefined,
+        'eta_cutoff': [OOBA, MANCER].includes(active_settings.type) ? active_settings.eta_cutoff : undefined,
+        'mirostat_mode': active_settings.mirostat_mode,
+        'mirostat_tau': active_settings.mirostat_tau,
+        'mirostat_eta': active_settings.mirostat_eta,
+        'custom_token_bans': [APHRODITE, MANCER].includes(active_settings.type) ?
             toIntArray(banned_tokens) :
             banned_tokens,
         'banned_strings': banned_strings,
-        'api_type': settings.type,
-        'api_server': getTextGenServer(),
-        'sampler_order': settings.type === textgen_types.KOBOLDCPP ? settings.sampler_order : undefined,
-        'xtc_threshold': settings.xtc_threshold,
-        'xtc_probability': settings.xtc_probability,
-        'nsigma': settings.nsigma,
+        'api_type': active_settings.type,
+        'api_server': api_url ?? getTextGenServer(active_settings.type),
+        'sampler_order': active_settings.type === textgen_types.KOBOLDCPP ? active_settings.sampler_order : undefined,
+        'xtc_threshold': active_settings.xtc_threshold,
+        'xtc_probability': active_settings.xtc_probability,
+        'nsigma': active_settings.nsigma,
     };
     const nonAphroditeParams = {
-        'rep_pen': settings.rep_pen,
-        'rep_pen_range': settings.rep_pen_range,
-        'repetition_decay': settings.type === TABBY ? settings.rep_pen_decay : undefined,
-        'repetition_penalty_range': settings.rep_pen_range,
-        'encoder_repetition_penalty': settings.type === OOBA ? settings.encoder_rep_pen : undefined,
-        'no_repeat_ngram_size': settings.type === OOBA ? settings.no_repeat_ngram_size : undefined,
-        'penalty_alpha': settings.type === OOBA ? settings.penalty_alpha : undefined,
-        'temperature_last': (settings.type === OOBA || settings.type === APHRODITE || settings.type == TABBY) ? settings.temperature_last : undefined,
-        'speculative_ngram': settings.type === TABBY ? settings.speculative_ngram : undefined,
-        'do_sample': settings.type === OOBA ? settings.do_sample : undefined,
-        'seed': settings.seed >= 0 ? settings.seed : undefined,
-        'guidance_scale': cfgValues?.guidanceScale?.value ?? settings.guidance_scale ?? 1,
-        'negative_prompt': cfgValues?.negativePrompt ?? substituteParams(settings.negative_prompt) ?? '',
-        'grammar_string': settings.grammar_string,
-        'json_schema': [TABBY, LLAMACPP].includes(settings.type) ? settings.json_schema : undefined,
+        'rep_pen': active_settings.rep_pen,
+        'rep_pen_range': active_settings.rep_pen_range,
+        'repetition_decay': active_settings.type === TABBY ? active_settings.rep_pen_decay : undefined,
+        'repetition_penalty_range': active_settings.rep_pen_range,
+        'encoder_repetition_penalty': active_settings.type === OOBA ? active_settings.encoder_rep_pen : undefined,
+        'no_repeat_ngram_size': active_settings.type === OOBA ? active_settings.no_repeat_ngram_size : undefined,
+        'penalty_alpha': active_settings.type === OOBA ? active_settings.penalty_alpha : undefined,
+        'temperature_last': (active_settings.type === OOBA || active_settings.type === APHRODITE || active_settings.type == TABBY) ? active_settings.temperature_last : undefined,
+        'speculative_ngram': active_settings.type === TABBY ? active_settings.speculative_ngram : undefined,
+        'do_sample': active_settings.type === OOBA ? active_settings.do_sample : undefined,
+        'seed': active_settings.seed >= 0 ? active_settings.seed : undefined,
+        'guidance_scale': cfgValues?.guidanceScale?.value ?? active_settings.guidance_scale ?? 1,
+        'negative_prompt': cfgValues?.negativePrompt ?? substituteParams(active_settings.negative_prompt) ?? '',
+        'grammar_string': active_settings.grammar_string,
+        'json_schema': [TABBY, LLAMACPP].includes(active_settings.type) ? active_settings.json_schema : undefined,
         // llama.cpp aliases. In case someone wants to use LM Studio as Text Completion API
-        'repeat_penalty': settings.rep_pen,
-        'tfs_z': settings.tfs,
-        'repeat_last_n': settings.rep_pen_range,
+        'repeat_penalty': active_settings.rep_pen,
+        'tfs_z': active_settings.tfs,
+        'repeat_last_n': active_settings.rep_pen_range,
         'n_predict': maxTokens,
         'num_predict': maxTokens,
         'num_ctx': max_context,
-        'mirostat': settings.mirostat_mode,
-        'ignore_eos': settings.ban_eos_token,
+        'mirostat': active_settings.mirostat_mode,
+        'ignore_eos': active_settings.ban_eos_token,
         'n_probs': power_user.request_token_probabilities ? 10 : undefined,
-        'rep_pen_slope': settings.rep_pen_slope,
+        'rep_pen_slope': active_settings.rep_pen_slope,
     };
     const vllmParams = {
-        'n': canMultiSwipe ? settings.n : 1,
-        'ignore_eos': settings.ignore_eos_token,
-        'spaces_between_special_tokens': settings.spaces_between_special_tokens,
-        'seed': settings.seed >= 0 ? settings.seed : undefined,
+        'n': canMultiSwipe ? active_settings.n : 1,
+        'ignore_eos': active_settings.ignore_eos_token,
+        'spaces_between_special_tokens': active_settings.spaces_between_special_tokens,
+        'seed': active_settings.seed >= 0 ? active_settings.seed : undefined,
     };
     const aphroditeParams = {
-        'n': canMultiSwipe ? settings.n : 1,
-        'frequency_penalty': settings.freq_pen,
-        'presence_penalty': settings.presence_pen,
-        'repetition_penalty': settings.rep_pen,
-        'seed': settings.seed >= 0 ? settings.seed : undefined,
+        'n': canMultiSwipe ? active_settings.n : 1,
+        'frequency_penalty': active_settings.freq_pen,
+        'presence_penalty': active_settings.presence_pen,
+        'repetition_penalty': active_settings.rep_pen,
+        'seed': active_settings.seed >= 0 ? active_settings.seed : undefined,
         'stop': getStoppingStrings(isImpersonate, isContinue),
-        'temperature': dynatemp ? (settings.min_temp + settings.max_temp) / 2 : settings.temp,
-        'temperature_last': settings.temperature_last,
-        'top_p': settings.top_p,
-        'top_k': settings.top_k,
-        'top_a': settings.top_a,
-        'min_p': settings.min_p,
-        'tfs': settings.tfs,
-        'eta_cutoff': settings.eta_cutoff,
-        'epsilon_cutoff': settings.epsilon_cutoff,
-        'typical_p': settings.typical_p,
-        'smoothing_factor': settings.smoothing_factor,
-        'smoothing_curve': settings.smoothing_curve,
-        'ignore_eos': settings.ignore_eos_token,
-        'min_tokens': settings.min_length,
-        'skip_special_tokens': settings.skip_special_tokens,
-        'spaces_between_special_tokens': settings.spaces_between_special_tokens,
-        'guided_grammar': settings.grammar_string,
-        'guided_json': settings.json_schema,
+        'temperature': dynatemp ? (active_settings.min_temp + active_settings.max_temp) / 2 : active_settings.temp,
+        'temperature_last': active_settings.temperature_last,
+        'top_p': active_settings.top_p,
+        'top_k': active_settings.top_k,
+        'top_a': active_settings.top_a,
+        'min_p': active_settings.min_p,
+        'tfs': active_settings.tfs,
+        'eta_cutoff': active_settings.eta_cutoff,
+        'epsilon_cutoff': active_settings.epsilon_cutoff,
+        'typical_p': active_settings.typical_p,
+        'smoothing_factor': active_settings.smoothing_factor,
+        'smoothing_curve': active_settings.smoothing_curve,
+        'ignore_eos': active_settings.ignore_eos_token,
+        'min_tokens': active_settings.min_length,
+        'skip_special_tokens': active_settings.skip_special_tokens,
+        'spaces_between_special_tokens': active_settings.spaces_between_special_tokens,
+        'guided_grammar': active_settings.grammar_string,
+        'guided_json': active_settings.json_schema,
         'early_stopping': false, // hacks
         'include_stop_str_in_output': false,
-        'dynatemp_min': dynatemp ? settings.min_temp : undefined,
-        'dynatemp_max': dynatemp ? settings.max_temp : undefined,
-        'dynatemp_exponent': dynatemp ? settings.dynatemp_exponent : undefined,
-        'xtc_threshold': settings.xtc_threshold,
-        'xtc_probability': settings.xtc_probability,
-        'nsigma': settings.nsigma,
+        'dynatemp_min': dynatemp ? active_settings.min_temp : undefined,
+        'dynatemp_max': dynatemp ? active_settings.max_temp : undefined,
+        'dynatemp_exponent': dynatemp ? active_settings.dynatemp_exponent : undefined,
+        'xtc_threshold': active_settings.xtc_threshold,
+        'xtc_probability': active_settings.xtc_probability,
+        'nsigma': active_settings.nsigma,
         'custom_token_bans': toIntArray(banned_tokens),
-        'no_repeat_ngram_size': settings.no_repeat_ngram_size,
-        'sampler_priority': settings.type === APHRODITE && !arraysEqual(
-            settings.samplers_priorities,
+        'no_repeat_ngram_size': active_settings.no_repeat_ngram_size,
+        'sampler_priority': active_settings.type === APHRODITE && !arraysEqual(
+            active_settings.samplers_priorities,
             APHRODITE_DEFAULT_ORDER)
-            ? settings.samplers_priorities
+            ? active_settings.samplers_priorities
             : undefined,
     };
 
-    if (settings.type === OPENROUTER) {
-        params.provider = settings.openrouter_providers;
-        params.allow_fallbacks = settings.openrouter_allow_fallbacks;
+    if (active_settings.type === OPENROUTER) {
+        params.provider = active_settings.openrouter_providers;
+        params.allow_fallbacks = active_settings.openrouter_allow_fallbacks;
     }
 
-    if (settings.type === KOBOLDCPP) {
-        params.grammar = settings.grammar_string;
+    if (active_settings.type === KOBOLDCPP) {
+        params.grammar = active_settings.grammar_string;
         params.trim_stop = true;
     }
 
-    if (settings.type === HUGGINGFACE) {
+    if (active_settings.type === HUGGINGFACE) {
         params.top_p = Math.min(Math.max(Number(params.top_p), 0.0), 0.999);
         params.stop = Array.isArray(params.stop) ? params.stop.slice(0, 4) : [];
-        nonAphroditeParams.seed = settings.seed >= 0 ? settings.seed : Math.floor(Math.random() * Math.pow(2, 32));
+        nonAphroditeParams.seed = active_settings.seed >= 0 ? active_settings.seed : Math.floor(Math.random() * Math.pow(2, 32));
     }
 
-    if (settings.type === MANCER) {
-        params.n = canMultiSwipe ? settings.n : 1;
+    if (active_settings.type === MANCER) {
+        params.n = canMultiSwipe ? active_settings.n : 1;
         params.epsilon_cutoff /= 1000;
         params.eta_cutoff /= 1000;
         params.dynatemp_mode = params.dynamic_temperature ? 1 : 0;
@@ -1434,11 +1488,11 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         delete params.dynatemp_high;
     }
 
-    if (settings.type === TABBY) {
-        params.n = canMultiSwipe ? settings.n : 1;
+    if (active_settings.type === TABBY) {
+        params.n = canMultiSwipe ? active_settings.n : 1;
     }
 
-    switch (settings.type) {
+    switch (active_settings.type) {
         case VLLM:
         case INFERMATICAI:
             params = Object.assign(params, vllmParams);
@@ -1454,13 +1508,13 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
             break;
     }
 
-    if (Array.isArray(settings.logit_bias) && settings.logit_bias.length) {
+    if (Array.isArray(active_settings.logit_bias) && active_settings.logit_bias.length) {
         const logitBias = BIAS_CACHE.get(BIAS_KEY) || calculateLogitBias();
         BIAS_CACHE.set(BIAS_KEY, logitBias);
         params.logit_bias = logitBias;
     }
 
-    if (settings.type === LLAMACPP || settings.type === OLLAMA) {
+    if (active_settings.type === LLAMACPP || active_settings.type === OLLAMA) {
         // Convert bias and token bans to array of arrays
         const logitBiasArray = (params.logit_bias && typeof params.logit_bias === 'object' && Object.keys(params.logit_bias).length > 0)
             ? Object.entries(params.logit_bias).map(([key, value]) => [Number(key), value])
@@ -1481,7 +1535,7 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         const llamaCppParams = {
             'logit_bias': logitBiasArray,
             // Conflicts with ooba's grammar_string
-            'grammar': settings.grammar_string,
+            'grammar': active_settings.grammar_string,
             'cache_prompt': true,
             'dry_sequence_breakers': sequenceBreakers,
         };
@@ -1491,10 +1545,12 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         }
     }
 
-    await eventSource.emit(event_types.TEXT_COMPLETION_SETTINGS_READY, params);
+    if (emitEvent) {
+        await eventSource.emit(event_types.TEXT_COMPLETION_SETTINGS_READY, params);
+    }
 
     // Grammar conflicts with with json_schema
-    if (settings.type === LLAMACPP) {
+    if (active_settings.type === LLAMACPP) {
         if (params.json_schema && Object.keys(params.json_schema).length > 0) {
             delete params.grammar_string;
             delete params.grammar;

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -108,12 +108,12 @@ const BIAS_KEY = '#textgenerationwebui_api-settings';
 // (7 days later) The future has come.
 const MANCER_SERVER_KEY = 'mancer_server';
 const MANCER_SERVER_DEFAULT = 'https://neuro.mancer.tech';
-let MANCER_SERVER = localStorage.getItem(MANCER_SERVER_KEY) ?? MANCER_SERVER_DEFAULT;
-let TOGETHERAI_SERVER = 'https://api.together.xyz';
-let INFERMATICAI_SERVER = 'https://api.totalgpt.ai';
-let DREAMGEN_SERVER = 'https://dreamgen.com';
-let OPENROUTER_SERVER = 'https://openrouter.ai/api';
-let FEATHERLESS_SERVER = 'https://api.featherless.ai/v1';
+export let MANCER_SERVER = localStorage.getItem(MANCER_SERVER_KEY) ?? MANCER_SERVER_DEFAULT;
+export let TOGETHERAI_SERVER = 'https://api.together.xyz';
+export let INFERMATICAI_SERVER = 'https://api.totalgpt.ai';
+export let DREAMGEN_SERVER = 'https://dreamgen.com';
+export let OPENROUTER_SERVER = 'https://openrouter.ai/api';
+export let FEATHERLESS_SERVER = 'https://api.featherless.ai/v1';
 
 export const SERVER_INPUTS = {
     [textgen_types.OOBA]: '#textgenerationwebui_api_url_text',
@@ -128,7 +128,7 @@ export const SERVER_INPUTS = {
 };
 
 const KOBOLDCPP_ORDER = [6, 0, 1, 3, 4, 2, 5];
-const textgenerationwebui_settings = {
+const settings = {
     temp: 0.7,
     temperature_last: true,
     top_p: 0.5,
@@ -217,7 +217,7 @@ const textgenerationwebui_settings = {
 };
 
 export {
-    textgenerationwebui_settings,
+    settings as textgenerationwebui_settings,
 };
 
 export let textgenerationwebui_banned_in_macros = [];
@@ -300,7 +300,7 @@ export const setting_names = [
 const DYNATEMP_BLOCK = document.getElementById('dynatemp_block_ooba');
 
 export function validateTextGenUrl() {
-    const selector = SERVER_INPUTS[textgenerationwebui_settings.type];
+    const selector = SERVER_INPUTS[settings.type];
 
     if (!selector) {
         return;
@@ -324,7 +324,7 @@ export function validateTextGenUrl() {
  * @returns {string} API URL
  */
 export function getTextGenServer(type = null) {
-    const selectedType = type ?? textgenerationwebui_settings.type;
+    const selectedType = type ?? settings.type;
     switch (selectedType) {
         case FEATHERLESS:
             return FEATHERLESS_SERVER;
@@ -339,7 +339,7 @@ export function getTextGenServer(type = null) {
         case OPENROUTER:
             return OPENROUTER_SERVER;
         default:
-            return textgenerationwebui_settings.server_urls[selectedType] ?? '';
+            return settings.server_urls[selectedType] ?? '';
     }
 }
 
@@ -350,7 +350,7 @@ async function selectPreset(name) {
         return;
     }
 
-    textgenerationwebui_settings.preset = name;
+    settings.preset = name;
     for (const name of setting_names) {
         const value = preset[name];
         setSettingByName(name, value, true);
@@ -364,7 +364,7 @@ async function selectPreset(name) {
 export function formatTextGenURL(value) {
     try {
         const noFormatTypes = [MANCER, TOGETHERAI, INFERMATICAI, DREAMGEN, OPENROUTER];
-        if (noFormatTypes.includes(textgenerationwebui_settings.type)) {
+        if (noFormatTypes.includes(settings.type)) {
             return value;
         }
 
@@ -381,7 +381,7 @@ function convertPresets(presets) {
 }
 
 function getTokenizerForTokenIds() {
-    if (power_user.tokenizer === tokenizers.API_CURRENT && TEXTGEN_TOKENIZERS.includes(textgenerationwebui_settings.type)) {
+    if (power_user.tokenizer === tokenizers.API_CURRENT && TEXTGEN_TOKENIZERS.includes(settings.type)) {
         return tokenizers.API_CURRENT;
     }
 
@@ -389,11 +389,11 @@ function getTokenizerForTokenIds() {
         return power_user.tokenizer;
     }
 
-    if (textgenerationwebui_settings.type === OPENROUTER) {
+    if (settings.type === OPENROUTER) {
         return getCurrentOpenRouterModelTokenizer();
     }
 
-    if (textgenerationwebui_settings.type === DREAMGEN) {
+    if (settings.type === DREAMGEN) {
         return getCurrentDreamGenModelTokenizer();
     }
 
@@ -402,11 +402,10 @@ function getTokenizerForTokenIds() {
 
 /**
  * @typedef {{banned_tokens: string, banned_strings: string[]}} TokenBanResult
- * @param {object} textgenerationwebui_settings If it's set, ignores active settings
  * @returns {TokenBanResult} String with comma-separated banned token IDs
  */
-function getCustomTokenBans({ banned_tokens } = textgenerationwebui_settings) {
-    if (!textgenerationwebui_settings.send_banned_tokens || (!banned_tokens && !textgenerationwebui_settings.global_banned_tokens && !textgenerationwebui_banned_in_macros.length)) {
+function getCustomTokenBans() {
+    if (!settings.send_banned_tokens || (!settings.banned_tokens && !settings.global_banned_tokens && !textgenerationwebui_banned_in_macros.length)) {
         return {
             banned_tokens: '',
             banned_strings: [],
@@ -414,11 +413,11 @@ function getCustomTokenBans({ banned_tokens } = textgenerationwebui_settings) {
     }
 
     const tokenizer = getTokenizerForTokenIds();
-    const result_banned_tokens = [];
+    const banned_tokens = [];
     const banned_strings = [];
     const sequences = []
-        .concat(banned_tokens.split('\n'))
-        .concat(textgenerationwebui_settings.global_banned_tokens.split('\n'))
+        .concat(settings.banned_tokens.split('\n'))
+        .concat(settings.global_banned_tokens.split('\n'))
         .concat(textgenerationwebui_banned_in_macros)
         .filter(x => x.length > 0)
         .filter(onlyUnique);
@@ -438,7 +437,7 @@ function getCustomTokenBans({ banned_tokens } = textgenerationwebui_settings) {
                 const tokens = JSON.parse(line);
 
                 if (Array.isArray(tokens) && tokens.every(t => Number.isInteger(t))) {
-                    result_banned_tokens.push(...tokens);
+                    banned_tokens.push(...tokens);
                 } else {
                     throw new Error('Not an array of integers');
                 }
@@ -452,7 +451,7 @@ function getCustomTokenBans({ banned_tokens } = textgenerationwebui_settings) {
         } else {
             try {
                 const tokens = getTextTokens(tokenizer, line);
-                result_banned_tokens.push(...tokens);
+                banned_tokens.push(...tokens);
             } catch {
                 console.log(`Could not tokenize raw text: ${line}`);
             }
@@ -460,7 +459,7 @@ function getCustomTokenBans({ banned_tokens } = textgenerationwebui_settings) {
     }
 
     return {
-        banned_tokens: result_banned_tokens.filter(onlyUnique).map(x => String(x)).join(','),
+        banned_tokens: banned_tokens.filter(onlyUnique).map(x => String(x)).join(','),
         banned_strings: banned_strings,
     };
 }
@@ -473,7 +472,7 @@ function getCustomTokenBans({ banned_tokens } = textgenerationwebui_settings) {
 function toggleBannedStringsKillSwitch(isEnabled, title) {
     $('#send_banned_tokens_textgenerationwebui').prop('checked', isEnabled);
     $('#send_banned_tokens_label').find('.menu_button').toggleClass('toggleEnabled', isEnabled).prop('title', title);
-    textgenerationwebui_settings.send_banned_tokens = isEnabled;
+    settings.send_banned_tokens = isEnabled;
     saveSettingsDebounced();
 }
 
@@ -482,7 +481,7 @@ function toggleBannedStringsKillSwitch(isEnabled, title) {
  * @returns {object} Logit bias object
  */
 function calculateLogitBias() {
-    if (!Array.isArray(textgenerationwebui_settings.logit_bias) || textgenerationwebui_settings.logit_bias.length === 0) {
+    if (!Array.isArray(settings.logit_bias) || settings.logit_bias.length === 0) {
         return {};
     }
 
@@ -508,7 +507,7 @@ function calculateLogitBias() {
         return result;
     }
 
-    getLogitBiasListResult(textgenerationwebui_settings.logit_bias, tokenizer, addBias);
+    getLogitBiasListResult(settings.logit_bias, tokenizer, addBias);
 
     return result;
 }
@@ -516,25 +515,25 @@ function calculateLogitBias() {
 export function loadTextGenSettings(data, loadedSettings) {
     textgenerationwebui_presets = convertPresets(data.textgenerationwebui_presets);
     textgenerationwebui_preset_names = data.textgenerationwebui_preset_names ?? [];
-    Object.assign(textgenerationwebui_settings, loadedSettings.textgenerationwebui_settings ?? {});
+    Object.assign(settings, loadedSettings.textgenerationwebui_settings ?? {});
 
     if (loadedSettings.api_server_textgenerationwebui) {
         for (const type of Object.keys(SERVER_INPUTS)) {
-            textgenerationwebui_settings.server_urls[type] = loadedSettings.api_server_textgenerationwebui;
+            settings.server_urls[type] = loadedSettings.api_server_textgenerationwebui;
         }
         delete loadedSettings.api_server_textgenerationwebui;
     }
 
     for (const [type, selector] of Object.entries(SERVER_INPUTS)) {
         const control = $(selector);
-        control.val(textgenerationwebui_settings.server_urls[type] ?? '').on('input', function () {
-            textgenerationwebui_settings.server_urls[type] = String($(this).val()).trim();
+        control.val(settings.server_urls[type] ?? '').on('input', function () {
+            settings.server_urls[type] = String($(this).val()).trim();
             saveSettingsDebounced();
         });
     }
 
     if (loadedSettings.api_use_mancer_webui) {
-        textgenerationwebui_settings.type = MANCER;
+        settings.type = MANCER;
     }
 
     for (const name of textgenerationwebui_preset_names) {
@@ -544,20 +543,20 @@ export function loadTextGenSettings(data, loadedSettings) {
         $('#settings_preset_textgenerationwebui').append(option);
     }
 
-    if (textgenerationwebui_settings.preset) {
-        $('#settings_preset_textgenerationwebui').val(textgenerationwebui_settings.preset);
+    if (settings.preset) {
+        $('#settings_preset_textgenerationwebui').val(settings.preset);
     }
 
     for (const i of setting_names) {
-        const value = textgenerationwebui_settings[i];
+        const value = settings[i];
         setSettingByName(i, value);
     }
 
-    $('#textgen_type').val(textgenerationwebui_settings.type);
-    $('#openrouter_providers_text').val(textgenerationwebui_settings.openrouter_providers).trigger('change');
-    showTypeSpecificControls(textgenerationwebui_settings.type);
+    $('#textgen_type').val(settings.type);
+    $('#openrouter_providers_text').val(settings.openrouter_providers).trigger('change');
+    showTypeSpecificControls(settings.type);
     BIAS_CACHE.delete(BIAS_KEY);
-    displayLogitBias(textgenerationwebui_settings.logit_bias, BIAS_KEY);
+    displayLogitBias(settings.logit_bias, BIAS_KEY);
 
     registerDebugFunction('change-mancer-url', 'Change Mancer base URL', 'Change Mancer API server base URL', () => {
         const result = prompt(`Enter Mancer base URL\nDefault: ${MANCER_SERVER_DEFAULT}`, MANCER_SERVER);
@@ -634,15 +633,15 @@ jQuery(function () {
             $('#koboldcpp_order').children().each(function () {
                 order.push($(this).data('id'));
             });
-            textgenerationwebui_settings.sampler_order = order;
-            console.log('Samplers reordered:', textgenerationwebui_settings.sampler_order);
+            settings.sampler_order = order;
+            console.log('Samplers reordered:', settings.sampler_order);
             saveSettingsDebounced();
         },
     });
 
     $('#koboldcpp_default_order').on('click', function () {
-        textgenerationwebui_settings.sampler_order = KOBOLDCPP_ORDER;
-        sortKoboldItemsByOrder(textgenerationwebui_settings.sampler_order);
+        settings.sampler_order = KOBOLDCPP_ORDER;
+        sortKoboldItemsByOrder(settings.sampler_order);
         saveSettingsDebounced();
     });
 
@@ -653,16 +652,16 @@ jQuery(function () {
             $('#llamacpp_samplers_sortable').children().each(function () {
                 order.push($(this).data('name'));
             });
-            textgenerationwebui_settings.samplers = order;
-            console.log('Samplers reordered:', textgenerationwebui_settings.samplers);
+            settings.samplers = order;
+            console.log('Samplers reordered:', settings.samplers);
             saveSettingsDebounced();
         },
     });
 
     $('#llamacpp_samplers_default_order').on('click', function () {
         sortLlamacppItemsByOrder(LLAMACPP_DEFAULT_ORDER);
-        textgenerationwebui_settings.samplers = LLAMACPP_DEFAULT_ORDER;
-        console.log('Default samplers order loaded:', textgenerationwebui_settings.samplers);
+        settings.samplers = LLAMACPP_DEFAULT_ORDER;
+        console.log('Default samplers order loaded:', settings.samplers);
         saveSettingsDebounced();
     });
 
@@ -673,8 +672,8 @@ jQuery(function () {
             $('#sampler_priority_container').children().each(function () {
                 order.push($(this).data('name'));
             });
-            textgenerationwebui_settings.sampler_priority = order;
-            console.log('Samplers reordered:', textgenerationwebui_settings.sampler_priority);
+            settings.sampler_priority = order;
+            console.log('Samplers reordered:', settings.sampler_priority);
             saveSettingsDebounced();
         },
     });
@@ -686,8 +685,8 @@ jQuery(function () {
             $('#sampler_priority_container_aphrodite').children().each(function () {
                 order.push($(this).data('name'));
             });
-            textgenerationwebui_settings.samplers_priorities = order;
-            console.log('Samplers reordered:', textgenerationwebui_settings.samplers_priorities);
+            settings.samplers_priorities = order;
+            console.log('Samplers reordered:', settings.samplers_priorities);
             saveSettingsDebounced();
         },
     });
@@ -696,7 +695,7 @@ jQuery(function () {
         const json_schema_string = String($(this).val());
 
         try {
-            textgenerationwebui_settings.json_schema = JSON.parse(json_schema_string || '{}');
+            settings.json_schema = JSON.parse(json_schema_string || '{}');
         } catch {
             // Ignore errors from here
         }
@@ -705,38 +704,38 @@ jQuery(function () {
 
     $('#textgenerationwebui_default_order').on('click', function () {
         sortOobaItemsByOrder(OOBA_DEFAULT_ORDER);
-        textgenerationwebui_settings.sampler_priority = OOBA_DEFAULT_ORDER;
-        console.log('Default samplers order loaded:', textgenerationwebui_settings.sampler_priority);
+        settings.sampler_priority = OOBA_DEFAULT_ORDER;
+        console.log('Default samplers order loaded:', settings.sampler_priority);
         saveSettingsDebounced();
     });
 
     $('#aphrodite_default_order').on('click', function () {
         sortAphroditeItemsByOrder(APHRODITE_DEFAULT_ORDER);
-        textgenerationwebui_settings.samplers_priorities = APHRODITE_DEFAULT_ORDER;
-        console.log('Default samplers order loaded:', textgenerationwebui_settings.samplers_priorities);
+        settings.samplers_priorities = APHRODITE_DEFAULT_ORDER;
+        console.log('Default samplers order loaded:', settings.samplers_priorities);
         saveSettingsDebounced();
     });
 
     $('#textgen_type').on('change', function () {
         const type = String($(this).val());
-        textgenerationwebui_settings.type = type;
+        settings.type = type;
 
-        if ([VLLM, APHRODITE, INFERMATICAI].includes(textgenerationwebui_settings.type)) {
+        if ([VLLM, APHRODITE, INFERMATICAI].includes(settings.type)) {
             $('#mirostat_mode_textgenerationwebui').attr('step', 2); //Aphro disallows mode 1
             $('#do_sample_textgenerationwebui').prop('checked', true); //Aphro should always do sample; 'otherwise set temp to 0 to mimic no sample'
             $('#ban_eos_token_textgenerationwebui').prop('checked', false); //Aphro should not ban EOS, just ignore it; 'add token '2' to ban list do to this'
             //special handling for vLLM/Aphrodite topK -1 disable state
             $('#top_k_textgenerationwebui').attr('min', -1);
-            if ($('#top_k_textgenerationwebui').val() === '0' || textgenerationwebui_settings['top_k'] === 0) {
-                textgenerationwebui_settings['top_k'] = -1;
+            if ($('#top_k_textgenerationwebui').val() === '0' || settings['top_k'] === 0) {
+                settings['top_k'] = -1;
                 $('#top_k_textgenerationwebui').val('-1').trigger('input');
             }
         } else {
             $('#mirostat_mode_textgenerationwebui').attr('step', 1);
             //undo special vLLM/Aphrodite setup for topK
             $('#top_k_textgenerationwebui').attr('min', 0);
-            if ($('#top_k_textgenerationwebui').val() === '-1' || textgenerationwebui_settings['top_k'] === -1) {
-                textgenerationwebui_settings['top_k'] = 0;
+            if ($('#top_k_textgenerationwebui').val() === '-1' || settings['top_k'] === -1) {
+                settings['top_k'] = 0;
                 $('#top_k_textgenerationwebui').val('0').trigger('input');
             }
         }
@@ -747,7 +746,7 @@ jQuery(function () {
 
         $('#main_api').trigger('change');
 
-        if (!SERVER_INPUTS[type] || textgenerationwebui_settings.server_urls[type]) {
+        if (!SERVER_INPUTS[type] || settings.server_urls[type]) {
             $('#api_button_textgenerationwebui').trigger('click');
         }
 
@@ -762,7 +761,7 @@ jQuery(function () {
     $('#samplerResetButton').off('click').on('click', function () {
         const inputs = {
             'temp_textgenerationwebui': 1,
-            'top_k_textgenerationwebui': [INFERMATICAI, APHRODITE, VLLM].includes(textgenerationwebui_settings.type) ? -1 : 0,
+            'top_k_textgenerationwebui': [INFERMATICAI, APHRODITE, VLLM].includes(settings.type) ? -1 : 0,
             'top_p_textgenerationwebui': 1,
             'min_p_textgenerationwebui': 0,
             'rep_pen_textgenerationwebui': 1,
@@ -837,19 +836,19 @@ jQuery(function () {
 
             if (isCheckbox) {
                 const value = $(this).prop('checked');
-                textgenerationwebui_settings[id] = value;
+                settings[id] = value;
             }
             else if (isText) {
                 const value = $(this).val();
-                textgenerationwebui_settings[id] = value;
+                settings[id] = value;
             }
             else {
                 const value = Number($(this).val());
                 $(`#${id}_counter_textgenerationwebui`).val(value);
-                textgenerationwebui_settings[id] = value;
+                settings[id] = value;
                 //special handling for vLLM/Aphrodite using -1 as disabled instead of 0
-                if ($(this).attr('id') === 'top_k_textgenerationwebui' && [INFERMATICAI, APHRODITE, VLLM].includes(textgenerationwebui_settings.type) && value === 0) {
-                    textgenerationwebui_settings[id] = -1;
+                if ($(this).attr('id') === 'top_k_textgenerationwebui' && [INFERMATICAI, APHRODITE, VLLM].includes(settings.type) && value === 0) {
+                    settings[id] = -1;
                     $(this).val(-1);
                 }
             }
@@ -857,7 +856,7 @@ jQuery(function () {
         });
     }
 
-    $('#textgen_logit_bias_new_entry').on('click', () => createNewLogitBiasEntry(textgenerationwebui_settings.logit_bias, BIAS_KEY));
+    $('#textgen_logit_bias_new_entry').on('click', () => createNewLogitBiasEntry(settings.logit_bias, BIAS_KEY));
 
     $('#openrouter_providers_text').on('change', function () {
         const selectedProviders = $(this).val();
@@ -867,7 +866,7 @@ jQuery(function () {
             return;
         }
 
-        textgenerationwebui_settings.openrouter_providers = selectedProviders;
+        settings.openrouter_providers = selectedProviders;
 
         saveSettingsDebounced();
     });
@@ -921,7 +920,7 @@ function setSettingByName(setting, value, trigger) {
     if ('sampler_order' === setting) {
         value = Array.isArray(value) ? value : KOBOLDCPP_ORDER;
         sortKoboldItemsByOrder(value);
-        textgenerationwebui_settings.sampler_order = value;
+        settings.sampler_order = value;
         return;
     }
 
@@ -929,7 +928,7 @@ function setSettingByName(setting, value, trigger) {
         value = Array.isArray(value) ? value : OOBA_DEFAULT_ORDER;
         insertMissingArrayItems(OOBA_DEFAULT_ORDER, value);
         sortOobaItemsByOrder(value);
-        textgenerationwebui_settings.sampler_priority = value;
+        settings.sampler_priority = value;
         return;
     }
 
@@ -937,7 +936,7 @@ function setSettingByName(setting, value, trigger) {
         value = Array.isArray(value) ? value : APHRODITE_DEFAULT_ORDER;
         insertMissingArrayItems(APHRODITE_DEFAULT_ORDER, value);
         sortAphroditeItemsByOrder(value);
-        textgenerationwebui_settings.samplers_priorities = value;
+        settings.samplers_priorities = value;
         return;
     }
 
@@ -945,18 +944,18 @@ function setSettingByName(setting, value, trigger) {
         value = Array.isArray(value) ? value : LLAMACPP_DEFAULT_ORDER;
         insertMissingArrayItems(LLAMACPP_DEFAULT_ORDER, value);
         sortLlamacppItemsByOrder(value);
-        textgenerationwebui_settings.samplers = value;
+        settings.samplers = value;
         return;
     }
 
     if ('logit_bias' === setting) {
-        textgenerationwebui_settings.logit_bias = Array.isArray(value) ? value : [];
+        settings.logit_bias = Array.isArray(value) ? value : [];
         return;
     }
 
     if ('json_schema' === setting) {
-        textgenerationwebui_settings.json_schema = value ?? {};
-        $('#tabby_json_schema').val(JSON.stringify(textgenerationwebui_settings.json_schema, null, 2));
+        settings.json_schema = value ?? {};
+        $('#tabby_json_schema').val(JSON.stringify(settings.json_schema, null, 2));
         return;
     }
 
@@ -1064,7 +1063,7 @@ export function parseTextgenLogprobs(token, logprobs) {
         return null;
     }
 
-    switch (textgenerationwebui_settings.type) {
+    switch (settings.type) {
         case KOBOLDCPP:
         case TABBY:
         case VLLM:
@@ -1166,50 +1165,45 @@ function toIntArray(string) {
     return string.split(',').map(x => parseInt(x)).filter(x => !isNaN(x));
 }
 
-/**
- * Returns the model to use based on the type
- * @param {string} type If it's set, ignores active type
- * @returns {string | undefined}
- */
-export function getTextGenModel(type = null) {
-    switch (type ?? textgenerationwebui_settings.type) {
+export function getTextGenModel() {
+    switch (settings.type) {
         case OOBA:
-            if (textgenerationwebui_settings.custom_model) {
-                return textgenerationwebui_settings.custom_model;
+            if (settings.custom_model) {
+                return settings.custom_model;
             }
             break;
         case GENERIC:
-            if (textgenerationwebui_settings.generic_model) {
-                return textgenerationwebui_settings.generic_model;
+            if (settings.generic_model) {
+                return settings.generic_model;
             }
             break;
         case MANCER:
-            return textgenerationwebui_settings.mancer_model;
+            return settings.mancer_model;
         case TOGETHERAI:
-            return textgenerationwebui_settings.togetherai_model;
+            return settings.togetherai_model;
         case INFERMATICAI:
-            return textgenerationwebui_settings.infermaticai_model;
+            return settings.infermaticai_model;
         case DREAMGEN:
-            return textgenerationwebui_settings.dreamgen_model;
+            return settings.dreamgen_model;
         case OPENROUTER:
-            return textgenerationwebui_settings.openrouter_model;
+            return settings.openrouter_model;
         case VLLM:
-            return textgenerationwebui_settings.vllm_model;
+            return settings.vllm_model;
         case APHRODITE:
-            return textgenerationwebui_settings.aphrodite_model;
+            return settings.aphrodite_model;
         case OLLAMA:
-            if (!textgenerationwebui_settings.ollama_model) {
+            if (!settings.ollama_model) {
                 toastr.error(t`No Ollama model selected.`, 'Text Completion API');
                 throw new Error('No Ollama model selected');
             }
-            return textgenerationwebui_settings.ollama_model;
+            return settings.ollama_model;
         case FEATHERLESS:
-            return textgenerationwebui_settings.featherless_model;
+            return settings.featherless_model;
         case HUGGINGFACE:
             return 'tgi';
         case TABBY:
-            if (textgenerationwebui_settings.tabby_model) {
-                return textgenerationwebui_settings.tabby_model;
+            if (settings.tabby_model) {
+                return settings.tabby_model;
             }
             break;
         default:
@@ -1220,19 +1214,11 @@ export function getTextGenModel(type = null) {
 }
 
 export function isJsonSchemaSupported() {
-    return [TABBY, LLAMACPP].includes(textgenerationwebui_settings.type) && main_api === 'textgenerationwebui';
+    return [TABBY, LLAMACPP].includes(settings.type) && main_api === 'textgenerationwebui';
 }
 
-/**
- * Checks if dynamic temperature is supported for the selected type.
- * @param {boolean} dynatemp If it's set, ignores active dynatemp
- * @param {string} type If it's set, ignores active type
- * @returns {boolean}
- */
-function isDynamicTemperatureSupported(dynatemp = null, type = null) {
-    const selectedDynatemp = dynatemp ?? textgenerationwebui_settings.dynatemp;
-    const selectedType = type ?? textgenerationwebui_settings.type;
-    return selectedDynatemp && DYNATEMP_BLOCK?.dataset?.tgType?.includes(selectedType);
+function isDynamicTemperatureSupported() {
+    return settings.dynatemp && DYNATEMP_BLOCK?.dataset?.tgType?.includes(settings.type);
 }
 
 /**
@@ -1241,7 +1227,7 @@ function isDynamicTemperatureSupported(dynatemp = null, type = null) {
  * @returns {number} Number of logprobs to request
  */
 export function getLogprobsNumber(type = null) {
-    const selectedType = type ?? textgenerationwebui_settings.type;
+    const selectedType = type ?? settings.type;
     if (selectedType === VLLM || selectedType === INFERMATICAI) {
         return 5;
     }
@@ -1277,52 +1263,14 @@ export function replaceMacrosInList(str) {
     }
 }
 
-export function textCompletionPresetToSettings(preset) {
-    let result = {};
-
-    // Add preset values.
-    for (const [key, value] of Object.entries(preset)) {
-        const isSettingExist = setting_names.includes(key);
-        if (!isSettingExist) {
-            console.warn(`Unknown setting/preset name: ${key}`);
-            continue;
-        }
-
-        result[key] = value;
-    }
-
-    // Merge with settings
-    for (const [key, value] of Object.entries(textgenerationwebui_settings)) {
-        if (!Object.hasOwn(result, key)) {
-            result[key] = value;
-        }
-    }
-
-    return result;
-}
-
-/**
- * @param {string} finalPrompt
- * @param {number} maxTokens
- * @param {boolean} isImpersonate
- * @param {boolean} isContinue
- * @param {object} cfgValues
- * @param {string} type inpersonate, continue, etc.
- * @param {{preset?: object, model?: string, textgen_type?: string, api_url?: string}} custom
- * @param {boolean} emitEvent
- * @returns
- */
-export async function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type, { preset, model, textgen_type, api_url } = {}, emitEvent = true) {
-    const settings = structuredClone(preset ? textCompletionPresetToSettings(preset) : textgenerationwebui_settings);
-    settings.type = textgen_type ?? settings.type;
-
+export async function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type) {
     const canMultiSwipe = !isContinue && !isImpersonate && type !== 'quiet';
-    const dynatemp = isDynamicTemperatureSupported(settings.dynatemp, settings.type);
-    const { banned_tokens, banned_strings } = getCustomTokenBans(settings);
+    const dynatemp = isDynamicTemperatureSupported();
+    const { banned_tokens, banned_strings } = getCustomTokenBans();
 
     let params = {
         'prompt': finalPrompt,
-        'model': model ?? getTextGenModel(settings.type),
+        'model': getTextGenModel(),
         'max_new_tokens': maxTokens,
         'max_tokens': maxTokens,
         'logprobs': power_user.request_token_probabilities ? getLogprobsNumber() : undefined,
@@ -1377,7 +1325,7 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
             banned_tokens,
         'banned_strings': banned_strings,
         'api_type': settings.type,
-        'api_server': api_url ?? getTextGenServer(settings.type),
+        'api_server': getTextGenServer(),
         'sampler_order': settings.type === textgen_types.KOBOLDCPP ? settings.sampler_order : undefined,
         'xtc_threshold': settings.xtc_threshold,
         'xtc_probability': settings.xtc_probability,
@@ -1543,9 +1491,7 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         }
     }
 
-    if (emitEvent) {
-        await eventSource.emit(event_types.TEXT_COMPLETION_SETTINGS_READY, params);
-    }
+    await eventSource.emit(event_types.TEXT_COMPLETION_SETTINGS_READY, params);
 
     // Grammar conflicts with with json_schema
     if (settings.type === LLAMACPP) {


### PR DESCRIPTION
Adding preset support to payload generation methods. So extensions could pick a chat/text preset and generate payload according to that.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
