### PR TITLE
Add `/input` arguments to execute closures on success and on cancel 

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1287,26 +1287,42 @@ export function initDefaultSlashCommands() {
         callback: inputCallback,
         returns: 'user input',
         namedArgumentList: [
-            new SlashCommandNamedArgument(
-                'default', 'default value of the input field', [ARGUMENT_TYPE.STRING], false, false, '"string"',
-            ),
-            new SlashCommandNamedArgument(
-                'large', 'show large input field', [ARGUMENT_TYPE.BOOLEAN], false, false, 'off', commonEnumProviders.boolean('onOff')(),
-            ),
-            new SlashCommandNamedArgument(
-                'wide', 'show wide input field', [ARGUMENT_TYPE.BOOLEAN], false, false, 'off', commonEnumProviders.boolean('onOff')(),
-            ),
-            new SlashCommandNamedArgument(
-                'okButton', 'text for the ok button', [ARGUMENT_TYPE.STRING], false,
-            ),
-            new SlashCommandNamedArgument(
-                'rows', 'number of rows for the input field', [ARGUMENT_TYPE.NUMBER], false,
-            ),
+            SlashCommandNamedArgument.fromProps({
+                name: 'default',
+                description: 'default value of the input field',
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'large',
+                description: 'show large input field',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'off',
+                enumList: commonEnumProviders.boolean('onOff')(),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'wide',
+                description: 'show wide input field',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'off',
+                enumList: commonEnumProviders.boolean('onOff')(),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'okButton',
+                description: 'text for the ok button',
+                typeList: [ARGUMENT_TYPE.STRING],
+                defaultValue: 'Ok',
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'rows',
+                description: 'number of rows for the input field',
+                typeList: [ARGUMENT_TYPE.NUMBER],
+            }),
         ],
         unnamedArgumentList: [
-            new SlashCommandArgument(
-                'text to display', [ARGUMENT_TYPE.STRING], false,
-            ),
+            SlashCommandArgument.fromProps({
+                description: 'text to display',
+                typeList: [ARGUMENT_TYPE.STRING],
+            }),
         ],
         helpString: `
         <div>


### PR DESCRIPTION
Add optional args to `/input` argument to execute on popup success or popup cancel/failure.

This allows slash command code to be executed when there input was canceled, and not just accepted with empty content.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
