### PR TITLE
Fixing user_prompt_bias being incorrectly added using generateRaw()

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5884,14 +5884,14 @@ function extractMultiSwipes(data, type) {
     return swipes;
 }
 
-export function cleanUpMessage(getMessage, isImpersonate, isContinue, displayIncompleteSentences = false, stoppingStrings = null, include_user_prompt_bias=true) {
+export function cleanUpMessage(getMessage, isImpersonate, isContinue, displayIncompleteSentences = false, stoppingStrings = null, includeUserPromptBias = true) {
     if (!getMessage) {
         return '';
     }
 
     // Add the prompt bias before anything else
     if (
-        include_user_prompt_bias &&
+        includeUserPromptBias &&
         power_user.user_prompt_bias &&
         !isImpersonate &&
         !isContinue &&

--- a/public/script.js
+++ b/public/script.js
@@ -3611,7 +3611,8 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
             throw new Error(data.response);
         }
 
-        const message = cleanUpMessage(extractMessageFromData(data), false, false, true);
+        // format result, exclude user prompt bias
+        const message = cleanUpMessage(extractMessageFromData(data), false, false, true, null, false);
 
         if (!message) {
             throw new Error('No message generated');
@@ -5883,13 +5884,14 @@ function extractMultiSwipes(data, type) {
     return swipes;
 }
 
-export function cleanUpMessage(getMessage, isImpersonate, isContinue, displayIncompleteSentences = false, stoppingStrings = null) {
+export function cleanUpMessage(getMessage, isImpersonate, isContinue, displayIncompleteSentences = false, stoppingStrings = null, include_user_prompt_bias=true) {
     if (!getMessage) {
         return '';
     }
 
     // Add the prompt bias before anything else
     if (
+        include_user_prompt_bias &&
         power_user.user_prompt_bias &&
         !isImpersonate &&
         !isContinue &&


### PR DESCRIPTION
## Description

This adds a parameter to `cleanUpMessage()` which determines whether the `user_prompt_bias` will be prepended to the passed text. It is true by default to avoid disrupting current usage. Additionally, this parameter is set to `false` when used in `generateRaw()`, as the `user_prompt_bias` is explicitly not used in that function.

## Motivation

This fixes a bug where the `user_prompt_bias` was incorrectly being prepended to generations when using `generateRaw()` even though it wasn't being added to the prompt. Bug was demonstrated in [this](https://discord.com/channels/1100685673633153084/1100820587586273343/1351034190514356375) discord message and the solution discussed in [this](https://discord.com/channels/1100685673633153084/1100820587586273343/1351311267436167199) one.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
