### PR TITLE
Add info block for find regex flags

### DIFF
--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -16,6 +16,13 @@
         </small>
         <hr />
 
+        <div id="regex_info_block" class="info-block">
+            <span class="info-block-text"></span>
+            <a class="info-block-flags-hint" href="http://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags" target="_blank" rel="noopener noreferrer">
+                <i class="fa-solid fa-circle-info" title="Click here to learn more about regex flags."></i>
+            </a>
+        </div>
+
         <div id="regex_test_mode" class="flex1 flex-container displayNone">
             <div class="flex1">
                 <label class="title_restorable" for="regex_test_input">

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -16,9 +16,9 @@
         </small>
         <hr />
 
-        <div id="regex_info_block" class="info-block">
-            <span class="info-block-text"></span>
-            <a class="info-block-flags-hint" href="http://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags" target="_blank" rel="noopener noreferrer">
+        <div id="regex_info_block_wrapper">
+            <div id="regex_info_block" class="info-block"></div>
+            <a id="regex_info_block_flags_hint" href="http://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#advanced_searching_with_flags" target="_blank" rel="noopener noreferrer">
                 <i class="fa-solid fa-circle-info" title="Click here to learn more about regex flags."></i>
             </a>
         </div>

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -335,8 +335,6 @@ function updateInfoBlock(editorHtml) {
         }
 
         const flagInfo = [];
-        // Check flags
-
         flagInfo.push(regex.flags.includes('g') ? t`Applies to all matches` : t`Applies to the first match`);
         flagInfo.push(regex.flags.includes('i') ? t`Case insensitive` : t`Case sensitive`);
 
@@ -346,7 +344,6 @@ function updateInfoBlock(editorHtml) {
     } catch (error) {
         infoBlock.addClass('error');
         infoBlockTextSpan.text(error.message);
-        return;
     }
 }
 

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -7,7 +7,7 @@ import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '
 import { enumIcons } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { SlashCommandEnumValue, enumTypes } from '../../slash-commands/SlashCommandEnumValue.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
-import { download, getFileText, getSortableDelay, regexFromString, uuidv4 } from '../../utils.js';
+import { download, getFileText, getSortableDelay, regexFromString, setInfoBlock, uuidv4 } from '../../utils.js';
 import { regex_placement, runRegexScript, substitute_find_regex } from './engine.js';
 import { t } from '../../i18n.js';
 import { accountStorage } from '../../util/AccountStorage.js';
@@ -313,18 +313,15 @@ async function onRegexEditorOpenClick(existingId, isScoped) {
  * @param {JQuery<HTMLElement>} editorHtml The editor HTML
  */
 function updateInfoBlock(editorHtml) {
-    const infoBlock = editorHtml.find('.info-block');
-    const infoBlockTextSpan = infoBlock.find('.info-block-text');
-    const infoBlockFlagsHint = infoBlock.find('.info-block-flags-hint');
+    const infoBlock = editorHtml.find('.info-block').get(0);
+    const infoBlockFlagsHint = editorHtml.find('#regex_info_block_flags_hint');
     const findRegex = String(editorHtml.find('.find_regex').val());
 
-    infoBlock.removeClass('error hint info warning');
     infoBlockFlagsHint.hide();
 
     // Clear the info block if the find regex is empty
     if (!findRegex) {
-        infoBlock.addClass('info');
-        infoBlockTextSpan.text(t`Find Regex is empty`);
+        setInfoBlock(infoBlock, t`Find Regex is empty`, 'info');
         return;
     }
 
@@ -338,12 +335,10 @@ function updateInfoBlock(editorHtml) {
         flagInfo.push(regex.flags.includes('g') ? t`Applies to all matches` : t`Applies to the first match`);
         flagInfo.push(regex.flags.includes('i') ? t`Case insensitive` : t`Case sensitive`);
 
-        infoBlock.addClass('hint');
-        infoBlockTextSpan.text(flagInfo.join('. '));
+        setInfoBlock(infoBlock, flagInfo.join('. '), 'hint');
         infoBlockFlagsHint.show();
     } catch (error) {
-        infoBlock.addClass('error');
-        infoBlockTextSpan.text(error.message);
+        setInfoBlock(infoBlock, error.message, 'error');
     }
 }
 

--- a/public/scripts/extensions/regex/style.css
+++ b/public/scripts/extensions/regex/style.css
@@ -105,3 +105,21 @@ input.enable_scoped {
 .disable_regex:not(:checked) ~ .regex-toggle-on {
     display: block;
 }
+
+#regex_info_block {
+    position: relative;
+    margin: 10px 0;
+    padding: 5px 20px;
+    font-size: 0.9em;
+}
+
+#regex_info_block:empty {
+    display: none;
+}
+
+#regex_info_block .info-block-flags-hint {
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    transform: translateY(-50%);
+}

--- a/public/scripts/extensions/regex/style.css
+++ b/public/scripts/extensions/regex/style.css
@@ -106,18 +106,21 @@ input.enable_scoped {
     display: block;
 }
 
-#regex_info_block {
+#regex_info_block_wrapper {
     position: relative;
+}
+
+#regex_info_block {
     margin: 10px 0;
     padding: 5px 20px;
     font-size: 0.9em;
 }
 
-#regex_info_block:empty {
+#regex_info_block_wrapper:has(#regex_info_block:empty) {
     display: none;
 }
 
-#regex_info_block .info-block-flags-hint {
+#regex_info_block_flags_hint {
     position: absolute;
     top: 50%;
     right: 10px;


### PR DESCRIPTION
Addresses a common misunderstanding of regex flags by providing immediate response about the flags used in the find regex.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
