### PR TITLE
Update Claude model list

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2958,11 +2958,9 @@
                                         <option value="claude-3-5-sonnet-20240620">claude-3-5-sonnet-20240620</option>
                                         <option value="claude-3-5-haiku-latest">claude-3-5-haiku-latest</option>
                                         <option value="claude-3-5-haiku-20241022">claude-3-5-haiku-20241022</option>
+                                        <option value="claude-3-opus-latest">claude-3-opus-latest</option>
                                         <option value="claude-3-opus-20240229">claude-3-opus-20240229</option>
-                                        <option value="claude-3-sonnet-20240229">claude-3-sonnet-20240229</option>
                                         <option value="claude-3-haiku-20240307">claude-3-haiku-20240307</option>
-                                        <option value="claude-2.1">claude-2.1</option>
-                                        <option value="claude-2.0">claude-2.0</option>
                                     </optgroup>
                                 </select>
                             </div>


### PR DESCRIPTION
Removed unavailable models and added `latest` alias for opus.
(`claude-3-sonnet-20240229` is still on the list in documentation, but it's actually unavailable)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
