### PR TITLE
Add support for KoboldCpp embeddings in Vector Storage

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -1172,6 +1172,11 @@ async function createKoboldCppEmbeddings(items) {
 
     const embeddings = /** @type {Record<string, number[]>} */ ({});
     for (let i = 0; i < data.embeddings.length; i++) {
+        if (!Array.isArray(data.embeddings[i]) || data.embeddings[i].length === 0) {
+            toastr.warning('Reduce the chunk size and/or size threshold for files and try again.', 'KoboldCpp returned an empty embedding');
+            throw new Error('Invalid embedding data from KoboldCpp');
+        }
+
         embeddings[items[i]] = data.embeddings[i];
     }
 

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -803,6 +803,12 @@ async function getAdditionalArgs(items) {
         case 'webllm':
             args.embeddings = await createWebLlmEmbeddings(items);
             break;
+        case 'koboldcpp': {
+            const { embeddings, model } = await createKoboldCppEmbeddings(items);
+            args.embeddings = embeddings;
+            args.model = model;
+            break;
+        }
     }
     return args;
 }
@@ -872,6 +878,7 @@ function throwIfSourceInvalid() {
 
     if (settings.source === 'ollama' && !textgenerationwebui_settings.server_urls[textgen_types.OLLAMA] ||
         settings.source === 'vllm' && !textgenerationwebui_settings.server_urls[textgen_types.VLLM] ||
+        settings.source === 'koboldcpp' && !textgenerationwebui_settings.server_urls[textgen_types.KOBOLDCPP] ||
         settings.source === 'llamacpp' && !textgenerationwebui_settings.server_urls[textgen_types.LLAMACPP]) {
         throw new Error('Vectors: API URL missing', { cause: 'api_url_missing' });
     }
@@ -1071,6 +1078,7 @@ function toggleSettings() {
     $('#vllm_vectorsModel').toggle(settings.source === 'vllm');
     $('#nomicai_apiKey').toggle(settings.source === 'nomicai');
     $('#webllm_vectorsModel').toggle(settings.source === 'webllm');
+    $('#koboldcpp_vectorsModel').toggle(settings.source === 'koboldcpp');
     if (settings.source === 'webllm') {
         loadWebLlmModels();
     }
@@ -1136,6 +1144,41 @@ async function createWebLlmEmbeddings(items) {
         }
         return result;
     });
+}
+
+/**
+ * Creates KoboldCpp embeddings for a list of items.
+ * @param {string[]} items Items to embed
+ * @returns {Promise<{embeddings: Record<string, number[]>, model: string}>} Calculated embeddings
+ */
+async function createKoboldCppEmbeddings(items) {
+    const response = await fetch('/api/backends/kobold/embed', {
+        method: 'POST',
+        headers: getRequestHeaders(),
+        body: JSON.stringify({
+            items: items,
+            server: textgenerationwebui_settings.server_urls[textgen_types.KOBOLDCPP],
+        }),
+    });
+
+    if (!response.ok) {
+        throw new Error('Failed to get KoboldCpp embeddings');
+    }
+
+    const data = await response.json();
+    if (!Array.isArray(data.embeddings) || !data.model || data.embeddings.length !== items.length) {
+        throw new Error('Invalid response from KoboldCpp embeddings');
+    }
+
+    const embeddings = /** @type {Record<string, number[]>} */ ({});
+    for (let i = 0; i < data.embeddings.length; i++) {
+        embeddings[items[i]] = data.embeddings[i];
+    }
+
+    return {
+        embeddings: embeddings,
+        model: data.model,
+    };
 }
 
 async function onPurgeClick() {

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -565,6 +565,8 @@ async function retrieveFileChunks(queryText, collectionId) {
  * @returns {Promise<boolean>} True if successful, false if not
  */
 async function vectorizeFile(fileText, fileName, collectionId, chunkSize, overlapPercent) {
+    let toast = jQuery();
+
     try {
         if (settings.translate_files && typeof globalThis.translate === 'function') {
             console.log(`Vectors: Translating file ${fileName} to English...`);
@@ -574,7 +576,7 @@ async function vectorizeFile(fileText, fileName, collectionId, chunkSize, overla
 
         const batchSize = getBatchSize();
         const toastBody = $('<span>').text('This may take a while. Please wait...');
-        const toast = toastr.info(toastBody, `Ingesting file ${escapeHtml(fileName)}`, { closeButton: false, escapeHtml: false, timeOut: 0, extendedTimeOut: 0 });
+        toast = toastr.info(toastBody, `Ingesting file ${escapeHtml(fileName)}`, { closeButton: false, escapeHtml: false, timeOut: 0, extendedTimeOut: 0 });
         const overlapSize = Math.round(chunkSize * overlapPercent / 100);
         const delimiters = getChunkDelimiters();
         // Overlap should not be included in chunk size. It will be later compensated by overlapChunks
@@ -596,6 +598,7 @@ async function vectorizeFile(fileText, fileName, collectionId, chunkSize, overla
         console.log(`Vectors: Inserted ${chunks.length} vector items for file ${fileName} into ${collectionId}`);
         return true;
     } catch (error) {
+        toastr.clear(toast);
         toastr.error(String(error), 'Failed to vectorize file', { preventDuplicates: true });
         console.error('Vectors: Failed to vectorize file', error);
         return false;
@@ -1173,8 +1176,7 @@ async function createKoboldCppEmbeddings(items) {
     const embeddings = /** @type {Record<string, number[]>} */ ({});
     for (let i = 0; i < data.embeddings.length; i++) {
         if (!Array.isArray(data.embeddings[i]) || data.embeddings[i].length === 0) {
-            toastr.warning('Reduce the chunk size and/or size threshold for files and try again.', 'KoboldCpp returned an empty embedding');
-            throw new Error('Invalid embedding data from KoboldCpp');
+            throw new Error('KoboldCpp returned an empty embedding. Reduce the chunk size and/or size threshold and try again.');
         }
 
         embeddings[items[i]] = data.embeddings[i];

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -13,6 +13,7 @@
                     <option value="cohere">Cohere</option>
                     <option value="extras">Extras (deprecated)</option>
                     <option value="palm">Google AI Studio</option>
+                    <option value="koboldcpp">KoboldCpp</option>
                     <option value="llamacpp">llama.cpp</option>
                     <option value="transformers" data-i18n="Local (Transformers)">Local (Transformers)</option>
                     <option value="mistral">MistralAI</option>
@@ -54,6 +55,14 @@
                 <i data-i18n="Hint: Set the URL in the API connection settings.">
                     Hint: Set the URL in the API connection settings.
                 </i>
+            </div>
+            <div class="flex-container flexFlowColumn" id="koboldcpp_vectorsModel">
+                <span>
+                    Set the KoboldCpp URL in the Text Completion API connection settings.
+                </span>
+                <span>
+                    Must use version 1.87 or higher and have an embedding model loaded.
+                </span>
             </div>
             <div class="flex-container flexFlowColumn" id="llamacpp_vectorsModel">
                 <span data-i18n="The server MUST be started with the --embedding flag to use this feature!">

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -31,6 +31,7 @@ const SOURCES = [
     'llamacpp',
     'vllm',
     'webllm',
+    'koboldcpp',
 ];
 
 /**
@@ -65,6 +66,8 @@ async function getVector(source, sourceSettings, text, isQuery, directories) {
         case 'ollama':
             return getOllamaVector(text, sourceSettings.apiUrl, sourceSettings.model, sourceSettings.keep, directories);
         case 'webllm':
+            return sourceSettings.embeddings[text];
+        case 'koboldcpp':
             return sourceSettings.embeddings[text];
     }
 
@@ -117,6 +120,9 @@ async function getBatchVector(source, sourceSettings, texts, isQuery, directorie
                 results.push(...await getOllamaBatchVector(batch, sourceSettings.apiUrl, sourceSettings.model, sourceSettings.keep, directories));
                 break;
             case 'webllm':
+                results.push(...texts.map(x => sourceSettings.embeddings[x]));
+                break;
+            case 'koboldcpp':
                 results.push(...texts.map(x => sourceSettings.embeddings[x]));
                 break;
             default:
@@ -185,6 +191,11 @@ function getSourceSettings(source, request) {
                 model: 'nomic-embed-text-v1.5',
             };
         case 'webllm':
+            return {
+                model: String(request.body.model),
+                embeddings: request.body.embeddings ?? {},
+            };
+        case 'koboldcpp':
             return {
                 model: String(request.body.model),
                 embeddings: request.body.embeddings ?? {},


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Requires the latest KoboldCpp release and a GGUF model.

https://github.com/LostRuins/koboldcpp/releases/tag/v1.87
https://huggingface.co/yixuan-chia/snowflake-arctic-embed-s-

---

This pull request introduces support for the KoboldCpp embedding model in the vectors extension. The changes span multiple files and primarily focus on adding functionality to handle embeddings from the KoboldCpp model.

Key changes include:

### Enhancements to Embeddings Handling:
* Added a new case for `koboldcpp` in the `getAdditionalArgs` function to handle embeddings and model retrieval. (`public/scripts/extensions/vectors/index.js`)
* Implemented a new function `createKoboldCppEmbeddings` to fetch embeddings from the KoboldCpp API and process the response. (`public/scripts/extensions/vectors/index.js`)

### Validation and UI Updates:
* Updated the `throwIfSourceInvalid` function to include validation for the KoboldCpp source. (`public/scripts/extensions/vectors/index.js`)
* Modified the `toggleSettings` function to toggle the visibility of the KoboldCpp settings UI element. (`public/scripts/extensions/vectors/index.js`)
* Added new UI elements in the settings HTML to support KoboldCpp, including instructions and requirements. (`public/scripts/extensions/vectors/settings.html`) [[1]](diffhunk://#diff-beaedec9fd04d767ff35874b25759c9782bba8eda082768e2719afe0f5242231R16) [[2]](diffhunk://#diff-beaedec9fd04d767ff35874b25759c9782bba8eda082768e2719afe0f5242231R59-R66)

### Backend Support:
* Added a new endpoint `/embed` in the Kobold backend to handle embedding requests and process responses from the KoboldCpp API. (`src/endpoints/backends/kobold.js`)
* Updated the vectors endpoint to recognize `koboldcpp` as a valid source and handle embedding retrieval accordingly. (`src/endpoints/vectors.js`) [[1]](diffhunk://#diff-282a48a5efe2a9ff5c2ee12c095f03c0b82f764d941cd536986dc735547404a4R34) [[2]](diffhunk://#diff-282a48a5efe2a9ff5c2ee12c095f03c0b82f764d941cd536986dc735547404a4R70-R71) [[3]](diffhunk://#diff-282a48a5efe2a9ff5c2ee12c095f03c0b82f764d941cd536986dc735547404a4R125-R127) [[4]](diffhunk://#diff-282a48a5efe2a9ff5c2ee12c095f03c0b82f764d941cd536986dc735547404a4R198-R202)

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
