### PR TITLE
exporting parseReasoningFromString()

### DIFF
--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1075,7 +1075,7 @@ export function removeReasoningFromString(str) {
  * @param {boolean} [options.strict=true] Whether the reasoning block **has** to be at the beginning of the provided string (excluding whitespaces), or can be anywhere in it
  * @returns {ParsedReasoning|null} Parsed reasoning block and message content
  */
-function parseReasoningFromString(str, { strict = true } = {}) {
+export function parseReasoningFromString(str, { strict = true } = {}) {
     // Both prefix and suffix must be defined
     if (!power_user.reasoning.prefix || !power_user.reasoning.suffix) {
         return null;

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -79,7 +79,7 @@ import { timestampToMoment, uuidv4 } from './utils.js';
 import { getGlobalVariable, getLocalVariable, setGlobalVariable, setLocalVariable } from './variables.js';
 import { convertCharacterBook, loadWorldInfo, saveWorldInfo, updateWorldInfoList } from './world-info.js';
 import { ChatCompletionService, TextCompletionService } from './custom-request.js';
-import { updateReasoningUI } from './reasoning.js';
+import { updateReasoningUI, parseReasoningFromString } from './reasoning.js';
 
 export function getContext() {
     return {
@@ -213,6 +213,7 @@ export function getContext() {
         ChatCompletionService,
         TextCompletionService,
         updateReasoningUI,
+        parseReasoningFromString,
         unshallowCharacter,
         unshallowGroupMembers,
     };


### PR DESCRIPTION
Just exports `parseRasoningFromString()` and makes it accessible through the `getContext()`.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
