### PR TITLE
Fix Expression Override not resetting if empty

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -2154,7 +2154,7 @@ function migrateSettings() {
             imgElement.src = '';
         }
 
-        setExpressionOverrideHtml();
+        setExpressionOverrideHtml(true); // force-clear, as the character might not have an override defined
 
         if (isVisualNovelMode()) {
             $('#visual-novel-wrapper').empty();


### PR DESCRIPTION
- When switching chars, override field gets correctly loaded. The display value won't be reset when the override was empty. This was likely unintended.

Fixes #3697.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
