### PR TITLE
add printMessages in st-context.getContext()

### DIFF
--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -46,6 +46,7 @@ import {
     updateChatMetadata,
     updateMessageBlock,
     printMessages,
+    clearChat,
 } from '../script.js';
 import {
     extension_settings,
@@ -205,6 +206,7 @@ export function getContext() {
         getPresetManager,
         getChatCompletionModel,
         printMessages,
+        clearChat,
     };
 }
 

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -45,6 +45,7 @@ import {
     this_chid,
     updateChatMetadata,
     updateMessageBlock,
+    printMessages,
 } from '../script.js';
 import {
     extension_settings,
@@ -203,6 +204,7 @@ export function getContext() {
         extractMessageFromData,
         getPresetManager,
         getChatCompletionModel,
+        printMessages,
     };
 }
 


### PR DESCRIPTION
This addition was made to allow extensions to modify the entire chat array and update the display using the same logic from scripts.js.
so that we can use this func in extension like this
```
            chat.splice(0, chat.length, ...nativeChat2);
            context.printMessages();
            context.eventSource.emit(context.eventTypes.CHAT_CHANGED, context.getCurrentChatId());
```

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
