### PR TITLE
Add 'none' expression classifier API option and set as default

### DIFF
--- a/public/scripts/extensions/expressions/settings.html
+++ b/public/scripts/extensions/expressions/settings.html
@@ -22,6 +22,7 @@
                 <label for="expression_api" data-i18n="Classifier API">Classifier API</label>
                 <small data-i18n="Select the API for classifying expressions.">Select the API for classifying expressions.</small>
                 <select id="expression_api" class="flex1 margin0">
+                    <option value="99" data-i18n="[ None ]">[ None ]</option>
                     <option value="0" data-i18n="Local">Local</option>
                     <option value="1" data-i18n="Extras">Extras (deprecated)</option>
                     <option value="2" data-i18n="Main API">Main API</option>


### PR DESCRIPTION
Fixes my too-hastily-made commit.

### Explanation
Introduces a no-op API selection to disable expression classification Shows warnings when no valid API is selected to prevent silent failures Updates migration logic and settings UI to use new default value

This allows users to explicitly opt-out of automatic expression detection while maintaining backwards compatibility with existing configurations

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).

## Copilot
This pull request introduces a new "None" option for the classifier API in the expressions extension. This change ensures that users can select no classifier API if desired, and the system will handle this selection appropriately. The most important changes include updating the API options, modifying the classification logic, and adjusting the settings migration.

Updates to API options:

* [`public/scripts/extensions/expressions/index.js`](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR86): Added a new `none` option with value `99` to the `EXPRESSION_API` constant.
* [`public/scripts/extensions/expressions/settings.html`](diffhunk://#diff-5f5ded47b33d8fec494d1c3487a8396219f8ca599fcd63cab08c357e16124dd7R25): Added a new option for "None" in the classifier API dropdown menu.

Modifications to classification logic:

* [`public/scripts/extensions/expressions/index.js`](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR696-R700): Updated the `classifyCallback` function to handle the new `none` option by displaying a warning and returning an empty string.
* [`public/scripts/extensions/expressions/index.js`](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL1064-R1070): Updated the `getExpressionLabel` function to handle the `none` option by returning an empty string and adding a default case to handle invalid API selections. [[1]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL1064-R1070) [[2]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR1088-R1096)

Adjustments to settings migration:

* [`public/scripts/extensions/expressions/index.js`](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL2063-R2078): Modified the `migrateSettings` function to set the default API to `none` if it is undefined. [[1]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL2063-R2078) [[2]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bL2145-R2160)