### PR TITLE
Rebranding a certain feature to Endpoint Override

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2741,12 +2741,12 @@
                         </select>
                         <div class="inline-drawer wide100p" data-source="openai,claude,mistralai,makersuite,deepseek">
                             <div class="inline-drawer-toggle inline-drawer-header">
-                                <b data-i18n="Reverse Proxy">Reverse Proxy</b>
+                                <b data-i18n="Endpoint Override">Endpoint Override</b>
                                 <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                             </div>
                             <div class="inline-drawer-content">
-                                <div class="range-block-title justifyLeft" data-i18n="Proxy Presets">
-                                    Proxy Presets
+                                <div class="range-block-title justifyLeft" data-i18n="Endpoint Override Presets">
+                                    Endpoint Override Presets
                                 </div>
                                 <div class="toggle-description justifyLeft">
                                     <span data-i18n="Saved addresses and passwords.">
@@ -2757,27 +2757,27 @@
                                 <div class="openai_logit_bias_preset_form">
                                     <select id="openai_proxy_preset">
                                     </select>
-                                    <i id="save_proxy" class="menu_button fa-solid fa-save" title="Save Proxy" data-i18n="[title]Save Proxy"></i>
-                                    <i id="delete_proxy" class="menu_button fa-solid fa-trash" title="Delete Proxy" data-i18n="[title]Delete Proxy"></i>
+                                    <i id="save_proxy" class="menu_button fa-solid fa-save" title="Save Endpoint Override" data-i18n="[title]Save Endpoint Override"></i>
+                                    <i id="delete_proxy" class="menu_button fa-solid fa-trash" title="Delete Endpoint Override" data-i18n="[title]Delete Endpoint Override"></i>
                                 </div>
-                                <div class="range-block-title justifyLeft" data-i18n="Proxy Name">
-                                    Proxy Name
+                                <div class="range-block-title justifyLeft" data-i18n="Name of Endpoint Override Preset">
+                                    Name of Endpoint Override Preset
                                 </div>
                                 <div class="toggle-description justifyLeft">
-                                    <span data-i18n="This will show up as your saved preset.">
-                                        This will show up as your saved preset.
+                                    <span data-i18n="This will be the name of the preset for the endpoint override.">
+                                        This will be the name of the preset for the endpoint override.
                                     </span>
                                     <br>
                                 </div>
                                 <div class="wide100p">
                                     <input id="openai_reverse_proxy_name" type="text" class="text_pole" placeholder="..." />
                                 </div>
-                                <div class="range-block-title justifyLeft" data-i18n="Proxy Server URL">
-                                    Proxy Server URL
+                                <div class="range-block-title justifyLeft" data-i18n="Override endpoint server URL">
+                                    Override endpoint server URL
                                 </div>
                                 <div class="toggle-description justifyLeft wide100p">
-                                    <span data-i18n="Alternative server URL (leave empty to use the default value).">
-                                        Alternative server URL (leave empty to use the default value).
+                                    <span data-i18n="Override endpoint server URL (leave empty to use the default value).">
+                                        Override endpoint server URL (leave empty to use the default value).
                                     </span>
                                     <br>
                                 </div>
@@ -2787,12 +2787,12 @@
                                         <span data-i18n="Doesn't work? Try adding">Doesn't work? Try adding</span> <code>/v1</code> <span data-i18n="at the end!">at the end!</span>
                                     </small>
                                 </div>
-                                <div class="range-block-title justifyLeft" data-i18n="Proxy Password">
-                                    Proxy Password
+                                <div class="range-block-title justifyLeft" data-i18n="Override Key">
+                                    Override Key
                                 </div>
                                 <div class="toggle-description justifyLeft">
-                                    <span data-i18n="Will be used as a password for the proxy instead of API key.">
-                                        Will be used as a password for the proxy instead of API key.
+                                    <span data-i18n="Will be used as the key instead of the one from the API Key field.">
+                                        Will be used as the key instead of the one from the API Key field.
                                     </span>
                                     <br>
                                 </div>
@@ -2805,11 +2805,11 @@
                         <div id="ReverseProxyWarningMessage" data-source="openai,claude,mistralai,makersuite,deepseek">
                             <div class="reverse_proxy_warning">
                                 <b>
-                                    <div data-i18n="Using a proxy that you're not running yourself is a risk to your data privacy.">
-                                        Using a proxy that you're not running yourself is a risk to your data privacy.
+                                    <div data-i18n="Using an endpoint override is a potential risk to your data privacy.">
+                                        Using an endpoint override is a potential risk to your data privacy.
                                     </div>
-                                    <div data-i18n="ANY support requests will be REFUSED if you are using a proxy.">
-                                        ANY support requests will be REFUSED if you are using a proxy.
+                                    <div data-i18n="ANY support requests will be REFUSED if you are using this feature.">
+                                        ANY support requests will be REFUSED if you are using this feature.
                                     </div>
                                     <hr>
                                     <i data-i18n="Do not proceed if you do not agree to this!">
@@ -2819,7 +2819,7 @@
                             </div>
                         </div>
                         <form id="openai_form" data-source="openai" action="javascript:void(null);" method="post" enctype="multipart/form-data">
-                            <h4><span data-i18n="OpenAI API key">OpenAI API key</span></h4>
+                            <h4><span data-i18n="OpenAI API Key">OpenAI API Key</span></h4>
                             <div>
                                 <a id="openai_api_usage" href="https://platform.openai.com/account/usage" target="_blank">
                                     <span data-i18n="View API Usage Metrics">View API Usage Metrics</span>
@@ -2842,8 +2842,8 @@
                                 <div title="Clear your API key" data-i18n="[title]Clear your API key" class="menu_button fa-solid fa-circle-xmark clear-api-key" data-key="api_key_openai"></div>
                             </div>
                             <div id="ReverseProxyWarningMessage2" class="reverse_proxy_warning">
-                                <b data-i18n="Use Proxy password field instead. This input will be ignored.">
-                                    Use "Proxy password" field instead. This input will be ignored.
+                                <b data-i18n="Endpoint URL is being overridden, use the Override Key field instead.">
+                                    Endpoint URL is being overridden, use the Override Key field instead.
                                 </b>
                             </div>
                             <div data-for="api_key_openai" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you reload the page.">

--- a/public/index.html
+++ b/public/index.html
@@ -2745,8 +2745,8 @@
                                 <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                             </div>
                             <div class="inline-drawer-content">
-                                <div class="range-block-title justifyLeft" data-i18n="Endpoint Override Presets">
-                                    Endpoint Override Presets
+                                <div class="range-block-title justifyLeft" data-i18n="Endpoint Override Configurations">
+                                    Endpoint Override Configurations
                                 </div>
                                 <div class="toggle-description justifyLeft">
                                     <span data-i18n="Saved addresses and passwords.">
@@ -2760,12 +2760,12 @@
                                     <i id="save_proxy" class="menu_button fa-solid fa-save" title="Save Endpoint Override" data-i18n="[title]Save Endpoint Override"></i>
                                     <i id="delete_proxy" class="menu_button fa-solid fa-trash" title="Delete Endpoint Override" data-i18n="[title]Delete Endpoint Override"></i>
                                 </div>
-                                <div class="range-block-title justifyLeft" data-i18n="Name of Endpoint Override Preset">
-                                    Name of Endpoint Override Preset
+                                <div class="range-block-title justifyLeft" data-i18n="Name of Endpoint Override Configuration">
+                                    Name of Endpoint Override Configuration
                                 </div>
                                 <div class="toggle-description justifyLeft">
-                                    <span data-i18n="This will be the name of the preset for the endpoint override.">
-                                        This will be the name of the preset for the endpoint override.
+                                    <span data-i18n="This will be the name of the configuration for the endpoint override.">
+                                        This will be the name of the configuration for the endpoint override.
                                     </span>
                                     <br>
                                 </div>
@@ -2805,8 +2805,8 @@
                         <div id="ReverseProxyWarningMessage" data-source="openai,claude,mistralai,makersuite,deepseek">
                             <div class="reverse_proxy_warning">
                                 <b>
-                                    <div data-i18n="Using an endpoint override is a potential risk to your data privacy.">
-                                        Using an endpoint override is a potential risk to your data privacy.
+                                    <div data-i18n="Using an endpoint override is a risk to your data privacy.">
+                                        Using an endpoint override is a risk to your data privacy.
                                     </div>
                                     <div data-i18n="ANY support requests will be REFUSED if you are using this feature.">
                                         ANY support requests will be REFUSED if you are using this feature.

--- a/public/locales/ar-sa.json
+++ b/public/locales/ar-sa.json
@@ -355,7 +355,7 @@
     "Proxy Password": "كلمة مرور الوكيل",
     "Will be used as a password for the proxy instead of API key.": "سيتم استخدامها ككلمة مرور للوكيل بدلاً من مفتاح API.",
     "Peek a password": "نظرة خاطفة على كلمة المرور",
-    "OpenAI API key": "مفتاح API لـ OpenAI",
+    "OpenAI API Key": "مفتاح API لـ OpenAI",
     "View API Usage Metrics": "عرض مقاييس استخدام واجهة برمجة التطبيقات",
     "Follow": "اتبع",
     "these directions": "هذه التوجيهات",

--- a/public/locales/de-de.json
+++ b/public/locales/de-de.json
@@ -355,7 +355,7 @@
     "Proxy Password": "Proxy-Passwort",
     "Will be used as a password for the proxy instead of API key.": "Wird anstelle des API-Schlüssels als Kennwort für den Proxy verwendet.",
     "Peek a password": "Einsehen eines Passworts",
-    "OpenAI API key": "OpenAI API-Schlüssel",
+    "OpenAI API Key": "OpenAI API-Schlüssel",
     "View API Usage Metrics": "API-Nutzungsmetriken anzeigen",
     "Follow": "Folgen",
     "these directions": "diesen Anweisungen",

--- a/public/locales/es-es.json
+++ b/public/locales/es-es.json
@@ -355,7 +355,7 @@
     "Proxy Password": "Contraseña de proxy",
     "Will be used as a password for the proxy instead of API key.": "Se utilizará como contraseña para el proxy en lugar de clave API.",
     "Peek a password": "Mira una contraseña",
-    "OpenAI API key": "Clave de API de OpenAI",
+    "OpenAI API Key": "Clave de API de OpenAI",
     "View API Usage Metrics": "Ver métricas de uso de la API",
     "Follow": "Seguir",
     "these directions": "estas instrucciones",

--- a/public/locales/fr-fr.json
+++ b/public/locales/fr-fr.json
@@ -336,7 +336,7 @@
     "Proxy Password": "Mot de passe proxy",
     "Will be used as a password for the proxy instead of API key.": "Sera utilisé comme mot de passe pour le proxy au lieu de la clé API.",
     "Peek a password": "Jetez un œil à un mot de passe",
-    "OpenAI API key": "Clé API OpenAI",
+    "OpenAI API Key": "Clé API OpenAI",
     "View API Usage Metrics": "Afficher les statistiques d'utilisation de l'API",
     "Follow": "Suivre",
     "these directions": "ces instructions",

--- a/public/locales/is-is.json
+++ b/public/locales/is-is.json
@@ -355,7 +355,7 @@
     "Proxy Password": "Lykilorð umboðsmanns",
     "Will be used as a password for the proxy instead of API key.": "Verður notað sem lykilorð fyrir proxy í stað API lykils.",
     "Peek a password": "Skoðaðu lykilorð",
-    "OpenAI API key": "OpenAI API lykill",
+    "OpenAI API Key": "OpenAI API lykill",
     "View API Usage Metrics": "Skoða notkun gagnafræði API",
     "Follow": "Fylgja",
     "these directions": "þessum leiðbeiningum",

--- a/public/locales/it-it.json
+++ b/public/locales/it-it.json
@@ -355,7 +355,7 @@
     "Proxy Password": "Password proxy",
     "Will be used as a password for the proxy instead of API key.": "Verrà utilizzato come password per il proxy anziché come chiave API.",
     "Peek a password": "Dai un'occhiata a una password",
-    "OpenAI API key": "Chiave API di OpenAI",
+    "OpenAI API Key": "Chiave API di OpenAI",
     "View API Usage Metrics": "Visualizza le metriche sull'uso dell'API",
     "Follow": "Segui",
     "these directions": "queste istruzioni",

--- a/public/locales/ja-jp.json
+++ b/public/locales/ja-jp.json
@@ -355,7 +355,7 @@
     "Proxy Password": "プロキシパスワード",
     "Will be used as a password for the proxy instead of API key.": "API キーの代わりにプロキシのパスワードとして使用されます。",
     "Peek a password": "パスワードを覗く",
-    "OpenAI API key": "OpenAI APIキー",
+    "OpenAI API Key": "OpenAI APIキー",
     "View API Usage Metrics": "API使用メトリクスを表示",
     "Follow": "フォロー",
     "these directions": "これらの指示",

--- a/public/locales/ko-kr.json
+++ b/public/locales/ko-kr.json
@@ -359,7 +359,7 @@
     "Proxy Password": "프록시 비밀번호",
     "Will be used as a password for the proxy instead of API key.": "API 키 대신 프록시의 비밀번호로 사용됩니다.",
     "Peek a password": "비밀번호를 엿보세요",
-    "OpenAI API key": "OpenAI API 키",
+    "OpenAI API Key": "OpenAI API 키",
     "View API Usage Metrics": "API 사용 지표 보기",
     "Follow": "OpenAI API 키를 얻으려면",
     "these directions": "이 지시 사항",

--- a/public/locales/nl-nl.json
+++ b/public/locales/nl-nl.json
@@ -355,7 +355,7 @@
     "Proxy Password": "Proxywachtwoord",
     "Will be used as a password for the proxy instead of API key.": "Wordt gebruikt als wachtwoord voor de proxy in plaats van API-sleutel.",
     "Peek a password": "Zoek een wachtwoord",
-    "OpenAI API key": "OpenAI API-sleutel",
+    "OpenAI API Key": "OpenAI API-sleutel",
     "View API Usage Metrics": "Bekijk API-gebruiksstatistieken",
     "Follow": "Volgen",
     "these directions": "deze instructies",

--- a/public/locales/pt-pt.json
+++ b/public/locales/pt-pt.json
@@ -355,7 +355,7 @@
     "Proxy Password": "Senha do proxy",
     "Will be used as a password for the proxy instead of API key.": "Será usado como senha do proxy em vez da chave API.",
     "Peek a password": "Espie uma senha",
-    "OpenAI API key": "Chave da API OpenAI",
+    "OpenAI API Key": "Chave da API OpenAI",
     "View API Usage Metrics": "Ver métricas de uso da API",
     "Follow": "Seguir",
     "these directions": "estas direções",

--- a/public/locales/ru-ru.json
+++ b/public/locales/ru-ru.json
@@ -301,7 +301,7 @@
     "Get your NovelAI API Key": "Получите свой API-ключ для NovelAI",
     "AI Horde": "AI Horde",
     "NovelAI": "NovelAI",
-    "OpenAI API key": "Ключ для API OpenAI",
+    "OpenAI API Key": "Ключ для API OpenAI",
     "Trim spaces": "Обрезать пробелы",
     "Trim Incomplete Sentences": "Удалять неоконченные предложения",
     "Include Newline": "Добавлять новую строку",

--- a/public/locales/uk-ua.json
+++ b/public/locales/uk-ua.json
@@ -355,7 +355,7 @@
     "Proxy Password": "Пароль проксі",
     "Will be used as a password for the proxy instead of API key.": "Використовуватиметься як пароль для проксі замість ключа API.",
     "Peek a password": "Подивіться пароль",
-    "OpenAI API key": "Ключ API для OpenAI",
+    "OpenAI API Key": "Ключ API для OpenAI",
     "View API Usage Metrics": "Переглянути метрики використання API",
     "Follow": "Дотримуйтесь",
     "these directions": "цих інструкцій",

--- a/public/locales/vi-vn.json
+++ b/public/locales/vi-vn.json
@@ -355,7 +355,7 @@
     "Proxy Password": "Mật khẩu cho proxy",
     "Will be used as a password for the proxy instead of API key.": "Sẽ được sử dụng làm mật khẩu cho proxy thay vì key API.",
     "Peek a password": "Xem mật khẩu",
-    "OpenAI API key": "OpenAI API key",
+    "OpenAI API Key": "OpenAI API key",
     "View API Usage Metrics": "Xem stats xài API",
     "Follow": "Theo dõi",
     "these directions": "những hướng dẫn này",

--- a/public/locales/zh-cn.json
+++ b/public/locales/zh-cn.json
@@ -406,7 +406,7 @@
     "Using a proxy that you're not running yourself is a risk to your data privacy.": "使用您自己未运行的代理会对您的数据隐私造成风险。",
     "ANY support requests will be REFUSED if you are using a proxy.": "如果您使用代理，任何支持请求都将被拒绝。",
     "Do not proceed if you do not agree to this!": "如果您不同意，请不要继续！",
-    "OpenAI API key": "OpenAI API 密钥",
+    "OpenAI API Key": "OpenAI API 密钥",
     "View API Usage Metrics": "查看API使用情况",
     "Follow": "按照",
     "these directions": "这些步骤",

--- a/public/locales/zh-tw.json
+++ b/public/locales/zh-tw.json
@@ -356,7 +356,7 @@
     "Proxy Password": "代理伺服器密碼",
     "Will be used as a password for the proxy instead of API key.": "將用作代理的密碼，而不是 API 金鑰",
     "Peek a password": "顯示密碼",
-    "OpenAI API key": "OpenAI API 金鑰",
+    "OpenAI API Key": "OpenAI API 金鑰",
     "View API Usage Metrics": "檢視 API 使用指標",
     "Follow": "遵循",
     "these directions": "這些指示",

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -52,7 +52,7 @@ const FANCY_NAMES = {
     'api-url': 'Server URL',
     'preset': 'Settings Preset',
     'model': 'Model',
-    'proxy': 'Proxy Preset',
+    'proxy': 'Endpoint Override Configuration',
     'sysprompt-state': 'Use System Prompt',
     'sysprompt': 'System Prompt Name',
     'instruct-state': 'Instruct Mode',
@@ -136,7 +136,7 @@ const profilesProvider = () => [
  * @property {string} [api] API
  * @property {string} [preset] Settings Preset
  * @property {string} [model] Model
- * @property {string} [proxy] Proxy Preset
+ * @property {string} [proxy] Endpoint Override Configuration
  * @property {string} [instruct] Instruct Template
  * @property {string} [context] Context Template
  * @property {string} [instruct-state] Instruct Mode

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5179,17 +5179,17 @@ export function initOpenAI() {
         name: 'endpoint-override',
         aliases: ['proxy'],
         callback: runProxyCallback,
-        returns: 'current Endpoint Override preset',
+        returns: 'current Endpoint Override configuration',
         namedArgumentList: [],
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: 'name',
                 typeList: [ARGUMENT_TYPE.STRING],
                 isRequired: true,
-                enumProvider: () => proxies.map(preset => new SlashCommandEnumValue(preset.name, preset.url)),
+                enumProvider: () => proxies.map(config => new SlashCommandEnumValue(config.name, config.url)),
             }),
         ],
-        helpString: 'Sets an Endpoint Override by its preset name.',
+        helpString: 'Sets an Endpoint Override by its configuration name.',
     }));
 
     $('#test_api_button').on('click', testApiConnection);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5179,7 +5179,7 @@ export function initOpenAI() {
         name: 'endpoint-override',
         aliases: ['proxy'],
         callback: runProxyCallback,
-        returns: 'current Endpoint Override configuration',
+        returns: 'current Endpoint Override Configuration',
         namedArgumentList: [],
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5176,9 +5176,10 @@ function runProxyCallback(_, value) {
 
 export function initOpenAI() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'proxy',
+        name: 'endpoint-override',
+        aliases: ['proxy'],
         callback: runProxyCallback,
-        returns: 'current proxy',
+        returns: 'current Endpoint Override preset',
         namedArgumentList: [],
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
@@ -5188,7 +5189,7 @@ export function initOpenAI() {
                 enumProvider: () => proxies.map(preset => new SlashCommandEnumValue(preset.name, preset.url)),
             }),
         ],
-        helpString: 'Sets a proxy preset by name.',
+        helpString: 'Sets an Endpoint Override by its preset name.',
     }));
 
     $('#test_api_button').on('click', testApiConnection);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

SillyTavern has taken a hard stance against unofficial servers that provide access to paid LLM services. However, this feature has legitimate use-cases outside of that. The UI still indicates that no support will be given when this feature is being utilized.

The id attributes are currently all still the same.

Also, a slight casing change: `OpenAI API key` → `OpenAI API Key` (to be consistent with the other sources, as well as it being clearer what the UI is referring to when `API Key field` is stated on line 2795).