### PR TITLE
Add option to parse reasoning only after both prefix and suffix are generated during streaming

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3899,6 +3899,12 @@
                                             Show Hidden
                                         </small>
                                     </label>
+                                    <label class="checkbox_label flex1" for="reasoning_parse_mode" title="Wait for both prefix and suffix to appear before parsing reasoning. If disabled, parsing begins as soon as prefix appears." data-i18n="[title]reasoning_parse_mode">
+                                        <input id="reasoning_parse_mode" type="checkbox" />
+                                        <small data-i18n="Wait for Full Reasoning">
+                                            Wait for Full Reasoning
+                                        </small>
+                                    </label>
                                 </div>
                                 <div class="flex-container alignItemsBaseline">
                                     <label class="checkbox_label flex1" for="reasoning_add_to_prompts" title="Add existing reasoning blocks to prompts. To add a new reasoning block, use the message edit menu." data-i18n="[title]reasoning_add_to_prompts">

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -428,7 +428,7 @@ export class ReasoningHandler {
                     message.mes = trimSpaces(parseTarget.slice(this.#parsingReasoningMesStartIndex));
                     
                     // Set state and timing info directly to Done since we already have complete reasoning
-                    this.state = ReasoningState.Thinking;
+                    this.state = ReasoningState.Done;
                     this.startTime = this.startTime ?? this.initialTime;
                     this.endTime = new Date();
                 }

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -46,6 +46,7 @@ const UI = {
     $showHidden: $('#reasoning_show_hidden'),
     $addToPrompts: $('#reasoning_add_to_prompts'),
     $maxAdditions: $('#reasoning_max_additions'),
+    $parseMode: $('#reasoning_parse_mode'),
 };
 
 /**
@@ -409,8 +410,31 @@ export class ReasoningHandler {
         }
 
         if (this.state === ReasoningState.None || this.#isHiddenReasoningModel) {
-            // If streamed message starts with the opening, cut it out and put all inside reasoning
-            if (parseTarget.startsWith(power_user.reasoning.prefix) && parseTarget.length > power_user.reasoning.prefix.length) {
+            // Check if wait_for_suffix is enabled - then only start parsing if we have both prefix and suffix
+            if (power_user.reasoning.wait_for_suffix) {
+                if (parseTarget.startsWith(power_user.reasoning.prefix) && 
+                    parseTarget.includes(power_user.reasoning.suffix) && 
+                    parseTarget.length > power_user.reasoning.prefix.length) {
+                    
+                    // Extract reasoning directly since we have both prefix and suffix
+                    const reasoning = parseTarget.slice(
+                        power_user.reasoning.prefix.length, 
+                        parseTarget.indexOf(power_user.reasoning.suffix)
+                    );
+                    this.reasoning = reasoning;
+                    
+                    // Extract message content after suffix
+                    this.#parsingReasoningMesStartIndex = parseTarget.indexOf(power_user.reasoning.suffix) + power_user.reasoning.suffix.length;
+                    message.mes = trimSpaces(parseTarget.slice(this.#parsingReasoningMesStartIndex));
+                    
+                    // Set state and timing info directly to Done since we already have complete reasoning
+                    this.state = ReasoningState.Thinking;
+                    this.startTime = this.startTime ?? this.initialTime;
+                    this.endTime = new Date();
+                }
+            } 
+            // Otherwise: If streamed message starts with the opening, cut it out and put all inside reasoning
+            else if (parseTarget.startsWith(power_user.reasoning.prefix) && parseTarget.length > power_user.reasoning.prefix.length) {
                 this.#isParsingReasoning = true;
 
                 // Manually set starting state here, as we might already have received the ending suffix
@@ -734,6 +758,12 @@ function loadReasoningSettings() {
     UI.$autoParse.prop('checked', power_user.reasoning.auto_parse);
     UI.$autoParse.on('change', function () {
         power_user.reasoning.auto_parse = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    UI.$parseMode.prop('checked', power_user.reasoning.wait_for_suffix);
+    UI.$parseMode.on('change', function () {
+        power_user.reasoning.wait_for_suffix = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

The update to reasoning auto-parsing during streaming can be problematic if API providers are experiencing instability, as it may parse out incomplete reasoning and make continuing from that point difficult.

The change is quite small and adds a simple checkbox to the reasoning UI as well as alternate logic for parsing during streaming to bring back the old method of only parsing once both prefix and suffix are generated if that box is checked.