### PR TITLE
Prevent similarily-ish world info, preset and chat file renames (preventing data loss on on case-insensitive systems)

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9884,7 +9884,7 @@ export async function renameChat(oldFileName, newName) {
         return;
     }
     if (equalsIgnoreCaseAndAccents(body.original_file, body.renamed_file)) {
-        toastr.warning('Name not accepted, as it is the same as before (ignoring case and accents).', 'Rename Chat');
+        toastr.warning(t`Name not accepted, as it is the same as before (ignoring case and accents).`, t`Rename Chat`);
         return;
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -173,6 +173,7 @@ import {
     escapeHtml,
     saveBase64AsFile,
     uuidv4,
+    equalsIgnoreCaseAndAccents,
 } from './scripts/utils.js';
 import { debounce_timeout, IGNORE_SYMBOL } from './scripts/constants.js';
 
@@ -9877,6 +9878,11 @@ export async function renameChat(oldFileName, newName) {
         original_file: `${oldFileName}.jsonl`,
         renamed_file: `${newName.trim()}.jsonl`,
     };
+
+    if (equalsIgnoreCaseAndAccents(body.original_file, body.renamed_file)) {
+        console.warn('Chat name is the same (ignoring case and accents)');
+        return;
+    }
 
     try {
         showLoader();

--- a/public/script.js
+++ b/public/script.js
@@ -9879,8 +9879,12 @@ export async function renameChat(oldFileName, newName) {
         renamed_file: `${newName.trim()}.jsonl`,
     };
 
+    if (body.original_file === body.renamed_file) {
+        console.debug('Chat rename cancelled, old and new names are the same');
+        return;
+    }
     if (equalsIgnoreCaseAndAccents(body.original_file, body.renamed_file)) {
-        console.warn('Chat name is the same (ignoring case and accents)');
+        toastr.warning('Name not accepted, as it is the same as before (ignoring case and accents).', 'Rename Chat');
         return;
     }
 

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -896,7 +896,7 @@ export async function initPresetManager() {
             return;
         }
         if (equalsIgnoreCaseAndAccents(oldName, newName)) {
-            toastr.warning('Name not accepted, as it is the same as before (ignoring case and accents).', 'Rename Preset');
+            toastr.warning(t`Name not accepted, as it is the same as before (ignoring case and accents).`, t`Rename Preset`);
             return;
         }
 

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -36,7 +36,7 @@ import {
     textgenerationwebui_presets,
     textgenerationwebui_settings as textgen_settings,
 } from './textgen-settings.js';
-import { download, parseJsonFile, waitUntilCondition } from './utils.js';
+import { download, equalsIgnoreCaseAndAccents, parseJsonFile, waitUntilCondition } from './utils.js';
 import { t } from './i18n.js';
 import { reasoning_templates } from './reasoning.js';
 
@@ -454,6 +454,9 @@ class PresetManager {
 
     async renamePreset(newName) {
         const oldName = this.getSelectedPresetName();
+        if (equalsIgnoreCaseAndAccents(oldName, newName)) {
+            throw new Error('New name must be different from old name');
+        }
         try {
             await this.savePreset(newName);
             await this.deletePreset(oldName);
@@ -890,6 +893,10 @@ export async function initPresetManager() {
         const newName = await Popup.show.input(popupHeader, t`Enter a new name:`, oldName);
         if (!newName || oldName === newName) {
             console.debug(!presetManager.isAdvancedFormatting() ? 'Preset rename cancelled' : 'Template rename cancelled');
+            return;
+        }
+        if (equalsIgnoreCaseAndAccents(oldName, newName)) {
+            console.warn('Preset name is the same (ignoring case and accents)');
             return;
         }
 

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -896,7 +896,7 @@ export async function initPresetManager() {
             return;
         }
         if (equalsIgnoreCaseAndAccents(oldName, newName)) {
-            console.warn('Preset name is the same (ignoring case and accents)');
+            toastr.warning('Name not accepted, as it is the same as before (ignoring case and accents).', 'Rename Preset');
             return;
         }
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3587,7 +3587,7 @@ async function renameWorldInfo(name, data) {
         return;
     }
     if (equalsIgnoreCaseAndAccents(oldName, newName)) {
-        console.warn('World info name is the same (ignoring case and accents)');
+        toastr.warning('Name not accepted, as it is the same as before (ignoring case and accents).', 'Rename World Info');
         return;
     }
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1,7 +1,7 @@
 import { Fuse } from '../lib.js';
 
 import { saveSettings, substituteParams, getRequestHeaders, chat_metadata, this_chid, characters, saveCharacterDebounced, menu_type, eventSource, event_types, getExtensionPromptByName, saveMetadata, getCurrentChatId, extension_prompt_roles } from '../script.js';
-import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique } from './utils.js';
+import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents } from './utils.js';
 import { extension_settings, getContext } from './extensions.js';
 import { NOTE_MODULE_NAME, metadata_keys, shouldWIAddPrompt } from './authors-note.js';
 import { isMobile } from './RossAscends-mods.js';
@@ -3584,6 +3584,10 @@ async function renameWorldInfo(name, data) {
 
     if (oldName === newName || !newName) {
         console.debug('World info rename cancelled');
+        return;
+    }
+    if (equalsIgnoreCaseAndAccents(oldName, newName)) {
+        console.warn('World info name is the same (ignoring case and accents)');
         return;
     }
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3587,7 +3587,7 @@ async function renameWorldInfo(name, data) {
         return;
     }
     if (equalsIgnoreCaseAndAccents(oldName, newName)) {
-        toastr.warning('Name not accepted, as it is the same as before (ignoring case and accents).', 'Rename World Info');
+        toastr.warning(t`Name not accepted, as it is the same as before (ignoring case and accents).`, t`Rename World Info`);
         return;
     }
 


### PR DESCRIPTION
Thanks Giglio.
This is actually somewhat critical, because it literally deletes your WI Lorebook if you simply change casing in names.

Happens because the WI rename calls /save and then /delete after, just using the file name as part of the path for the file to delete.
At least on windows, this will delete the new/same file.

This now works like renames in many other apps. You first have to rename to an actually different name, then back to the one before with different casing.
That's a workaround we have to live with.

I think this way is cleaner.

Edit: Added the same functionality for presets and chat.
Presets had the same bug with data loss, chat files just had a 400 error on the backend.

### Reasoning
Adds validation to block renaming world info entries when new name matches existing name after ignoring case and accents

This avoids unnecessary operations and potential data duplication issues caused by superficial name changes that don't meaningfully differ in normalized form

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).

## Copilot
This pull request includes changes to the `public/scripts/world-info.js` file to enhance the functionality of renaming world information. The most important changes include adding a new utility function and improving the rename function to handle case and accent insensitivity.

### Improvements to world info renaming:

* [`public/scripts/world-info.js`](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496L4-R4): Imported the new utility function `equalsIgnoreCaseAndAccents` from `utils.js`.
* [`public/scripts/world-info.js`](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R3589-R3592): Added a check in the `renameWorldInfo` function to log a warning and return early if the new name is the same as the old name, ignoring case and accents.