### PR TITLE
Add collapse argument to `/reasoning-set` slash command

### DIFF
--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -832,6 +832,12 @@ function registerReasoningSlashCommands() {
                 typeList: ARGUMENT_TYPE.NUMBER,
                 enumProvider: commonEnumProviders.messages(),
             }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'collapse',
+                description: 'Whether to collapse the reasoning block. (If not provided, uses the default expand setting)',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
         ],
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
@@ -856,6 +862,9 @@ function registerReasoningSlashCommands() {
 
             closeMessageEditor('reasoning');
             updateMessageBlock(messageId, message);
+
+            if (isTrueBoolean(String(args.collapse))) $(`#chat [mesid="${messageId}"] .mes_reasoning_details`).removeAttr('open');
+            if (isFalseBoolean(String(args.collapse))) $(`#chat [mesid="${messageId}"] .mes_reasoning_details`).attr('open', '');
             return message.extra.reasoning;
         },
     }));


### PR DESCRIPTION
Allows controlling visibility of reasoning blocks through slash commands by adding a boolean 'collapse' parameter Respects default expansion settings when not explicitly provided

This gives users direct control over block visibility during command execution rather than relying solely on global preferences

@Succubyss 

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).

## Copilot
This pull request includes changes to the `public/scripts/reasoning.js` file to enhance the functionality of the reasoning slash commands. The most important changes include adding a new argument to control the collapse state of the reasoning block and updating the message block based on this argument.

Enhancements to reasoning slash commands:

* Added a new named argument `collapse` to the `registerReasoningSlashCommands` function to allow users to specify whether to collapse the reasoning block. This argument accepts a boolean value.
* Updated the message block logic in the `registerReasoningSlashCommands` function to collapse or expand the reasoning block based on the value of the `collapse` argument.