### PR TITLE
Clickable image attachments — no more fiddling with the magnifying glass button.

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -1608,7 +1608,7 @@ jQuery(function () {
         reloadCurrentChat();
     });
 
-    $(document).on('click', '.mes_img.img_inline', expandMessageImage);
+    $(document).on('click', '.mes_img', expandMessageImage);
     $(document).on('click', '.mes_img_enlarge', expandAndZoomMessageImage);
     $(document).on('click', '.mes_img_delete', deleteMessageImage);
 

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -575,8 +575,8 @@ export function isExternalMediaAllowed() {
     return !power_user.forbid_external_media;
 }
 
-async function enlargeMessageImage() {
-    const mesBlock = $(this).closest('.mes');
+function expandMessageImage(event) {
+    const mesBlock = $(event.currentTarget).closest('.mes');
     const mesId = mesBlock.attr('mesid');
     const message = chat[mesId];
     const imgSrc = message?.extra?.image;
@@ -620,7 +620,12 @@ async function enlargeMessageImage() {
         popup.completeCancelled();
     });
 
-    await popup.show();
+    popup.show();
+    return img;
+}
+
+function expandAndZoomMessageImage(event) {
+    expandMessageImage(event).click();
 }
 
 async function deleteMessageImage() {
@@ -1603,7 +1608,8 @@ jQuery(function () {
         reloadCurrentChat();
     });
 
-    $(document).on('click', '.mes_img_enlarge', enlargeMessageImage);
+    $(document).on('click', '.mes_img.img_inline', expandMessageImage);
+    $(document).on('click', '.mes_img_enlarge', expandAndZoomMessageImage);
     $(document).on('click', '.mes_img_delete', deleteMessageImage);
 
     $('#file_form_input').on('change', async () => {

--- a/public/style.css
+++ b/public/style.css
@@ -4990,6 +4990,10 @@ a:hover {
     padding: 0.5rem;
 }
 
+.mes_img.img_inline {
+    cursor: pointer;
+}
+
 .mes_img {
     border-radius: 10px;
     max-width: 100%;

--- a/public/style.css
+++ b/public/style.css
@@ -4990,15 +4990,12 @@ a:hover {
     padding: 0.5rem;
 }
 
-.mes_img.img_inline {
-    cursor: pointer;
-}
-
 .mes_img {
     border-radius: 10px;
     max-width: 100%;
     max-height: 40vh;
     image-rendering: -webkit-optimize-contrast;
+    cursor: pointer;
 }
 
 .mes_img_swipes,


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Now the image itself in a message can be clicked to expand it.  
The magnifying glass button now expands and immediately zooms in.

Will explain code changes in self-review.