### PR TITLE
Add Gemini 2.5 Flash Preview to Model List (Makersuite) 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3162,6 +3162,7 @@
                                         <option value="gemini-2.5-pro-exp-03-25">Gemini 2.5 Pro Experimental 2025-03-25</option>
                                         <option value="gemini-2.0-pro-exp">Gemini 2.0 Pro Experimental</option>
                                         <option value="gemini-2.0-pro-exp-02-05">Gemini 2.0 Pro Experimental 2025-02-05</option>
+                                        <option value="gemini-2.5-flash-preview-04-17">Gemini 2.5 Flash Preview 2025-04-17</option>
                                         <option value="gemini-2.0-flash-lite-preview">Gemini 2.0 Flash-Lite Preview</option>
                                         <option value="gemini-2.0-flash-lite-preview-02-05">Gemini 2.0 Flash-Lite Preview 2025-02-05</option>
                                         <option value="gemini-2.0-flash-001">Gemini 2.0 Flash [001]</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -80,6 +80,7 @@
                         <option data-type="google" value="gemini-2.5-pro-exp-03-25">gemini-2.5-pro-exp-03-25</option>
                         <option data-type="google" value="gemini-2.0-pro-exp">gemini-2.0-pro-exp</option>
                         <option data-type="google" value="gemini-2.0-pro-exp-02-05">gemini-2.0-pro-exp-02-05</option>
+                        <option data-type="google" value="gemini-2.5-flash-preview-04-17">gemini-2.5-flash-preview-04-17</option>
                         <option data-type="google" value="gemini-2.0-flash-lite-preview">gemini-2.0-flash-lite-preview</option>
                         <option data-type="google" value="gemini-2.0-flash-lite-preview-02-05">gemini-2.0-flash-lite-preview-02-05</option>
                         <option data-type="google" value="gemini-2.0-flash">gemini-2.0-flash</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4451,7 +4451,7 @@ async function onModelChange() {
             $('#openai_max_context').attr('max', max_32k);
         } else if (value.includes('gemini-1.5-pro') || value.includes('gemini-exp-1206') || value.includes('gemini-2.0-pro')) {
             $('#openai_max_context').attr('max', max_2mil);
-        } else if (value.includes('gemini-1.5-flash') || value.includes('gemini-2.0-flash') || value.includes('gemini-2.5-pro-exp-03-25') || value.includes('gemini-2.5-pro-preview-03-25')) {
+        } else if (value.includes('gemini-1.5-flash') || value.includes('gemini-2.0-flash') || value.includes('gemini-2.5-flash-preview-04-17') || value.includes('gemini-2.5-pro-exp-03-25') || value.includes('gemini-2.5-pro-preview-03-25')) {
             $('#openai_max_context').attr('max', max_1mil);
         } else if (value.includes('gemini-1.0-pro') || value === 'gemini-pro') {
             $('#openai_max_context').attr('max', max_32k);
@@ -5165,7 +5165,7 @@ export function isImageInliningSupported() {
         case chat_completion_sources.OPENAI:
             return visionSupportedModels.some(model => oai_settings.openai_model.includes(model) && !oai_settings.openai_model.includes('gpt-4-turbo-preview') && !oai_settings.openai_model.includes('o3-mini'));
         case chat_completion_sources.MAKERSUITE:
-            return visionSupportedModels.some(model => oai_settings.google_model.includes(model));
+            return visionSupportedModels.some(model => oai_settings.google_model.includes(model)) || oai_settings.google_model.includes('gemini-2.5-flash-preview');
         case chat_completion_sources.CLAUDE:
             return visionSupportedModels.some(model => oai_settings.claude_model.includes(model));
         case chat_completion_sources.OPENROUTER:

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5103,6 +5103,7 @@ export function isImageInliningSupported() {
         'gemini-2.5-pro-preview-03-25',
         'gemini-2.0-pro-exp',
         'gemini-2.0-pro-exp-02-05',
+        'gemini-2.5-flash-preview-04-17',
         'gemini-2.0-flash-lite-preview',
         'gemini-2.0-flash-lite-preview-02-05',
         'gemini-2.0-flash',
@@ -5165,7 +5166,7 @@ export function isImageInliningSupported() {
         case chat_completion_sources.OPENAI:
             return visionSupportedModels.some(model => oai_settings.openai_model.includes(model) && !oai_settings.openai_model.includes('gpt-4-turbo-preview') && !oai_settings.openai_model.includes('o3-mini'));
         case chat_completion_sources.MAKERSUITE:
-            return visionSupportedModels.some(model => oai_settings.google_model.includes(model)) || oai_settings.google_model.includes('gemini-2.5-flash-preview');
+            return visionSupportedModels.some(model => oai_settings.google_model.includes(model));
         case chat_completion_sources.CLAUDE:
             return visionSupportedModels.some(model => oai_settings.claude_model.includes(model));
         case chat_completion_sources.OPENROUTER:

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -366,6 +366,7 @@ async function sendMakerSuiteRequest(request, response) {
 
         const useSystemPrompt = !useMultiModal && (
             model.includes('gemini-2.5-pro') ||
+            model.includes('gemini-2.5-flash') ||
             model.includes('gemini-2.0-pro') ||
             model.includes('gemini-2.0-flash') ||
             model.includes('gemini-2.0-flash-thinking-exp') ||

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -364,6 +364,7 @@ export function convertGooglePrompt(messages, model, useSysPrompt, names) {
         'gemini-2.5-pro-exp-03-25',
         'gemini-2.0-pro-exp',
         'gemini-2.0-pro-exp-02-05',
+        'gemini-2.5-flash-preview-04-17',
         'gemini-2.0-flash-lite-preview',
         'gemini-2.0-flash-lite-preview-02-05',
         'gemini-2.0-flash',


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

This pull request updates public/index.html and public/scripts/openai.js to add day 0 support for Gemini 2.5 Flash Preview in Chat Completion from Google AI Studio

Edit: This does not include adding a new toggle for the thinking functionality. I forgot they made that an option, and I'm honestly not confident enough to try to add a brand new toggle and the request logic for that.