### PR TITLE
Fix persona auto-lock to chat not working when the persona was already selected

### DIFF
--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1464,6 +1464,10 @@ async function loadPersonaForCurrentChat({ doRender = false } = {}) {
             toastr.success(message, t`Persona Auto Selected`, { escapeHtml: false });
         }
     }
+    // Even if it's the same persona, we still might need to auto-lock to chat if that's enabled
+    else if (chatPersona && power_user.persona_auto_lock && !chat_metadata['persona']) {
+        lockPersona('chat');
+    }
 
     updatePersonaUIStates();
 


### PR DESCRIPTION
Fixed my own fuck-up.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).

## Copilot
This pull request includes a small but important change to the `public/scripts/personas.js` file. The change ensures that the persona auto-lock feature is triggered even if the same persona is selected, provided that auto-lock is enabled and no persona is currently locked to the chat.

* [`public/scripts/personas.js`](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fR1467-R1470): Added logic to auto-lock the persona to the chat if the `persona_auto_lock` feature is enabled and no persona is currently locked (`chat_metadata['persona']` is falsy).