### PR TITLE
change language when context size exceeded

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1412,9 +1412,9 @@ export async function prepareOpenAIMessages({
         await populateChatCompletion(prompts, chatCompletion, { bias, quietPrompt, quietImage, type, cyclePrompt, messages, messageExamples });
     } catch (error) {
         if (error instanceof TokenBudgetExceededError) {
-            toastr.error(t`An error occurred while counting tokens: Token budget exceeded.`);
-            chatCompletion.log('Token budget exceeded.');
-            promptManager.error = t`Not enough free tokens for mandatory prompts. Raise your token Limit or disable custom prompts.`;
+            toastr.error(t`Context size exceeded.`);
+            chatCompletion.log('Context size exceeded.');
+            promptManager.error = t`Not enough free tokens for mandatory prompts. Raise your token limit or disable custom prompts.`;
         } else if (error instanceof InvalidCharacterNameError) {
             toastr.warning(t`An error occurred while counting tokens: Invalid character name`);
             chatCompletion.log('Invalid character name');

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1412,8 +1412,8 @@ export async function prepareOpenAIMessages({
         await populateChatCompletion(prompts, chatCompletion, { bias, quietPrompt, quietImage, type, cyclePrompt, messages, messageExamples });
     } catch (error) {
         if (error instanceof TokenBudgetExceededError) {
-            toastr.error(t`Context size exceeded.`);
-            chatCompletion.log('Context size exceeded.');
+            toastr.error(t`Mandatory prompts exceed the context size.`);
+            chatCompletion.log('Mandatory prompts exceed the context size.');
             promptManager.error = t`Not enough free tokens for mandatory prompts. Raise your token limit or disable custom prompts.`;
         } else if (error instanceof InvalidCharacterNameError) {
             toastr.warning(t`An error occurred while counting tokens: Invalid character name`);


### PR DESCRIPTION
I believe this language is less confusing, as it makes it clear that it isn't an error like "we can't even count the number of tokens since there's too much" and is consistent with the wording the "sampler" configuration panel uses.
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
