### PR TITLE
Chat titles are now included in the search. Query terms don't have to occur in the same message anymore.

### DIFF
--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -785,7 +785,7 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
 
             // Search through chats
             const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
-            const text = messages.map(message => message?.mes).join('').toLowerCase();
+            const text = messages.map(message => message?.mes).join("\n").toLowerCase();
             const stem = chatFile.path.toLowerCase().split(/[\\\/]/).pop().replace(/.jsonl$/, '');
             const hasMatch = fragments.every(fragment => (stem + text).includes(fragment));
 

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -783,7 +783,7 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
                 continue;
             }
 
-            // Search through chats
+            // Search through title and messages of the chat
             const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
             const text = [chatFile.path.split(/[\\\/]/).pop().replace(/.jsonl$/, ''),
                 ...messages.map(message => message?.mes)].join("\n").toLowerCase();

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -783,12 +783,11 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
                 continue;
             }
 
-            // Search through messages
+            // Search through chats
             const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
-            const hasMatch = messages.some(message => {
-                const text = message?.mes?.toLowerCase();
-                return text && fragments.every(fragment => text.includes(fragment));
-            });
+            const text = messages.map(message => message?.mes).join('').toLowerCase();
+            const stem = chatFile.path.toLowerCase().split(/[\\\/]/).pop().replace(/.jsonl$/, '');
+            const hasMatch = fragments.every(fragment => (stem + text).includes(fragment));
 
             if (hasMatch) {
                 results.push({

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -785,9 +785,9 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
 
             // Search through chats
             const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
-            const text = messages.map(message => message?.mes).join("\n").toLowerCase();
-            const stem = chatFile.path.toLowerCase().split(/[\\\/]/).pop().replace(/.jsonl$/, '');
-            const hasMatch = fragments.every(fragment => (stem + text).includes(fragment));
+            const text = [chatFile.path.split(/[\\\/]/).pop().replace(/.jsonl$/, ''),
+                ...messages.map(message => message?.mes)].join("\n").toLowerCase();
+            const hasMatch = fragments.every(fragment => (text).includes(fragment));
 
             if (hasMatch) {
                 results.push({

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -785,9 +785,9 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
 
             // Search through title and messages of the chat
             const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
-            const text = [chatFile.path.split(/[\\\/]/).pop().replace(/.jsonl$/, ''),
-                ...messages.map(message => message?.mes)].join("\n").toLowerCase();
-            const hasMatch = fragments.every(fragment => (text).includes(fragment));
+            const text = [chatFile.path.split(/[\\/]/).pop().replace(/.jsonl$/, ''),
+                ...messages.map(message => message?.mes)].join('\n').toLowerCase();
+            const hasMatch = fragments.every(fragment => text.includes(fragment));
 
             if (hasMatch) {
                 results.push({


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Problems

- Unable to search by chat titles.
- Unable to search by terms occurring in distinct messages of a chat.

## Solution

Concat the filename stem with the entire message content of the chat — simplify away upper case and spaces in the process — and grep that.

## Tests

- Name a chat "narbacular" and then search for that term.
- Create a chat containing "helicopter" in one message and "aqueduct" in another, then search for both terms.

## Future improvement

It could be worthwhile including other fields — such as image captions or prompts — in the search.