### PR TITLE
Fix replacing user_prompt_bias on display

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2069,8 +2069,9 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
     }
 
     // Prompt bias replacement should be applied on the raw message
-    if (!power_user.show_user_prompt_bias && ch_name && !isUser && !isSystem) {
-        mes = mes.replaceAll(substituteParams(power_user.user_prompt_bias), '');
+    const replacedPromptBias = power_user.user_prompt_bias && substituteParams(power_user.user_prompt_bias);
+    if (!power_user.show_user_prompt_bias && ch_name && !isUser && !isSystem && replacedPromptBias && mes.startsWith(replacedPromptBias)) {
+        mes = mes.slice(replacedPromptBias.length);
     }
 
     if (!isSystem) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Instead of just replacing a prefix, it replaced all occurences within a display string. So SRW containing just a newline would strip all line breaks (instead of just a prefix).

## Copilot summary

This pull request includes an important change to the `messageFormatting` function in `public/script.js` to improve the handling of user prompt bias replacement.

Improvements to user prompt bias replacement:

* [`public/script.js`](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L2072-R2074): Modified the `messageFormatting` function to check if the message starts with the user prompt bias before removing it, ensuring more accurate message formatting.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
