### PR TITLE
Added proxy support to ChatCompletionService

### DIFF
--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -43,10 +43,12 @@ import EventSourceStream from './sse-stream.js';
  * @property {boolean?} [stream=false] - Whether to stream the response
  * @property {ChatCompletionMessage[]} messages - Array of chat messages
  * @property {string} [model] - Optional model name to use for completion
- * @property {string} chat_completion_source - Source provider for chat completion
+ * @property {string} chat_completion_source - Source provider
  * @property {number} max_tokens - Maximum number of tokens to generate
  * @property {number} [temperature] - Optional temperature parameter for response randomness
- * @property {string} [custom_url] - Optional custom URL for chat completion
+ * @property {string} [custom_url] - Optional custom URL
+ * @property {string} [reverse_proxy] - Optional reverse proxy URL
+ * @property {string} [proxy_password] - Optional proxy password
  */
 
 /** @typedef {Record<string, any> & ChatCompletionPayloadBase} ChatCompletionPayload */
@@ -387,7 +389,7 @@ export class ChatCompletionService {
      * @param {ChatCompletionPayload} custom
      * @returns {ChatCompletionPayload}
      */
-    static createRequestData({ stream = false, messages, model, chat_completion_source, max_tokens, temperature, custom_url, ...props }) {
+    static createRequestData({ stream = false, messages, model, chat_completion_source, max_tokens, temperature, custom_url, reverse_proxy, proxy_password, ...props }) {
         const payload = {
             ...props,
             stream,
@@ -397,6 +399,8 @@ export class ChatCompletionService {
             max_tokens,
             temperature,
             custom_url,
+            reverse_proxy,
+            proxy_password,
         };
 
         // Remove undefined values to avoid API errors

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -82,7 +82,6 @@ export class TextCompletionService {
      */
     static createRequestData({ stream = false, prompt, max_tokens, model, api_type, api_server, temperature, min_p, ...props }) {
         const payload = {
-            ...props,
             stream,
             prompt,
             max_tokens,
@@ -92,6 +91,7 @@ export class TextCompletionService {
             api_server: api_server ?? getTextGenServer(api_type),
             temperature,
             min_p,
+            ...props,
         };
 
         // Remove undefined values to avoid API errors
@@ -391,7 +391,6 @@ export class ChatCompletionService {
      */
     static createRequestData({ stream = false, messages, model, chat_completion_source, max_tokens, temperature, custom_url, reverse_proxy, proxy_password, ...props }) {
         const payload = {
-            ...props,
             stream,
             messages,
             model,
@@ -401,6 +400,9 @@ export class ChatCompletionService {
             custom_url,
             reverse_proxy,
             proxy_password,
+            use_makersuite_sysprompt: true,
+            claude_use_sysprompt: true,
+            ...props,
         };
 
         // Remove undefined values to avoid API errors

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -306,9 +306,10 @@ export class ConnectionManagerRequestService {
      * @param {boolean?} [custom.includePreset=true]
      * @param {boolean?} [custom.includeInstruct=true]
      * @param {Partial<InstructSettings>?} [custom.instructSettings] Override instruct settings
+     * @param {Record<string, any>} [overridePayload] - Override payload for the request
      * @returns {Promise<import('../custom-request.js').ExtractedData | (() => AsyncGenerator<import('../custom-request.js').StreamResponse>)>} If not streaming, returns extracted data; if streaming, returns a function that creates an AsyncGenerator
      */
-    static async sendRequest(profileId, prompt, maxTokens, custom = this.defaultSendRequestParams) {
+    static async sendRequest(profileId, prompt, maxTokens, custom = this.defaultSendRequestParams, overridePayload = {}) {
         const { stream, signal, extractData, includePreset, includeInstruct, instructSettings } = { ...this.defaultSendRequestParams, ...custom };
 
         const context = SillyTavern.getContext();
@@ -338,6 +339,7 @@ export class ConnectionManagerRequestService {
                         custom_url: profile['api-url'],
                         reverse_proxy: proxyPreset?.url,
                         proxy_password: proxyPreset?.password,
+                        ...overridePayload,
                     }, {
                         presetName: includePreset ? profile.preset : undefined,
                     }, extractData, signal);
@@ -354,6 +356,7 @@ export class ConnectionManagerRequestService {
                         model: profile.model,
                         api_type: selectedApiMap.type,
                         api_server: profile['api-url'],
+                        ...overridePayload,
                     }, {
                         instructName: includeInstruct ? profile.instruct : undefined,
                         presetName: includePreset ? profile.preset : undefined,

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -1,7 +1,7 @@
 import { CONNECT_API_MAP, getRequestHeaders } from '../../script.js';
 import { extension_settings, openThirdPartyExtensionMenu } from '../extensions.js';
 import { t } from '../i18n.js';
-import { oai_settings } from '../openai.js';
+import { oai_settings, proxies } from '../openai.js';
 import { SECRET_KEYS, secret_state } from '../secrets.js';
 import { textgen_types, textgenerationwebui_settings } from '../textgen-settings.js';
 import { getTokenCountAsync } from '../tokenizers.js';
@@ -326,6 +326,8 @@ export class ConnectionManagerRequestService {
                         throw new Error(`API type ${selectedApiMap.selected} does not support chat completions`);
                     }
 
+                    const proxyPreset = proxies.find((p) => p.name === profile.proxy);
+
                     const messages = Array.isArray(prompt) ? prompt : [{ role: 'user', content: prompt }];
                     return await context.ChatCompletionService.processRequest({
                         stream,
@@ -334,6 +336,8 @@ export class ConnectionManagerRequestService {
                         model: profile.model,
                         chat_completion_source: selectedApiMap.source,
                         custom_url: profile['api-url'],
+                        reverse_proxy: proxyPreset?.url,
+                        proxy_password: proxyPreset?.password,
                     }, {
                         presetName: includePreset ? profile.preset : undefined,
                     }, extractData, signal);


### PR DESCRIPTION
- Added reverse proxy support.
- Enabled sysprompt by default for claude and makersuite (I only saw those two)
- Added ability to override request payload. This is not going to break API. For example, the extension developers can override the default sysprompt behaviour. Feel free to oppose.