### PR TITLE
Adding option to disable removal of "{{user}}:" and "{{char}}:" in generateRaw()

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6031,8 +6031,8 @@ export function cleanUpMessage({ getMessage, isImpersonate, isContinue, displayI
         // This only occurs if the corresponding "power_user.allow_nameX_display" is false.
 
         let wrongName = isImpersonate
-            ? (power_user.allow_name2_display ? '' : name2)  // char
-            : (power_user.allow_name1_display ? '' : name1);  // user
+            ? (!power_user.allow_name2_display ? name2 : '')  // char
+            : (!power_user.allow_name1_display ? name1 : '');  // user
 
         if (wrongName) {
             // If the message starts with the wrong name, delete the entire response

--- a/public/script.js
+++ b/public/script.js
@@ -5970,6 +5970,7 @@ function extractMultiSwipes(data, type) {
  * @param {array} [options.stoppingStrings] Array of stopping strings.
  * @param {boolean} [options.includeUserPromptBias] Whether to permit prepending the user prompt bias at the beginning.
  * @param {boolean} [options.trimNames] Whether to allow trimming "{{char}}:" or "{{user}}:" from the beginning.
+ * @param {boolean} [options.trimWrongNames] Whether to allow deleting responses prefixed by the incorrect name, depending on isImpersonate
  *
  * @returns {string} The formatted message
  */

--- a/public/script.js
+++ b/public/script.js
@@ -3320,7 +3320,7 @@ class StreamingProcessor {
                     isImpersonate: false,
                     isContinue: false,
                     displayIncompleteSentences: true,
-                    stoppingStrings: this.stoppingStrings
+                    stoppingStrings: this.stoppingStrings,
                 });
             }
         }
@@ -3330,7 +3330,7 @@ class StreamingProcessor {
             isImpersonate: isImpersonate,
             isContinue: isContinue,
             displayIncompleteSentences: !isFinal,
-            stoppingStrings: this.stoppingStrings
+            stoppingStrings: this.stoppingStrings,
         });
 
         const charsToBalance = ['*', '"', '```'];
@@ -3660,7 +3660,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
             isImpersonate: false,
             isContinue: false,
             displayIncompleteSentences: true,
-            includeUserPromptBias: false
+            includeUserPromptBias: false,
         });
 
         if (!message) {
@@ -4866,7 +4866,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 getMessage: getMessage,
                 isImpersonate: isImpersonate,
                 isContinue: isContinue,
-                displayIncompleteSentences: false
+                displayIncompleteSentences: false,
             });
 
             if (isContinue) {
@@ -4955,7 +4955,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             getMessage: getMessage,
             isImpersonate: isImpersonate,
             isContinue: isContinue,
-            displayIncompleteSentences: false
+            displayIncompleteSentences: false,
         });
 
 
@@ -4976,7 +4976,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             getMessage: getMessage,
             isImpersonate: isImpersonate,
             isContinue: isContinue,
-            displayIncompleteSentences: displayIncomplete
+            displayIncompleteSentences: displayIncomplete,
         });
 
         if (isImpersonate) {
@@ -5947,7 +5947,7 @@ function extractMultiSwipes(data, type) {
                 getMessage: text,
                 isImpersonate: false,
                 isContinue: false,
-                displayIncompleteSentences: false
+                displayIncompleteSentences: false,
             });
 
             swipes.push(cleanedText);
@@ -5970,7 +5970,7 @@ function extractMultiSwipes(data, type) {
  *
  * @returns {string} The formatted message
  */
-export function cleanUpMessage({ getMessage, isImpersonate, isContinue, displayIncompleteSentences = false, stoppingStrings = null, includeUserPromptBias = true, trimNames = true} = {}) {
+export function cleanUpMessage({ getMessage, isImpersonate, isContinue, displayIncompleteSentences = false, stoppingStrings = null, includeUserPromptBias = true, trimNames = true } = {}) {
     if (arguments.length > 0 && typeof arguments[0] !== 'object') {
         console.trace('cleanUpMessage called with positional arguments. Please use an object instead.');
         [getMessage, isImpersonate, isContinue, displayIncompleteSentences, stoppingStrings, includeUserPromptBias] = arguments;
@@ -6035,7 +6035,7 @@ export function cleanUpMessage({ getMessage, isImpersonate, isContinue, displayI
         }
 
         // account for case where the name is after a newline
-        let startIndex = getMessage.indexOf(`\n${nameToTrim}:`)
+        let startIndex = getMessage.indexOf(`\n${nameToTrim}:`);
         if (nameToTrim && startIndex >= 0) {
             getMessage = getMessage.substring(startIndex + nameToTrim.length + 2);
         }

--- a/public/script.js
+++ b/public/script.js
@@ -6036,7 +6036,7 @@ export function cleanUpMessage({ getMessage, isImpersonate, isContinue, displayI
 
         if (wrongName) {
             // If the message starts with the wrong name, delete the entire response
-            let startIndex = getMessage.indexOf(`${wrongName}`);
+            let startIndex = getMessage.indexOf(`${wrongName}:`);
             if (startIndex === 0) {
                 getMessage = '';
                 console.debug(`Message started with the wrong name: "${wrongName}" - response was deleted.`);

--- a/public/script.js
+++ b/public/script.js
@@ -5971,10 +5971,10 @@ export function cleanUpMessage(getMessage, isImpersonate, isContinue, displayInc
     }
 
     if (nameToTrim && getMessage.indexOf(`${nameToTrim}:`) == 0) {
-        getMessage = getMessage.substring(0, getMessage.indexOf(`${nameToTrim}:`));
+        getMessage = getMessage.substring(getMessage.indexOf(`${nameToTrim}:`)+nameToTrim.length);
     }
     if (nameToTrim && getMessage.indexOf(`\n${nameToTrim}:`) >= 0) {
-        getMessage = getMessage.substring(0, getMessage.indexOf(`\n${nameToTrim}:`));
+        getMessage = getMessage.substring(getMessage.indexOf(`\n${nameToTrim}:`)+nameToTrim.length);
     }
     if (getMessage.indexOf('<|endoftext|>') != -1) {
         getMessage = getMessage.substring(0, getMessage.indexOf('<|endoftext|>'));

--- a/public/script.js
+++ b/public/script.js
@@ -5963,10 +5963,10 @@ function extractMultiSwipes(data, type) {
  * @param {string} [options.getMessage] The message to clean up
  * @param {boolean} [options.isImpersonate] Whether this is an impersonated message
  * @param {boolean} [options.isContinue] Whether this is a continued message
- * @param {boolean} [options.displayIncompleteSentences] Whether to *not* trim incomplete sentences.
+ * @param {boolean} [options.displayIncompleteSentences] Whether to keep incomplete sentences at the end.
  * @param {array} [options.stoppingStrings] Array of stopping strings.
  * @param {boolean} [options.includeUserPromptBias] Whether to permit prepending the user prompt bias at the beginning.
-@param {boolean} [options.trimNames] Whether to allow trimming "{{char}}:" or "{{user}}:" from the beginning.
+ * @param {boolean} [options.trimNames] Whether to allow trimming "{{char}}:" or "{{user}}:" from the beginning.
  *
  * @returns {string} The formatted message
  */

--- a/public/script.js
+++ b/public/script.js
@@ -6047,9 +6047,6 @@ export function cleanUpMessage({ getMessage, isImpersonate, isContinue, displayI
             if (startIndex >= 0) {
                 getMessage = getMessage.substring(0, startIndex);
             }
-
-            // remove any whitespace at the beginning
-            getMessage = getMessage.trimStart();
         }
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -5970,12 +5970,18 @@ export function cleanUpMessage(getMessage, isImpersonate, isContinue, displayInc
         nameToTrim = power_user.allow_name1_display ? '' : name1;
     }
 
-    if (nameToTrim && getMessage.indexOf(`${nameToTrim}:`) == 0) {
-        getMessage = getMessage.substring(getMessage.indexOf(`${nameToTrim}:`)+nameToTrim.length);
+    // get text from after the name (and colon) to the end of the string
+    if (nameToTrim && getMessage.indexOf(`${nameToTrim}:`) === 0) {
+        getMessage = getMessage.substring(nameToTrim.length+1);
     }
-    if (nameToTrim && getMessage.indexOf(`\n${nameToTrim}:`) >= 0) {
-        getMessage = getMessage.substring(getMessage.indexOf(`\n${nameToTrim}:`)+nameToTrim.length);
+
+    // account for case where the name is after a newline
+    let startIndex = getMessage.indexOf(`\n${nameToTrim}:`)
+    if (nameToTrim && startIndex >= 0) {
+        // get text from after the name (and colon) to the end of the string
+        getMessage = getMessage.substring(startIndex+nameToTrim.length+2);
     }
+
     if (getMessage.indexOf('<|endoftext|>') != -1) {
         getMessage = getMessage.substring(0, getMessage.indexOf('<|endoftext|>'));
     }

--- a/public/scripts/logprobs.js
+++ b/public/scripts/logprobs.js
@@ -368,7 +368,12 @@ function onToggleLogprobsPanel() {
 function createSwipe(messageId, prompt) {
     // need to call `cleanUpMessage` on our new prompt, because we were working
     // with raw model output and our new prompt is missing trimming/macro replacements
-    const cleanedPrompt = cleanUpMessage(prompt, false, false, true);
+    const cleanedPrompt = cleanUpMessage({
+        getMessage: prompt,
+        isImpersonate: false,
+        isContinue: false,
+        displayIncompleteSentences: true
+    });
 
     const msg = chat[messageId];
     const newSwipeInfo = {

--- a/public/scripts/logprobs.js
+++ b/public/scripts/logprobs.js
@@ -372,7 +372,7 @@ function createSwipe(messageId, prompt) {
         getMessage: prompt,
         isImpersonate: false,
         isContinue: false,
-        displayIncompleteSentences: true
+        displayIncompleteSentences: true,
     });
 
     const msg = chat[messageId];


### PR DESCRIPTION
### Description:
In `cleanUpMessage()`, the lines for removing "{{user}}:" or "{{char}}:" at the beginning of responses would instead remove the entire response. This was because they evaluated to `message.substring(0, 0)`. I have modified it so that it only removes the name at the beginning, i.e. `message.substring(index+length)`

### Motivation:
This fixes a bug where `generateRaw()` would mistakenly return an empty string when "{{user}}:" or "{{char}}:" appeared at the beginning and the corresponding user settings were disabled ("Show {{char}}: in responses" and "Show {{user}}: in responses").

I am not *fully* aware of what secondary effects this might have, but this change does fix that bug.

## Checklist:
- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
