### PR TITLE
Fix `/buttons` buttons not being displayed on log popup texts

### DIFF
--- a/public/css/scrollable-button.css
+++ b/public/css/scrollable-button.css
@@ -1,6 +1,5 @@
 .scrollable-buttons-container {
     max-height: 50vh;  /* Use viewport height instead of fixed pixels */
-    overflow-y: auto;
     -webkit-overflow-scrolling: touch; /* Momentum scrolling on iOS */
     margin-top: 1rem; /* m-t-1 is equivalent to margin-top: 1rem; */
     flex-shrink: 1;


### PR DESCRIPTION
On long popup texts, the buttons of the `/popup` slash command will not be displayed, cause by an unneeded overflow CSS property

Fixes #3654

Tested this both with very long popup texts, and also with hundreds of buttons that are still displayed and scrollable.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
