### PR TITLE
Fix for generation interceptors messing with WI timed effects

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5303,7 +5303,7 @@ function formatMessageHistoryItem(chatItem, isInstruct, forceOutputSequence) {
 
     // Don't format messages with undefined content
     if (chatItem.mes === undefined) {
-        return ""
+        return '';
     }
 
     // Don't include a name if it's empty

--- a/public/script.js
+++ b/public/script.js
@@ -5301,8 +5301,9 @@ function formatMessageHistoryItem(chatItem, isInstruct, forceOutputSequence) {
     const itemName = chatItem.is_user ? chatItem['name'] : characterName;
     const shouldPrependName = !isNarratorType;
 
-    // Don't format messages with undefined content
-    if (chatItem.mes === undefined) {
+    // If this flag is set, completely ignore the message.
+    // This can be used to hide messages without affecting the number of messages in the chat.
+    if (chatItem.ignore_formatting) {
         return '';
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -5301,6 +5301,11 @@ function formatMessageHistoryItem(chatItem, isInstruct, forceOutputSequence) {
     const itemName = chatItem.is_user ? chatItem['name'] : characterName;
     const shouldPrependName = !isNarratorType;
 
+    // Don't format messages with undefined content
+    if (chatItem.mes === undefined) {
+        return ""
+    }
+
     // Don't include a name if it's empty
     let textResult = chatItem?.name && shouldPrependName ? `${itemName}: ${chatItem.mes}\n` : `${chatItem.mes}\n`;
 

--- a/public/script.js
+++ b/public/script.js
@@ -5303,7 +5303,7 @@ function formatMessageHistoryItem(chatItem, isInstruct, forceOutputSequence) {
 
     // If this flag is set, completely ignore the message.
     // This can be used to hide messages without affecting the number of messages in the chat.
-    if (chatItem.ignore_formatting) {
+    if (chatItem.extra?.ignore) {
         return '';
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -174,7 +174,7 @@ import {
     saveBase64AsFile,
     uuidv4,
 } from './scripts/utils.js';
-import { debounce_timeout } from './scripts/constants.js';
+import { debounce_timeout, IGNORE_SYMBOL } from './scripts/constants.js';
 
 import { doDailyExtensionUpdatesCheck, extension_settings, initExtensions, loadExtensionSettings, runGenerationInterceptors, saveMetadataDebounced } from './scripts/extensions.js';
 import { COMMENT_NAME_DEFAULT, executeSlashCommandsOnChatInput, getSlashCommandsHelp, initDefaultSlashCommands, isExecutingCommandsFromChatInput, pauseScriptExecution, processChatSlashCommands, stopScriptExecution } from './scripts/slash-commands.js';
@@ -5295,6 +5295,7 @@ export function getBiasStrings(textareaText, type) {
  * @param {boolean} isInstruct Whether instruct mode is enabled.
  * @param {boolean|number} forceOutputSequence Whether to force the first/last output sequence for instruct mode.
  */
+
 function formatMessageHistoryItem(chatItem, isInstruct, forceOutputSequence) {
     const isNarratorType = chatItem?.extra?.type === system_message_types.NARRATOR;
     const characterName = chatItem?.name ? chatItem.name : name2;
@@ -5303,7 +5304,7 @@ function formatMessageHistoryItem(chatItem, isInstruct, forceOutputSequence) {
 
     // If this flag is set, completely ignore the message.
     // This can be used to hide messages without affecting the number of messages in the chat.
-    if (chatItem.extra?.ignore) {
+    if (chatItem.extra?.[IGNORE_SYMBOL]) {
         return '';
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -5295,14 +5295,13 @@ export function getBiasStrings(textareaText, type) {
  * @param {boolean} isInstruct Whether instruct mode is enabled.
  * @param {boolean|number} forceOutputSequence Whether to force the first/last output sequence for instruct mode.
  */
-
 function formatMessageHistoryItem(chatItem, isInstruct, forceOutputSequence) {
     const isNarratorType = chatItem?.extra?.type === system_message_types.NARRATOR;
     const characterName = chatItem?.name ? chatItem.name : name2;
     const itemName = chatItem.is_user ? chatItem['name'] : characterName;
     const shouldPrependName = !isNarratorType;
 
-    // If this flag is set, completely ignore the message.
+    // If this symbol flag is set, completely ignore the message.
     // This can be used to hide messages without affecting the number of messages in the chat.
     if (chatItem.extra?.[IGNORE_SYMBOL]) {
         return '';

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -15,9 +15,10 @@ export const debounce_timeout = {
     extended: 5000,
 };
 
-/*
-Used as an ephemeral key in message extra metadata.
-When set, the message will be excluded from generation prompts without affecting the number of chat messages,
-    which is needed to preserve world info timed effects.
+/**
+ * Used as an ephemeral key in message extra metadata.
+ * When set, the message will be excluded from generation
+ * prompts without affecting the number of chat messages,
+ * which is needed to preserve world info timed effects.
  */
 export const IGNORE_SYMBOL = Symbol.for('ignore');

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -14,3 +14,9 @@ export const debounce_timeout = {
     /** [5 sec] For delayed tasks, like auto-saving or completing batch operations that need a significant pause. */
     extended: 5000,
 };
+
+/*
+Used as an ephemeral key in message extra metadata.
+When set, the message will be excluded from context.
+ */
+export const IGNORE_SYMBOL = Symbol.for('ignore');

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -17,6 +17,7 @@ export const debounce_timeout = {
 
 /*
 Used as an ephemeral key in message extra metadata.
-When set, the message will be excluded from context.
+When set, the message will be excluded from generation prompts without affecting the number of chat messages,
+    which is needed to preserve world info timed effects.
  */
 export const IGNORE_SYMBOL = Symbol.for('ignore');

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -75,7 +75,7 @@ import { Popup, POPUP_RESULT } from './popup.js';
 import { t } from './i18n.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
-import {IGNORE_SYMBOL} from "./constants.js";
+import { IGNORE_SYMBOL } from './constants.js';
 
 export {
     openai_messages_count,

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -75,6 +75,7 @@ import { Popup, POPUP_RESULT } from './popup.js';
 import { t } from './i18n.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
+import {IGNORE_SYMBOL} from "./constants.js";
 
 export {
     openai_messages_count,
@@ -528,7 +529,7 @@ function setOpenAIMessages(chat) {
         let content = chat[j]['mes'];
 
         // If this flag is set, completely ignore the message
-        if (chat[j].extra?.ignore) {
+        if (chat[j].extra?.[IGNORE_SYMBOL]) {
             j++;
             continue;
         }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -527,6 +527,12 @@ function setOpenAIMessages(chat) {
         let role = chat[j]['is_user'] ? 'user' : 'assistant';
         let content = chat[j]['mes'];
 
+        // If this flag is set, completely ignore the message
+        if (chat[j].extra?.ignore) {
+            j++;
+            continue;
+        }
+
         // 100% legal way to send a message as system
         if (chat[j].extra?.type === system_message_types.NARRATOR) {
             role = 'system';

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -528,7 +528,7 @@ function setOpenAIMessages(chat) {
         let role = chat[j]['is_user'] ? 'user' : 'assistant';
         let content = chat[j]['mes'];
 
-        // If this flag is set, completely ignore the message.
+        // If this symbol flag is set, completely ignore the message.
         // This can be used to hide messages without affecting the number of messages in the chat.
         if (chat[j].extra?.[IGNORE_SYMBOL]) {
             j++;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -528,7 +528,8 @@ function setOpenAIMessages(chat) {
         let role = chat[j]['is_user'] ? 'user' : 'assistant';
         let content = chat[j]['mes'];
 
-        // If this flag is set, completely ignore the message
+        // If this flag is set, completely ignore the message.
+        // This can be used to hide messages without affecting the number of messages in the chat.
         if (chat[j].extra?.[IGNORE_SYMBOL]) {
             j++;
             continue;

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -83,6 +83,7 @@ import { convertCharacterBook, getWorldInfoPrompt, loadWorldInfo, reloadEditor, 
 import { ChatCompletionService, TextCompletionService } from './custom-request.js';
 import { ConnectionManagerRequestService } from './extensions/shared.js';
 import { updateReasoningUI, parseReasoningFromString } from './reasoning.js';
+import { IGNORE_SYMBOL } from './constants.js';
 
 export function getContext() {
     return {
@@ -225,6 +226,9 @@ export function getContext() {
         parseReasoningFromString,
         unshallowCharacter,
         unshallowGroupMembers,
+        symbols: {
+            ignore: IGNORE_SYMBOL,
+        },
     };
 }
 


### PR DESCRIPTION
### Description

This adds a check within `formatMessageHistoryItem()` to avoid formatting messages with undefined content.

### Motivation
I know we've talked about this before, but here me out. The `Message Limit` extension (and mine) has an issue where world info timed effects get completely borked because they rely on the number of messages in the chat. I believe I have a minimal solution for this: instead of removing messages from chat, we instead just remove the *content* of messages. Previously, this didn't work because those empty messages would still get formatted and you'd end up with a bunch of empty message templates in your prompt. With this change, you can instead set the message content to `undefined` and `formatMessageHistoryItems()` will ignore it, effectively allowing you to remove messages from the chat without messing with world info timed effects.

I specifically didn't make the check to just ignore empty strings, as I figured that would likely have unintended consequences. This works as expected as world info timed effects appear to be preserved (from my testing), but let me know if this would mess anything up.

### Update

Now uses an `ignore` flag on message extras.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).