### PR TITLE
Fix auto-parsing of continue from reasoning

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3287,7 +3287,7 @@ class StreamingProcessor {
             chat[messageId]['extra']['time_to_first_token'] = this.timeToFirstToken;
 
             // Update reasoning
-            await this.reasoningHandler.process(messageId, mesChanged);
+            await this.reasoningHandler.process(messageId, mesChanged, this.promptReasoning);
             processedText = chat[messageId]['mes'];
 
             // Token count update.
@@ -5953,7 +5953,7 @@ export function cleanUpMessage(getMessage, isImpersonate, isContinue, displayInc
         getMessage = trimToEndSentence(getMessage);
     }
 
-    if (power_user.trim_spaces) {
+    if (power_user.trim_spaces && !PromptReasoning.getLatestPrefix()) {
         getMessage = getMessage.trim();
     }
 
@@ -6147,12 +6147,16 @@ export function syncMesToSwipe(messageId = null) {
     }
 
     const targetMessageId = messageId ?? chat.length - 1;
-    if (chat.length > targetMessageId || targetMessageId < 0) {
+    if (targetMessageId >= chat.length || targetMessageId < 0) {
         console.warn(`[syncMesToSwipe] Invalid message ID: ${messageId}`);
         return false;
     }
 
     const targetMessage = chat[targetMessageId];
+
+    if (!targetMessage) {
+        return false;
+    }
 
     // No swipe data there yet, exit out
     if (typeof targetMessage.swipe_id !== 'number') {


### PR DESCRIPTION
Continues #3606

Introduces the ability to correctly parse continuations on reasoning with empty contents.

## Copilot rambling

This pull request includes significant updates to the reasoning handling logic in the `public/script.js` and `public/scripts/reasoning.js` files. The changes focus on improving the reasoning process by incorporating a `PromptReasoning` object and handling incomplete reasoning prefixes.

### Reasoning Handling Enhancements:

* [`public/script.js`](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L3290-R3290): Updated `StreamingProcessor` and `cleanUpMessage` functions to include `PromptReasoning` object and handle incomplete reasoning prefixes. [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L3290-R3290) [[2]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L5956-R5956)
* [`public/scripts/reasoning.js`](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L199-R199): Modified `ReasoningHandler` class to include `PromptReasoning` in the `process` method and adjusted the reasoning parsing logic to handle incomplete prefixes. [[1]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L199-R199) [[2]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627R327-R331) [[3]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L348-R356) [[4]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627R366-R376) [[5]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L380-R397)

### New `PromptReasoning` Class:

* [`public/scripts/reasoning.js`](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627R537-R586): Introduced the `PromptReasoning` class with new static methods and properties to manage the latest reasoning instance and handle reasoning placeholders. [[1]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627R537-R586) [[2]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627R633-R636) [[3]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627R645-R648)

### Event Handling Updates:

* [`public/scripts/reasoning.js`](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L1052-R1114): Enhanced `registerReasoningAppEvents` function to include reasoning prefix handling and clear the latest reasoning instance on specific events. [[1]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L1052-R1114) [[2]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L1070-R1132) [[3]](diffhunk://#diff-602cba79d857d4f9229ec1108e4845a273e7975f30fc6c6853af347ccd89b627L1114-R1175)

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
