### PR TITLE
Added option to use secondary API URL in vector extension

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -1475,12 +1475,12 @@ jQuery(async () => {
         settings.use_alt_endpoint = $('#altEndpointUrl_enabled').prop('checked');
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
-    })
+    });
     $('#altEndpoint_address').val(settings.alt_endpoint_url).on('change', () => {
         settings.alt_endpoint_url = String($('#altEndpoint_address').val());
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
-    })
+    });
     $('#api_key_nomicai').on('click', async () => {
         const popupText = 'NomicAI API Key:';
         const key = await callGenericPopup(popupText, POPUP_TYPE.INPUT, '', {

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -111,7 +111,7 @@ const settings = {
 const moduleWorker = new ModuleWorkerWrapper(synchronizeChat);
 const webllmProvider = new WebLlmVectorProvider();
 const cachedSummaries = new Map();
-const vector_api_requires_url = ['llamacpp', 'vllm', 'ollama', 'koboldcpp'];
+const vectorApiRequiresUrl = ['llamacpp', 'vllm', 'ollama', 'koboldcpp'];
 
 /**
  * Gets the Collection ID for a file embedded in the chat.
@@ -886,11 +886,18 @@ function throwIfSourceInvalid() {
         throw new Error('Vectors: API key missing', { cause: 'api_key_missing' });
     }
 
-    if (settings.source === 'ollama' && !textgenerationwebui_settings.server_urls[textgen_types.OLLAMA] ||
-        settings.source === 'vllm' && !textgenerationwebui_settings.server_urls[textgen_types.VLLM] ||
-        settings.source === 'koboldcpp' && !textgenerationwebui_settings.server_urls[textgen_types.KOBOLDCPP] ||
-        settings.source === 'llamacpp' && !textgenerationwebui_settings.server_urls[textgen_types.LLAMACPP]) {
-        throw new Error('Vectors: API URL missing', { cause: 'api_url_missing' });
+    if (vectorApiRequiresUrl.includes(settings.source) && settings.use_alt_endpoint) {
+        if (!settings.alt_endpoint_url) {
+            throw new Error('Vectors: API URL missing', { cause: 'api_url_missing' });
+        }
+    }
+    else {
+        if (settings.source === 'ollama' && !textgenerationwebui_settings.server_urls[textgen_types.OLLAMA] ||
+            settings.source === 'vllm' && !textgenerationwebui_settings.server_urls[textgen_types.VLLM] ||
+            settings.source === 'koboldcpp' && !textgenerationwebui_settings.server_urls[textgen_types.KOBOLDCPP] ||
+            settings.source === 'llamacpp' && !textgenerationwebui_settings.server_urls[textgen_types.LLAMACPP]) {
+            throw new Error('Vectors: API URL missing', { cause: 'api_url_missing' });
+        }
     }
 
     if (settings.source === 'ollama' && !settings.ollama_model || settings.source === 'vllm' && !settings.vllm_model) {
@@ -1090,7 +1097,7 @@ function toggleSettings() {
     $('#webllm_vectorsModel').toggle(settings.source === 'webllm');
     $('#koboldcpp_vectorsModel').toggle(settings.source === 'koboldcpp');
     $('#google_vectorsModel').toggle(settings.source === 'palm');
-    $('#altEndpointUrl').toggle(vector_api_requires_url.includes(settings.source));
+    $('#vector_altEndpointUrl').toggle(vectorApiRequiresUrl.includes(settings.source));
     if (settings.source === 'webllm') {
         loadWebLlmModels();
     }
@@ -1471,13 +1478,13 @@ jQuery(async () => {
         saveSettingsDebounced();
         toggleSettings();
     });
-    $('#altEndpointUrl_enabled').prop('checked', settings.use_alt_endpoint).on('input', () => {
-        settings.use_alt_endpoint = $('#altEndpointUrl_enabled').prop('checked');
+    $('#vector_altEndpointUrl_enabled').prop('checked', settings.use_alt_endpoint).on('input', () => {
+        settings.use_alt_endpoint = $('#vector_altEndpointUrl_enabled').prop('checked');
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });
-    $('#altEndpoint_address').val(settings.alt_endpoint_url).on('change', () => {
-        settings.alt_endpoint_url = String($('#altEndpoint_address').val());
+    $('#vector_altEndpoint_address').val(settings.alt_endpoint_url).on('change', () => {
+        settings.alt_endpoint_url = String($('#vector_altEndpoint_address').val());
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -33,7 +33,7 @@
                 <label for="vector_altEndpoint_address" data-i18n="Secondary Embedding endpoint URL">
                     Secondary Embedding endpoint URL
                 </label>
-                <input id="vector_altEndpoint_address" class="text_pole" type="text" placeholder="URL for secondary endpoint" />
+                <input id="vector_altEndpoint_address" class="text_pole" type="text" placeholder="e.g. http://localhost:5001" />
             </div>
             <div class="flex-container flexFlowColumn" id="webllm_vectorsModel">
                 <label for="vectors_webllm_model" data-i18n="Vectorization Model">

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -25,15 +25,15 @@
                     <option value="webllm" data-i18n="WebLLM Extension">WebLLM Extension</option>
                 </select>
             </div>
-            <div class="flex-container flexFlowColumn" id="altEndpointUrl">
-                <label class="checkbox_label" for="altEndpointUrl_enabled" title="Enable secondary endpoint URL usage, instead of the main one.">
-                    <input id="altEndpointUrl_enabled" type="checkbox" class="checkbox">
+            <div class="flex-container flexFlowColumn" id="vector_altEndpointUrl">
+                <label class="checkbox_label" for="vector_altEndpointUrl_enabled" title="Enable secondary endpoint URL usage, instead of the main one.">
+                    <input id="vector_altEndpointUrl_enabled" type="checkbox" class="checkbox">
                     <span data-i18n="Use secondary URL">Use secondary URL</span>
                 </label>
-                <label for="altEndpoint_address" data-i18n="Secondary Embedding endpoint URL">
+                <label for="vector_altEndpoint_address" data-i18n="Secondary Embedding endpoint URL">
                     Secondary Embedding endpoint URL
                 </label>
-                <input id="altEndpoint_address" class="text_pole" type="text" placeholder="URL for secondary endpoint" />
+                <input id="vector_altEndpoint_address" class="text_pole" type="text" placeholder="URL for secondary endpoint" />
             </div>
             <div class="flex-container flexFlowColumn" id="webllm_vectorsModel">
                 <label for="vectors_webllm_model" data-i18n="Vectorization Model">

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -25,6 +25,16 @@
                     <option value="webllm" data-i18n="WebLLM Extension">WebLLM Extension</option>
                 </select>
             </div>
+            <div class="flex-container flexFlowColumn" id="altEndpointUrl">
+                <label class="checkbox_label" for="altEndpointUrl_enabled" title="Enable secondary endpoint URL usage, instead of the main one.">
+                    <input id="altEndpointUrl_enabled" type="checkbox" class="checkbox">
+                    <span data-i18n="Use secondary URL">Use secondary URL</span>
+                </label>
+                <label for="altEndpoint_address" data-i18n="Secondary Embedding endpoint URL">
+                    Secondary Embedding endpoint URL
+                </label>
+                <input id="altEndpoint_address" class="text_pole" type="text" placeholder="URL for secondary endpoint" />
+            </div>
             <div class="flex-container flexFlowColumn" id="webllm_vectorsModel">
                 <label for="vectors_webllm_model" data-i18n="Vectorization Model">
                     Vectorization Model


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Implemented the ability to use secondary instance of the same API for vector embeddings (e.g. two llamacpp servers) as was discussed in https://github.com/SillyTavern/SillyTavern/discussions/3473#discussioncomment-12196930
