### PR TITLE
Add group pooled order

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5382,6 +5382,7 @@
                                                 <option value="2" data-i18n="Manual">Manual</option>
                                                 <option value="0" data-i18n="Natural order">Natural order</option>
                                                 <option value="1" data-i18n="List order">List order</option>
+                                                <option value="3" data-i18n="Pooled order">Pooled order</option>
                                             </select>
                                         </div>
                                         <div class="flex1 flexGap5">

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1031,7 +1031,9 @@ function activateListOrder(members) {
  * @returns {number[]} List of character ids
  */
 function activatePooledOrder(members, lastMessage) {
-    const activatedMembers = [];
+    /** @type {string} */
+    let activatedMember = null;
+    /** @type {string[]} */
     const spokenSinceUser = [];
 
     for (const message of chat.slice().reverse()) {
@@ -1051,19 +1053,17 @@ function activatePooledOrder(members, lastMessage) {
     const haveNotSpoken = members.filter(x => !spokenSinceUser.includes(x));
 
     if (haveNotSpoken.length) {
-        activatedMembers.push(haveNotSpoken[Math.floor(Math.random() * haveNotSpoken.length)]);
+        activatedMember = haveNotSpoken[Math.floor(Math.random() * haveNotSpoken.length)];
     }
 
-    if (activatedMembers.length === 0) {
+    if (activatedMember === null) {
         const lastMessageAvatar = members.length > 1 && lastMessage && !lastMessage.is_user && lastMessage.original_avatar;
         const randomPool = lastMessageAvatar ? members.filter(x => x !== lastMessage.original_avatar) : members;
-        activatedMembers.push(randomPool[Math.floor(Math.random() * randomPool.length)]);
+        activatedMember = randomPool[Math.floor(Math.random() * randomPool.length)];
     }
 
-    const memberIds = activatedMembers
-        .map((x) => characters.findIndex((y) => y.avatar === x))
-        .filter((x) => x !== -1);
-    return memberIds;
+    const memberId = characters.findIndex(y => y.avatar === activatedMember);
+    return memberId !== -1 ? [memberId] : [];
 }
 
 function activateNaturalOrder(members, input, lastMessage, allowSelfResponses, isUserInput) {


### PR DESCRIPTION
Closes #3650

> Add an option to Manual Order or a new strategy that causes the random selection to prioritize characters who haven't spoken since {{user}}'s last message. Then the user can simply press [Enter] until the whole group has spoken without repeats.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
