### PR TITLE
Adds filtering to expressions to ignore labels that do not have sprites available

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -4,7 +4,7 @@ import { characters, eventSource, event_types, generateRaw, getRequestHeaders, m
 import { dragElement, isMobile } from '../../RossAscends-mods.js';
 import { getContext, getApiUrl, modules, extension_settings, ModuleWorkerWrapper, doExtrasFetch, renderExtensionTemplateAsync } from '../../extensions.js';
 import { loadMovingUIState, performFuzzySearch, power_user } from '../../power-user.js';
-import { onlyUnique, debounce, getCharaFilename, trimToEndSentence, trimToStartSentence, waitUntilCondition, findChar } from '../../utils.js';
+import { onlyUnique, debounce, getCharaFilename, trimToEndSentence, trimToStartSentence, waitUntilCondition, findChar, isTrueBoolean } from '../../utils.js';
 import { hideMutedSprites, selected_group } from '../../group-chats.js';
 import { isJsonSchemaSupported } from '../../textgen-settings.js';
 import { debounce_timeout } from '../../constants.js';
@@ -678,7 +678,7 @@ async function setSpriteFolderCommand(_, folder) {
     return '';
 }
 
-async function classifyCallback(/** @type {{api: string?, prompt: string?}} */ { api = null, prompt = null }, text) {
+async function classifyCallback(/** @type {{api: string?, filter: string?, prompt: string?}} */ { api = null, filter = null, prompt = null }, text) {
     if (!text) {
         toastr.error('No text provided');
         return '';
@@ -689,13 +689,14 @@ async function classifyCallback(/** @type {{api: string?, prompt: string?}} */ {
     }
 
     const expressionApi = EXPRESSION_API[api] || extension_settings.expressions.api;
+    const filterAvailable = isTrueBoolean(filter);
 
     if (!modules.includes('classify') && expressionApi == EXPRESSION_API.extras) {
         toastr.warning('Text classification is disabled or not available');
         return '';
     }
 
-    const label = await getExpressionLabel(text, expressionApi, { customPrompt: prompt });
+    const label = await getExpressionLabel(text, expressionApi, { filterAvailable: filterAvailable, customPrompt: prompt });
     console.debug(`Classification result for "${text}": ${label}`);
     return label;
 }
@@ -988,10 +989,11 @@ function onTextGenSettingsReady(args) {
  * @param {string} text - The text to classify and retrieve the expression label for.
  * @param {EXPRESSION_API} [expressionsApi=extension_settings.expressions.api] - The expressions API to use for classification.
  * @param {object} [options={}] - Optional arguments.
+ * @param {boolean?} [options.filterAvailable=null] - Whether to filter available expressions. If not specified, uses the extension setting.
  * @param {string?} [options.customPrompt=null] - The custom prompt to use for classification.
  * @returns {Promise<string?>} - The label of the expression.
  */
-export async function getExpressionLabel(text, expressionsApi = extension_settings.expressions.api, { customPrompt = null } = {}) {
+export async function getExpressionLabel(text, expressionsApi = extension_settings.expressions.api, { filterAvailable = null, customPrompt = null } = {}) {
     // Return if text is undefined, saving a costly fetch request
     if ((!modules.includes('classify') && expressionsApi == EXPRESSION_API.extras) || !text) {
         return extension_settings.expressions.fallback_expression;
@@ -1002,6 +1004,11 @@ export async function getExpressionLabel(text, expressionsApi = extension_settin
     }
 
     text = sampleClassifyText(text);
+
+    filterAvailable ??= extension_settings.expressions.filterAvailable;
+    if (filterAvailable && ![EXPRESSION_API.llm, EXPRESSION_API.webllm].includes(expressionsApi)) {
+        console.warn('Filter available is only supported for LLM and WebLLM expressions');
+    }
 
     try {
         switch (expressionsApi) {
@@ -1027,7 +1034,7 @@ export async function getExpressionLabel(text, expressionsApi = extension_settin
                     return extension_settings.expressions.fallback_expression;
                 }
 
-                const expressionsList = await getExpressionsList();
+                const expressionsList = await getExpressionsList({ filterAvailable: filterAvailable });
                 const prompt = substituteParamsExtended(customPrompt, { labels: expressionsList }) || await getLlmPrompt(expressionsList);
                 eventSource.once(event_types.TEXT_COMPLETION_SETTINGS_READY, onTextGenSettingsReady);
                 const emotionResponse = await generateRaw(text, main_api, false, false, prompt);
@@ -1040,7 +1047,7 @@ export async function getExpressionLabel(text, expressionsApi = extension_settin
                     return extension_settings.expressions.fallback_expression;
                 }
 
-                const expressionsList = await getExpressionsList();
+                const expressionsList = await getExpressionsList({ filterAvailable: filterAvailable });
                 const prompt = substituteParamsExtended(customPrompt, { labels: expressionsList }) || await getLlmPrompt(expressionsList);
                 const messages = [
                     { role: 'user', content: text + '\n\n' + prompt },
@@ -1320,11 +1327,27 @@ function getCachedExpressions() {
     return [...expressionsList, ...extension_settings.expressions.custom].filter(onlyUnique);
 }
 
-export async function getExpressionsList() {
-    // Return cached list if available
-    if (Array.isArray(expressionsList)) {
-        return getCachedExpressions();
+export async function getExpressionsList({ filterAvailable = false } = {}) {
+    // If there is no cached list, load and cache it
+    if (!Array.isArray(expressionsList)) {
+        expressionsList = await resolveExpressionsList();
     }
+
+    const expressions = getCachedExpressions();
+
+    // Filtering is only available for llm and webllm APIs
+    if (!filterAvailable || ![EXPRESSION_API.llm, EXPRESSION_API.webllm].includes(extension_settings.expressions.api)) {
+        return expressions;
+    }
+
+    // Get expressions with available sprites
+    const currentLastMessage = selected_group ? getLastCharacterMessage() : null;
+    const spriteFolderName = getSpriteFolderName(currentLastMessage, currentLastMessage?.name);
+
+    return expressions.filter(label => {
+        const expression = spriteCache[spriteFolderName]?.find(x => x.label === label);
+        return (expression?.files.length ?? 0) > 0;
+    });
 
     /**
      * Returns the list of expressions from the API or fallback in offline mode.
@@ -1372,9 +1395,6 @@ export async function getExpressionsList() {
         expressionsList = DEFAULT_EXPRESSIONS.slice();
         return expressionsList;
     }
-
-    const result = await resolveExpressionsList();
-    return [...result, ...extension_settings.expressions.custom].filter(onlyUnique);
 }
 
 /**
@@ -2102,6 +2122,10 @@ function migrateSettings() {
             extension_settings.expressions.rerollIfSame = !!$(this).prop('checked');
             saveSettingsDebounced();
         });
+        $('#expressions_filter_available').prop('checked', extension_settings.expressions.filterAvailable).on('input', function () {
+            extension_settings.expressions.filterAvailable = !!$(this).prop('checked');
+            saveSettingsDebounced();
+        });
         $('#expression_override_cleanup_button').on('click', onClickExpressionOverrideRemoveAllButton);
         $(document).on('dragstart', '.expression', (e) => {
             e.preventDefault();
@@ -2279,13 +2303,13 @@ function migrateSettings() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'expression-list',
         aliases: ['expressions'],
-        /** @type {(args: {return: string}) => Promise<string>} */
+        /** @type {(args: {return: string, filterAvailable: string}) => Promise<string>} */
         callback: async (args) => {
             let returnType =
                 /** @type {import('../../slash-commands/SlashCommandReturnHelper.js').SlashCommandReturnType} */
                 (args.return);
 
-            const list = await getExpressionsList();
+            const list = await getExpressionsList({ filterAvailable: isTrueBoolean(args.filterAvailable) });
 
             return await slashCommandReturnHelper.doReturn(returnType ?? 'pipe', list, { objectToStringFunc: list => list.join(', ') });
         },
@@ -2297,6 +2321,13 @@ function migrateSettings() {
                 defaultValue: 'pipe',
                 enumList: slashCommandReturnHelper.enumList({ allowObject: true }),
                 forceEnum: true,
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'filter',
+                description: 'Filter the list to only include expressions that have available sprites for the current character.',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+                defaultValue: 'true',
             }),
         ],
         returns: 'The comma-separated list of available expressions, including custom expressions.',
@@ -2312,6 +2343,13 @@ function migrateSettings() {
                 description: 'The Classifier API to classify with. If not specified, the configured one will be used.',
                 typeList: [ARGUMENT_TYPE.STRING],
                 enumList: Object.keys(EXPRESSION_API).map(api => new SlashCommandEnumValue(api, null, enumTypes.enum)),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'filter',
+                description: 'Filter the list to only include expressions that have available sprites for the current character.',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+                defaultValue: 'true',
             }),
             SlashCommandNamedArgument.fromProps({
                 name: 'prompt',

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1007,7 +1007,7 @@ export async function getExpressionLabel(text, expressionsApi = extension_settin
 
     filterAvailable ??= extension_settings.expressions.filterAvailable;
     if (filterAvailable && ![EXPRESSION_API.llm, EXPRESSION_API.webllm].includes(expressionsApi)) {
-        console.warn('Filter available is only supported for LLM and WebLLM expressions');
+        console.debug('Filter available is only supported for LLM and WebLLM expressions');
     }
 
     try {

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -4,7 +4,7 @@ import { characters, eventSource, event_types, generateRaw, getRequestHeaders, m
 import { dragElement, isMobile } from '../../RossAscends-mods.js';
 import { getContext, getApiUrl, modules, extension_settings, ModuleWorkerWrapper, doExtrasFetch, renderExtensionTemplateAsync } from '../../extensions.js';
 import { loadMovingUIState, performFuzzySearch, power_user } from '../../power-user.js';
-import { onlyUnique, debounce, getCharaFilename, trimToEndSentence, trimToStartSentence, waitUntilCondition, findChar, isTrueBoolean } from '../../utils.js';
+import { onlyUnique, debounce, getCharaFilename, trimToEndSentence, trimToStartSentence, waitUntilCondition, findChar, isFalseBoolean } from '../../utils.js';
 import { hideMutedSprites, selected_group } from '../../group-chats.js';
 import { isJsonSchemaSupported } from '../../textgen-settings.js';
 import { debounce_timeout } from '../../constants.js';
@@ -689,7 +689,7 @@ async function classifyCallback(/** @type {{api: string?, filter: string?, promp
     }
 
     const expressionApi = EXPRESSION_API[api] || extension_settings.expressions.api;
-    const filterAvailable = isTrueBoolean(filter);
+    const filterAvailable = !isFalseBoolean(filter);
 
     if (!modules.includes('classify') && expressionApi == EXPRESSION_API.extras) {
         toastr.warning('Text classification is disabled or not available');
@@ -2303,13 +2303,13 @@ function migrateSettings() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'expression-list',
         aliases: ['expressions'],
-        /** @type {(args: {return: string, filterAvailable: string}) => Promise<string>} */
+        /** @type {(args: {return: string, filter: string}) => Promise<string>} */
         callback: async (args) => {
             let returnType =
                 /** @type {import('../../slash-commands/SlashCommandReturnHelper.js').SlashCommandReturnType} */
                 (args.return);
 
-            const list = await getExpressionsList({ filterAvailable: isTrueBoolean(args.filterAvailable) });
+            const list = await getExpressionsList({ filterAvailable: !isFalseBoolean(args.filter) });
 
             return await slashCommandReturnHelper.doReturn(returnType ?? 'pipe', list, { objectToStringFunc: list => list.join(', ') });
         },

--- a/public/scripts/extensions/expressions/settings.html
+++ b/public/scripts/extensions/expressions/settings.html
@@ -29,7 +29,11 @@
                 </select>
             </div>
             <div class="expression_llm_prompt_block m-b-1 m-t-1">
-                <label for="expression_llm_prompt" class="title_restorable">
+                <label class="checkbox_label" for="expressions_filter_available" title="When using LLM or WebLLM classifier, only show and use expressions that have sprites assigned to them." data-i18n="[title]When using LLM or WebLLM classifier, only show and use expressions that have sprites assigned to them.">
+                    <input id="expressions_filter_available" type="checkbox">
+                    <span data-i18n="Filter expressions for available sprites">Filter expressions for available sprites</span>
+                </label>
+                <label for="expression_llm_prompt" class="title_restorable m-t-1">
                     <span data-i18n="LLM Prompt">LLM Prompt</span>
                     <div id="expression_llm_prompt_restore" title="Restore default value" class="right_menu_button">
                         <i class="fa-solid fa-clock-rotate-left fa-sm"></i>


### PR DESCRIPTION
- Functionality only available for LLM/webLLM
- New toggle to filter expressions on availalbe sprites
- `getExpressionsList` filters cached expressions when checked (using sprite folder name/override)
- `/expression-list` slash command has "filter" arg to filter list
- `/expression-classify` slash command has "filter" arg now, to use filtered list for classification
- `getExpressionLabel` uses filtered expressions when LLM/webLLM

Closes #3696

![image](https://github.com/user-attachments/assets/6a28f1ba-ff47-49dc-b251-7a988ed61b84)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).


## Copilot
This pull request introduces several enhancements to the expressions module in the `public/scripts/extensions/expressions/index.js` file. The primary focus is on adding a filtering option for expressions, allowing users to filter expressions based on the availability of sprites.

Key changes include:

### Enhancements to Expression Filtering:

* Added `isTrueBoolean` utility function to `import` statement to support new filtering logic.
* Introduced a new `filter` parameter to the `classifyCallback` function and updated its usage within the function to check for filter availability. [[1]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL681-R681) [[2]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR692-R699)
* Updated the `getExpressionLabel` function to include a new `filterAvailable` option, and added logic to handle filtering based on the availability of sprites. [[1]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR992-R996) [[2]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR1008-R1012) [[3]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL1030-R1037) [[4]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL1043-R1050)
* Modified the `getExpressionsList` function to accept a `filterAvailable` parameter and filter expressions accordingly. [[1]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL1323-R1351) [[2]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL1375-L1377)

### User Interface and Settings:

* Added a new checkbox input in the settings UI to enable or disable the expression filtering feature. [[1]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR2125-R2128) [[2]](diffhunk://#diff-5f5ded47b33d8fec494d1c3487a8396219f8ca599fcd63cab08c357e16124dd7L32-R36)
* Updated the slash command parser to include a new `filter` argument for the `expression-list` command, allowing users to filter expressions via slash commands. [[1]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL2282-R2312) [[2]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR2325-R2331) [[3]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR2347-R2353)