### PR TITLE
Clean reasoning from LLM/webLLM classify response on expression classification

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -17,6 +17,7 @@ import { slashCommandReturnHelper } from '../../slash-commands/SlashCommandRetur
 import { generateWebLlmChatPrompt, isWebLlmSupported } from '../shared.js';
 import { Popup, POPUP_RESULT } from '../../popup.js';
 import { t } from '../../i18n.js';
+import { removeReasoningFromString } from '../../reasoning.js';
 export { MODULE_NAME };
 
 /**
@@ -928,6 +929,9 @@ function parseLlmResponse(emotionResponse, labels) {
 
         return response;
     } catch {
+        // Clean possible reasoning from response
+        emotionResponse = removeReasoningFromString(emotionResponse);
+
         const fuse = new Fuse(labels, { includeScore: true });
         console.debug('Using fuzzy search in labels:', labels);
         const result = fuse.search(emotionResponse);


### PR DESCRIPTION
- If a reasoning model is used (via LLM, or R1 distill via webLLM), it'll likely return reasoning. That should not be used for the search of classification inside the response

Not sure why people would use reasoning models for classification, as those will slow down any possible classification, but someone might.
So why not make this right.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
