### PR TITLE
Fix nested inline-drawer behavior

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -11847,8 +11847,8 @@ jQuery(async function () {
             return;
         }
         const drawer = $(this).closest('.inline-drawer');
-        const icon = drawer.find('.inline-drawer-icon');
-        const drawerContent = drawer.find('.inline-drawer-content');
+        const icon = drawer.find('>.inline-drawer-header .inline-drawer-icon');
+        const drawerContent = drawer.find('>.inline-drawer-content');
         icon.toggleClass('down up');
         icon.toggleClass('fa-circle-chevron-down fa-circle-chevron-up');
         drawerContent.stop().slideToggle({


### PR DESCRIPTION
Simple fix to the inline-drawer event handler which currently does not work with nested drawers. At the moment, the selector will pick up on **every** `.inline-drawer-icon` and `.inline-drawer-content` inside the triggered `inline-drawer`, which causes every nested drawer to be affected as well. This fixes this behavior by selecting direct children instead.

At the moment I don't think there are any nested inline drawers that are affected by this change, but it opens up this possibility for future layout changes.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
