### PR TITLE
Allow specifying API in presetManager.getPresetList()

### DIFF
--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -439,11 +439,16 @@ class PresetManager {
 
     }
 
-    getPresetList() {
+    getPresetList(api) {
         let presets = [];
         let preset_names = {};
 
-        switch (this.apiId) {
+        // If no API specified, use the current API
+        if (api === undefined) {
+            api = this.apiId;
+        }
+
+        switch (api) {
             case 'koboldhorde':
             case 'kobold':
                 presets = koboldai_settings;
@@ -474,7 +479,7 @@ class PresetManager {
                 preset_names = system_prompts.map(x => x.name);
                 break;
             default:
-                console.warn(`Unknown API ID ${this.apiId}`);
+                console.warn(`Unknown API ID ${api}`);
         }
 
         return { presets, preset_names };


### PR DESCRIPTION
## Description

This just allows you to pass an API to `presetManager.getPresetList()`. If none is passed, it uses the selected API, identical to the current behavior. This makes it easy to retrieve the list of valid presets for a given API.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
