### PR TITLE
add char-archive to whitelistImportDomains

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -155,6 +155,7 @@ whitelistImportDomains:
   - cdn.discordapp.com
   - files.catbox.moe
   - raw.githubusercontent.com
+  - char-archive.evulid.cc
 # API request overrides (for KoboldAI and Text Completion APIs)
 ## Note: host includes the port number if it's not the default (80 or 443)
 ## Format is an array of objects:


### PR DESCRIPTION
Adds `char-archive.evulid.cc` to `whitelistImportDomains` in the default config to allow generic importing from this source by default.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
