### PR TITLE
OpenRouter: Fix OAuth flow with enabled accounts

### DIFF
--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -189,14 +189,17 @@ export async function findSecret(key) {
 }
 
 function authorizeOpenRouter() {
-    const openRouterUrl = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(location.origin)}`;
+    const redirectUrl = new URL('/callback/openrouter', window.location.origin);
+    const openRouterUrl = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(redirectUrl.toString())}`;
     location.href = openRouterUrl;
 }
 
 async function checkOpenRouterAuth() {
     const params = new URLSearchParams(location.search);
-    if (params.has('code')) {
-        const code = params.get('code');
+    const source = params.get('source');
+    if (source === 'openrouter') {
+        const query = new URLSearchParams(params.get('query'));
+        const code = query.get('code');
         try {
             const response = await fetch('https://openrouter.ai/api/v1/auth/keys', {
                 method: 'POST',

--- a/server.js
+++ b/server.js
@@ -150,7 +150,7 @@ if (cliArgs.enableCorsProxy) {
 
 app.use(cookieSession({
     name: getCookieSessionName(),
-    sameSite: 'strict',
+    sameSite: 'lax',
     httpOnly: true,
     maxAge: getSessionCookieAge(),
     secret: getCookieSecret(globalThis.DATA_ROOT),
@@ -211,6 +211,17 @@ app.get('/', getCacheBusterMiddleware(), (request, response) => {
     }
 
     return response.sendFile('index.html', { root: path.join(process.cwd(), 'public') });
+});
+
+// Callback endpoint for OAuth PKCE flows (e.g. OpenRouter)
+app.get('/callback/:source?', (request, response) => {
+    const source = request.params.source;
+    const query = request.url.split('?')[1];
+    const searchParams = new URLSearchParams();
+    source && searchParams.set('source', source);
+    query && searchParams.set('query', query);
+    const path = `/?${searchParams.toString()}`;
+    return response.redirect(307, path);
 });
 
 // Host login page


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

OpenRouter OAuth flow has been broken for multi-account mode. This PR addresses the following:

1. Sets session cookie SameSite value to "lax". Otherwise, the session cookie is not being passed to the callback on redirection, leading to a broken login flow.
2. Adds a generic `/callback` endpoint for other potential OAuth flows we might need to support in the future. Updates OpenRouter to use the new flow.

## Copilot summary

This pull request includes several changes to improve the OAuth authentication flow and session cookie handling. The most important changes include updating the `authorizeOpenRouter` function to use a new redirect URL, adding a callback endpoint for OAuth PKCE flows, and modifying the session cookie settings.

Improvements to OAuth authentication flow:

* [`public/scripts/secrets.js`](diffhunk://#diff-16308cd636476fb5001aed78c7c0491560b291d8cae209f45791a073e326aba8L192-R202): Updated the `authorizeOpenRouter` function to use a new redirect URL and modified the `checkOpenRouterAuth` function to handle the `source` parameter and nested query parameters.

* [`server.js`](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fR216-R226): Added a new callback endpoint for OAuth PKCE flows to handle different sources and redirect appropriately.

Session cookie handling:

* [`server.js`](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL153-R153): Changed the `sameSite` attribute of the session cookie from 'strict' to 'lax' to allow for cross-site requests in certain conditions.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
