### PR TITLE
Fix persona select on new chat not rerendering first message (and not replacing `{{user}}` macro)

### DIFF
--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -465,7 +465,7 @@ export function initPersona(avatarId, personaName, personaDescription) {
  * @returns {Promise<boolean>} A promise that resolves to true if the character was converted, false otherwise.
  */
 export async function convertCharacterToPersona(characterId = null) {
-    if (null === characterId) characterId = this_chid;
+    if (null === characterId) characterId = Number(this_chid);
 
     const avatarUrl = characters[characterId]?.avatar;
     if (!avatarUrl) {
@@ -1243,7 +1243,7 @@ function getPersonaStates(avatarId) {
     /** @type {PersonaConnection[]} */
     const connections = power_user.persona_descriptions[avatarId]?.connections;
     const hasCharLock = !!connections?.some(c =>
-        (!selected_group && c.type === 'character' && c.id === characters[this_chid]?.avatar)
+        (!selected_group && c.type === 'character' && c.id === characters[Number(this_chid)]?.avatar)
         || (selected_group && c.type === 'group' && c.id === selected_group));
 
     return {
@@ -1481,7 +1481,7 @@ async function loadPersonaForCurrentChat({ doRender = false } = {}) {
  * @returns {string[]} - An array of persona keys that are connected to the given character key
  */
 export function getConnectedPersonas(characterKey = undefined) {
-    characterKey ??= selected_group || characters[this_chid]?.avatar;
+    characterKey ??= selected_group || characters[Number(this_chid)]?.avatar;
     const connectedPersonas = Object.entries(power_user.persona_descriptions)
         .filter(([_, desc]) => desc.connections?.some(conn => conn.type === 'character' && conn.id === characterKey))
         .map(([key, _]) => key);
@@ -1513,7 +1513,7 @@ export async function showCharConnections() {
                 console.log(`Unlocking persona ${personaId} from current character ${name2}`);
                 power_user.persona_descriptions[personaId].connections = connections.filter(c => {
                     if (menu_type == 'group_edit' && c.type == 'group' && c.id == selected_group) return false;
-                    else if (c.type == 'character' && c.id == characters[this_chid]?.avatar) return false;
+                    else if (c.type == 'character' && c.id == characters[Number(this_chid)]?.avatar) return false;
                     return true;
                 });
                 saveSettingsDebounced();
@@ -1545,8 +1545,8 @@ export async function showCharConnections() {
 export function getCurrentConnectionObj() {
     if (selected_group)
         return { type: 'group', id: selected_group };
-    if (characters[this_chid]?.avatar)
-        return { type: 'character', id: characters[this_chid]?.avatar };
+    if (characters[Number(this_chid)]?.avatar)
+        return { type: 'character', id: characters[Number(this_chid)]?.avatar };
     return null;
 }
 
@@ -1664,7 +1664,7 @@ async function syncUserNameToPersona() {
  * Only works if only the first message is present, and not in group mode.
  */
 export function retriggerFirstMessageOnEmptyChat() {
-    if (this_chid >= 0 && !selected_group && chat.length === 1) {
+    if (Number(this_chid) >= 0 && !selected_group && chat.length === 1) {
         $('#firstmessage_textarea').trigger('input');
     }
 }
@@ -1979,4 +1979,3 @@ export async function initPersonas() {
     eventSource.on(event_types.CHAT_CHANGED, loadPersonaForCurrentChat);
     switchPersonaGridView();
 }
-

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -111,6 +111,7 @@ export function setUserAvatar(imgfile, { toastPersonaNameChange = true, navigate
     reloadUserAvatar();
     updatePersonaUIStates({ navigateToCurrent: navigateToCurrent });
     selectCurrentPersona({ toastPersonaNameChange: toastPersonaNameChange });
+    retriggerFirstMessageOnEmptyChat();
     saveSettingsDebounced();
     $('.zoomed_avatar[forchar]').remove();
 }
@@ -1782,7 +1783,6 @@ function setNameCallback({ mode = 'all' }, name) {
         if (!persona) persona = Object.entries(power_user.personas).find(([_, personaName]) => personaName.toLowerCase() === name.toLowerCase())?.[1];
         if (persona) {
             autoSelectPersona(persona);
-            retriggerFirstMessageOnEmptyChat();
             return '';
         } else if (mode === 'lookup') {
             toastr.warning(`Persona ${name} not found`);
@@ -1793,7 +1793,6 @@ function setNameCallback({ mode = 'all' }, name) {
     if (['temp', 'all'].includes(mode)) {
         // Otherwise, set just the name
         setUserName(name); //this prevented quickReply usage
-        retriggerFirstMessageOnEmptyChat();
     }
 
     return '';
@@ -1944,9 +1943,6 @@ export async function initPersonas() {
     $(document).on('click', '#user_avatar_block .avatar-container', function () {
         const imgfile = $(this).attr('data-avatar-id');
         setUserAvatar(imgfile);
-
-        // force firstMes {{user}} update on persona switch
-        retriggerFirstMessageOnEmptyChat();
     });
 
     $('#persona_rename_button').on('click', () => renamePersona(user_avatar));


### PR DESCRIPTION
There was no retrigger/rerender of the first message on persona switch. See explanation in the ticket.
Instead of adding it there, I moved the retrigger into `setUserAvatar`. Should always be called when that one is called anywhere - and was, in nearly all places.

Fixes #3774

Bonus: Fixed all linting error in `personas.js` that treated `this_chid` as a number even though it's a string.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
