### PR TITLE
[Fix] Edge Browser TTS Compatibility

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6261,7 +6261,6 @@ export function syncMesToSwipe(messageId = null) {
     }
 
     const targetMessage = chat[targetMessageId];
-
     if (!targetMessage) {
         return false;
     }
@@ -6290,6 +6289,68 @@ export function syncMesToSwipe(messageId = null) {
     targetSwipeInfo.gen_started = targetMessage.gen_started;
     targetSwipeInfo.gen_finished = targetMessage.gen_finished;
     targetSwipeInfo.extra = structuredClone(targetMessage.extra);
+
+    return true;
+}
+
+/**
+ * Syncs swipe data back to the message data at the given message ID (or the last message if no ID is given).
+ * If the swipe ID is not provided, the current swipe ID in the message object is used.
+ *
+ * If the swipe data is invalid in some way, this function will exit out without doing anything.
+ * @param {number?} [messageId=null] - The ID of the message to sync with the swipe data. If no ID is given, the last message is used.
+ * @param {number?} [swipeId=null] - The ID of the swipe to sync. If no ID is given, the current swipe ID in the message object is used.
+ * @returns {boolean} Whether the swipe data was successfully synced to the message
+ */
+export function syncSwipeToMes(messageId = null, swipeId = null) {
+    if (!chat.length) {
+        return false;
+    }
+
+    const targetMessageId = messageId ?? chat.length - 1;
+    if (targetMessageId >= chat.length || targetMessageId < 0) {
+        console.warn(`[syncSwipeToMes] Invalid message ID: ${messageId}`);
+        return false;
+    }
+
+    const targetMessage = chat[targetMessageId];
+    if (!targetMessage) {
+        return false;
+    }
+
+    if (swipeId !== null) {
+        if (isNaN(swipeId) || swipeId < 0) {
+            console.warn(`[syncSwipeToMes] Invalid swipe ID: ${swipeId}`);
+            return false;
+        }
+        targetMessage.swipe_id = swipeId;
+    }
+
+    // No swipe data there yet, exit out
+    if (typeof targetMessage.swipe_id !== 'number') {
+        return false;
+    }
+    // If swipes structure is invalid, exit out
+    if (!Array.isArray(targetMessage.swipe_info) || !Array.isArray(targetMessage.swipes)) {
+        return false;
+    }
+
+    const targetSwipeId = targetMessage.swipe_id;
+    if (!targetMessage.swipes[targetSwipeId] || !targetMessage.swipe_info[targetSwipeId]) {
+        console.warn(`[syncSwipeToMes] Invalid swipe ID: ${targetSwipeId}`);
+        return false;
+    }
+
+    const targetSwipeInfo = targetMessage.swipe_info[targetSwipeId];
+    if (typeof targetSwipeInfo !== 'object') {
+        return false;
+    }
+
+    targetMessage.mes = targetMessage.swipes[targetSwipeId];
+    targetMessage.send_date = targetSwipeInfo.send_date;
+    targetMessage.gen_started = targetSwipeInfo.gen_started;
+    targetMessage.gen_finished = targetSwipeInfo.gen_finished;
+    targetMessage.extra = structuredClone(targetSwipeInfo.extra);
 
     return true;
 }
@@ -8293,10 +8354,9 @@ export async function deleteSwipe(swipeId = null) {
         lastMessage.swipe_info.splice(swipeId, 1);
     }
 
-    // Select the next swip, or the one before if it was the last one
+    // Select the next swipe, or the one before if it was the last one
     const newSwipeId = Math.min(swipeId, lastMessage.swipes.length - 1);
-    lastMessage.swipe_id = newSwipeId;
-    lastMessage.mes = lastMessage.swipes[newSwipeId];
+    syncSwipeToMes(null, newSwipeId);
 
     await saveChatConditional();
     await reloadCurrentChat();

--- a/public/scripts/extensions/tts/system.js
+++ b/public/scripts/extensions/tts/system.js
@@ -78,6 +78,10 @@ class SystemTtsProvider {
     //########//
     // Config //
     //########//
+    
+    // Static constants for the simulated default voice
+    static BROWSER_DEFAULT_VOICE_ID = '__browser_default__';
+    static BROWSER_DEFAULT_VOICE_NAME = 'System Default Voice';
 
     settings;
     ready = false;
@@ -168,51 +172,123 @@ class SystemTtsProvider {
     //#################//
     fetchTtsVoiceObjects() {
         if (!('speechSynthesis' in window)) {
-            return [];
+            // Browser doesn't support speech synthesis
+            return Promise.resolve([]);
         }
 
         return new Promise((resolve) => {
+            // Use a minimal timeout to allow the voice list to potentially populate
             setTimeout(() => {
-                const voices = speechSynthesis
-                    .getVoices()
-                    .sort((a, b) => a.lang.localeCompare(b.lang) || a.name.localeCompare(b.name))
-                    .map(x => ({ name: x.name, voice_id: x.voiceURI, preview_url: false, lang: x.lang }));
+                let voices = speechSynthesis.getVoices();
 
-                resolve(voices);
-            }, 1);
+                if (voices.length === 0) {
+                    // If no voices returned (e.g., Edge on first load), provide a default option
+                    console.warn("SystemTTS: getVoices() returned empty list. Providing browser default option.");
+                    const defaultVoice = {
+                        name: SystemTtsProvider.BROWSER_DEFAULT_VOICE_NAME,
+                        voice_id: SystemTtsProvider.BROWSER_DEFAULT_VOICE_ID,
+                        preview_url: false,
+                        // Try to guess the browser's default language
+                        lang: navigator.language || 'en-US'
+                    };
+                    resolve([defaultVoice]);
+                } else {
+                    // If voices are available, map them as before
+                    const mappedVoices = voices
+                        .sort((a, b) => a.lang.localeCompare(b.lang) || a.name.localeCompare(b.name))
+                        .map(x => ({ name: x.name, voice_id: x.voiceURI, preview_url: false, lang: x.lang }));
+                    resolve(mappedVoices);
+                }
+            }, 50); // Increased timeout slightly just in case it helps voice population on some browsers
         });
     }
 
+
     previewTtsVoice(voiceId) {
         if (!('speechSynthesis' in window)) {
-            throw 'Speech synthesis API is not supported';
+            throw new Error('Speech synthesis API is not supported'); // Keep Error type for consistency
         }
 
-        const voice = speechSynthesis.getVoices().find(x => x.voiceURI === voiceId);
+        let voice = null;
+        // Check if the requested voice is NOT the browser default
+        if (voiceId !== SystemTtsProvider.BROWSER_DEFAULT_VOICE_ID) {
+            const voices = speechSynthesis.getVoices();
+             // Try to find the actual voice
+            voice = voices.find(x => x.voiceURI === voiceId);
 
-        if (!voice) {
-            throw `TTS Voice id ${voiceId} not found`;
+            if (!voice && voices.length > 0) {
+                // If voices are loaded but the specific ID wasn't found, log a warning
+                console.warn(`SystemTTS Preview: Voice ID "${voiceId}" not found among available voices. Using browser default.`);
+                // Fallback to default (voice remains null)
+            } else if (!voice && voices.length === 0) {
+                 // If no voices are loaded at all, we expect to use default
+                 console.warn(`SystemTTS Preview: Voice list is empty. Using browser default.`);
+                 // Fallback to default (voice remains null)
+            }
+        } else {
+             console.log("SystemTTS Preview: Using browser default voice as requested.");
+             // Use default (voice remains null)
         }
 
-        speechSynthesis.cancel();
-        const text = getPreviewString(voice.lang);
+        speechSynthesis.cancel(); // Stop any previous speech
+        // Use the language from the found voice if available, otherwise default to 'en-US' or browser lang for the preview text
+        const langForPreview = voice ? voice.lang : (navigator.language || 'en-US');
+        const text = getPreviewString(langForPreview);
         const utterance = new SpeechSynthesisUtterance(text);
-        utterance.voice = voice;
+
+        // Only set the voice if we found a specific one and it wasn't the default request
+        if (voice) {
+             utterance.voice = voice;
+        }
+        // Otherwise, utterance.voice remains null/undefined, causing the browser to use its default
+
         utterance.rate = this.settings.rate || 1;
         utterance.pitch = this.settings.pitch || 1;
+
+        // Add error handling for the speech itself
+        utterance.onerror = (event) => {
+             console.error(`SystemTTS Preview Error: ${event.error}`, event);
+             // Potentially notify the user here
+        };
+
         speechSynthesis.speak(utterance);
     }
 
     async getVoice(voiceName) {
         if (!('speechSynthesis' in window)) {
-            return { voice_id: null };
+            // Return a predictable null-like structure if API not supported
+             return { voice_id: null, name: 'API Not Supported' };
         }
 
+        // Check if the requested name is the browser default placeholder
+        if (voiceName === SystemTtsProvider.BROWSER_DEFAULT_VOICE_NAME) {
+            return {
+                voice_id: SystemTtsProvider.BROWSER_DEFAULT_VOICE_ID,
+                name: SystemTtsProvider.BROWSER_DEFAULT_VOICE_NAME
+            };
+        }
+
+        // Attempt to get voices, might be async
+        // Note: This relies on voices potentially being populated by now.
+        // A more robust approach might involve re-calling fetchTtsVoiceObjects if needed,
+        // but sticking to minimal changes based on original code structure.
         const voices = speechSynthesis.getVoices();
+
+        if (voices.length === 0) {
+             // If voices are still empty, we can't find any specific name
+             console.warn(`SystemTTS getVoice: Voice list empty, cannot find "${voiceName}". Falling back to browser default ID.`);
+             // Return the default placeholder as a fallback in this edge case
+             return {
+                 voice_id: SystemTtsProvider.BROWSER_DEFAULT_VOICE_ID,
+                 name: SystemTtsProvider.BROWSER_DEFAULT_VOICE_NAME
+             };
+        }
+
         const match = voices.find(x => x.name == voiceName);
 
         if (!match) {
-            throw `TTS Voice name ${voiceName} not found`;
+             // If voices are loaded but name not found, throw error as before
+            throw new Error(`SystemTTS getVoice: TTS Voice name "${voiceName}" not found`);
         }
 
         return { voice_id: match.voiceURI, name: match.name };
@@ -243,4 +319,4 @@ class SystemTtsProvider {
             });
         });
     }
-}
+} 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3087,7 +3087,7 @@ async function unhideMessageCallback(args, value) {
  * @returns {void}
  */
 function performGroupMemberAction(chid, action) {
-    const memberSelector = `.group_member[chid="${chid}"]`;
+    const memberSelector = `.group_member[data-chid="${chid}"]`;
     // Do not optimize. Paginator gets recreated on every action
     const paginationSelector = '#rm_group_members_pagination';
     const pageSizeSelector = '#rm_group_members_pagination select';


### PR DESCRIPTION
**Bug Fix:** Edge-compatible fallback for empty Web Speech voice lists  
**Problem:** Some browsers (e.g., Edge) return empty `getVoices()` on initial page load, blocking TTS functionality.  
**Solution:**  
- Added browser language-based default voice when `getVoices()` is empty  
- Enhanced error handling in preview/generate flows to prioritize system defaults  
- Added diagnostic warnings for voice initialization failures  
**Code Changes:**  
- `fetchTtsVoiceObjects()`: default injection  
- `previewTtsVoice()`: Fallback logic refinement  
- `getVoice()`: Empty list handling