### PR TITLE
Thinking budget for Google Ai studio (Gemini 2.5 flash)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2034,7 +2034,7 @@
                                             </span>
                                         </div>
                                     </div>
-                                    <div id="thinking_budget_master_container" data-source="makersuite" style="display: none;">
+                                    <div id="thinking_budget_master_container" data-source="makersuite">
                                         <hr>
                                         <div class="range-block">
                                             <label for="google_master_enable_thinking" class="checkbox_label widthFreeExpand">
@@ -2069,7 +2069,6 @@
                                                         <input class="neo-range-input" type="number" min="0" max="24576" step="1" data-for="thinking_budget_slider" id="thinking_budget_counter" value="1000">
                                                     </div>
                                                 </div>
-                                                <label for="oai_max_context_unlocked" class="checkbox_label displayNone"></label>
                                             </div>
                                         </div>
                                     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -2034,6 +2034,52 @@
                                             </span>
                                         </div>
                                     </div>
+                                    <div data-source="makersuite" id="thinking_budget_master_container">
+                                        <hr>
+                                        <div class="range-block">
+                                            <label for="master_enable_thinking" class="checkbox_label widthFreeExpand">
+                                                <input id="master_enable_thinking" type="checkbox" />
+                                                <span>
+                                                    <span data-i18n="Enable Thinking Feature">Enable thinking
+                                                        budget</span>
+                                                    <i class="opacity50p fa-solid fa-circle-info"
+                                                        title="Works with Gemini 2.5 Flash Preview only!"
+                                                        data-i18n="[title]Works with Gemini 2.5 Flash Preview only!"></i>
+                                                </span>
+                                            </label>
+                                            <div class="toggle-description justifyLeft marginBot5">
+                                                <span data-i18n="thinking_budget_desc_1">Sends a</span> <code>thinkingBudget</code> <span data-i18n="thinking_budget_desc_2">value. If unchecked, lets the model decide (default thinking mode).</span>
+                                            </div>
+                                        </div>
+                                        <div id="thinking_budget_controls" style="display: none;">
+                                            <div class="range-block">
+                                                <label for="use_thinking_budget_value"
+                                                    class="checkbox_label widthFreeExpand">
+                                                    <input id="use_thinking_budget_value" type="checkbox" disabled />
+                                                    <span data-i18n="Use Thinking Budget Value">Use thinking budget
+                                                        value</span>
+                                                </label>
+                                                <div class="toggle-description justifyLeft marginBot5">
+                                                    <span data-i18n="use_thinking_budget_desc">Uses the slider value below. If unchecked, the budget is explicitly set to 0 (thinking disabled).</span>
+                                                </div>
+                                            </div>
+                                            <div class="range-block">
+                                                <div class="range-block-title" data-i18n="Thinking Budget (Tokens)">
+                                                    Thinking Budget (tokens)
+                                                </div>
+                                                <div class="range-block-range-and-counter">
+                                                    <div class="range-block-range">
+                                                        <input class="neo-range-slider" type="range" id="thinking_budget_slider" name="volume" min="0" max="24576" step="1" value="1000" disabled>
+                                            </div>
+                                                    <div class="range-block-counter">
+                                                        <input class="neo-range-input" type="number" min="0" max="24576" step="1" data-for="thinking_budget_slider" id="thinking_budget_counter" value="1000" disabled>
+                                            </div>
+                                                </div>
+                                                <label for="oai_max_context_unlocked"
+                                                    class="checkbox_label displayNone"></label>
+                                            </div>
+                                        </div>
+                                    </div>
                                     <div class="range-block" data-source="deepseek,openrouter,custom,claude,xai">
                                         <label for="openai_show_thoughts" class="checkbox_label widthFreeExpand">
                                             <input id="openai_show_thoughts" type="checkbox" />

--- a/public/index.html
+++ b/public/index.html
@@ -1419,7 +1419,7 @@
                                         </div>
                                     </div>
 
-                                    <div data-tg-type="aphrodite, ooba, koboldcpp, tabby, llamacpp" id="dryBlock" class="wide100p">
+                                    <div data-tg-type="aphrodite, ooba, koboldcpp, tabby, llamacpp, dreamgen" id="dryBlock" class="wide100p">
                                         <h4 class="wide100p textAlignCenter" title="DRY penalizes tokens that would extend the end of the input into a sequence that has previously occurred in the input. Set multiplier to 0 to disable." data-i18n="[title]DRY_Repetition_Penalty_desc">
                                             <label data-i18n="DRY Repetition Penalty">DRY Repetition Penalty</label>
                                             <a href="https://github.com/oobabooga/text-generation-webui/pull/5677" target="_blank">
@@ -1574,7 +1574,7 @@
                                                     <div class="fa-solid fa-circle-info opacity50p " data-i18n="[title]Add the bos_token to the beginning of prompts. Disabling this can make the replies more creative" title="Add the bos_token to the beginning of prompts. Disabling this can make the replies more creative."></div>
                                                 </label>
                                             </label>
-                                            <label data-tg-type="ooba, llamacpp, tabby, koboldcpp" class="checkbox_label  flexGrow flexShrink" for="ban_eos_token_textgenerationwebui">
+                                            <label data-tg-type="ooba, llamacpp, tabby, koboldcpp, dreamgen" class="checkbox_label  flexGrow flexShrink" for="ban_eos_token_textgenerationwebui">
                                                 <input type="checkbox" id="ban_eos_token_textgenerationwebui" />
                                                 <label>
                                                     <small data-i18n="Ban EOS Token">Ban EOS Token</small>
@@ -2034,33 +2034,27 @@
                                             </span>
                                         </div>
                                     </div>
-                                    <div data-source="makersuite" id="thinking_budget_master_container">
+                                    <div id="thinking_budget_master_container" data-source="makersuite" style="display: none;">
                                         <hr>
                                         <div class="range-block">
-                                            <label for="master_enable_thinking" class="checkbox_label widthFreeExpand">
-                                                <input id="master_enable_thinking" type="checkbox" />
+                                            <label for="google_master_enable_thinking" class="checkbox_label widthFreeExpand">
+                                                <input id="google_master_enable_thinking" type="checkbox" />
                                                 <span>
-                                                    <span data-i18n="Enable Thinking Feature">Enable thinking
-                                                        budget</span>
-                                                    <i class="opacity50p fa-solid fa-circle-info"
-                                                        title="Works with Gemini 2.5 Flash Preview only!"
-                                                        data-i18n="[title]Works with Gemini 2.5 Flash Preview only!"></i>
+                                                    <span data-i18n="Enable thinking">Enable thinking</span>
                                                 </span>
                                             </label>
                                             <div class="toggle-description justifyLeft marginBot5">
-                                                <span data-i18n="thinking_budget_desc_1">Sends a</span> <code>thinkingBudget</code> <span data-i18n="thinking_budget_desc_2">value. If unchecked, lets the model decide (default thinking mode).</span>
+                                                <span data-i18n="thinking_budget_desc_master">Gemini 2.5 Flash Preview is the only thinking model that can have its thinking disabled.</span>
                                             </div>
                                         </div>
                                         <div id="thinking_budget_controls" style="display: none;">
                                             <div class="range-block">
-                                                <label for="use_thinking_budget_value"
-                                                    class="checkbox_label widthFreeExpand">
-                                                    <input id="use_thinking_budget_value" type="checkbox" disabled />
-                                                    <span data-i18n="Use Thinking Budget Value">Use thinking budget
-                                                        value</span>
+                                                <label for="google_set_thinking_budget" class="checkbox_label widthFreeExpand">
+                                                    <input id="google_set_thinking_budget" type="checkbox" />
+                                                    <span data-i18n="Set thinking budget">Set thinking budget</span>
                                                 </label>
                                                 <div class="toggle-description justifyLeft marginBot5">
-                                                    <span data-i18n="use_thinking_budget_desc">Uses the slider value below. If unchecked, the budget is explicitly set to 0 (thinking disabled).</span>
+                                                    <span data-i18n="use_thinking_budget_desc">Uses the slider value below. If unchecked, the budget is automatically determined by the API.</span>
                                                 </div>
                                             </div>
                                             <div class="range-block">
@@ -2069,14 +2063,13 @@
                                                 </div>
                                                 <div class="range-block-range-and-counter">
                                                     <div class="range-block-range">
-                                                        <input class="neo-range-slider" type="range" id="thinking_budget_slider" name="volume" min="0" max="24576" step="1" value="1000" disabled>
-                                            </div>
+                                                        <input class="neo-range-slider" type="range" id="thinking_budget_slider" name="volume" min="0" max="24576" step="1" value="1000">
+                                                    </div>
                                                     <div class="range-block-counter">
-                                                        <input class="neo-range-input" type="number" min="0" max="24576" step="1" data-for="thinking_budget_slider" id="thinking_budget_counter" value="1000" disabled>
-                                            </div>
+                                                        <input class="neo-range-input" type="number" min="0" max="24576" step="1" data-for="thinking_budget_slider" id="thinking_budget_counter" value="1000">
+                                                    </div>
                                                 </div>
-                                                <label for="oai_max_context_unlocked"
-                                                    class="checkbox_label displayNone"></label>
+                                                <label for="oai_max_context_unlocked" class="checkbox_label displayNone"></label>
                                             </div>
                                         </div>
                                     </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2106,21 +2106,14 @@ async function sendOpenAIRequest(type, messages, signal) {
 
     if (isGoogle) {
         const stopStringsLimit = 5;
-        const generationConfig = {};
-        generationConfig['top_k'] = Number(oai_settings.top_k_openai);
-        generationConfig['stopSequences'] = getCustomStoppingStrings(stopStringsLimit).slice(0, stopStringsLimit).filter(x => x.length >= 1 && x.length <= 16);
-        if (googleThinkingBudgetModels.includes(model)) {
-            if (!oai_settings.google_master_enable_thinking) {
-                // Master switch is OFF: Explicitly disable thinking
-                generationConfig['thinkingConfig'] = { thinkingBudget: 0 };
-            } else if (oai_settings.google_set_thinking_budget) {
-                // Master switch ON, Set Budget ON: Use slider value
-                generationConfig['thinkingConfig'] = { thinkingBudget: Number(oai_settings.thinking_budget) };
-            }
-            // If Master switch ON, Set Budget OFF: Do nothing, let API use default budget (don't send thinkingConfig)
-        }
-        generate_data['generationConfig'] = generationConfig;
+        generate_data['top_k'] = Number(oai_settings.top_k_openai);
+        generate_data['stop'] = getCustomStoppingStrings(stopStringsLimit).slice(0, stopStringsLimit).filter(x => x.length >= 1 && x.length <= 16);
         generate_data['use_makersuite_sysprompt'] = oai_settings.use_makersuite_sysprompt;
+        if (googleThinkingBudgetModels.includes(model)) {
+            generate_data['google_master_enable_thinking'] = oai_settings.google_master_enable_thinking;
+            generate_data['google_set_thinking_budget'] = oai_settings.google_set_thinking_budget;
+            generate_data['thinking_budget'] = oai_settings.thinking_budget;
+        }
     }
 
     if (isMistral) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -306,6 +306,9 @@ export const settingsToUpdate = {
     n: ['#n_openai', 'n', false],
     bypass_status_check: ['#openai_bypass_status_check', 'bypass_status_check', true],
     request_images: ['#openai_request_images', 'request_images', true],
+    masterEnableThinking: ['#master_enable_thinking', 'masterEnableThinking', true],
+    useThinkingBudget: ['#use_thinking_budget_value', 'useThinkingBudget', true],
+    thinkingBudget: ['#thinking_budget_slider', 'thinkingBudget', false],
 };
 
 const default_settings = {
@@ -387,6 +390,9 @@ const default_settings = {
     request_images: false,
     seed: -1,
     n: 1,
+    masterEnableThinking: false,
+    useThinkingBudget: false,
+    thinkingBudget: 1000,
 };
 
 const oai_settings = {
@@ -468,6 +474,9 @@ const oai_settings = {
     request_images: false,
     seed: -1,
     n: 1,
+    masterEnableThinking: false,
+    useThinkingBudget: false,
+    thinkingBudget: 1000,
 };
 
 export let proxies = [
@@ -2095,6 +2104,20 @@ async function sendOpenAIRequest(type, messages, signal) {
         generate_data['top_k'] = Number(oai_settings.top_k_openai);
         generate_data['stop'] = getCustomStoppingStrings(stopStringsLimit).slice(0, stopStringsLimit).filter(x => x.length >= 1 && x.length <= 16);
         generate_data['use_makersuite_sysprompt'] = oai_settings.use_makersuite_sysprompt;
+
+        if (oai_settings.masterEnableThinking && oai_settings.useThinkingBudget && oai_settings.thinkingBudget >= 0) {
+
+            generate_data.generationConfig = generate_data.generationConfig || {};
+            generate_data.generationConfig.thinkingConfig = {
+                thinkingBudget: oai_settings.thinkingBudget,
+            };
+        } else if (oai_settings.masterEnableThinking && !oai_settings.useThinkingBudget) {
+            generate_data.generationConfig = generate_data.generationConfig || {};
+            generate_data.generationConfig.thinkingConfig = {
+                thinkingBudget: 0,
+            };
+        }
+
     }
 
     if (isMistral) {
@@ -3301,6 +3324,9 @@ function loadOpenAISettings(data, settings) {
     oai_settings.continue_postfix = settings.continue_postfix ?? default_settings.continue_postfix;
     oai_settings.function_calling = settings.function_calling ?? default_settings.function_calling;
     oai_settings.openrouter_providers = settings.openrouter_providers ?? default_settings.openrouter_providers;
+    oai_settings.masterEnableThinking = settings.masterEnableThinking ?? default_settings.masterEnableThinking;
+    oai_settings.useThinkingBudget = settings.useThinkingBudget ?? default_settings.useThinkingBudget;
+    oai_settings.thinkingBudget = settings.thinkingBudget ?? default_settings.thinkingBudget;
 
     // Migrate from old settings
     if (settings.names_in_completion === true) {
@@ -3416,6 +3442,11 @@ function loadOpenAISettings(data, settings) {
     $('#openai_enable_web_search').prop('checked', oai_settings.enable_web_search);
     $('#openai_request_images').prop('checked', oai_settings.request_images);
 
+    $('#master_enable_thinking').prop('checked', oai_settings.masterEnableThinking);
+    $('#use_thinking_budget_value').prop('checked', oai_settings.useThinkingBudget);
+    $('#thinking_budget_slider').val(oai_settings.thinkingBudget);
+    $('#thinking_budget_counter').val(oai_settings.thinkingBudget);
+
     $('#openai_reasoning_effort').val(oai_settings.reasoning_effort);
     $(`#openai_reasoning_effort option[value="${oai_settings.reasoning_effort}"]`).prop('selected', true);
 
@@ -3458,6 +3489,47 @@ function loadOpenAISettings(data, settings) {
     $('#oai_max_context_unlocked').prop('checked', oai_settings.max_context_unlocked);
     $('#custom_prompt_post_processing').val(oai_settings.custom_prompt_post_processing);
     $(`#custom_prompt_post_processing option[value="${oai_settings.custom_prompt_post_processing}"]`).attr('selected', true);
+
+    updateThinkingBudgetUIState();
+}
+
+function updateThinkingBudgetUIState() {
+    const masterEnabled = oai_settings.masterEnableThinking;
+    const useSlider = oai_settings.useThinkingBudget;
+    const unlocked = oai_settings.max_context_unlocked;
+    const $controlsDiv = $('#thinking_budget_controls');
+    const $useBudgetCheckbox = $('#use_thinking_budget_value');
+    const $sliderContainer = $('#thinking_budget_slider_container');
+    const $slider = $('#thinking_budget_slider');
+    const $counter = $('#thinking_budget_counter');
+
+    // Show/hide the secondary controls container
+    if (masterEnabled) {
+        $controlsDiv.show();
+    } else {
+        $controlsDiv.hide();
+    }
+
+    $useBudgetCheckbox.prop('disabled', !masterEnabled);
+
+    const enableSliderControls = masterEnabled && useSlider;
+
+    $sliderContainer.css('opacity', enableSliderControls ? 1 : 0.5);
+
+    $slider.prop('disabled', !enableSliderControls);
+    $counter.prop('disabled', !enableSliderControls);
+
+    const maxBudgetValue = unlocked ? 1000000 : 24576;
+    $slider.attr('max', maxBudgetValue);
+    $counter.attr('max', maxBudgetValue);
+
+    if (oai_settings.thinkingBudget > maxBudgetValue) {
+        console.log(`Clamping thinkingBudget from ${oai_settings.thinkingBudget} to ${maxBudgetValue}`);
+        oai_settings.thinkingBudget = maxBudgetValue;
+        $slider.val(oai_settings.thinkingBudget);
+        $counter.val(oai_settings.thinkingBudget);
+        saveSettingsDebounced();
+    }
 }
 
 function setNamesBehaviorControls() {
@@ -4114,6 +4186,8 @@ function onSettingsPresetChange() {
                 oai_settings[setting] = preset[key];
             }
         }
+
+        updateThinkingBudgetUIState(); // Update dependent UI after preset load
 
         $('#chat_completion_source').trigger('change');
         $('#openai_logit_bias_preset').trigger('change');
@@ -5542,8 +5616,12 @@ export function initOpenAI() {
 
     $('#oai_max_context_unlocked').on('input', function (_e, data) {
         oai_settings.max_context_unlocked = !!$(this).prop('checked');
+
+        updateThinkingBudgetUIState(); // Update UI including max value and clamping
+
         if (data?.source !== 'preset') {
             $('#chat_completion_source').trigger('change');
+
         }
         saveSettingsDebounced();
     });
@@ -5756,6 +5834,44 @@ export function initOpenAI() {
 
         oai_settings.openrouter_providers = selectedProviders;
 
+        saveSettingsDebounced();
+    });
+
+    $('#master_enable_thinking').on('change', function () {
+        oai_settings.masterEnableThinking = $(this).prop('checked');
+        updateThinkingBudgetUIState();
+        saveSettingsDebounced();
+    });
+
+    $('#use_thinking_budget_value').on('change', function () {
+        oai_settings.useThinkingBudget = $(this).prop('checked');
+        updateThinkingBudgetUIState();
+        saveSettingsDebounced();
+    });
+
+    $('#thinking_budget_slider').on('input', function () {
+        const value = Number($(this).val());
+        oai_settings.thinkingBudget = value;
+        $('#thinking_budget_counter').val(value);
+        saveSettingsDebounced();
+    });
+
+    $('#thinking_budget_counter').on('input', function () {
+        const max = Number($(this).attr('max'));
+        const min = Number($(this).attr('min'));
+        let value = Number($(this).val());
+
+        if (value > max) {
+            value = max;
+            $(this).val(value);
+        }
+        if (value < min) {
+            value = min;
+            $(this).val(value);
+        }
+
+        oai_settings.thinkingBudget = value;
+        $('#thinking_budget_slider').val(value); // Update linked slider
         saveSettingsDebounced();
     });
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -165,6 +165,11 @@ const textCompletionModels = [
     'code-search-ada-code-001',
 ];
 
+const googleThinkingBudgetModels = [
+    'gemini-2.5-flash-preview-04-17',
+    // Add future models here
+];
+
 let biasCache = undefined;
 export let model_list = [];
 
@@ -301,14 +306,14 @@ export const settingsToUpdate = {
     function_calling: ['#openai_function_calling', 'function_calling', true],
     show_thoughts: ['#openai_show_thoughts', 'show_thoughts', true],
     reasoning_effort: ['#openai_reasoning_effort', 'reasoning_effort', false],
+    google_master_enable_thinking: ['#google_master_enable_thinking', 'google_master_enable_thinking', true],
+    google_set_thinking_budget: ['#google_set_thinking_budget', 'google_set_thinking_budget', true],
+    thinking_budget: ['#thinking_budget_slider', 'thinking_budget', false],
     enable_web_search: ['#openai_enable_web_search', 'enable_web_search', true],
     seed: ['#seed_openai', 'seed', false],
     n: ['#n_openai', 'n', false],
     bypass_status_check: ['#openai_bypass_status_check', 'bypass_status_check', true],
     request_images: ['#openai_request_images', 'request_images', true],
-    masterEnableThinking: ['#master_enable_thinking', 'masterEnableThinking', true],
-    useThinkingBudget: ['#use_thinking_budget_value', 'useThinkingBudget', true],
-    thinkingBudget: ['#thinking_budget_slider', 'thinkingBudget', false],
 };
 
 const default_settings = {
@@ -386,13 +391,13 @@ const default_settings = {
     custom_prompt_post_processing: custom_prompt_post_processing_types.NONE,
     show_thoughts: true,
     reasoning_effort: 'medium',
+    google_master_enable_thinking: true, // Similar to Google AI studio
+    google_set_thinking_budget: false,
+    thinking_budget: 1000,
     enable_web_search: false,
     request_images: false,
     seed: -1,
     n: 1,
-    masterEnableThinking: false,
-    useThinkingBudget: false,
-    thinkingBudget: 1000,
 };
 
 const oai_settings = {
@@ -470,13 +475,13 @@ const oai_settings = {
     custom_prompt_post_processing: custom_prompt_post_processing_types.NONE,
     show_thoughts: true,
     reasoning_effort: 'medium',
+    google_master_enable_thinking: true, // Similar to Google AI studio
+    google_set_thinking_budget: false,
+    thinking_budget: 1000,
     enable_web_search: false,
     request_images: false,
     seed: -1,
     n: 1,
-    masterEnableThinking: false,
-    useThinkingBudget: false,
-    thinkingBudget: 1000,
 };
 
 export let proxies = [
@@ -2101,23 +2106,21 @@ async function sendOpenAIRequest(type, messages, signal) {
 
     if (isGoogle) {
         const stopStringsLimit = 5;
-        generate_data['top_k'] = Number(oai_settings.top_k_openai);
-        generate_data['stop'] = getCustomStoppingStrings(stopStringsLimit).slice(0, stopStringsLimit).filter(x => x.length >= 1 && x.length <= 16);
-        generate_data['use_makersuite_sysprompt'] = oai_settings.use_makersuite_sysprompt;
-
-        if (oai_settings.masterEnableThinking && oai_settings.useThinkingBudget && oai_settings.thinkingBudget >= 0) {
-
-            generate_data.generationConfig = generate_data.generationConfig || {};
-            generate_data.generationConfig.thinkingConfig = {
-                thinkingBudget: oai_settings.thinkingBudget,
-            };
-        } else if (oai_settings.masterEnableThinking && !oai_settings.useThinkingBudget) {
-            generate_data.generationConfig = generate_data.generationConfig || {};
-            generate_data.generationConfig.thinkingConfig = {
-                thinkingBudget: 0,
-            };
+        const generationConfig = {};
+        generationConfig['top_k'] = Number(oai_settings.top_k_openai);
+        generationConfig['stopSequences'] = getCustomStoppingStrings(stopStringsLimit).slice(0, stopStringsLimit).filter(x => x.length >= 1 && x.length <= 16);
+        if (googleThinkingBudgetModels.includes(model)) {
+            if (!oai_settings.google_master_enable_thinking) {
+                // Master switch is OFF: Explicitly disable thinking
+                generationConfig['thinkingConfig'] = { thinkingBudget: 0 };
+            } else if (oai_settings.google_set_thinking_budget) {
+                // Master switch ON, Set Budget ON: Use slider value
+                generationConfig['thinkingConfig'] = { thinkingBudget: Number(oai_settings.thinking_budget) };
+            }
+            // If Master switch ON, Set Budget OFF: Do nothing, let API use default budget (don't send thinkingConfig)
         }
-
+        generate_data['generationConfig'] = generationConfig;
+        generate_data['use_makersuite_sysprompt'] = oai_settings.use_makersuite_sysprompt;
     }
 
     if (isMistral) {
@@ -3306,6 +3309,9 @@ function loadOpenAISettings(data, settings) {
     oai_settings.bypass_status_check = settings.bypass_status_check ?? default_settings.bypass_status_check;
     oai_settings.show_thoughts = settings.show_thoughts ?? default_settings.show_thoughts;
     oai_settings.reasoning_effort = settings.reasoning_effort ?? default_settings.reasoning_effort;
+    oai_settings.google_master_enable_thinking = settings.google_master_enable_thinking ?? default_settings.google_master_enable_thinking;
+    oai_settings.google_set_thinking_budget = settings.google_set_thinking_budget ?? default_settings.google_set_thinking_budget;
+    oai_settings.thinking_budget = settings.thinking_budget ?? default_settings.thinking_budget;
     oai_settings.enable_web_search = settings.enable_web_search ?? default_settings.enable_web_search;
     oai_settings.request_images = settings.request_images ?? default_settings.request_images;
     oai_settings.seed = settings.seed ?? default_settings.seed;
@@ -3324,9 +3330,6 @@ function loadOpenAISettings(data, settings) {
     oai_settings.continue_postfix = settings.continue_postfix ?? default_settings.continue_postfix;
     oai_settings.function_calling = settings.function_calling ?? default_settings.function_calling;
     oai_settings.openrouter_providers = settings.openrouter_providers ?? default_settings.openrouter_providers;
-    oai_settings.masterEnableThinking = settings.masterEnableThinking ?? default_settings.masterEnableThinking;
-    oai_settings.useThinkingBudget = settings.useThinkingBudget ?? default_settings.useThinkingBudget;
-    oai_settings.thinkingBudget = settings.thinkingBudget ?? default_settings.thinkingBudget;
 
     // Migrate from old settings
     if (settings.names_in_completion === true) {
@@ -3442,13 +3445,13 @@ function loadOpenAISettings(data, settings) {
     $('#openai_enable_web_search').prop('checked', oai_settings.enable_web_search);
     $('#openai_request_images').prop('checked', oai_settings.request_images);
 
-    $('#master_enable_thinking').prop('checked', oai_settings.masterEnableThinking);
-    $('#use_thinking_budget_value').prop('checked', oai_settings.useThinkingBudget);
-    $('#thinking_budget_slider').val(oai_settings.thinkingBudget);
-    $('#thinking_budget_counter').val(oai_settings.thinkingBudget);
-
     $('#openai_reasoning_effort').val(oai_settings.reasoning_effort);
     $(`#openai_reasoning_effort option[value="${oai_settings.reasoning_effort}"]`).prop('selected', true);
+
+    $('#google_master_enable_thinking').prop('checked', oai_settings.google_master_enable_thinking);
+    $('#google_set_thinking_budget').prop('checked', oai_settings.google_set_thinking_budget);
+    $('#thinking_budget_slider').val(oai_settings.thinking_budget);
+    $('#thinking_budget_counter').val(oai_settings.thinking_budget);
 
     if (settings.reverse_proxy !== undefined) oai_settings.reverse_proxy = settings.reverse_proxy;
     $('#openai_reverse_proxy').val(oai_settings.reverse_proxy);
@@ -3489,46 +3492,30 @@ function loadOpenAISettings(data, settings) {
     $('#oai_max_context_unlocked').prop('checked', oai_settings.max_context_unlocked);
     $('#custom_prompt_post_processing').val(oai_settings.custom_prompt_post_processing);
     $(`#custom_prompt_post_processing option[value="${oai_settings.custom_prompt_post_processing}"]`).attr('selected', true);
-
-    updateThinkingBudgetUIState();
+    updateThinkingBudgetUI();
 }
 
-function updateThinkingBudgetUIState() {
-    const masterEnabled = oai_settings.masterEnableThinking;
-    const useSlider = oai_settings.useThinkingBudget;
-    const unlocked = oai_settings.max_context_unlocked;
-    const $controlsDiv = $('#thinking_budget_controls');
-    const $useBudgetCheckbox = $('#use_thinking_budget_value');
-    const $sliderContainer = $('#thinking_budget_slider_container');
-    const $slider = $('#thinking_budget_slider');
-    const $counter = $('#thinking_budget_counter');
+/**
+ * Updates the visibility and state of the Google Thinking Budget controls.
+ */
+function updateThinkingBudgetUI() {
+    const isMakerSuite = oai_settings.chat_completion_source === chat_completion_sources.MAKERSUITE;
+    const modelSupportsControl = googleThinkingBudgetModels.includes(oai_settings.google_model);
+    const showMasterContainer = isMakerSuite && modelSupportsControl;
+    $('#thinking_budget_master_container').toggle(showMasterContainer);
 
-    // Show/hide the secondary controls container
-    if (masterEnabled) {
-        $controlsDiv.show();
+    if (showMasterContainer) {
+        const masterEnabled = oai_settings.google_master_enable_thinking;
+        $('#thinking_budget_controls').toggle(masterEnabled);
+
+        if (masterEnabled) {
+            const setBudgetEnabled = oai_settings.google_set_thinking_budget;
+            const sliderDisabled = !setBudgetEnabled;
+            $('#thinking_budget_slider').prop('disabled', sliderDisabled);
+            $('#thinking_budget_counter').prop('disabled', sliderDisabled);
+        }
     } else {
-        $controlsDiv.hide();
-    }
-
-    $useBudgetCheckbox.prop('disabled', !masterEnabled);
-
-    const enableSliderControls = masterEnabled && useSlider;
-
-    $sliderContainer.css('opacity', enableSliderControls ? 1 : 0.5);
-
-    $slider.prop('disabled', !enableSliderControls);
-    $counter.prop('disabled', !enableSliderControls);
-
-    const maxBudgetValue = unlocked ? 1000000 : 24576;
-    $slider.attr('max', maxBudgetValue);
-    $counter.attr('max', maxBudgetValue);
-
-    if (oai_settings.thinkingBudget > maxBudgetValue) {
-        console.log(`Clamping thinkingBudget from ${oai_settings.thinkingBudget} to ${maxBudgetValue}`);
-        oai_settings.thinkingBudget = maxBudgetValue;
-        $slider.val(oai_settings.thinkingBudget);
-        $counter.val(oai_settings.thinkingBudget);
-        saveSettingsDebounced();
+        $('#thinking_budget_controls').hide();
     }
 }
 
@@ -3756,6 +3743,9 @@ async function saveOpenAIPreset(name, settings, triggerUi = true) {
         function_calling: settings.function_calling,
         show_thoughts: settings.show_thoughts,
         reasoning_effort: settings.reasoning_effort,
+        google_master_enable_thinking: settings.google_master_enable_thinking,
+        google_set_thinking_budget: settings.google_set_thinking_budget,
+        thinking_budget: settings.thinking_budget,
         enable_web_search: settings.enable_web_search,
         request_images: settings.request_images,
         seed: settings.seed,
@@ -4187,8 +4177,6 @@ function onSettingsPresetChange() {
             }
         }
 
-        updateThinkingBudgetUIState(); // Update dependent UI after preset load
-
         $('#chat_completion_source').trigger('change');
         $('#openai_logit_bias_preset').trigger('change');
         $('#openrouter_providers_chat').trigger('change');
@@ -4541,6 +4529,7 @@ async function onModelChange() {
         $('#temp_openai').attr('max', makersuite_max_temp).val(oai_settings.temp_openai).trigger('input');
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
+        updateThinkingBudgetUI();
     }
 
     if (oai_settings.chat_completion_source == chat_completion_sources.OPENROUTER) {
@@ -5608,6 +5597,7 @@ export function initOpenAI() {
     $('#chat_completion_source').on('change', function () {
         oai_settings.chat_completion_source = String($(this).find(':selected').val());
         toggleChatCompletionForms();
+        updateThinkingBudgetUI();
         saveSettingsDebounced();
         reconnectOpenAi();
         forceCharacterEditorTokenize();
@@ -5616,12 +5606,8 @@ export function initOpenAI() {
 
     $('#oai_max_context_unlocked').on('input', function (_e, data) {
         oai_settings.max_context_unlocked = !!$(this).prop('checked');
-
-        updateThinkingBudgetUIState(); // Update UI including max value and clamping
-
         if (data?.source !== 'preset') {
             $('#chat_completion_source').trigger('change');
-
         }
         saveSettingsDebounced();
     });
@@ -5797,6 +5783,38 @@ export function initOpenAI() {
         saveSettingsDebounced();
     });
 
+    $('#google_master_enable_thinking').on('input', function () {
+        oai_settings.google_master_enable_thinking = !!$(this).prop('checked');
+        updateThinkingBudgetUI();
+        saveSettingsDebounced();
+    });
+
+    $('#google_set_thinking_budget').on('input', function () {
+        oai_settings.google_set_thinking_budget = !!$(this).prop('checked');
+        updateThinkingBudgetUI();
+        saveSettingsDebounced();
+    });
+
+    $('#thinking_budget_slider').on('input', function () {
+        if (!$(this).prop('disabled')) {
+            oai_settings.thinking_budget = Number($(this).val());
+            $('#thinking_budget_counter').val(oai_settings.thinking_budget);
+            saveSettingsDebounced();
+        }
+    });
+    $('#thinking_budget_counter').on('input', function () {
+        if (!$(this).prop('disabled')) {
+            let value = Number($(this).val());
+            const min = Number($('#thinking_budget_slider').attr('min'));
+            const max = Number($('#thinking_budget_slider').attr('max'));
+            value = Math.max(min, Math.min(max, value));
+            $(this).val(value);
+            oai_settings.thinking_budget = value;
+            $('#thinking_budget_slider').val(value);
+            saveSettingsDebounced();
+        }
+    });
+
     $('#openai_enable_web_search').on('input', function () {
         oai_settings.enable_web_search = !!$(this).prop('checked');
         calculateOpenRouterCost();
@@ -5834,44 +5852,6 @@ export function initOpenAI() {
 
         oai_settings.openrouter_providers = selectedProviders;
 
-        saveSettingsDebounced();
-    });
-
-    $('#master_enable_thinking').on('change', function () {
-        oai_settings.masterEnableThinking = $(this).prop('checked');
-        updateThinkingBudgetUIState();
-        saveSettingsDebounced();
-    });
-
-    $('#use_thinking_budget_value').on('change', function () {
-        oai_settings.useThinkingBudget = $(this).prop('checked');
-        updateThinkingBudgetUIState();
-        saveSettingsDebounced();
-    });
-
-    $('#thinking_budget_slider').on('input', function () {
-        const value = Number($(this).val());
-        oai_settings.thinkingBudget = value;
-        $('#thinking_budget_counter').val(value);
-        saveSettingsDebounced();
-    });
-
-    $('#thinking_budget_counter').on('input', function () {
-        const max = Number($(this).attr('max'));
-        const min = Number($(this).attr('min'));
-        let value = Number($(this).val());
-
-        if (value > max) {
-            value = max;
-            $(this).val(value);
-        }
-        if (value < min) {
-            value = min;
-            $(this).val(value);
-        }
-
-        oai_settings.thinkingBudget = value;
-        $('#thinking_budget_slider').val(value); // Update linked slider
         saveSettingsDebounced();
     });
 

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -354,6 +354,14 @@ async function sendMakerSuiteRequest(request, response) {
         responseSchema: request.body.responseSchema,
     };
 
+    const thinkingConfigFromRequest = request.body?.generationConfig?.thinkingConfig;
+    if (thinkingConfigFromRequest && typeof thinkingConfigFromRequest.thinkingBudget === 'number') {
+        generationConfig.thinkingConfig = {
+            thinkingBudget: thinkingConfigFromRequest.thinkingBudget,
+        };
+        console.log('[chat-completions.js] Added thinkingConfig to generationConfig:', generationConfig.thinkingConfig);
+    }
+
     function getGeminiBody() {
         if (!Array.isArray(generationConfig.stopSequences) || !generationConfig.stopSequences.length) {
             delete generationConfig.stopSequences;
@@ -439,7 +447,11 @@ async function sendMakerSuiteRequest(request, response) {
             controller.abort();
         });
 
-        const apiVersion = isThinking ? 'v1alpha' : 'v1beta';
+        let apiVersion = isThinking ? 'v1alpha' : 'v1beta';
+        if (generationConfig.thinkingConfig && apiVersion !== 'v1alpha') {
+            apiVersion = 'v1alpha';
+        }
+
         const responseType = (stream ? 'streamGenerateContent' : 'generateContent');
 
         const generateResponse = await fetch(`${apiUrl.toString().replace(/\/$/, '')}/${apiVersion}/models/${model}:${responseType}?key=${apiKey}${stream ? '&alt=sse' : ''}`, {
@@ -450,6 +462,8 @@ async function sendMakerSuiteRequest(request, response) {
             },
             signal: controller.signal,
         });
+
+
         // have to do this because of their busted ass streaming endpoint
         if (stream) {
             try {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -359,7 +359,6 @@ async function sendMakerSuiteRequest(request, response) {
         generationConfig.thinkingConfig = {
             thinkingBudget: thinkingConfigFromRequest.thinkingBudget,
         };
-        console.log('[chat-completions.js] Added thinkingConfig to generationConfig:', generationConfig.thinkingConfig);
     }
 
     function getGeminiBody() {
@@ -447,11 +446,7 @@ async function sendMakerSuiteRequest(request, response) {
             controller.abort();
         });
 
-        let apiVersion = isThinking ? 'v1alpha' : 'v1beta';
-        if (generationConfig.thinkingConfig && apiVersion !== 'v1alpha') {
-            apiVersion = 'v1alpha';
-        }
-
+        const apiVersion = isThinking ? 'v1alpha' : 'v1beta';
         const responseType = (stream ? 'streamGenerateContent' : 'generateContent');
 
         const generateResponse = await fetch(`${apiUrl.toString().replace(/\/$/, '')}/${apiVersion}/models/${model}:${responseType}?key=${apiKey}${stream ? '&alt=sse' : ''}`, {
@@ -462,8 +457,6 @@ async function sendMakerSuiteRequest(request, response) {
             },
             signal: controller.signal,
         });
-
-
         // have to do this because of their busted ass streaming endpoint
         if (stream) {
             try {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -336,6 +336,11 @@ async function sendMakerSuiteRequest(request, response) {
         return response.status(400).send({ error: true });
     }
 
+    const googleThinkingBudgetModels = [
+        'gemini-2.5-flash-preview-04-17',
+        // Add future models here
+    ];
+
     const model = String(request.body.model);
     const stream = Boolean(request.body.stream);
     const enableWebSearch = Boolean(request.body.enable_web_search);
@@ -354,11 +359,19 @@ async function sendMakerSuiteRequest(request, response) {
         responseSchema: request.body.responseSchema,
     };
 
-    const thinkingConfigFromRequest = request.body?.generationConfig?.thinkingConfig;
-    if (thinkingConfigFromRequest && typeof thinkingConfigFromRequest.thinkingBudget === 'number') {
-        generationConfig.thinkingConfig = {
-            thinkingBudget: thinkingConfigFromRequest.thinkingBudget,
-        };
+    if (googleThinkingBudgetModels.includes(model) && request.body.google_master_enable_thinking !== undefined) {
+        const thinkingMasterEnabled = Boolean(request.body.google_master_enable_thinking);
+        const setThinkingBudget = Boolean(request.body.google_set_thinking_budget);
+        const thinkingBudgetValue = Number(request.body.thinking_budget);
+
+        if (!thinkingMasterEnabled) {
+            // Master switch is OFF: Explicitly disable thinking
+            generationConfig.thinkingConfig = { thinkingBudget: 0 };
+        } else if (setThinkingBudget) {
+            // Master switch ON, Set Budget ON: Use received slider value
+            generationConfig.thinkingConfig = { thinkingBudget: thinkingBudgetValue };
+        }
+        // If Master switch ON, Set Budget OFF: Do nothing, generationConfig.thinkingConfig remains unset
     }
 
     function getGeminiBody() {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Second attempt, hopefully this works fine.

This adds a `Enable thinking` and `Set thinking budget` checkboxes for Gemini 2.5 flash (And future models) with a slider for `Thinking Budget (tokens)`

This behaves exactly like Google AI studio:

`Enable thinking` is ON, `Set thinking budget` is OFF = Default thinking without a budget.
`Enable thinking` is ON, `Set thinking budget` is ON  = Uses the `Thinking Budget (tokens)` slider value.
`Enable thinking` is OFF = No thinking. (thinking budget = 0)

This only appears/works for Gemini 2.5 flash.