### PR TITLE
Add gpt-4.5-preview (best model ™️ - most expensive for sure)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2867,6 +2867,10 @@
                                         <option value="o3-mini">o3-mini</option>
                                         <option value="o3-mini-2025-01-31">o3-mini-2025-01-31</option>
                                     </optgroup>
+                                    <optgroup label="GPT-4.5">
+                                        <option value="gpt-4.5-preview">gpt-4.5-preview</option>
+                                        <option value="gpt-4.5-preview-2025-02-27">gpt-4.5-preview-2025-02-27</option>
+                                    </optgroup>
                                     <optgroup label="GPT-4 Turbo and GPT-4">
                                         <option value="gpt-4-turbo">gpt-4-turbo</option>
                                         <option value="gpt-4-turbo-2024-04-09">gpt-4-turbo-2024-04-09</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1945,7 +1945,7 @@ async function sendOpenAIRequest(type, messages, signal) {
     }
 
     // Remove logit bias, logprobs and stop strings if it's not supported by the model
-    if (isOAI && oai_settings.openai_model.includes('vision') || isOpenRouter && oai_settings.openrouter_model.includes('vision')) {
+    if (isOAI && oai_settings.openai_model.includes('vision') || isOpenRouter && oai_settings.openrouter_model.includes('vision') || isOAI && oai_settings.openai_model.includes('gpt-4.5-preview')) {
         delete generate_data.logit_bias;
         delete generate_data.stop;
         delete generate_data.logprobs;
@@ -4997,6 +4997,8 @@ export function isImageInliningSupported() {
         'gpt-4-turbo',
         'gpt-4o',
         'gpt-4o-mini',
+        'gpt-4.5-preview',
+        'gpt-4.5-preview-2025-02-27',
         'o1',
         'o1-2024-12-17',
         'chatgpt-4o-latest',

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -108,6 +108,7 @@ export function isHiddenReasoningModel() {
 
     /** @type {{ name: string; func: MatchingFunc; }[]} */
     const hiddenReasoningModels = [
+        { name: 'gpt-4.5', func: FUNCS.startsWith },
         { name: 'o1', func: FUNCS.startsWith },
         { name: 'o3', func: FUNCS.startsWith },
         { name: 'gemini-2.0-flash-thinking-exp', func: FUNCS.startsWith },

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -410,6 +410,10 @@ export function getTokenizerModel(requestModel) {
         return 'gpt-4o';
     }
 
+    if (requestModel.includes('gpt-4.5-preview')) {
+        return 'gpt-4o';
+    }
+
     if (requestModel.includes('gpt-4-32k')) {
         return 'gpt-4-32k';
     }


### PR DESCRIPTION
I made sure to verify as much as I could.
This model does not support reasoning_effort. It does support vision, and is a hidden thinking model.
We must remove logprops, because OpenAI can't simply ignore them...

It support function calling, but I am not sure where to tie in for this.

Resources:
- [Announcement](https://openai.com/index/introducing-gpt-4-5/)
- [Model Page Listing](https://platform.openai.com/docs/models#gpt-4-5)
- [System Card](https://cdn.openai.com/gpt-4-5-system-card.pdf)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=Rie-gQxHlco).

## Copilot
This pull request includes updates to support the new `gpt-4.5-preview` model across various parts of the application. The changes primarily involve adding the new model to different lists and conditions to ensure proper functionality.

Support for `gpt-4.5-preview` model:

* [`public/index.html`](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR2870-R2873): Added `gpt-4.5-preview` and `gpt-4.5-preview-2025-02-27` options under a new `GPT-4.5` optgroup.
* [`public/scripts/openai.js`](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50L1948-R1948): Modified `sendOpenAIRequest` function to handle the new `gpt-4.5-preview` model by excluding unsupported features.
* [`public/scripts/openai.js`](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50R5000-R5001): Updated `isImageInliningSupported` function to include `gpt-4.5-preview` and `gpt-4.5-preview-2025-02-27` models.
* [`public/scripts/reasoning.js`](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627R111): Added `gpt-4.5` to the list of hidden reasoning models in the `isHiddenReasoningModel` function.
* [`src/endpoints/tokenizers.js`](diffhunk://#diff-8cd46649d286f378cc1f1081309004ec252515f121d42ff79a35d1f8338b3942R413-R416): Updated `getTokenizerModel` function to map `gpt-4.5-preview` to the appropriate tokenizer model.