### PR TITLE
Added api check for ConnectionManagerRequestService.handleDropdown

### DIFF
--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -384,7 +384,7 @@ export class ConnectionManagerRequestService {
      * @returns {boolean}
      */
     static isProfileSupported(profile) {
-        if (!profile) {
+        if (!profile || !profile.api) {
             return false;
         }
 


### PR DESCRIPTION

Without this check, users are getting errors because of their profiles that don't contain API