### PR TITLE
Added move button for lorebook entries

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6013,6 +6013,7 @@
                                     </div>
                                 </div>
                             </div>
+                            <i class="menu_button move_entry_button fa-solid fa-right-left" title="Move Entry to Another Lorebook" data-i18n="[title]Move Entry to Another Lorebook" type="button"></i>
                             <i class="menu_button duplicate_entry_button fa-solid fa-paste" title="Duplicate world info entry" data-i18n="[title]Duplicate world info entry" type="submit" value=""></i>
                             <i class="menu_button delete_entry_button fa-solid fa-trash-can" title="Delete world info entry" data-i18n="[title]Delete world info entry" type="submit" value=""></i>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -6013,7 +6013,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <i class="menu_button move_entry_button fa-solid fa-right-left" title="Move Entry to Another Lorebook" data-i18n="[title]Move Entry to Another Lorebook" type="button"></i>
+                            <i class="menu_button move_entry_button fa-solid fa-right-left" title="Move Entry to Another Lorebook" data-i18n="[title]Move Entry to Another Lorebook"></i>
                             <i class="menu_button duplicate_entry_button fa-solid fa-paste" title="Duplicate world info entry" data-i18n="[title]Duplicate world info entry" type="submit" value=""></i>
                             <i class="menu_button delete_entry_button fa-solid fa-trash-can" title="Delete world info entry" data-i18n="[title]Delete world info entry" type="submit" value=""></i>
                         </div>

--- a/public/scripts/templates/worldInfoKeywordHeaders.html
+++ b/public/scripts/templates/worldInfoKeywordHeaders.html
@@ -1,4 +1,4 @@
-<div id="WIEntryHeaderTitlesPC" class="flex-container wide100p spaceBetween justifyCenter textAlignCenter" style="padding:0 4.5em;">
+<div id="WIEntryHeaderTitlesPC" class="flex-container wide100p spaceBetween justifyCenter textAlignCenter" style="padding:0 7.0em;">
     <small class="flex1" data-i18n="Title/Memo">Title/Memo</small>
     <small style="width: calc(3.5em + 10px)" data-i18n="Strategy">Strategy</small>
     <small style="width: calc(3.5em + 20px)" data-i18n="Position">Position</small>

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3185,7 +3185,7 @@ export async function getWorldEntry(name, data, entry) {
 
         // Create wrapper div
         const wrapper = document.createElement('div');
-        wrapper.textContent = t`Move ${sourceName} to:`;
+        wrapper.textContent = t`Move "${sourceName}" to:`;
 
         // Create container and append elements
         const container = document.createElement('div');

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -5351,7 +5351,7 @@ jQuery(() => {
  *
  * @param {string} sourceName - The name of the source lorebook file.
  * @param {string} targetName - The name of the target lorebook file.
- * @param {number} uid - The UID of the entry to move from the source lorebook.
+ * @param {string|number} uid - The UID of the entry to move from the source lorebook.
  * @returns {Promise<boolean>} True if the move was successful, false otherwise.
  */
 export async function moveWorldInfoEntry(sourceName, targetName, uid) {

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3158,7 +3158,7 @@ export async function getWorldEntry(name, data, entry) {
 
         const select = document.createElement('select');
         select.id = 'move_entry_target_select';
-        select.classList.add('text_pole', 'wide100p', 'margin-top');
+        select.classList.add('text_pole', 'wide100p', 'marginTop10');
 
         const defaultOption = document.createElement('option');
         defaultOption.value = '';

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -5406,9 +5406,7 @@ export async function moveWorldInfoEntry(sourceName, targetName, uid) {
         }
 
         entryToMove.uid = newUid;
-        // Reset displayIndex or let it be recalculated based on target book's sorting?
-        // For simplicity, let's assign a high index initially, assuming it might be sorted later.
-        // Or maybe better, find the max displayIndex in target and add 1?
+        // Place the entry at the end of the target lorebook
         const maxDisplayIndex = Object.values(targetData.entries).reduce((max, entry) => Math.max(max, entry.displayIndex ?? -1), -1);
         entryToMove.displayIndex = maxDisplayIndex + 1;
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2232,7 +2232,7 @@ export function setWIOriginalDataValue(data, uid, key, value) {
  */
 export function deleteWIOriginalDataValue(data, uid) {
     if (data.originalData && Array.isArray(data.originalData.entries)) {
-        const originalIndex = data.originalData.entries.findIndex(x => x.uid === uid);
+        const originalIndex = data.originalData.entries.findIndex(x => String(x.uid) === String(uid));
 
         if (originalIndex >= 0) {
             data.originalData.entries.splice(originalIndex, 1);

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2232,7 +2232,9 @@ export function setWIOriginalDataValue(data, uid, key, value) {
  */
 export function deleteWIOriginalDataValue(data, uid) {
     if (data.originalData && Array.isArray(data.originalData.entries)) {
-        const originalIndex = data.originalData.entries.findIndex(x => String(x.uid) === String(uid));
+        // Non-strict equality is used here to allow for both string and number comparisons
+        // @eslint-disable-next-line eqeqeqeq
+        const originalIndex = data.originalData.entries.findIndex(x => x.uid == uid);
 
         if (originalIndex >= 0) {
             data.originalData.entries.splice(originalIndex, 1);

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3145,8 +3145,8 @@ export async function getWorldEntry(name, data, entry) {
     moveButton.attr('data-current-world', name);
     moveButton.on('click', async function (e) {
         e.stopPropagation();
-        const sourceUid = $(this).data('uid');
-        const sourceWorld = $(this).data('current-world');
+        const sourceUid = $(this).attr('data-uid');
+        const sourceWorld = $(this).attr('data-current-world');
         const sourceWorldInfo = await loadWorldInfo(sourceWorld);
         if (!sourceWorldInfo) {
             return;

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2233,7 +2233,7 @@ export function setWIOriginalDataValue(data, uid, key, value) {
 export function deleteWIOriginalDataValue(data, uid) {
     if (data.originalData && Array.isArray(data.originalData.entries)) {
         // Non-strict equality is used here to allow for both string and number comparisons
-        // @eslint-disable-next-line eqeqeqeq
+        // @eslint-disable-next-line eqeqeq
         const originalIndex = data.originalData.entries.findIndex(x => x.uid == uid);
 
         if (originalIndex >= 0) {

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -5419,9 +5419,9 @@ export async function moveWorldInfoEntry(sourceName, targetName, uid) {
         console.debug(`[WI Move] Removed entry UID ${entryUidString} from source '${sourceName}'.`);
 
 
-        await saveWorldInfo(targetName, targetData);
+        await saveWorldInfo(targetName, targetData, true);
         console.debug(`[WI Move] Saved target lorebook '${targetName}'.`);
-        await saveWorldInfo(sourceName, sourceData);
+        await saveWorldInfo(sourceName, sourceData, true);
         console.debug(`[WI Move] Saved source lorebook '${sourceName}'.`);
 
 


### PR DESCRIPTION
Added move button for lorebook entries


https://github.com/user-attachments/assets/9991aa39-eb35-4089-9f80-464a5fb8091a

To be honest, I also wanted to test Gemini 2.5 Pro. So I copied the whole `world-info.js` file. 5000~ lines, 50k token. It did a good job. Notes:
- Writing too many comments, logs and toastr messages, I trimmed most of it.
- `moveWorldInfoEntry` method is 100% written with Gemini except I simplified comments, logs and toastr messages.
- `moveButton.on('click',` is half written by AI because it couldn't figure out the popup usage and getting select value from popup.