### PR TITLE
Gemini inline images

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1998,6 +1998,23 @@
                                         </div>
                                     </div>
                                     <div class="range-block" data-source="makersuite">
+                                        <label for="openai_request_images" class="checkbox_label widthFreeExpand">
+                                            <input id="openai_request_images" type="checkbox" />
+                                            <span>
+                                                <span data-i18n="Request inline images">Request inline images</span>
+                                                <i class="opacity50p fa-solid fa-circle-info" title="Gemini 2.0 Flash Experimental"></i>
+                                            </span>
+                                        </label>
+                                        <div class="toggle-description justifyLeft marginBot5">
+                                            <span data-i18n="Allows the model to return image attachments.">
+                                                Allows the model to return image attachments.
+                                            </span>
+                                            <em data-source="makersuite" data-i18n="Request inline images_desc_2">
+                                                Incompatible with the following features: function calling, web search, system prompt.
+                                            </em>
+                                        </div>
+                                    </div>
+                                    <div class="range-block" data-source="makersuite">
                                         <label for="use_makersuite_sysprompt" class="checkbox_label widthFreeExpand">
                                             <input id="use_makersuite_sysprompt" type="checkbox" />
                                             <span>

--- a/public/script.js
+++ b/public/script.js
@@ -5735,20 +5735,30 @@ function extractTitleFromData(data) {
     return undefined;
 }
 
-function extractImageFromData(data) {
-    if (main_api === 'openai') {
-        switch (oai_settings.chat_completion_source) {
-            case chat_completion_sources.MAKERSUITE: {
-                const inlineData = data?.responseContent?.parts?.find(x => x.inlineData)?.inlineData;
-                if (inlineData) {
-                    return `data:${inlineData.mimeType};base64,${inlineData.data}`;
-                }
-            } break;
+/**
+ * Extracts the image from the response data.
+ * @param {object} data Response data
+ * @param {object} [options] Extraction options
+ * @param {string} [options.mainApi] Main API to use
+ * @param {string} [options.chatCompletionSource] Chat completion source
+ * @returns {string} Extracted image
+ */
+function extractImageFromData(data, { mainApi = null, chatCompletionSource = null } = {}) {
+    switch (mainApi ?? main_api) {
+        case 'openai': {
+            switch (chatCompletionSource ?? oai_settings.chat_completion_source) {
+                case chat_completion_sources.MAKERSUITE: {
+                    const inlineData = data?.responseContent?.parts?.find(x => x.inlineData)?.inlineData;
+                    if (inlineData) {
+                        return `data:${inlineData.mimeType};base64,${inlineData.data}`;
+                    }
+                } break;
 
+            }
         }
-    }
 
-    return undefined;
+            return undefined;
+    }
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -171,6 +171,7 @@ import {
     isElementInViewport,
     copyText,
     escapeHtml,
+    saveBase64AsFile,
 } from './scripts/utils.js';
 import { debounce_timeout } from './scripts/constants.js';
 
@@ -3203,6 +3204,8 @@ class StreamingProcessor {
         this.reasoningHandler = new ReasoningHandler(timeStarted);
         /** @type {PromptReasoning} */
         this.promptReasoning = promptReasoning;
+        /** @type {string} */
+        this.image = '';
     }
 
     /**
@@ -3250,7 +3253,7 @@ class StreamingProcessor {
             this.sendTextarea.value = '';
             this.sendTextarea.dispatchEvent(new Event('input', { bubbles: true }));
         } else {
-            await saveReply(this.type, text, true, '', [], '');
+            await saveReply(this.type, text, true, '', [], '', '');
             messageId = chat.length - 1;
             await this.#checkDomElements(messageId, continueOnReasoning);
             this.markUIGenStarted();
@@ -3468,6 +3471,7 @@ class StreamingProcessor {
                 }
                 // Get the updated reasoning string into the handler
                 this.reasoningHandler.updateReasoning(this.messageId, state?.reasoning);
+                this.image = state?.image ?? '';
                 await eventSource.emit(event_types.STREAM_TOKEN_RECEIVED, text);
                 await sw.tick(async () => await this.onProgressStreaming(this.messageId, this.continueMessage + text));
             }
@@ -4866,6 +4870,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         let getMessage = extractMessageFromData(data);
         let title = extractTitleFromData(data);
         let reasoning = extractReasoningFromData(data);
+        let image = extractImageFromData(data);
         kobold_horde_model = title;
 
         const swipes = extractMultiSwipes(data, type);
@@ -4898,10 +4903,10 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         else {
             // Without streaming we'll be having a full message on continuation. Treat it as a last chunk.
             if (originalType !== 'continue') {
-                ({ type, getMessage } = await saveReply(type, getMessage, false, title, swipes, reasoning));
+                ({ type, getMessage } = await saveReply(type, getMessage, false, title, swipes, reasoning, image));
             }
             else {
-                ({ type, getMessage } = await saveReply('appendFinal', getMessage, false, title, swipes, reasoning));
+                ({ type, getMessage } = await saveReply('appendFinal', getMessage, false, title, swipes, reasoning, image));
             }
 
             // This relies on `saveReply` having been called to add the message to the chat, so it must be last.
@@ -5725,6 +5730,22 @@ function extractTitleFromData(data) {
     return undefined;
 }
 
+function extractImageFromData(data) {
+    if (main_api === 'openai') {
+        switch (oai_settings.chat_completion_source) {
+            case chat_completion_sources.MAKERSUITE: {
+                const inlineData = data?.responseContent?.parts?.find(x => x.inlineData)?.inlineData;
+                if (inlineData) {
+                    return `data:${inlineData.mimeType};base64,${inlineData.data}`;
+                }
+            } break;
+
+        }
+    }
+
+    return undefined;
+}
+
 /**
  * parseAndSaveLogprobs receives the full data response for a non-streaming
  * generation, parses logprobs for all tokens in the message, and saves them
@@ -5974,7 +5995,40 @@ export function cleanUpMessage(getMessage, isImpersonate, isContinue, displayInc
     return getMessage;
 }
 
-export async function saveReply(type, getMessage, fromStreaming, title, swipes, reasoning) {
+/**
+ * Adds an image to the message.
+ * @returns {Promise<void>}
+ */
+async function processImageAttachment(message, { parsedImage, imageUrl }) {
+    if (parsedImage?.image) {
+        return saveImageToMessage(parsedImage, message);
+    }
+
+    if (!imageUrl) {
+        return;
+    }
+
+    if (isDataURL(imageUrl)) {
+        const [mime, base64] = /^data:(.*?);base64,(.*)$/.exec(imageUrl).slice(1);
+        const url = await saveBase64AsFile(base64, message.name, Date.now().toString(), mime.split('/')[1]);
+        saveImageToMessage({ image: url, inline: true }, message);
+    } else {
+        saveImageToMessage({ image: imageUrl, inline: true }, message);
+    }
+}
+
+/**
+ * Saves a resulting message to the chat.
+ * @param {string} type Type of generation
+ * @param {string} getMessage Generated message
+ * @param {boolean} fromStreaming If the message is from streaming
+ * @param {string} title Message tooltip
+ * @param {string[]} swipes Extra swipes
+ * @param {string} reasoning Message reasoning
+ * @param {string} imageUrl Link to an image
+ * @returns {Promise<{type: string, getMessage: string}>} Promise when the message is saved
+ */
+export async function saveReply(type, getMessage, fromStreaming, title, swipes, reasoning, imageUrl) {
     if (type != 'append' && type != 'continue' && type != 'appendFinal' && chat.length && (chat[chat.length - 1]['swipe_id'] === undefined ||
         chat[chat.length - 1]['is_user'])) {
         type = 'normal';
@@ -5995,8 +6049,8 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
 
     let oldMessage = '';
     const generationFinished = new Date();
-    const img = extractImageFromMessage(getMessage);
-    getMessage = img.getMessage;
+    const parsedImage = extractImageFromMessage(getMessage);
+    getMessage = parsedImage.getMessage;
     if (type === 'swipe') {
         oldMessage = chat[chat.length - 1]['mes'];
         chat[chat.length - 1]['swipes'].length++;
@@ -6010,6 +6064,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
             chat[chat.length - 1]['extra']['model'] = getGeneratingModel();
             chat[chat.length - 1]['extra']['reasoning'] = reasoning;
             chat[chat.length - 1]['extra']['reasoning_duration'] = null;
+            await processImageAttachment(chat[chat.length - 1], { parsedImage, imageUrl });
             if (power_user.message_token_count_enabled) {
                 const tokenCountText = (reasoning || '') + chat[chat.length - 1]['mes'];
                 chat[chat.length - 1]['extra']['token_count'] = await getTokenCountAsync(tokenCountText, 0);
@@ -6033,6 +6088,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
         chat[chat.length - 1]['extra']['model'] = getGeneratingModel();
         chat[chat.length - 1]['extra']['reasoning'] = reasoning;
         chat[chat.length - 1]['extra']['reasoning_duration'] = null;
+        await processImageAttachment(chat[chat.length - 1], { parsedImage, imageUrl });
         if (power_user.message_token_count_enabled) {
             const tokenCountText = (reasoning || '') + chat[chat.length - 1]['mes'];
             chat[chat.length - 1]['extra']['token_count'] = await getTokenCountAsync(tokenCountText, 0);
@@ -6052,6 +6108,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
         chat[chat.length - 1]['extra']['api'] = getGeneratingApi();
         chat[chat.length - 1]['extra']['model'] = getGeneratingModel();
         chat[chat.length - 1]['extra']['reasoning'] += reasoning;
+        await processImageAttachment(chat[chat.length - 1], { parsedImage, imageUrl });
         // We don't know if the reasoning duration extended, so we don't update it here on purpose.
         if (power_user.message_token_count_enabled) {
             const tokenCountText = (reasoning || '') + chat[chat.length - 1]['mes'];
@@ -6097,7 +6154,7 @@ export async function saveReply(type, getMessage, fromStreaming, title, swipes, 
             chat[chat.length - 1]['extra']['gen_id'] = group_generation_id;
         }
 
-        saveImageToMessage(img, chat[chat.length - 1]);
+        await processImageAttachment(chat[chat.length - 1], { parsedImage, imageUrl: imageUrl });
         const chat_id = (chat.length - 1);
 
         !fromStreaming && await eventSource.emit(event_types.MESSAGE_RECEIVED, chat_id, type);
@@ -6203,6 +6260,11 @@ export function syncMesToSwipe(messageId = null) {
     return true;
 }
 
+/**
+ * Saves the image to the message object.
+ * @param {{ image?: string, title?: string, inline?: boolean }} img Image object
+ * @param {object} mes Chat message object
+ */
 function saveImageToMessage(img, mes) {
     if (mes && img.image) {
         if (!mes.extra || typeof mes.extra !== 'object') {
@@ -6210,6 +6272,7 @@ function saveImageToMessage(img, mes) {
         }
         mes.extra.image = img.image;
         mes.extra.title = img.title;
+        mes.extra.inline_image = img.inline;
     }
 }
 
@@ -6252,7 +6315,7 @@ function extractImageFromMessage(getMessage) {
     const image = results ? results[1] : '';
     const title = results ? results[2] : '';
     getMessage = getMessage.replace(regex, '');
-    return { getMessage, image, title };
+    return { getMessage, image, title, inline: true };
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -6041,7 +6041,7 @@ async function processImageAttachment(message, { parsedImage, imageUrl }) {
 /**
  * Saves a resulting message to the chat.
  * @param {SaveReplyParams} params
- * @returns {Promise<{type: string, getMessage: string}>} Promise when the message is saved
+ * @returns {Promise<SaveReplyResult>} Promise when the message is saved
  *
  * @typedef {object} SaveReplyParams
  * @property {string} type Type of generation

--- a/public/script.js
+++ b/public/script.js
@@ -5755,10 +5755,10 @@ function extractImageFromData(data, { mainApi = null, chatCompletionSource = nul
                 } break;
 
             }
-        }
-
-            return undefined;
+        } break;
     }
+
+    return undefined;
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -3253,7 +3253,7 @@ class StreamingProcessor {
             this.sendTextarea.value = '';
             this.sendTextarea.dispatchEvent(new Event('input', { bubbles: true }));
         } else {
-            await saveReply({ type: this.type, getMessage: text, fromStreaming: true, title: '', swipes: [], reasoning: '', imageUrl: '' });
+            await saveReply({ type: this.type, getMessage: text, fromStreaming: true });
             messageId = chat.length - 1;
             await this.#checkDomElements(messageId, continueOnReasoning);
             this.markUIGenStarted();
@@ -4908,10 +4908,10 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         else {
             // Without streaming we'll be having a full message on continuation. Treat it as a last chunk.
             if (originalType !== 'continue') {
-                ({ type, getMessage } = await saveReply({ type, getMessage, fromStreaming: false, title, swipes, reasoning, imageUrl }));
+                ({ type, getMessage } = await saveReply({ type, getMessage, title, swipes, reasoning, imageUrl }));
             }
             else {
-                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, fromStreaming: false, title, swipes, reasoning, imageUrl }));
+                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, title, swipes, reasoning, imageUrl }));
             }
 
             // This relies on `saveReply` having been called to add the message to the chat, so it must be last.
@@ -6046,17 +6046,17 @@ async function processImageAttachment(message, { parsedImage, imageUrl }) {
  * @typedef {object} SaveReplyParams
  * @property {string} type Type of generation
  * @property {string} getMessage Generated message
- * @property {boolean} fromStreaming If the message is from streaming
- * @property {string} title Message tooltip
- * @property {string[]} swipes Extra swipes
- * @property {string} reasoning Message reasoning
- * @property {string} imageUrl Link to an image
+ * @property {boolean} [fromStreaming] If the message is from streaming
+ * @property {string} [title] Message tooltip
+ * @property {string[]} [swipes] Extra swipes
+ * @property {string} [reasoning] Message reasoning
+ * @property {string} [imageUrl] Link to an image
  *
  * @typedef {object} SaveReplyResult
  * @property {string} type Type of generation
  * @property {string} getMessage Generated message
  */
-export async function saveReply({ type, getMessage, fromStreaming, title, swipes, reasoning, imageUrl }) {
+export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrl = '' }) {
     // Backward compatibility
     if (arguments.length > 1 && typeof arguments[0] === 'string') {
         console.trace('saveReply called with positional arguments. Please use an object instead.');

--- a/public/script.js
+++ b/public/script.js
@@ -6029,13 +6029,13 @@ async function processImageAttachment(message, { parsedImage, imageUrl }) {
         return;
     }
 
-    if (isDataURL(imageUrl)) {
+    let url = imageUrl;
+    if (isDataURL(url)) {
+        const fileName = `inline_image_${Date.now().toString()}`;
         const [mime, base64] = /^data:(.*?);base64,(.*)$/.exec(imageUrl).slice(1);
-        const url = await saveBase64AsFile(base64, message.name, Date.now().toString(), mime.split('/')[1]);
-        saveImageToMessage({ image: url, inline: true }, message);
-    } else {
-        saveImageToMessage({ image: imageUrl, inline: true }, message);
+        url = await saveBase64AsFile(base64, message.name, fileName, mime.split('/')[1]);
     }
+    saveImageToMessage({ image: url, inline: true }, message);
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -6058,7 +6058,7 @@ async function processImageAttachment(message, { parsedImage, imageUrl }) {
  */
 export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrl = '' }) {
     // Backward compatibility
-    if (arguments.length > 1 && typeof arguments[0] === 'string') {
+    if (arguments.length > 1 && typeof arguments[0] !== 'object') {
         console.trace('saveReply called with positional arguments. Please use an object instead.');
         [type, getMessage, fromStreaming, title, swipes, reasoning, imageUrl] = arguments;
     }

--- a/public/script.js
+++ b/public/script.js
@@ -3375,6 +3375,11 @@ class StreamingProcessor {
             chat[messageId].swipe_info.push(...swipeInfoArray);
         }
 
+        if (this.image) {
+            await processImageAttachment(chat[messageId], { imageUrl: this.image, parsedImage: null });
+            appendMediaToMessage(chat[messageId], $(this.messageDom));
+        }
+
         if (this.type !== 'impersonate') {
             await eventSource.emit(event_types.MESSAGE_RECEIVED, this.messageId, this.type);
             await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, this.messageId, this.type);

--- a/public/script.js
+++ b/public/script.js
@@ -6012,11 +6012,17 @@ export function cleanUpMessage(getMessage, isImpersonate, isContinue, displayInc
 
 /**
  * Adds an image to the message.
+ * @param {object} message Message object
+ * @param {object} sources Image sources
+ * @param {ParsedImage} [sources.parsedImage] Parsed image
+ * @param {string} [sources.imageUrl] Image URL
+ *
  * @returns {Promise<void>}
  */
 async function processImageAttachment(message, { parsedImage, imageUrl }) {
     if (parsedImage?.image) {
-        return saveImageToMessage(parsedImage, message);
+        saveImageToMessage(parsedImage, message);
+        return;
     }
 
     if (!imageUrl) {
@@ -6277,8 +6283,9 @@ export function syncMesToSwipe(messageId = null) {
 
 /**
  * Saves the image to the message object.
- * @param {{ image?: string, title?: string, inline?: boolean }} img Image object
+ * @param {ParsedImage} img Image object
  * @param {object} mes Chat message object
+ * @typedef {{ image?: string, title?: string, inline?: boolean }} ParsedImage
  */
 function saveImageToMessage(img, mes) {
     if (mes && img.image) {

--- a/public/script.js
+++ b/public/script.js
@@ -3253,7 +3253,7 @@ class StreamingProcessor {
             this.sendTextarea.value = '';
             this.sendTextarea.dispatchEvent(new Event('input', { bubbles: true }));
         } else {
-            await saveReply(this.type, text, true, '', [], '', '');
+            await saveReply({ type: this.type, getMessage: text, fromStreaming: true, title: '', swipes: [], reasoning: '', imageUrl: '' });
             messageId = chat.length - 1;
             await this.#checkDomElements(messageId, continueOnReasoning);
             this.markUIGenStarted();
@@ -4875,7 +4875,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         let getMessage = extractMessageFromData(data);
         let title = extractTitleFromData(data);
         let reasoning = extractReasoningFromData(data);
-        let image = extractImageFromData(data);
+        let imageUrl = extractImageFromData(data);
         kobold_horde_model = title;
 
         const swipes = extractMultiSwipes(data, type);
@@ -4908,10 +4908,10 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         else {
             // Without streaming we'll be having a full message on continuation. Treat it as a last chunk.
             if (originalType !== 'continue') {
-                ({ type, getMessage } = await saveReply(type, getMessage, false, title, swipes, reasoning, image));
+                ({ type, getMessage } = await saveReply({ type, getMessage, fromStreaming: false, title, swipes, reasoning, imageUrl }));
             }
             else {
-                ({ type, getMessage } = await saveReply('appendFinal', getMessage, false, title, swipes, reasoning, image));
+                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, fromStreaming: false, title, swipes, reasoning, imageUrl }));
             }
 
             // This relies on `saveReply` having been called to add the message to the chat, so it must be last.
@@ -6040,16 +6040,29 @@ async function processImageAttachment(message, { parsedImage, imageUrl }) {
 
 /**
  * Saves a resulting message to the chat.
- * @param {string} type Type of generation
- * @param {string} getMessage Generated message
- * @param {boolean} fromStreaming If the message is from streaming
- * @param {string} title Message tooltip
- * @param {string[]} swipes Extra swipes
- * @param {string} reasoning Message reasoning
- * @param {string} imageUrl Link to an image
+ * @param {SaveReplyParams} params
  * @returns {Promise<{type: string, getMessage: string}>} Promise when the message is saved
+ *
+ * @typedef {object} SaveReplyParams
+ * @property {string} type Type of generation
+ * @property {string} getMessage Generated message
+ * @property {boolean} fromStreaming If the message is from streaming
+ * @property {string} title Message tooltip
+ * @property {string[]} swipes Extra swipes
+ * @property {string} reasoning Message reasoning
+ * @property {string} imageUrl Link to an image
+ *
+ * @typedef {object} SaveReplyResult
+ * @property {string} type Type of generation
+ * @property {string} getMessage Generated message
  */
-export async function saveReply(type, getMessage, fromStreaming, title, swipes, reasoning, imageUrl) {
+export async function saveReply({ type, getMessage, fromStreaming, title, swipes, reasoning, imageUrl }) {
+    // Backward compatibility
+    if (arguments.length > 1 && typeof arguments[0] === 'string') {
+        console.trace('saveReply called with positional arguments. Please use an object instead.');
+        [type, getMessage, fromStreaming, title, swipes, reasoning, imageUrl] = arguments;
+    }
+
     if (type != 'append' && type != 'continue' && type != 'appendFinal' && chat.length && (chat[chat.length - 1]['swipe_id'] === undefined ||
         chat[chat.length - 1]['is_user'])) {
         type = 'normal';

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2257,6 +2257,10 @@ function getStreamingReply(data, state) {
         }
         return data?.delta?.text || '';
     } else if (oai_settings.chat_completion_source === chat_completion_sources.MAKERSUITE) {
+        const inlineData = data?.candidates?.[0]?.content?.parts?.find(x => x.inlineData)?.inlineData;
+        if (inlineData) {
+            state.image = `data:${inlineData.mimeType};base64,${inlineData.data}`;
+        }
         if (oai_settings.show_thoughts) {
             state.reasoning += (data?.candidates?.[0]?.content?.parts?.filter(x => x.thought)?.map(x => x.text)?.[0] || '');
         }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -304,6 +304,7 @@ export const settingsToUpdate = {
     seed: ['#seed_openai', 'seed', false],
     n: ['#n_openai', 'n', false],
     bypass_status_check: ['#openai_bypass_status_check', 'bypass_status_check', true],
+    request_images: ['#openai_request_images', 'request_images', true],
 };
 
 const default_settings = {
@@ -382,6 +383,7 @@ const default_settings = {
     show_thoughts: true,
     reasoning_effort: 'medium',
     enable_web_search: false,
+    request_images: false,
     seed: -1,
     n: 1,
 };
@@ -462,6 +464,7 @@ const oai_settings = {
     show_thoughts: true,
     reasoning_effort: 'medium',
     enable_web_search: false,
+    request_images: false,
     seed: -1,
     n: 1,
 };
@@ -2013,6 +2016,7 @@ async function sendOpenAIRequest(type, messages, signal) {
         'include_reasoning': Boolean(oai_settings.show_thoughts),
         'reasoning_effort': String(oai_settings.reasoning_effort),
         'enable_web_search': Boolean(oai_settings.enable_web_search),
+        'request_images': Boolean(oai_settings.request_images),
     };
 
     if (!canMultiSwipe && ToolManager.canPerformToolCalls(type)) {
@@ -2199,7 +2203,7 @@ async function sendOpenAIRequest(type, messages, signal) {
             let text = '';
             const swipes = [];
             const toolCalls = [];
-            const state = { reasoning: '' };
+            const state = { reasoning: '', image: '' };
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) return;
@@ -3245,6 +3249,7 @@ function loadOpenAISettings(data, settings) {
     oai_settings.show_thoughts = settings.show_thoughts ?? default_settings.show_thoughts;
     oai_settings.reasoning_effort = settings.reasoning_effort ?? default_settings.reasoning_effort;
     oai_settings.enable_web_search = settings.enable_web_search ?? default_settings.enable_web_search;
+    oai_settings.request_images = settings.request_images ?? default_settings.request_images;
     oai_settings.seed = settings.seed ?? default_settings.seed;
     oai_settings.n = settings.n ?? default_settings.n;
 
@@ -3373,6 +3378,7 @@ function loadOpenAISettings(data, settings) {
     $('#n_openai').val(oai_settings.n);
     $('#openai_show_thoughts').prop('checked', oai_settings.show_thoughts);
     $('#openai_enable_web_search').prop('checked', oai_settings.enable_web_search);
+    $('#openai_request_images').prop('checked', oai_settings.request_images);
 
     $('#openai_reasoning_effort').val(oai_settings.reasoning_effort);
     $(`#openai_reasoning_effort option[value="${oai_settings.reasoning_effort}"]`).prop('selected', true);
@@ -3638,6 +3644,7 @@ async function saveOpenAIPreset(name, settings, triggerUi = true) {
         show_thoughts: settings.show_thoughts,
         reasoning_effort: settings.reasoning_effort,
         enable_web_search: settings.enable_web_search,
+        request_images: settings.request_images,
         seed: settings.seed,
         n: settings.n,
     };
@@ -5599,6 +5606,11 @@ export function initOpenAI() {
 
     $('#openai_enable_web_search').on('input', function () {
         oai_settings.enable_web_search = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#openai_request_images').on('input', function () {
+        oai_settings.request_images = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -138,10 +138,11 @@ async function* parseStreamData(json) {
         for (let i = 0; i < json.candidates.length; i++) {
             const isNotPrimary = json.candidates?.[0]?.index > 0;
             const hasToolCalls = json?.candidates?.[0]?.content?.parts?.some(p => p?.functionCall);
+            const hasInlineData = json?.candidates?.[0]?.content?.parts?.some(p => p?.inlineData);
             if (isNotPrimary || json.candidates.length === 0) {
                 return null;
             }
-            if (hasToolCalls) {
+            if (hasToolCalls || hasInlineData) {
                 yield { data: json, chunk: '' };
                 return;
             }

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -356,7 +356,12 @@ async function sendMakerSuiteRequest(request, response) {
             delete generationConfig.stopSequences;
         }
 
-        const should_use_system_prompt = (
+        const useMultiModal = (model.includes('gemini-2.0-flash-exp'));
+        if (useMultiModal) {
+            generationConfig.responseModalities = ['text', 'image'];
+        }
+
+        const useSystemPrompt = (
             model.includes('gemini-2.0-pro') ||
             model.includes('gemini-2.0-flash') ||
             model.includes('gemini-2.0-flash-thinking-exp') ||
@@ -366,7 +371,7 @@ async function sendMakerSuiteRequest(request, response) {
         ) && request.body.use_makersuite_sysprompt;
 
         const tools = [];
-        const prompt = convertGooglePrompt(request.body.messages, model, should_use_system_prompt, getPromptNames(request));
+        const prompt = convertGooglePrompt(request.body.messages, model, useSystemPrompt, getPromptNames(request));
         let safetySettings = GEMINI_SAFETY;
 
         // These old models do not support setting the threshold to OFF at all.
@@ -405,7 +410,7 @@ async function sendMakerSuiteRequest(request, response) {
             generationConfig: generationConfig,
         };
 
-        if (should_use_system_prompt) {
+        if (useSystemPrompt) {
             body.systemInstruction = prompt.system_instruction;
         }
 
@@ -469,10 +474,11 @@ async function sendMakerSuiteRequest(request, response) {
 
             const responseContent = candidates[0].content ?? candidates[0].output;
             const functionCall = (candidates?.[0]?.content?.parts ?? []).some(part => part.functionCall);
+            const inlineData = (candidates?.[0]?.content?.parts ?? []).some(part => part.inlineData);
             console.warn('Google AI Studio response:', responseContent);
 
             const responseText = typeof responseContent === 'string' ? responseContent : responseContent?.parts?.filter(part => !part.thought)?.map(part => part.text)?.join('\n\n');
-            if (!responseText && !functionCall) {
+            if (!responseText && !functionCall && !inlineData) {
                 let message = 'Google AI Studio Candidate text empty';
                 console.warn(message, generateResponseJson);
                 return response.send({ error: { message } });

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -338,6 +338,7 @@ async function sendMakerSuiteRequest(request, response) {
     const model = String(request.body.model);
     const stream = Boolean(request.body.stream);
     const enableWebSearch = Boolean(request.body.enable_web_search);
+    const requestImages = Boolean(request.body.request_images);
     const isThinking = model.includes('thinking');
 
     const generationConfig = {
@@ -356,12 +357,12 @@ async function sendMakerSuiteRequest(request, response) {
             delete generationConfig.stopSequences;
         }
 
-        const useMultiModal = (model.includes('gemini-2.0-flash-exp'));
+        const useMultiModal = requestImages && (model.includes('gemini-2.0-flash-exp'));
         if (useMultiModal) {
             generationConfig.responseModalities = ['text', 'image'];
         }
 
-        const useSystemPrompt = (
+        const useSystemPrompt = !useMultiModal && (
             model.includes('gemini-2.0-pro') ||
             model.includes('gemini-2.0-flash') ||
             model.includes('gemini-2.0-flash-thinking-exp') ||
@@ -384,14 +385,14 @@ async function sendMakerSuiteRequest(request, response) {
         }
         // Most of the other models allow for setting the threshold of filters, except for HARM_CATEGORY_CIVIC_INTEGRITY, to OFF.
 
-        if (enableWebSearch) {
+        if (enableWebSearch && !useMultiModal) {
             const searchTool = model.includes('1.5') || model.includes('1.0')
                 ? ({ google_search_retrieval: {} })
                 : ({ google_search: {} });
             tools.push(searchTool);
         }
 
-        if (Array.isArray(request.body.tools) && request.body.tools.length > 0) {
+        if (Array.isArray(request.body.tools) && request.body.tools.length > 0 && !useMultiModal) {
             const functionDeclarations = [];
             for (const tool of request.body.tools) {
                 if (tool.type === 'function') {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Closes #3674

Requires a separate toggle cause it directly forbids using 3 other toggles. Help me, I'm in a toggle hell.

## Copilot summary

This pull request introduces a new feature to support inline image attachments in chat messages. The changes span across multiple files to integrate this functionality, including updates to the HTML, JavaScript, and settings configurations.

### New Feature: Inline Image Attachments

* **HTML Changes:**
  - Added a new checkbox in `public/index.html` to enable the "Request inline images" feature.

* **JavaScript Changes:**
  - **Utilities and Imports:**
    - Added `saveBase64AsFile` to the list of imported utilities in `public/script.js`.
  - **Streaming Processor:**
    - Introduced a new `image` property in the `StreamingProcessor` class to handle image data. [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R3207-R3208) [[2]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R3479)
    - Updated the `saveReply` function to include an `imageUrl` parameter and process image attachments. [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L3253-R3256) [[2]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R3378-R3382) [[3]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R4878) [[4]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L4901-R4914) [[5]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L5977-R6036) [[6]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L5998-R6058) [[7]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R6072) [[8]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R6096) [[9]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R6116) [[10]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L6100-R6162)
    - Added `processImageAttachment` and `saveImageToMessage` functions to handle image data processing and saving. [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L6255-R6323) [[2]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R6268-R6280)
    - Introduced `extractImageFromData` to extract image data from API responses.
  - **OpenAI Integration:**
    - Updated OpenAI settings to include the `request_images` option and handle its state. [[1]](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50R307) [[2]](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50R386) [[3]](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50R467) [[4]](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50R3252) [[5]](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50R3381) [[6]](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50R3647) [[7]](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50R5612-R5616)
    - Modified the `sendOpenAIRequest` function to include the `request_images` parameter. [[1]](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50R2019) [[2]](diffhunk://#diff-aa8e9c6c2fa3dc41e3d3dbad0ea2c8c6eae81dd52d991609a9d3c011f2c7fb50L2202-R2206)
    - Updated the `getStreamingReply` function to handle inline image data.

* **SSE Stream:**
  - Updated `parseStreamData` to yield data when inline image data is present.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
