### PR TITLE
Fix not being able to upload sprite when no sprite existed for an expression

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1810,7 +1810,7 @@ async function onClickExpressionUpload(event) {
                 }
             }
         } else {
-            spriteName = withoutExtension(clickedFileName);
+            spriteName = withoutExtension(expression);
         }
 
         if (!spriteName) {


### PR DESCRIPTION
- When no sprite was defined before, it falsely tried to derive the filename from the existing filename when "allow multiple" was not enabled. It now correctly just utilizes the expression name, not relying on filename anymore.

My own fuck-up. Don't know how we missed this.

![image](https://github.com/user-attachments/assets/d5ac9d5b-6af2-4c3d-a662-cf3a0efd44c7)


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).