### PR TITLE
Exported reloadEditor

### DIFF
--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -79,7 +79,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { timestampToMoment, uuidv4 } from './utils.js';
 import { getGlobalVariable, getLocalVariable, setGlobalVariable, setLocalVariable } from './variables.js';
-import { convertCharacterBook, getWorldInfoPrompt, loadWorldInfo, saveWorldInfo, updateWorldInfoList } from './world-info.js';
+import { convertCharacterBook, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList } from './world-info.js';
 import { ChatCompletionService, TextCompletionService } from './custom-request.js';
 import { ConnectionManagerRequestService } from './extensions/shared.js';
 import { updateReasoningUI, parseReasoningFromString } from './reasoning.js';
@@ -207,6 +207,7 @@ export function getContext() {
         },
         loadWorldInfo,
         saveWorldInfo,
+        reloadWorldInfoEditor: reloadEditor,
         updateWorldInfoList,
         convertCharacterBook,
         getWorldInfoPrompt,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -908,20 +908,20 @@ export function setWorldInfoSettings(settings, data) {
     registerWorldInfoSlashCommands();
 }
 
-function registerWorldInfoSlashCommands() {
-    /**
-     * Reloads the editor with the specified world info file
-     * @param {string} file - The file to load in the editor
-     * @param {boolean} [loadIfNotSelected=false] - Indicates whether to load the file even if it's not currently selected
-     */
-    function reloadEditor(file, loadIfNotSelected = false) {
-        const currentIndex = Number($('#world_editor_select').val());
-        const selectedIndex = world_names.indexOf(file);
-        if (selectedIndex !== -1 && (loadIfNotSelected || currentIndex === selectedIndex)) {
-            $('#world_editor_select').val(selectedIndex).trigger('change');
-        }
+/**
+ * Reloads the editor with the specified world info file
+ * @param {string} file - The file to load in the editor
+ * @param {boolean} [loadIfNotSelected=false] - Indicates whether to load the file even if it's not currently selected
+ */
+export function reloadEditor(file, loadIfNotSelected = false) {
+    const currentIndex = Number($('#world_editor_select').val());
+    const selectedIndex = world_names.indexOf(file);
+    if (selectedIndex !== -1 && (loadIfNotSelected || currentIndex === selectedIndex)) {
+        $('#world_editor_select').val(selectedIndex).trigger('change');
     }
+}
 
+function registerWorldInfoSlashCommands() {
     /**
      * Gets a *rough* approximation of the current chat context.
      * Normally, it is provided externally by the prompt builder.


### PR DESCRIPTION
Adding to `getContext()` is not necessary for me. But I believe `reloadEditor()` is necessary when adding a new entry. So it would be useful.

If I didn't see `reloadEditor()`, I was exporting `updateEditor` with new `data` param 😛