### PR TITLE
Add locale data loading for extensions

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -384,7 +384,7 @@ async function activateExtensions() {
         if (meetsModuleRequirements && !isDisabled) {
             try {
                 console.debug('Activating extension', name);
-                const promise = Promise.all([addExtensionScript(name, manifest), addExtensionStyle(name, manifest), addExtensionLocale(name, manifest)]);
+                const promise = addExtensionLocale(name, manifest).finally(() => Promise.all([addExtensionScript(name, manifest), addExtensionStyle(name, manifest)]));
                 await promise
                     .then(() => activeExtensions.add(name))
                     .catch(err => console.log('Could not activate extension', name, err));

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -12,6 +12,30 @@ var localeData;
 export const getCurrentLocale = () => localeFile;
 
 /**
+ * Adds additional localization data to the current locale file.
+ * @param {string} localeId Locale ID (e.g. 'fr-fr' or 'zh-cn')
+ * @param {Record<string, string>} data Localization data to add
+ */
+export function addLocaleData(localeId, data) {
+    if (!localeData) {
+        console.warn('Localization data not loaded yet. Additional data will not be added.');
+        return;
+    }
+
+    if (localeId !== localeFile) {
+        console.debug('Ignoring addLocaleData call for different locale', localeId);
+        return;
+    }
+
+    for (const [key, value] of Object.entries(data)) {
+        // Overrides for default locale data are not allowed
+        if (!Object.hasOwn(localeData, key)) {
+            localeData[key] = value;
+        }
+    }
+}
+
+/**
  * An observer that will check if any new i18n elements are added to the document
  * @type {MutationObserver}
  */

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -54,7 +54,7 @@ import {
     writeExtensionField,
 } from './extensions.js';
 import { groups, openGroupChat, selected_group } from './group-chats.js';
-import { t, translate } from './i18n.js';
+import { addLocaleData, getCurrentLocale, t, translate } from './i18n.js';
 import { hideLoader, showLoader } from './loader.js';
 import { MacrosParser } from './macros.js';
 import { getChatCompletionModel, oai_settings } from './openai.js';
@@ -165,6 +165,8 @@ export function getContext() {
         isMobile,
         t,
         translate,
+        getCurrentLocale,
+        addLocaleData,
         tags,
         tagMap: tag_map,
         menuType: menu_type,


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Adds ability for extensions to register additional locale data for usage in `t`, `translate` functions and `renderExtensionTemplateAsync` with `data-i18n` attribute.

1. Direct `addLocaleData` call

```js
SillyTavern.getContext().addLocaleData('fr-fr', { 'Hello': 'Bonjour' });
```

2. Via the extension manifest

Add a i18n object with a list of supported locales and a relative path to its corresponding JSON file.

See the list of supported locales here (`lang` key): https://github.com/SillyTavern/SillyTavern/blob/release/public/locales/lang.json

```json
{
  "display_name": "Foobar",
  "js": "index.js",
  // rest of the fields
  "i18n": {
    "fr-fr": "i18n/fr.json"
  }
}
```
  

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
