### PR TITLE
No swiping hotkeys when modifiers are held.

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -1018,6 +1018,14 @@ export function initRossMods() {
         return false;
     }
 
+    function isModifiedKeyboardEvent(event) {
+        return (event instanceof KeyboardEvent &&
+            event.shiftKey ||
+            event.ctrlKey ||
+            event.altKey ||
+            event.metaKey);
+    }
+
     $(document).on('keydown', async function (event) {
         await processHotkeys(event.originalEvent);
     });
@@ -1141,7 +1149,8 @@ export function initRossMods() {
                 $('#send_textarea').val() === '' &&
                 $('#character_popup').css('display') === 'none' &&
                 $('#shadow_select_chat_popup').css('display') === 'none' &&
-                !isInputElementInFocus()
+                !isInputElementInFocus() &&
+                !isModifiedKeyboardEvent(event)
             ) {
                 $('.swipe_left:last').trigger('click', { source: 'keyboard', repeated: event.repeat });
                 return;
@@ -1154,7 +1163,8 @@ export function initRossMods() {
                 $('#send_textarea').val() === '' &&
                 $('#character_popup').css('display') === 'none' &&
                 $('#shadow_select_chat_popup').css('display') === 'none' &&
-                !isInputElementInFocus()
+                !isInputElementInFocus() &&
+                !isModifiedKeyboardEvent(event)
             ) {
                 $('.swipe_right:last').trigger('click', { source: 'keyboard', repeated: event.repeat });
                 return;

--- a/public/scripts/templates/hotkeys.html
+++ b/public/scripts/templates/hotkeys.html
@@ -5,7 +5,7 @@
     <li><kbd data-i18n="help_hotkeys_1">Up</kbd> = <span data-i18n="help_hotkeys_2">Edit last message in chat</span></li>
     <li><kbd data-i18n="help_hotkeys_3">Ctrl+Up</kbd> = <span data-i18n="help_hotkeys_4">Edit last USER message in chat</span></li>
     <li><kbd data-i18n="help_hotkeys_5">Left</kbd> = <span data-i18n="help_hotkeys_6">swipe left</span></li>
-    <li><kbd data-i18n="help_hotkeys_7">Right</kbd> = <span data-i18n="help_hotkeys_8">swipe right (NOTE: swipe hotkeys are disabled when chatbar has something typed into it)</span></li>
+    <li><kbd data-i18n="help_hotkeys_7">Right</kbd> = <span data-i18n="help_hotkeys_8">swipe right (NOTE: swipe hotkeys only apply without modifiers and are disabled when chatbar has something typed into it)</span></li>
     <li><kbd data-i18n="help_hotkeys_9">Enter</kbd> <span data-i18n="help_hotkeys_10">(with chat bar selected)</span> = <span data-i18n="help_hotkeys_10_1">send your message to AI</span></li>
     <li><kbd data-i18n="help_hotkeys_11">Ctrl+Enter</kbd> = <span data-i18n="help_hotkeys_12">Regenerate the last AI response</span></li>
     <li><kbd data-i18n="help_hotkeys_13">Alt+Enter</kbd> = <span data-i18n="help_hotkeys_14">Continue the last AI response</span></li>


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Problem

Swipe shortcut triggers unintentionally when keyboard-selecting text in the chatlog.

## Solution

Ignore `KeyboardEvent`s with modifiers when handling swipe shortcuts.

## Test

Swipe shortcuts function without modifiers, but don't when modifier keys are held.
Further permute with message entry box focused and not, with text contained within it and not.

## Known issue

In own testing I discovered the following edge case.
When message entry box contains text but is not focused — it is not possible to trigger the swipe shortcut.
Seems like unintended UX.
That issue is outside of the scope of this PR as it was present prior to my changes.