### PR TITLE
Add expand editor for WI content

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6101,8 +6101,11 @@
                                         <label for="content ">
                                             <small>
                                                 <span class="alignitemscenter flex-container flexnowrap wide100p justifySpaceBetween">
-                                                    <span data-i18n="Content" class="alignitemscenter flex-container flexNoGap mdhotkey_location">
-                                                        Content
+                                                    <span class="alignitemscenter flex-container">
+                                                        <span data-i18n="Content" class="mdhotkey_location">
+                                                            Content
+                                                        </span>
+                                                        <i class="editor_maximize fa-solid fa-maximize right_menu_button" title="Expand the editor" data-i18n="[title]Expand the editor"></i>
                                                     </span>
                                                     <span>
                                                         (<span data-i18n="extension_token_counter">Tokens:</span>&nbsp; <span class="world_entry_form_token_counter" data-first-run="true">counting...</span>)&nbsp;

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2680,8 +2680,10 @@ export async function getWorldEntry(name, data, entry) {
         $(counter).text(numberOfTokens);
     }, debounce_timeout.relaxed);
 
+    const contentInputId = `world_entry_content_${entry.uid}`;
     const contentInput = template.find('textarea[name="content"]');
     contentInput.data('uid', entry.uid);
+    contentInput.attr('id', contentInputId);
     contentInput.on('input', async function (_, { skipCount } = {}) {
         const uid = $(this).data('uid');
         const value = $(this).val();
@@ -2698,7 +2700,9 @@ export async function getWorldEntry(name, data, entry) {
         countTokensDebounced(counter, value);
     });
     contentInput.val(entry.content).trigger('input', { skipCount: true });
-    //initScrollHeight(contentInput);
+
+    const contentExpandButton = template.find('.editor_maximize');
+    contentExpandButton.attr('data-for', contentInputId);
 
     template.find('.inline-drawer-toggle').on('click', function () {
         if (counter.data('first-run')) {


### PR DESCRIPTION
Closes #3764

The title is pretty self explanatory.

## Copilot slop

This pull request includes updates to the `public/index.html` and `public/scripts/world-info.js` files to enhance the user interface and improve functionality.

Improvements to user interface:

* [`public/index.html`](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL6104-R6109): Added an expand button to the content editor with an icon and title for better usability.

Enhancements to functionality:

* [`public/scripts/world-info.js`](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R2683-R2686): Assigned a unique ID to the content input element to facilitate better interaction and tracking.
* [`public/scripts/world-info.js`](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496L2701-R2705): Linked the expand button to the content input element using the newly assigned unique ID.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
