### PR TITLE
Added time to first token

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2621,7 +2621,7 @@ function formatGenerationTimer(gen_started, gen_finished, tokenCount, timeToFirs
         `Time to generate: ${seconds} seconds`,
         timeToFirstToken ? `Time to first token: ${timeToFirstToken / 1000} seconds` : '',
         reasoningDuration > 0 ? `Time to think: ${reasoningDuration / 1000} seconds` : '',
-        tokenCount > 0 ? `Token rate: ${Number(tokenCount / seconds).toFixed(1)} t/s` : '',
+        tokenCount > 0 ? `Token rate: ${Number(tokenCount / seconds).toFixed(3)} t/s` : '',
     ].filter(x => x).join('\n').trim();
 
     if (isNaN(seconds) || seconds < 0) {

--- a/public/script.js
+++ b/public/script.js
@@ -2477,7 +2477,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         timestamp: timestamp,
         extra: mes.extra,
         tokenCount: mes.extra?.token_count ?? 0,
-        ...formatGenerationTimer(mes.gen_started, mes.gen_finished, mes.extra?.token_count, mes.extra?.time_to_first_token, mes.extra?.reasoning_duration),
+        ...formatGenerationTimer(mes.gen_started, mes.gen_finished, mes.extra?.token_count, mes.extra?.reasoning_duration, mes.extra?.time_to_first_token),
     };
 
     const renderedMessage = getMessageFromTemplate(params);
@@ -2597,15 +2597,15 @@ export function formatCharacterAvatar(characterAvatar) {
  * @param {Date} gen_started Date when generation was started
  * @param {Date} gen_finished Date when generation was finished
  * @param {number} tokenCount Number of tokens generated (0 if not available)
- * @param {number | null} timeToFirstToken Time to first token
  * @param {number?} [reasoningDuration=null] Reasoning duration (null if no reasoning was done)
+ * @param {number?} [timeToFirstToken=null] Time to first token
  * @returns {Object} Object containing the formatted timer value and title
  * @example
  * const { timerValue, timerTitle } = formatGenerationTimer(gen_started, gen_finished, tokenCount);
  * console.log(timerValue); // 1.2s
  * console.log(timerTitle); // Generation queued: 12:34:56 7 Jan 2021\nReply received: 12:34:57 7 Jan 2021\nTime to generate: 1.2 seconds\nToken rate: 5 t/s
  */
-function formatGenerationTimer(gen_started, gen_finished, tokenCount, timeToFirstToken, reasoningDuration = null) {
+function formatGenerationTimer(gen_started, gen_finished, tokenCount, reasoningDuration = null, timeToFirstToken = null) {
     if (!gen_started || !gen_finished) {
         return {};
     }
@@ -3160,9 +3160,7 @@ class StreamingProcessor {
         this.abortController = new AbortController();
         this.firstMessageText = '...';
         this.timeStarted = timeStarted;
-        /**
-         * @type {number?}
-         */
+        /** @type {number?} */
         this.timeToFirstToken = null;
         this.createdAt = new Date();
         this.continueMessage = type === 'continue' ? continueMessage : '';
@@ -3295,7 +3293,7 @@ class StreamingProcessor {
                 this.messageTextDom.innerHTML = formattedText;
             }
 
-            const timePassed = formatGenerationTimer(this.timeStarted, currentTime, currentTokenCount, this.timeToFirstToken, this.reasoningHandler.getDuration());
+            const timePassed = formatGenerationTimer(this.timeStarted, currentTime, currentTokenCount, this.reasoningHandler.getDuration(), this.timeToFirstToken);
             if (this.messageTimerDom instanceof HTMLElement) {
                 this.messageTimerDom.textContent = timePassed.timerValue;
                 this.messageTimerDom.title = timePassed.timerTitle;

--- a/public/script.js
+++ b/public/script.js
@@ -2477,7 +2477,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         timestamp: timestamp,
         extra: mes.extra,
         tokenCount: mes.extra?.token_count ?? 0,
-        ...formatGenerationTimer(mes.gen_started, mes.gen_finished, mes.extra?.token_count, mes.time_to_first_token, mes.extra?.reasoning_duration),
+        ...formatGenerationTimer(mes.gen_started, mes.gen_finished, mes.extra?.token_count, mes.extra?.time_to_first_token, mes.extra?.reasoning_duration),
     };
 
     const renderedMessage = getMessageFromTemplate(params);
@@ -3252,11 +3252,11 @@ class StreamingProcessor {
             const currentTime = new Date();
             chat[messageId]['mes'] = processedText;
             chat[messageId]['gen_started'] = this.timeStarted;
-            chat[messageId]['time_to_first_token'] = this.timeToFirstToken;
             chat[messageId]['gen_finished'] = currentTime;
             if (!chat[messageId]['extra']) {
                 chat[messageId]['extra'] = {};
             }
+            chat[messageId]['extra']['time_to_first_token'] = this.timeToFirstToken;
 
             // Update reasoning
             await this.reasoningHandler.process(messageId, mesChanged);
@@ -3278,7 +3278,6 @@ class StreamingProcessor {
                     'send_date': chat[messageId]['send_date'],
                     'gen_started': chat[messageId]['gen_started'],
                     'gen_finished': chat[messageId]['gen_finished'],
-                    'time_to_first_token': chat[messageId]['time_to_first_token'],
                     'extra': JSON.parse(JSON.stringify(chat[messageId]['extra']))
                 };
             }
@@ -3375,7 +3374,6 @@ class StreamingProcessor {
                     'send_date': chat[messageId]['send_date'],
                     'gen_started': chat[messageId]['gen_started'],
                     'gen_finished': chat[messageId]['gen_finished'],
-                    'time_to_first_token': chat[messageId]['time_to_first_token'],
                     'extra': JSON.parse(JSON.stringify(chat[messageId]['extra'])) };
             }
         }
@@ -6094,7 +6092,6 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
             send_date: item['send_date'],
             gen_started: item['gen_started'],
             gen_finished: item['gen_finished'],
-            time_to_first_token: item['time_to_first_token'],
             extra: JSON.parse(JSON.stringify(item['extra'])),
         };
     } else {
@@ -6105,7 +6102,6 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
             send_date: chat[chat.length - 1]['send_date'],
             gen_started: chat[chat.length - 1]['gen_started'],
             gen_finished: chat[chat.length - 1]['gen_finished'],
-            time_to_first_token: chat[chat.length - 1]['time_to_first_token'],
             extra: JSON.parse(JSON.stringify(chat[chat.length - 1]['extra'])),
         };
     }
@@ -8859,7 +8855,6 @@ const swipe_right = () => {
             'send_date': chat[chat.length - 1]['send_date'],
             'gen_started': chat[chat.length - 1]['gen_started'],
             'gen_finished': chat[chat.length - 1]['gen_finished'],
-            'time_to_first_token': chat[chat.length - 1]['time_to_first_token'],
             'extra': JSON.parse(JSON.stringify(chat[chat.length - 1]['extra']))
         };
         //assign swipe info array with last message from chat

--- a/public/script.js
+++ b/public/script.js
@@ -3273,7 +3273,13 @@ class StreamingProcessor {
 
             if ((this.type == 'swipe' || this.type === 'continue') && Array.isArray(chat[messageId]['swipes'])) {
                 chat[messageId]['swipes'][chat[messageId]['swipe_id']] = processedText;
-                chat[messageId]['swipe_info'][chat[messageId]['swipe_id']] = { 'send_date': chat[messageId]['send_date'], 'gen_started': chat[messageId]['gen_started'], 'gen_finished': chat[messageId]['gen_finished'], 'extra': JSON.parse(JSON.stringify(chat[messageId]['extra'])) };
+                chat[messageId]['swipe_info'][chat[messageId]['swipe_id']] = {
+                    'send_date': chat[messageId]['send_date'],
+                    'gen_started': chat[messageId]['gen_started'],
+                    'gen_finished': chat[messageId]['gen_finished'],
+                    'time_to_first_token': chat[messageId]['time_to_first_token'],
+                    'extra': JSON.parse(JSON.stringify(chat[messageId]['extra']))
+                };
             }
 
             const formattedText = messageFormatting(
@@ -3364,7 +3370,12 @@ class StreamingProcessor {
         if (this.type !== 'swipe' && this.type !== 'impersonate') {
             if (Array.isArray(chat[messageId]['swipes']) && chat[messageId]['swipes'].length === 1 && chat[messageId]['swipe_id'] === 0) {
                 chat[messageId]['swipes'][0] = chat[messageId]['mes'];
-                chat[messageId]['swipe_info'][0] = { 'send_date': chat[messageId]['send_date'], 'gen_started': chat[messageId]['gen_started'], 'gen_finished': chat[messageId]['gen_finished'], 'extra': JSON.parse(JSON.stringify(chat[messageId]['extra'])) };
+                chat[messageId]['swipe_info'][0] = {
+                    'send_date': chat[messageId]['send_date'],
+                    'gen_started': chat[messageId]['gen_started'],
+                    'gen_finished': chat[messageId]['gen_finished'],
+                    'time_to_first_token': chat[messageId]['time_to_first_token'],
+                    'extra': JSON.parse(JSON.stringify(chat[messageId]['extra'])) };
             }
         }
     }
@@ -6078,6 +6089,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
             send_date: item['send_date'],
             gen_started: item['gen_started'],
             gen_finished: item['gen_finished'],
+            time_to_first_token: item['time_to_first_token'],
             extra: JSON.parse(JSON.stringify(item['extra'])),
         };
     } else {
@@ -6088,6 +6100,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
             send_date: chat[chat.length - 1]['send_date'],
             gen_started: chat[chat.length - 1]['gen_started'],
             gen_finished: chat[chat.length - 1]['gen_finished'],
+            time_to_first_token: chat[chat.length - 1]['time_to_first_token'],
             extra: JSON.parse(JSON.stringify(chat[chat.length - 1]['extra'])),
         };
     }
@@ -8837,7 +8850,13 @@ const swipe_right = () => {
         chat[chat.length - 1]['swipes'] = [];                         // empty the array
         chat[chat.length - 1]['swipe_info'] = [];
         chat[chat.length - 1]['swipes'][0] = chat[chat.length - 1]['mes'];  //assign swipe array with last message from chat
-        chat[chat.length - 1]['swipe_info'][0] = { 'send_date': chat[chat.length - 1]['send_date'], 'gen_started': chat[chat.length - 1]['gen_started'], 'gen_finished': chat[chat.length - 1]['gen_finished'], 'extra': JSON.parse(JSON.stringify(chat[chat.length - 1]['extra'])) };
+        chat[chat.length - 1]['swipe_info'][0] = {
+            'send_date': chat[chat.length - 1]['send_date'],
+            'gen_started': chat[chat.length - 1]['gen_started'],
+            'gen_finished': chat[chat.length - 1]['gen_finished'],
+            'time_to_first_token': chat[chat.length - 1]['time_to_first_token'],
+            'extra': JSON.parse(JSON.stringify(chat[chat.length - 1]['extra']))
+        };
         //assign swipe info array with last message from chat
     }
     if (chat.length === 1 && chat[0]['swipe_id'] !== undefined && chat[0]['swipe_id'] === chat[0]['swipes'].length - 1) {    // if swipe_right is called on the last alternate greeting, loop back around

--- a/public/script.js
+++ b/public/script.js
@@ -3374,7 +3374,8 @@ class StreamingProcessor {
                     'send_date': chat[messageId]['send_date'],
                     'gen_started': chat[messageId]['gen_started'],
                     'gen_finished': chat[messageId]['gen_finished'],
-                    'extra': JSON.parse(JSON.stringify(chat[messageId]['extra'])) };
+                    'extra': JSON.parse(JSON.stringify(chat[messageId]['extra'])),
+                };
             }
         }
     }
@@ -8855,7 +8856,7 @@ const swipe_right = () => {
             'send_date': chat[chat.length - 1]['send_date'],
             'gen_started': chat[chat.length - 1]['gen_started'],
             'gen_finished': chat[chat.length - 1]['gen_finished'],
-            'extra': JSON.parse(JSON.stringify(chat[chat.length - 1]['extra']))
+            'extra': JSON.parse(JSON.stringify(chat[chat.length - 1]['extra'])),
         };
         //assign swipe info array with last message from chat
     }

--- a/public/script.js
+++ b/public/script.js
@@ -2619,7 +2619,7 @@ function formatGenerationTimer(gen_started, gen_finished, tokenCount, timeToFirs
         `Generation queued: ${start.format(dateFormat)}`,
         `Reply received: ${finish.format(dateFormat)}`,
         `Time to generate: ${seconds} seconds`,
-        timeToFirstToken ? `Time to first token: ${(timeToFirstToken / 1000).toFixed(1)} seconds` : '',
+        timeToFirstToken ? `Time to first token: ${timeToFirstToken / 1000} seconds` : '',
         reasoningDuration > 0 ? `Time to think: ${reasoningDuration / 1000} seconds` : '',
         tokenCount > 0 ? `Token rate: ${Number(tokenCount / seconds).toFixed(1)} t/s` : '',
     ].filter(x => x).join('\n').trim();

--- a/public/script.js
+++ b/public/script.js
@@ -3161,7 +3161,7 @@ class StreamingProcessor {
         this.firstMessageText = '...';
         this.timeStarted = timeStarted;
         /**
-         * @type {number | null}
+         * @type {number?}
          */
         this.timeToFirstToken = null;
         this.createdAt = new Date();


### PR DESCRIPTION
Added time to first token. Timer is calculating between `StreamingProcessor.createdAt` and `StreamingProcessor.onStartStreaming()` . For _exact_ timing, it should be after sending the request. However, that seems a little... hard. Feel free to reject this PR if we need an exact timing.

![image](https://github.com/user-attachments/assets/00a34b1a-caf9-474a-959e-5859a0af1a52)


## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
