### PR TITLE
downloadGenericPng() handle missing file PNG extension

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -12179,8 +12179,20 @@ jQuery(async function () {
 
             const data = await request.blob();
             const customContentType = request.headers.get('X-Custom-Content-Type');
-            const fileName = request.headers.get('Content-Disposition').split('filename=')[1].replace(/"/g, '');
-            const file = new File([data], fileName, { type: data.type });
+            let fileName = sanitize(result.url.split('?')[0].split('/').reverse()[0]);
+            const contentType = result.headers.get('content-type') || 'image/png'; //yoink it from AICC function lol
+
+            // The `importCharacter()` function detects the MIME (content-type) of the file
+            // using its file extension. The problem is that not all third-party APIs serve
+            // their cards with a `.png` extension. To support more third-party sites,
+            // dynamically append the `.png` extension to the filename if it doesn't
+            // already have a file extension.
+            if (contentType === 'image/png') {
+                const ext = fileName.match(/\.(\w+)$/); // Same regex used by `importCharacter()`
+                if (!ext) {
+                    fileName += '.png';
+                }
+            }
 
             switch (customContentType) {
                 case 'character':


### PR DESCRIPTION
The `importCharacter()` function detects the MIME (content-type) of the file using its file extension. The problem is that not all third-party APIs serve their cards with a `.png` extension. To support more third-party sites, the `.png` extension is dynamically appended to the filename if it doesn't already have a file extension.

This will support URLs like `https://example.com/api/character/bobjoe123`

Also, log downloaded generic URL in the server console.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
