### PR TITLE
fix : Handle full-word matching for CJK (Chinese, Japanese, Korean) c…

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -259,6 +259,12 @@ class WorldInfoBuffer {
         if (matchWholeWords) {
             const keyWords = transformedString.split(/\s+/);
 
+            // Handle full-word matching for CJK (Chinese, Japanese, Korean) characters
+            const isCJK = /[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7a3]/.test(transformedString);
+            if (isCJK) {
+                return haystack.includes(transformedString);
+            }
+
             if (keyWords.length > 1) {
                 return haystack.includes(transformedString);
             }


### PR DESCRIPTION

Handle full-word matching for CJK (Chinese, Japanese, Korean) characters ,to solve the problem of incorrect matching caused by the reason that \w cannot recognize these language characters.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
