### PR TITLE
Prevent rollover on keyboard left swipe if repeating

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -8746,17 +8746,29 @@ function formatSwipeCounter(current, total) {
     return `${current}\u200b/\u200b${total}`;
 }
 
-function swipe_left() {      // when we swipe left..but no generation.
+/**
+ * Handles the swipe to the left event.
+ * @param {JQuery.Event} _event Event.
+ * @param {object} params Additional parameters.
+ * @param {string} [params.source] The source of the swipe event.
+ * @param {boolean} [params.repeated] Is the swipe event repeated.
+ * @returns
+ */
+function swipe_left(_event, { source, repeated } = {}) {      // when we swipe left..but no generation.
     if (chat.length - 1 === Number(this_edit_mes_id)) {
         closeMessageEditor();
     }
-
     if (isStreamingEnabled() && streamingProcessor) {
         streamingProcessor.onStopStreaming();
     }
 
     // Make sure ad-hoc changes to extras are saved before swiping away
     syncMesToSwipe();
+
+    if (source === 'keyboard' && repeated && chat[chat.length - 1].swipe_id === 0) {
+        // If the user is holding down the key and we're at the first swipe, don't do anything
+        return;
+    }
 
     const swipe_duration = 120;
     const swipe_range = '700px';

--- a/public/script.js
+++ b/public/script.js
@@ -8752,7 +8752,6 @@ function formatSwipeCounter(current, total) {
  * @param {object} params Additional parameters.
  * @param {string} [params.source] The source of the swipe event.
  * @param {boolean} [params.repeated] Is the swipe event repeated.
- * @returns
  */
 function swipe_left(_event, { source, repeated } = {}) {      // when we swipe left..but no generation.
     if (chat.length - 1 === Number(this_edit_mes_id)) {
@@ -8765,8 +8764,8 @@ function swipe_left(_event, { source, repeated } = {}) {      // when we swipe l
     // Make sure ad-hoc changes to extras are saved before swiping away
     syncMesToSwipe();
 
+    // If the user is holding down the key and we're at the first swipe, don't do anything
     if (source === 'keyboard' && repeated && chat[chat.length - 1].swipe_id === 0) {
-        // If the user is holding down the key and we're at the first swipe, don't do anything
         return;
     }
 
@@ -8895,8 +8894,14 @@ function swipe_left(_event, { source, repeated } = {}) {      // when we swipe l
     }
 }
 
-// when we click swipe right button
-const swipe_right = () => {
+/**
+ * Handles the swipe to the right event.
+ * @param {JQuery.Event} _event Event.
+ * @param {object} params Additional parameters.
+ * @param {string} [params.source] The source of the swipe event.
+ * @param {boolean} [params.repeated] Is the swipe event repeated.
+ */
+function swipe_right(_event, { source, repeated } = {}) {
     if (chat.length - 1 === Number(this_edit_mes_id)) {
         closeMessageEditor();
     }
@@ -8929,6 +8934,10 @@ const swipe_right = () => {
     if (chat.length === 1 && chat[0]['swipe_id'] !== undefined && chat[0]['swipe_id'] === chat[0]['swipes'].length - 1) {    // if swipe_right is called on the last alternate greeting, loop back around
         chat[0]['swipe_id'] = 0;
     } else {
+        // If the user is holding down the key and we're at the last swipe, don't do anything
+        if (source === 'keyboard' && repeated && chat[chat.length - 1].swipe_id === chat[chat.length - 1].swipes.length - 1) {
+            return;
+        }
         chat[chat.length - 1]['swipe_id']++;                                // make new slot in array
     }
     if (chat[chat.length - 1].extra) {
@@ -9077,7 +9086,7 @@ const swipe_right = () => {
             },
         });
     }
-};
+}
 
 export const CONNECT_API_MAP = {
     // Default APIs not contined inside text gen / chat gen

--- a/public/script.js
+++ b/public/script.js
@@ -8753,7 +8753,7 @@ function formatSwipeCounter(current, total) {
  * @param {string} [params.source] The source of the swipe event.
  * @param {boolean} [params.repeated] Is the swipe event repeated.
  */
-function swipe_left(_event, { source, repeated } = {}) {      // when we swipe left..but no generation.
+function swipe_left(_event, { source, repeated } = {}) {
     if (chat.length - 1 === Number(this_edit_mes_id)) {
         closeMessageEditor();
     }

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -1143,7 +1143,7 @@ export function initRossMods() {
                 $('#shadow_select_chat_popup').css('display') === 'none' &&
                 !isInputElementInFocus()
             ) {
-                $('.swipe_left:last').click();
+                $('.swipe_left:last').trigger('click', { source: 'keyboard', repeated: event.repeat });
                 return;
             }
         }

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -1156,7 +1156,7 @@ export function initRossMods() {
                 $('#shadow_select_chat_popup').css('display') === 'none' &&
                 !isInputElementInFocus()
             ) {
-                $('.swipe_right:last').click();
+                $('.swipe_right:last').trigger('click', { source: 'keyboard', repeated: event.repeat });
                 return;
             }
         }


### PR DESCRIPTION
Closes #3636

This pull request includes enhancements to the swipe functionality in the `public/script.js` and `public/scripts/RossAscends-mods.js` files. The changes focus on improving the handling of swipe events and adding more detailed event parameters.

Enhancements to swipe functionality:

* [`public/script.js`](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L8749-R8772): Updated the `swipe_left` function to handle additional parameters such as `source` and `repeated`, improving the control over swipe events triggered by different sources.
* [`public/scripts/RossAscends-mods.js`](diffhunk://#diff-945d6d3576a92ebc6111470aa7b7e6fa33c13ce5c4f0e3af1a5a0157550150c5L1146-R1146): Modified the `initRossMods` function to trigger the `swipe_left` event with the new parameters, ensuring consistent behavior when swiping using the keyboard.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
