### PR TITLE
added button to rename chat completion preset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -176,13 +176,13 @@
                                         </strong>
 
                                         <div class="flex-container gap3px">
-                                            <div id="import_oai_preset" class="margin0 menu_button menu_button_icon" title="Import preset" data-i18n="[title]Import preset">
+                                            <div data-preset-manager-import="openai" class="margin0 menu_button_icon menu_button" title="Import preset" data-i18n="[title]Import preset">
                                                 <i class="fa-fw fa-solid fa-file-import"></i>
                                             </div>
-                                            <div id="export_oai_preset" class="margin0 menu_button menu_button_icon" title="Export preset" data-i18n="[title]Export preset">
+                                            <div data-preset-manager-export="openai"  class="margin0 menu_button_icon menu_button" title="Export preset" data-i18n="[title]Export preset">
                                                 <i class="fa-fw fa-solid fa-file-export"></i>
                                             </div>
-                                            <div id="delete_oai_preset" class="margin0 menu_button menu_button_icon" title="Delete the preset" data-i18n="[title]Delete the preset">
+                                            <div data-preset-manager-delete="openai" class="margin0 menu_button_icon menu_button" title="Delete the preset" data-i18n="[title]Delete the preset">
                                                 <i class="fa-fw fa-solid fa-trash-can"></i>
                                             </div>
                                         </div>
@@ -193,11 +193,14 @@
                                             <option value="gui" data-i18n="Default">Default</option>
                                         </select>
                                         <div class="flex-container marginLeft5 gap3px">
-                                            <input id="openai_preset_import_file" type="file" accept=".json,.settings" hidden />
-                                            <div id="update_oai_preset" class="menu_button menu_button_icon" title="Update current preset" data-i18n="[title]Update current preset">
+                                            <input type="file" hidden data-preset-manager-file="openai" accept=".json, .settings">
+                                            <div data-preset-manager-update="openai" class="menu_button menu_button_icon" title="Update current preset" data-i18n="[title]Update current preset">
                                                 <i class="fa-fw fa-solid fa-save"></i>
                                             </div>
-                                            <div id="new_oai_preset" class="menu_button menu_button_icon" title="Save preset as" data-i18n="[title]Save preset as">
+                                            <div data-preset-manager-rename="openai" class="menu_button menu_button_icon" title="Rename current preset" data-i18n="[title]Rename current preset">
+                                                <i class="fa-fw fa-solid fa-pencil"></i>
+                                            </div>
+                                            <div data-preset-manager-new="openai" class="menu_button menu_button_icon" title="Save preset as" data-i18n="[title]Save preset as">
                                                 <i class="fa-fw fa-solid fa-file-circle-plus"></i>
                                             </div>
                                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -176,10 +176,11 @@
                                         </strong>
 
                                         <div class="flex-container gap3px">
-                                            <div data-preset-manager-import="openai" class="margin0 menu_button_icon menu_button" title="Import preset" data-i18n="[title]Import preset">
+                                            <input id="openai_preset_import_file" type="file" accept=".json,.settings" hidden />
+                                            <div id="import_oai_preset" class="margin0 menu_button menu_button_icon" title="Import preset" data-i18n="[title]Import preset">
                                                 <i class="fa-fw fa-solid fa-file-import"></i>
                                             </div>
-                                            <div id="export_oai_preset" data-preset-manager-export="openai" class="margin0 menu_button_icon menu_button" title="Export preset" data-i18n="[title]Export preset">
+                                            <div id="export_oai_preset" class="margin0 menu_button menu_button_icon" title="Export preset" data-i18n="[title]Export preset">
                                                 <i class="fa-fw fa-solid fa-file-export"></i>
                                             </div>
                                             <div data-preset-manager-delete="openai" class="margin0 menu_button_icon menu_button" title="Delete the preset" data-i18n="[title]Delete the preset">
@@ -193,7 +194,6 @@
                                             <option value="gui" data-i18n="Default">Default</option>
                                         </select>
                                         <div class="flex-container marginLeft5 gap3px">
-                                            <input id="openai_preset_import_file" type="file" hidden data-preset-manager-file="openai" accept=".json, .settings">
                                             <div data-preset-manager-update="openai" class="menu_button menu_button_icon" title="Update current preset" data-i18n="[title]Update current preset">
                                                 <i class="fa-fw fa-solid fa-save"></i>
                                             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -176,7 +176,6 @@
                                         </strong>
 
                                         <div class="flex-container gap3px">
-                                            <input id="openai_preset_import_file" type="file" accept=".json,.settings" hidden />
                                             <div id="import_oai_preset" class="margin0 menu_button menu_button_icon" title="Import preset" data-i18n="[title]Import preset">
                                                 <i class="fa-fw fa-solid fa-file-import"></i>
                                             </div>
@@ -194,13 +193,14 @@
                                             <option value="gui" data-i18n="Default">Default</option>
                                         </select>
                                         <div class="flex-container marginLeft5 gap3px">
-                                            <div data-preset-manager-update="openai" class="menu_button menu_button_icon" title="Update current preset" data-i18n="[title]Update current preset">
+                                            <input id="openai_preset_import_file" type="file" accept=".json,.settings" hidden />
+                                            <div id="update_oai_preset" class="menu_button menu_button_icon" title="Update current preset" data-i18n="[title]Update current preset">
                                                 <i class="fa-fw fa-solid fa-save"></i>
                                             </div>
                                             <div data-preset-manager-rename="openai" class="menu_button menu_button_icon" title="Rename current preset" data-i18n="[title]Rename current preset">
                                                 <i class="fa-fw fa-solid fa-pencil"></i>
                                             </div>
-                                            <div data-preset-manager-new="openai" class="menu_button menu_button_icon" title="Save preset as" data-i18n="[title]Save preset as">
+                                            <div id="new_oai_preset" class="menu_button menu_button_icon" title="Save preset as" data-i18n="[title]Save preset as">
                                                 <i class="fa-fw fa-solid fa-file-circle-plus"></i>
                                             </div>
                                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -179,7 +179,7 @@
                                             <div data-preset-manager-import="openai" class="margin0 menu_button_icon menu_button" title="Import preset" data-i18n="[title]Import preset">
                                                 <i class="fa-fw fa-solid fa-file-import"></i>
                                             </div>
-                                            <div data-preset-manager-export="openai"  class="margin0 menu_button_icon menu_button" title="Export preset" data-i18n="[title]Export preset">
+                                            <div id="export_oai_preset" data-preset-manager-export="openai" class="margin0 menu_button_icon menu_button" title="Export preset" data-i18n="[title]Export preset">
                                                 <i class="fa-fw fa-solid fa-file-export"></i>
                                             </div>
                                             <div data-preset-manager-delete="openai" class="margin0 menu_button_icon menu_button" title="Delete the preset" data-i18n="[title]Delete the preset">
@@ -193,7 +193,7 @@
                                             <option value="gui" data-i18n="Default">Default</option>
                                         </select>
                                         <div class="flex-container marginLeft5 gap3px">
-                                            <input type="file" hidden data-preset-manager-file="openai" accept=".json, .settings">
+                                            <input id="openai_preset_import_file" type="file" hidden data-preset-manager-file="openai" accept=".json, .settings">
                                             <div data-preset-manager-update="openai" class="menu_button menu_button_icon" title="Update current preset" data-i18n="[title]Update current preset">
                                                 <i class="fa-fw fa-solid fa-save"></i>
                                             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -182,7 +182,7 @@
                                             <div id="export_oai_preset" class="margin0 menu_button menu_button_icon" title="Export preset" data-i18n="[title]Export preset">
                                                 <i class="fa-fw fa-solid fa-file-export"></i>
                                             </div>
-                                            <div data-preset-manager-delete="openai" class="margin0 menu_button_icon menu_button" title="Delete the preset" data-i18n="[title]Delete the preset">
+                                            <div id="delete_oai_preset" class="margin0 menu_button menu_button_icon" title="Delete the preset" data-i18n="[title]Delete the preset">
                                                 <i class="fa-fw fa-solid fa-trash-can"></i>
                                             </div>
                                         </div>


### PR DESCRIPTION
Addresses feature request #3358.  
(really sorry for the issues from earlier, I'm quite new to this ;u; Let me know if there are more issues with this one! ty for your patience with me!)

<ul>
<li>added button to rename chat completion preset</li>
<li>moved Chat Completion …into the preset manager subsystem (I think!!)</li>
</ul>


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
