### PR TITLE
Respect "Allow self-responses" setting in manual order strategy

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -885,7 +885,7 @@ async function generateGroupWrapper(by_auto_mode, type = null, params = {}) {
             activatedMembers = activatePooledOrder(enabledMembers, lastMessage, isUserInput);
         }
         else if (activationStrategy === group_activation_strategy.MANUAL && !isUserInput) {
-            activatedMembers = shuffle(enabledMembers).slice(0, 1).map(x => characters.findIndex(y => y.avatar === x)).filter(x => x !== -1);
+            activatedMembers = activateManual(enabledMembers, lastMessage, group.allow_self_responses);
         }
 
         if (activatedMembers.length === 0) {
@@ -1067,6 +1067,18 @@ function activatePooledOrder(members, lastMessage, isUserInput) {
 
     const memberId = characters.findIndex(y => y.avatar === activatedMember);
     return memberId !== -1 ? [memberId] : [];
+}
+
+function activateManual(members, lastMessage, allowSelfResponses) {
+    // prevents the same character from speaking twice
+    let bannedUser = lastMessage && !lastMessage.is_user && lastMessage.name;
+
+    // ...unless allowed to do so
+    if (allowSelfResponses) {
+        bannedUser = undefined;
+    }
+
+    return shuffle(members).map(x => characters.findIndex(y => y.avatar === x && y.name !== bannedUser)).filter(x => x !== -1).slice(0,1);
 }
 
 function activateNaturalOrder(members, input, lastMessage, allowSelfResponses, isUserInput) {


### PR DESCRIPTION
This makes a minor change to the random choice logic when manually triggering a group response, filtering out the sender of the last message if self responses aren't allowed. I copied the last-replied logic from the natural order function for consistency.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

(Resubmitting because I accidentally created the PR against release the first time...)