### PR TITLE
Debug function to track missing dynamic translation fields (`t` and `translate` calls)

### DIFF
--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -9,6 +9,9 @@ var langs;
 // eslint-disable-next-line prefer-const
 var localeData;
 
+/** @type {Array<string>|null} Array of translations keys if they should be tracked - if not tracked then null */
+let trackMissingDynamicTranslate = null;
+
 export const getCurrentLocale = () => localeFile;
 
 /**
@@ -97,6 +100,9 @@ export function t(strings, ...values) {
  */
 export function translate(text, key = null) {
     const translationKey = key || text;
+    if (trackMissingDynamicTranslate && localeData && !Object.hasOwn(localeData, translationKey) && !trackMissingDynamicTranslate.includes(translationKey)) {
+        trackMissingDynamicTranslate.push(translationKey);
+    }
     return localeData?.[translationKey] || text;
 }
 
@@ -153,13 +159,28 @@ function translateElement(element) {
     }
 }
 
+/**
+ * Checks if the given locale is supported and not English.
+ * @param {string} [locale=null] The locale to check (defaults to the current locale)
+ * @returns {boolean} True if the locale is not English and supported
+ */
+function isSupportedNonEnglish(locale = null) {
+    const lang = locale || localeFile;
+    return lang && lang != 'en' && findLang(lang);
+}
 
 async function getMissingTranslations() {
+    /** @type {Array<{key: string, language: string, value: string}>} */
     const missingData = [];
 
+    if (trackMissingDynamicTranslate) {
+        for (const key of trackMissingDynamicTranslate) {
+            missingData.push({ key, language: localeFile, value: key });
+        }
+    }
+
     // Determine locales to search for untranslated strings
-    const isNotSupported = !findLang(localeFile);
-    const langsToProcess = (isNotSupported || localeFile == 'en') ? langs : [findLang(localeFile)];
+    const langsToProcess = isSupportedNonEnglish() ? [findLang(localeFile)] : langs;
 
     for (const language of langsToProcess) {
         const localeData = await getLocaleData(language.lang);
@@ -170,7 +191,7 @@ async function getMissingTranslations() {
                 if (attributeMatch) { // attribute-tagged key
                     const localizedValue = localeData?.[attributeMatch[2]];
                     if (!localizedValue) {
-                        missingData.push({ key, language: language.lang, value: $(this).attr(attributeMatch[1]) });
+                        missingData.push({ key, language: language.lang, value: String($(this).attr(attributeMatch[1])) });
                     }
                 } else { // No attribute tag, treat as 'text'
                     const localizedValue = localeData?.[key];
@@ -196,14 +217,18 @@ async function getMissingTranslations() {
     // Map to { language: { key: value } }
     let missingDataMap = {};
     for (const { key, value } of uniqueMissingData) {
-        if (!missingDataMap) {
-            missingDataMap = {};
-        }
         missingDataMap[key] = value;
     }
 
+    console.log('Missing Translations:');
     console.table(uniqueMissingData);
+    console.log('Full map of missing data:');
     console.log(missingDataMap);
+
+    if (trackMissingDynamicTranslate) {
+        console.log('Dynamic translations missing:');
+        console.log(trackMissingDynamicTranslate);
+    }
 
     toastr.success(`Found ${uniqueMissingData.length} missing translations. See browser console for details.`);
 }
@@ -266,6 +291,31 @@ export async function initLocales() {
         attributeFilter: ['data-i18n'],
     });
 
-    registerDebugFunction('getMissingTranslations', 'Get missing translations', 'Detects missing localization data in the current locale and dumps the data into the browser console. If the current locale is English, searches all other locales.', getMissingTranslations);
+    if (localStorage.getItem('trackDynamicTranslate') === 'true' && isSupportedNonEnglish()) {
+        trackMissingDynamicTranslate = [];
+    }
+
+    registerDebugFunction('getMissingTranslations', 'Get missing translations',
+        'Detects missing localization data in the current locale and dumps the data into the browser console. ' +
+        'If the current locale is English, searches all other locales.',
+        getMissingTranslations);
+    registerDebugFunction('trackDynamicTranslate', 'Track dynamic translation',
+        'Toggles tracking of dynamic translations, which will be dumped into the missing translations translations too. ' +
+        'This includes things translated via the t`...` function and translate(). It will only track strings translated <b>after</b> this is toggled on, '
+        + 'and when they actually pop up, so refreshing the page and opening popups, etc, is needed. Will only track if the current locale is not English.',
+        () => {
+            const isTracking = localStorage.getItem('trackDynamicTranslate') !== 'true';
+            localStorage.setItem('trackDynamicTranslate', isTracking ? 'true' : 'false');
+            if (isTracking && isSupportedNonEnglish()) {
+                trackMissingDynamicTranslate = [];
+                toastr.success('Dynamic translation tracking enabled.');
+            } else if (isTracking) {
+                trackMissingDynamicTranslate = null;
+                toastr.warning('Dynamic translation tracking enabled, but will not be tracked with locale English.');
+            } else {
+                trackMissingDynamicTranslate = null;
+                toastr.info('Dynamic translation tracking disabled.');
+            }
+        });
     registerDebugFunction('applyLocale', 'Apply locale', 'Reapplies the currently selected locale to the page.', applyLocale);
 }

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -1,6 +1,5 @@
 import { registerDebugFunction } from './power-user.js';
 import { updateSecretDisplay } from './secrets.js';
-import { accountStorage } from './util/AccountStorage.js';
 
 const storageKey = 'language';
 const overrideLanguage = localStorage.getItem(storageKey);
@@ -292,7 +291,7 @@ export async function initLocales() {
         attributeFilter: ['data-i18n'],
     });
 
-    if (accountStorage.getItem('trackDynamicTranslate') === 'true' && isSupportedNonEnglish()) {
+    if (localStorage.getItem('trackDynamicTranslate') === 'true' && isSupportedNonEnglish()) {
         trackMissingDynamicTranslate = new Set();
     }
 
@@ -305,8 +304,8 @@ export async function initLocales() {
         'This includes things translated via the t`...` function and translate(). It will only track strings translated <b>after</b> this is toggled on, '
         + 'and when they actually pop up, so refreshing the page and opening popups, etc, is needed. Will only track if the current locale is not English.',
         () => {
-            const isTracking = accountStorage.getItem('trackDynamicTranslate') !== 'true';
-            accountStorage.setItem('trackDynamicTranslate', isTracking ? 'true' : 'false');
+            const isTracking = localStorage.getItem('trackDynamicTranslate') !== 'true';
+            localStorage.setItem('trackDynamicTranslate', isTracking ? 'true' : 'false');
             if (isTracking && isSupportedNonEnglish()) {
                 trackMissingDynamicTranslate = new Set();
                 toastr.success('Dynamic translation tracking enabled.');

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -100,6 +100,10 @@ export function t(strings, ...values) {
  */
 export function translate(text, key = null) {
     const translationKey = key || text;
+    if (translationKey === null || translationKey === undefined) {
+        console.trace('WARN: No translation key provided');
+        return '';
+    }
     if (trackMissingDynamicTranslate && localeData && !Object.hasOwn(localeData, translationKey) && !trackMissingDynamicTranslate.includes(translationKey)) {
         trackMissingDynamicTranslate.push(translationKey);
     }

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -178,9 +178,7 @@ async function getMissingTranslations() {
     const missingData = [];
 
     if (trackMissingDynamicTranslate) {
-        for (const key of trackMissingDynamicTranslate) {
-            missingData.push({ key, language: localeFile, value: key });
-        }
+        missingData.push(...trackMissingDynamicTranslate.map(key => ({ key, language: localeFile, value: key })));
     }
 
     // Determine locales to search for untranslated strings
@@ -219,19 +217,17 @@ async function getMissingTranslations() {
     uniqueMissingData.sort((a, b) => a.language.localeCompare(b.language) || a.key.localeCompare(b.key));
 
     // Map to { language: { key: value } }
-    let missingDataMap = {};
-    for (const { key, value } of uniqueMissingData) {
-        missingDataMap[key] = value;
-    }
+    const missingDataMap = Object.fromEntries(uniqueMissingData.map(({ key, value }) => [key, value]));
 
-    console.log('Missing Translations:');
+    console.log(`Missing Translations (${uniqueMissingData.length}):`);
     console.table(uniqueMissingData);
-    console.log('Full map of missing data:');
+    console.log(`Full map of missing data (${Object.keys(missingDataMap).length}):`);
     console.log(missingDataMap);
 
     if (trackMissingDynamicTranslate) {
-        console.log('Dynamic translations missing:');
-        console.log(trackMissingDynamicTranslate);
+        const trackMissingDynamicTranslateMap = Object.fromEntries(trackMissingDynamicTranslate.map(key => [key, key]));
+        console.log(`Dynamic translations missing (${Object.keys(trackMissingDynamicTranslateMap).length}):`);
+        console.log(trackMissingDynamicTranslateMap);
     }
 
     toastr.success(`Found ${uniqueMissingData.length} missing translations. See browser console for details.`);

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -1,5 +1,6 @@
 import { registerDebugFunction } from './power-user.js';
 import { updateSecretDisplay } from './secrets.js';
+import { accountStorage } from './util/AccountStorage.js';
 
 const storageKey = 'language';
 const overrideLanguage = localStorage.getItem(storageKey);
@@ -291,7 +292,7 @@ export async function initLocales() {
         attributeFilter: ['data-i18n'],
     });
 
-    if (localStorage.getItem('trackDynamicTranslate') === 'true' && isSupportedNonEnglish()) {
+    if (accountStorage.getItem('trackDynamicTranslate') === 'true' && isSupportedNonEnglish()) {
         trackMissingDynamicTranslate = new Set();
     }
 
@@ -304,8 +305,8 @@ export async function initLocales() {
         'This includes things translated via the t`...` function and translate(). It will only track strings translated <b>after</b> this is toggled on, '
         + 'and when they actually pop up, so refreshing the page and opening popups, etc, is needed. Will only track if the current locale is not English.',
         () => {
-            const isTracking = localStorage.getItem('trackDynamicTranslate') !== 'true';
-            localStorage.setItem('trackDynamicTranslate', isTracking ? 'true' : 'false');
+            const isTracking = accountStorage.getItem('trackDynamicTranslate') !== 'true';
+            accountStorage.setItem('trackDynamicTranslate', isTracking ? 'true' : 'false');
             if (isTracking && isSupportedNonEnglish()) {
                 trackMissingDynamicTranslate = new Set();
                 toastr.success('Dynamic translation tracking enabled.');

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -493,7 +493,7 @@ export class ReasoningHandler {
             data = null;
         }
 
-        if (this.type !== ReasoningType.Model) {
+        if (this.type && this.type !== ReasoningType.Model) {
             title += ` [${translate(this.type)}]`;
             title = title.trim();
         }


### PR DESCRIPTION
This is for @RivelleDays.

![image](https://github.com/user-attachments/assets/da6f68e1-660d-437a-933e-1a3353ecb2d6)


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=ViaxRQ3zThA).

## Copilot 
This pull request includes several changes to improve the handling and tracking of missing translations in the `public/scripts/i18n.js` file. The key changes focus on adding functionality to dynamically track missing translations and refactoring existing code for better readability and efficiency.

Improvements to translation tracking:

* Added a new variable `trackMissingDynamicTranslate` to store an array of translation keys that should be tracked dynamically.
* Enhanced the `translate` function to log a warning when no translation key is provided and to track missing dynamic translations if enabled.
* Introduced the `isSupportedNonEnglish` function to check if a given locale is supported and not English.
* Updated the `getMissingTranslations` function to include dynamically tracked missing translations and refactored the creation of the `missingDataMap` for better efficiency. [[1]](diffhunk://#diff-b3dc696cc81b860f07a6ec28bf73e4d7b0b0edc55e9f247b55d95cde9187e9a8L173-R196) [[2]](diffhunk://#diff-b3dc696cc81b860f07a6ec28bf73e4d7b0b0edc55e9f247b55d95cde9187e9a8L197-R232)

Enhancements to initialization and debugging:

* Modified the `initLocales` function to initialize `trackMissingDynamicTranslate` based on local storage settings and added a debug function to toggle dynamic translation tracking.