### PR TITLE
Change Message Squash Separator for Text Completion Mode

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4956,7 +4956,7 @@ async function doChatInject(messages, isContinue) {
             [extension_prompt_roles.ASSISTANT]: name2,
         };
         const roleMessages = [];
-        const separator = '\n';
+        const separator = '\n\n';
         const wrap = false;
 
         for (const role of roles) {

--- a/public/script.js
+++ b/public/script.js
@@ -4032,7 +4032,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         flushWIDepthInjections();
         if (Array.isArray(worldInfoDepth)) {
             worldInfoDepth.forEach((e) => {
-                const joinedEntries = e.entries.join('\n');
+                const joinedEntries = e.entries.join("\n\n");
                 setExtensionPrompt(`customDepthWI-${e.depth}-${e.role}`, joinedEntries, extension_prompt_types.IN_CHAT, e.depth, false, e.role);
             });
         }
@@ -4956,7 +4956,7 @@ async function doChatInject(messages, isContinue) {
             [extension_prompt_roles.ASSISTANT]: name2,
         };
         const roleMessages = [];
-        const separator = '\n\n';
+        const separator = '\n';
         const wrap = false;
 
         for (const role of roles) {


### PR DESCRIPTION
This changes ONLY the message squash separator to allow better control over separation of 'blocks' being sent to the model.

This doesn't change anything with chat mode or WI or AN, as these don't have as straightforward an applicable use case.


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
