### PR TITLE
chore: add llama 4 chat templates & separate system from user role in chat template for llama 3

### DIFF
--- a/default/content/index.json
+++ b/default/content/index.json
@@ -564,6 +564,10 @@
         "type": "context"
     },
     {
+        "filename": "presets/context/Llama 4 Instruct.json",
+        "type": "context"
+    },
+    {
         "filename": "presets/context/Phi.json",
         "type": "context"
     },
@@ -661,6 +665,10 @@
     },
     {
         "filename": "presets/instruct/Llama 3 Instruct.json",
+        "type": "instruct"
+    },
+    {
+        "filename": "presets/instruct/Llama 4 Instruct.json",
         "type": "instruct"
     },
     {

--- a/default/content/presets/context/Llama 4 Instruct.json
+++ b/default/content/presets/context/Llama 4 Instruct.json
@@ -1,5 +1,5 @@
 {
-    "story_string": "<|start_header_id|>system<|end_header_id|>\n\n{{#if system}}{{system}}\n{{/if}}{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{persona}}\n{{/if}}{{trim}}<|eot|>",
+    "story_string": "<|header_start|>system<|header_end|>\n\n{{#if system}}{{system}}\n{{/if}}{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{persona}}\n{{/if}}{{trim}}<|eot|>",
     "example_separator": "",
     "chat_start": "",
     "use_stop_strings": false,

--- a/default/content/presets/context/Llama 4 Instruct.json
+++ b/default/content/presets/context/Llama 4 Instruct.json
@@ -1,5 +1,5 @@
 {
-    "story_string": "<|header_start|>system<|header_end|>\n\n{{#if system}}{{system}}\n{{/if}}{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{persona}}\n{{/if}}{{trim}}<|eot|>",
+    "story_string": "<|begin_of_text|><|header_start|>system<|header_end|>\n\n{{#if system}}{{system}}\n{{/if}}{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{persona}}\n{{/if}}{{trim}}<|eot|>",
     "example_separator": "",
     "chat_start": "",
     "use_stop_strings": false,

--- a/default/content/presets/context/Llama 4 Instruct.json
+++ b/default/content/presets/context/Llama 4 Instruct.json
@@ -1,0 +1,11 @@
+{
+    "story_string": "<|start_header_id|>system<|end_header_id|>\n\n{{#if system}}{{system}}\n{{/if}}{{#if wiBefore}}{{wiBefore}}\n{{/if}}{{#if description}}{{description}}\n{{/if}}{{#if personality}}{{char}}'s personality: {{personality}}\n{{/if}}{{#if scenario}}Scenario: {{scenario}}\n{{/if}}{{#if wiAfter}}{{wiAfter}}\n{{/if}}{{#if persona}}{{persona}}\n{{/if}}{{trim}}<|eot|>",
+    "example_separator": "",
+    "chat_start": "",
+    "use_stop_strings": false,
+    "allow_jailbreak": false,
+    "always_force_name2": true,
+    "trim_sentences": false,
+    "single_line": false,
+    "name": "Llama 4 Instruct"
+}

--- a/default/content/presets/instruct/Llama 3 Instruct.json
+++ b/default/content/presets/instruct/Llama 3 Instruct.json
@@ -16,7 +16,7 @@
     "input_suffix": "<|eot_id|>",
     "system_suffix": "<|eot_id|>",
     "user_alignment_message": "",
-    "system_same_as_user": true,
+    "system_same_as_user": false,
     "last_system_sequence": "",
     "name": "Llama 3 Instruct"
 }

--- a/default/content/presets/instruct/Llama 4 Instruct.json
+++ b/default/content/presets/instruct/Llama 4 Instruct.json
@@ -1,8 +1,8 @@
 {
-    "input_sequence": "<|start_header_id|>user<|end_header_id|>\n\n",
-    "output_sequence": "<|start_header_id|>assistant<|end_header_id|>\n\n",
+    "input_sequence": "<|header_start|>user<|header_end|>\n\n",
+    "output_sequence": "<|header_start|>assistant<|header_end|>\n\n",
     "last_output_sequence": "",
-    "system_sequence": "<|start_header_id|>system<|end_header_id|>\n\n",
+    "system_sequence": "<|header_start|>system<|header_end|>\n\n",
     "stop_sequence": "<|eot|>",
     "wrap": false,
     "macro": true,

--- a/default/content/presets/instruct/Llama 4 Instruct.json
+++ b/default/content/presets/instruct/Llama 4 Instruct.json
@@ -1,0 +1,22 @@
+{
+    "input_sequence": "<|start_header_id|>user<|end_header_id|>\n\n",
+    "output_sequence": "<|start_header_id|>assistant<|end_header_id|>\n\n",
+    "last_output_sequence": "",
+    "system_sequence": "<|start_header_id|>system<|end_header_id|>\n\n",
+    "stop_sequence": "<|eot|>",
+    "wrap": false,
+    "macro": true,
+    "names_behavior": "always",
+    "activation_regex": "",
+    "system_sequence_prefix": "",
+    "system_sequence_suffix": "",
+    "first_output_sequence": "",
+    "skip_examples": false,
+    "output_suffix": "<|eot|>",
+    "input_suffix": "<|eot|>",
+    "system_suffix": "<|eot|>",
+    "user_alignment_message": "",
+    "system_same_as_user": true,
+    "last_system_sequence": "",
+    "name": "Llama 4 Instruct"
+}

--- a/default/content/presets/instruct/Llama 4 Instruct.json
+++ b/default/content/presets/instruct/Llama 4 Instruct.json
@@ -16,7 +16,7 @@
     "input_suffix": "<|eot|>",
     "system_suffix": "<|eot|>",
     "user_alignment_message": "",
-    "system_same_as_user": true,
+    "system_same_as_user": false,
     "last_system_sequence": "",
     "name": "Llama 4 Instruct"
 }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Explanation:

Following the documentation [here](https://www.llama.com/docs/model-cards-and-prompt-formats/llama4_omni/), the chat template has changed.

Here's the example prompt:

```
<|begin_of_text|><|header_start|>system<|header_end|>

You are a helpful assistant<|eot|><|header_start|>user<|header_end|>

Answer who are you in the form of jeopardy?<|eot|><|header_start|>assistant<|header_end|>
```

And the example response:

```
"What am I?"

(Wait for it...)

I am a helpful assistant, what am I?

Answer should be in the form:

Who is a helpful assistant?<|eot|>
```