### PR TITLE
Added support for NovelAI Diffusion V4 Full via API to Image Generation extension.

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2334,19 +2334,12 @@ function processReply(str) {
     }
 
     str = str.replaceAll('"', '');
-    str = str.replaceAll('"', '');
+    str = str.replaceAll('“', '');
     str = str.replaceAll('\n', ', ');
     str = str.normalize('NFD');
     
-    // Check if using NAI Diffusion V4 models and preserve pipe (|) and hash (#) characters
-    if (extension_settings.sd.model === 'nai-diffusion-4-full' || 
-        extension_settings.sd.model === 'nai-diffusion-4-curated-preview') {
-        // Keep pipe and hash characters for NAI Diffusion V4 models
-        str = str.replace(/[^a-zA-Z0-9.,:_(){}<>[\]\-'|#]+/g, ' ');
-    } else {
-        // Original behavior for other models
-        str = str.replace(/[^a-zA-Z0-9.,:_(){}<>[\]\-']+/g, ' ');
-    }
+    // Strip out non-alphanumeric characters barring model syntax exceptions
+    str = str.replace(/[^a-zA-Z0-9.,:_(){}<>[\]\-'|#]+/g, ' ');
     
     str = str.replace(/\s+/g, ' '); // Collapse multiple whitespaces into one
     str = str.trim();
@@ -3242,8 +3235,7 @@ function getNovelParams() {
     }
 
     if (extension_settings.sd.sampler === 'ddim' || 
-        extension_settings.sd.model === 'nai-diffusion-4-curated-preview' || 
-        extension_settings.sd.model === 'nai-diffusion-4-full') {
+        ['nai-diffusion-4-curated-preview', 'nai-diffusion-4-full'].includes(extension_settings.sd.model)) {
         sm = false;
         sm_dyn = false;
     }

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2011,6 +2011,10 @@ async function loadVladModels() {
 async function loadNovelModels() {
     return [
         {
+            value: 'nai-diffusion-4-full',
+            text: 'NAI Diffusion Anime V4 (Full)',
+        },
+        {
             value: 'nai-diffusion-4-curated-preview',
             text: 'NAI Diffusion Anime V4 (Curated Preview)',
         },
@@ -3227,7 +3231,9 @@ function getNovelParams() {
         extension_settings.sd.scheduler = 'karras';
     }
 
-    if (extension_settings.sd.sampler === 'ddim' || extension_settings.sd.model === 'nai-diffusion-4-curated-preview') {
+    if (extension_settings.sd.sampler === 'ddim' || 
+        extension_settings.sd.model === 'nai-diffusion-4-curated-preview' || 
+        extension_settings.sd.model === 'nai-diffusion-4-full') {
         sm = false;
         sm_dyn = false;
     }

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2334,10 +2334,20 @@ function processReply(str) {
     }
 
     str = str.replaceAll('"', '');
-    str = str.replaceAll('“', '');
+    str = str.replaceAll('"', '');
     str = str.replaceAll('\n', ', ');
     str = str.normalize('NFD');
-    str = str.replace(/[^a-zA-Z0-9.,:_(){}<>[\]\-']+/g, ' ');
+    
+    // Check if using NAI Diffusion V4 models and preserve pipe (|) and hash (#) characters
+    if (extension_settings.sd.model === 'nai-diffusion-4-full' || 
+        extension_settings.sd.model === 'nai-diffusion-4-curated-preview') {
+        // Keep pipe and hash characters for NAI Diffusion V4 models
+        str = str.replace(/[^a-zA-Z0-9.,:_(){}<>[\]\-'|#]+/g, ' ');
+    } else {
+        // Original behavior for other models
+        str = str.replace(/[^a-zA-Z0-9.,:_(){}<>[\]\-']+/g, ' ');
+    }
+    
     str = str.replace(/\s+/g, ' '); // Collapse multiple whitespaces into one
     str = str.trim();
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

NovelAI just released the full version of NAI Diffusion V4 and it was not yet supported in the Image Generation extension as a model parameter. I added the appropriate value/text pair to the loadNovelModels method. You can test this by entering a valid NAI API key and generating an image with 'NAI Diffusion Anime V4 (Full)' selected from the dropdown.
