### PR TITLE
World Info chat-independent data matching

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -124,6 +124,10 @@
     cursor: initial;
 }
 
+.world_entry .inline-drawer-header-pointer {
+    cursor: pointer;
+}
+
 .world_entry .killSwitch {
     cursor: pointer;
 }

--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -275,6 +275,6 @@ select.keyselect+span.select2-container .select2-selection--multiple {
     width: 100%;
 }
 
-.world_entry:has(input[name="delay_until_recursion"]:not(:checked)) .world_entry_form_control_recursion_delay:has(input[name="delayUntilRecursionLevel"]) {
+.world_entry:has(input[name="delay_until_recursion"]:not(:checked)) .world_entry_form_control:has(input[name="delayUntilRecursionLevel"]) {
     display: none;
 }

--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -275,6 +275,6 @@ select.keyselect+span.select2-container .select2-selection--multiple {
     width: 100%;
 }
 
-.world_entry:has(input[name="delay_until_recursion"]:not(:checked)) .world_entry_form_control:has(input[name="delayUntilRecursionLevel"]) {
+.world_entry:has(input[name="delay_until_recursion"]:not(:checked)) .world_entry_form_control_recursion_delay:has(input[name="delayUntilRecursionLevel"]) {
     display: none;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -6087,9 +6087,6 @@
                                         </button>
                                     </div>
                                 </div>
-
-
-
                                 <div name="contentAndCharFilterBlock" class="world_entry_thin_controls flex2">
                                     <div class="world_entry_form_control flex1">
                                         <label for="content ">

--- a/public/index.html
+++ b/public/index.html
@@ -6297,41 +6297,43 @@
                                     <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                 </div>
                                 <div class="inline-drawer-content flex-container flexFlowRow flexGap10 paddingBottom5px">
-                                    <small>
-                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <input type="checkbox" name="matchPersonaDescription" />
-                                            <span data-i18n="Match Persona Description">
-                                                Match Persona Description
-                                            </span>
-                                        </label>
+                                    <small class="flex-container flex1 flexFlowColumn">
                                         <label class="checkbox flex-container alignItemsCenter flexNoGap">
                                             <input type="checkbox" name="matchCharacterDescription" />
-                                            <span data-i18n="Match Character Description">
-                                                Match Character Description
+                                            <span data-i18n="Character Description">
+                                                Character Description
                                             </span>
                                         </label>
                                         <label class="checkbox flex-container alignItemsCenter flexNoGap">
                                             <input type="checkbox" name="matchCharacterPersonality" />
-                                            <span data-i18n="Match Character Personality">
-                                                Match Character Personality
-                                            </span>
-                                        </label>
-                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <input type="checkbox" name="matchCharacterDepthPrompt" />
-                                            <span data-i18n="Match Character Note">
-                                                Match Character Note
+                                            <span data-i18n="Character Personality">
+                                                Character Personality
                                             </span>
                                         </label>
                                         <label class="checkbox flex-container alignItemsCenter flexNoGap">
                                             <input type="checkbox" name="matchScenario" />
-                                            <span data-i18n="Match Scenario">
-                                                Match Scenario
+                                            <span data-i18n="Scenario">
+                                                Scenario
+                                            </span>
+                                        </label>
+                                    </small>
+                                    <small class="flex-container flex1 flexFlowColumn">
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchPersonaDescription" />
+                                            <span data-i18n="Persona Description">
+                                                Persona Description
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchCharacterDepthPrompt" />
+                                            <span data-i18n="Character's Note">
+                                                Character's Note
                                             </span>
                                         </label>
                                         <label class="checkbox flex-container alignItemsCenter flexNoGap">
                                             <input type="checkbox" name="matchCreatorNotes" />
-                                            <span data-i18n="Match Creator Notes">
-                                                Match Creator Notes
+                                            <span data-i18n="Creator's Notes">
+                                                Creator's Notes
                                             </span>
                                         </label>
                                     </small>

--- a/public/index.html
+++ b/public/index.html
@@ -6087,6 +6087,47 @@
                                         </button>
                                     </div>
                                 </div>
+                                <div name="perEntryOverridesBlock" class="flex-container wide100p alignitemscenter">
+                                    <div class="world_entry_form_control flex1">
+                                        <small class="textAlignCenter" data-i18n="Scan Depth">Scan Depth</small>
+                                        <input class="text_pole margin0" name="scanDepth" type="number" placeholder="Use global setting" data-i18n="[placeholder]Use global setting" max="1000">
+                                    </div>
+                                    <div class="world_entry_form_control flex1">
+                                        <small class="textAlignCenter" data-i18n="Case-Sensitive">Case-Sensitive</small>
+                                        <select name="caseSensitive" class="text_pole widthNatural margin0">
+                                            <option value="null" data-i18n="Use global">Use global</option>
+                                            <option value="true" data-i18n="Yes">Yes</option>
+                                            <option value="false" data-i18n="No">No</option>
+                                        </select>
+                                    </div>
+                                    <div class="world_entry_form_control flex1">
+                                        <small class="textAlignCenter" data-i18n="Whole Words">Whole Words</small>
+                                        <select name="matchWholeWords" class="text_pole widthNatural margin0">
+                                            <option value="null" data-i18n="Use global">Use global</option>
+                                            <option value="true" data-i18n="Yes">Yes</option>
+                                            <option value="false" data-i18n="No">No</option>
+                                        </select>
+                                    </div>
+                                    <div class="world_entry_form_control flex1">
+                                        <small class="textAlignCenter" data-i18n="Group Scoring">Group Scoring</small>
+                                        <select name="useGroupScoring" class="text_pole widthNatural margin0">
+                                            <option value="null" data-i18n="Use global">Use global</option>
+                                            <option value="true" data-i18n="Yes">Yes</option>
+                                            <option value="false" data-i18n="No">No</option>
+                                        </select>
+                                    </div>
+                                    <div class="world_entry_form_control flex1" title="Can be used to automatically activate Quick Replies" data-i18n="[title]Can be used to automatically activate Quick Replies">
+                                        <small class="textAlignCenter" data-i18n="Automation ID">Automation ID</small>
+                                        <input class="text_pole margin0" name="automationId" type="text" placeholder="( None )" data-i18n="[placeholder]( None )">
+                                    </div>
+                                    <div class="world_entry_form_control flex1" title="Defines delay levels for recursive scans.&#13;&#13;Initially, only the first level (smallest number) will match.&#13;Once no matches are found, the next level becomes eligible for matching.&#13;This repeats until all levels are checked.&#13;&#13;Tied to the &quot;Delay until recursion&quot; setting." data-i18n="[title]delay_until_recursion_level">
+                                        <small class="textAlignCenter">
+                                            <span data-i18n="Recursion Level">Recursion Level</span>
+                                            <div class="fa-solid fa-circle-info opacity50p"></div>
+                                        </small>
+                                        <input class="text_pole margin0" name="delayUntilRecursionLevel" type="text" placeholder="1">
+                                    </div>
+                                </div>
                                 <div name="contentAndCharFilterBlock" class="world_entry_thin_controls flex2">
                                     <div class="world_entry_form_control flex1">
                                         <label for="content ">
@@ -6102,6 +6143,26 @@
                                                         (<span data-i18n="extension_token_counter">Tokens:</span>&nbsp; <span class="world_entry_form_token_counter" data-first-run="true">counting...</span>)&nbsp;
                                                         <span class="world_entry_form_uid_value" data-first-run="true"></span>
                                                     </span>
+                                                    <div>
+                                                        <label class="checkbox flex-container alignitemscenter flexNoGap">
+                                                            <input type="checkbox" name="exclude_recursion" />
+                                                            <span data-i18n="Non-recursable (will not be activated by another)">
+                                                                Non-recursable (will not be activated by another)
+                                                            </span>
+                                                        </label>
+                                                        <label class="checkbox flex-container alignitemscenter flexNoGap">
+                                                            <input type="checkbox" name="prevent_recursion" />
+                                                            <span data-i18n="Prevent further recursion (this entry will not activate others)">
+                                                                Prevent further recursion (will not activate others)
+                                                            </span>
+                                                        </label>
+                                                        <label class="checkbox flex-container alignitemscenter flexNoGap">
+                                                            <input type="checkbox" name="delay_until_recursion" />
+                                                            <span data-i18n="Delay until recursion (can only be activated on recursive checking)">
+                                                                Delay until recursion (can only be activated on recursive checking)
+                                                            </span>
+                                                        </label>
+                                                    </div>
                                                 </span>
                                             </small>
                                             <small class="displayNone">
@@ -6119,113 +6180,48 @@
 
                             <div class="inline-drawer wide100p flexFlowColumn">
                                 <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable">
-                                    <strong>Activation Settings</strong>
+                                    <strong>Additional Matching Sources</strong>
                                     <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                 </div>
                                 <div class="inline-drawer-content flex-container flexFlowRow flexGap10 paddingBottom5px">
-                                    <div class="flex1 flex-container flexFlowColumn flexGap10">
-                                        <div class="flex-container flexFlowRow alignItemsCenter justifySpaceBetween" title="Can be used to automatically activate Quick Replies" data-i18n="[title]Can be used to automatically activate Quick Replies">
-                                            <small class="flex1" data-i18n="Automation ID">Automation ID</small>
-                                            <input class="flex1 text_pole margin0" name="automationId" type="text" placeholder="( None )" data-i18n="[placeholder]( None )">
-                                        </div>
-                                        <div class="flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Scan Depth">Scan Depth</small>
-                                            <input class="text_pole margin0 flex1" name="scanDepth" type="number" placeholder="Use global setting" data-i18n="[placeholder]Use global setting" max="1000">
-                                        </div>
-                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Case-Sensitive">Case-Sensitive</small>
-                                            <select name="caseSensitive" class="text_pole widthNatural margin0 flex1">
-                                                <option value="null" data-i18n="Use global">Use global</option>
-                                                <option value="true" data-i18n="Yes">Yes</option>
-                                                <option value="false" data-i18n="No">No</option>
-                                            </select>
-                                        </div>
-                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Whole Words">Whole Words</small>
-                                            <select name="matchWholeWords" class="text_pole widthNatural margin0 flex1">
-                                                <option value="null" data-i18n="Use global">Use global</option>
-                                                <option value="true" data-i18n="Yes">Yes</option>
-                                                <option value="false" data-i18n="No">No</option>
-                                            </select>
-                                        </div>
-                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Group Scoring">Group Scoring</small>
-                                            <select name="useGroupScoring" class="text_pole widthNatural margin0 flex1">
-                                                <option value="null" data-i18n="Use global">Use global</option>
-                                                <option value="true" data-i18n="Yes">Yes</option>
-                                                <option value="false" data-i18n="No">No</option>
-                                            </select>
-                                        </div>
-
-                                        <small>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="delay_until_recursion" />
-                                                <span data-i18n="Delay until recursion (can only be activated on recursive checking)">
-                                                    Delay until recursion (can only be activated on recursive checking)
-                                                </span>
-                                            </label>
-                                        </small>
-                                        <div class="world_entry_form_control_recursion_delay flex-container alignItemsCenter" title="Defines delay levels for recursive scans.&#13;&#13;Initially, only the first level (smallest number) will match.&#13;Once no matches are found, the next level becomes eligible for matching.&#13;This repeats until all levels are checked.&#13;&#13;Tied to the &quot;Delay until recursion&quot; setting." data-i18n="[title]delay_until_recursion_level">
-                                            <small class="flex1">
-                                                <span data-i18n="Recursion Level">Recursion Level</span>
-                                                <div class="fa-solid fa-circle-info opacity50p"></div>
-                                            </small>
-                                            <input class="flex1 text_pole margin0" name="delayUntilRecursionLevel" type="text" placeholder="1">
-                                        </div>
-                                    </div>
-
-                                    <div class="flex1 flex-container flexFlowColumn flexGap10">
-                                        <small>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="exclude_recursion" />
-                                                <span data-i18n="Non-recursable (will not be activated by another)">
-                                                    Non-recursable (will not be activated by another)
-                                                </span>
-                                            </label>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="prevent_recursion" />
-                                                <span data-i18n="Prevent further recursion (this entry will not activate others)">
-                                                    Prevent further recursion (will not activate others)
-                                                </span>
-                                            </label>                                            
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="matchPersonaDescription" />
-                                                <span data-i18n="Match Persona Description">
-                                                    Match Persona Description
-                                                </span>
-                                            </label>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="matchCharacterDescription" />
-                                                <span data-i18n="Match Character Description">
-                                                    Match Character Description
-                                                </span>
-                                            </label>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="matchCharacterPersonality" />
-                                                <span data-i18n="Match Character Personality">
-                                                    Match Character Personality
-                                                </span>
-                                            </label>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="matchCharacterDepthPrompt" />
-                                                <span data-i18n="Match Character Note">
-                                                    Match Character Note
-                                                </span>
-                                            </label>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="matchScenario" />
-                                                <span data-i18n="Match Scenario">
-                                                    Match Scenario
-                                                </span>
-                                            </label>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="matchCreatorNotes" />
-                                                <span data-i18n="Match Creator Notes">
-                                                    Match Creator Notes
-                                                </span>
-                                            </label>
-                                        </small>
-                                    </div>
+                                    <small>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchPersonaDescription" />
+                                            <span data-i18n="Match Persona Description">
+                                                Match Persona Description
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchCharacterDescription" />
+                                            <span data-i18n="Match Character Description">
+                                                Match Character Description
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchCharacterPersonality" />
+                                            <span data-i18n="Match Character Personality">
+                                                Match Character Personality
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchCharacterDepthPrompt" />
+                                            <span data-i18n="Match Character Note">
+                                                Match Character Note
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchScenario" />
+                                            <span data-i18n="Match Scenario">
+                                                Match Scenario
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchCreatorNotes" />
+                                            <span data-i18n="Match Creator Notes">
+                                                Match Creator Notes
+                                            </span>
+                                        </label>
+                                    </small>
                                 </div>
                             </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -6293,7 +6293,7 @@
                             </div>
                             <div class="inline-drawer wide100p flexFlowColumn">
                                 <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable">
-                                    <strong>Additional Matching Sources</strong>
+                                    <strong data-i18n="Additional Matching Sources">Additional Matching Sources</strong>
                                     <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                 </div>
                                 <div class="inline-drawer-content flex-container flexFlowRow flexGap10 paddingBottom5px">

--- a/public/index.html
+++ b/public/index.html
@@ -6210,7 +6210,7 @@
                                                 </span>
                                             </label>
                                             <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="matchCharacterNote" />
+                                                <input type="checkbox" name="matchCharacterDepthPrompt" />
                                                 <span data-i18n="Match Character Note">
                                                     Match Character Note
                                                 </span>

--- a/public/index.html
+++ b/public/index.html
@@ -6177,54 +6177,6 @@
                                 <div class="world_entry_thin_controls commentContainer">
                                 </div>
                             </div>
-
-                            <div class="inline-drawer wide100p flexFlowColumn">
-                                <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable">
-                                    <strong>Additional Matching Sources</strong>
-                                    <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
-                                </div>
-                                <div class="inline-drawer-content flex-container flexFlowRow flexGap10 paddingBottom5px">
-                                    <small>
-                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <input type="checkbox" name="matchPersonaDescription" />
-                                            <span data-i18n="Match Persona Description">
-                                                Match Persona Description
-                                            </span>
-                                        </label>
-                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <input type="checkbox" name="matchCharacterDescription" />
-                                            <span data-i18n="Match Character Description">
-                                                Match Character Description
-                                            </span>
-                                        </label>
-                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <input type="checkbox" name="matchCharacterPersonality" />
-                                            <span data-i18n="Match Character Personality">
-                                                Match Character Personality
-                                            </span>
-                                        </label>
-                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <input type="checkbox" name="matchCharacterDepthPrompt" />
-                                            <span data-i18n="Match Character Note">
-                                                Match Character Note
-                                            </span>
-                                        </label>
-                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <input type="checkbox" name="matchScenario" />
-                                            <span data-i18n="Match Scenario">
-                                                Match Scenario
-                                            </span>
-                                        </label>
-                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <input type="checkbox" name="matchCreatorNotes" />
-                                            <span data-i18n="Match Creator Notes">
-                                                Match Creator Notes
-                                            </span>
-                                        </label>
-                                    </small>
-                                </div>
-                            </div>
-
                             <div class="flex-container wide100p flexGap10">
                                 <div class="flex4 flex-container flexFlowColumn flexNoGap">
                                     <div class="flex-container justifySpaceBetween">
@@ -6337,6 +6289,52 @@
                                         <input type="checkbox" name="addMemo">
                                         <span data-i18n="Add Memo">Add Memo</span>
                                     </label>
+                                </div>
+                            </div>
+                            <div class="inline-drawer wide100p flexFlowColumn">
+                                <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable">
+                                    <strong>Additional Matching Sources</strong>
+                                    <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                                </div>
+                                <div class="inline-drawer-content flex-container flexFlowRow flexGap10 paddingBottom5px">
+                                    <small>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchPersonaDescription" />
+                                            <span data-i18n="Match Persona Description">
+                                                Match Persona Description
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchCharacterDescription" />
+                                            <span data-i18n="Match Character Description">
+                                                Match Character Description
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchCharacterPersonality" />
+                                            <span data-i18n="Match Character Personality">
+                                                Match Character Personality
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchCharacterDepthPrompt" />
+                                            <span data-i18n="Match Character Note">
+                                                Match Character Note
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchScenario" />
+                                            <span data-i18n="Match Scenario">
+                                                Match Scenario
+                                            </span>
+                                        </label>
+                                        <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <input type="checkbox" name="matchCreatorNotes" />
+                                            <span data-i18n="Match Creator Notes">
+                                                Match Creator Notes
+                                            </span>
+                                        </label>
+                                    </small>
                                 </div>
                             </div>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -6292,7 +6292,7 @@
                                 </div>
                             </div>
                             <div class="inline-drawer wide100p flexFlowColumn">
-                                <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable">
+                                <div class="inline-drawer-toggle inline-drawer-header inline-drawer-header-pointer userSettingsInnerExpandable">
                                     <strong data-i18n="Additional Matching Sources">Additional Matching Sources</strong>
                                     <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -6174,26 +6174,12 @@
                                     <strong>Activation Settings</strong>
                                     <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                 </div>
-                                <div class="inline-drawer-content flex-container flexFlowRow flexGap10">
+                                <div class="inline-drawer-content flex-container flexFlowRow flexGap10 paddingBottom5px">
                                     <div class="flex1 flex-container flexFlowColumn flexGap10">
                                         <div class="flex-container flexFlowRow alignItemsCenter justifySpaceBetween" title="Can be used to automatically activate Quick Replies" data-i18n="[title]Can be used to automatically activate Quick Replies">
                                             <small class="flex1" data-i18n="Automation ID">Automation ID</small>
                                             <input class="flex1 text_pole margin0" name="automationId" type="text" placeholder="( None )" data-i18n="[placeholder]( None )">
                                         </div>
-                                        <small>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="exclude_recursion" />
-                                                <span data-i18n="Non-recursable (will not be activated by another)">
-                                                    Non-recursable (will not be activated by another)
-                                                </span>
-                                            </label>
-                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
-                                                <input type="checkbox" name="prevent_recursion" />
-                                                <span data-i18n="Prevent further recursion (this entry will not activate others)">
-                                                    Prevent further recursion (will not activate others)
-                                                </span>
-                                            </label>
-                                        </small>
                                         <div class="flex-container alignItemsCenter flexNoGap">
                                             <small class="flex1" data-i18n="Scan Depth">Scan Depth</small>
                                             <input class="text_pole margin0 flex1" name="scanDepth" type="number" placeholder="Use global setting" data-i18n="[placeholder]Use global setting" max="1000">
@@ -6241,54 +6227,56 @@
                                     </div>
 
                                     <div class="flex1 flex-container flexFlowColumn flexGap10">
-                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Match Persona Description">Match Persona Description</small>
-                                            <select name="matchPersonaDescription" class="text_pole widthNatural margin0 flex1">
-                                                <option value="null" data-i18n="Use global">Use global</option>
-                                                <option value="true" data-i18n="Yes">Yes</option>
-                                                <option value="false" data-i18n="No">No</option>
-                                            </select>
-                                        </div>
-                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Match Character Description">Match Character Description</small>
-                                            <select name="matchCharacterDescription" class="text_pole widthNatural margin0 flex1">
-                                                <option value="null" data-i18n="Use global">Use global</option>
-                                                <option value="true" data-i18n="Yes">Yes</option>
-                                                <option value="false" data-i18n="No">No</option>
-                                            </select>
-                                        </div>
-                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Match Character Personality">Match Character Personality</small>
-                                            <select name="matchCharacterPersonality" class="text_pole widthNatural margin0 flex1">
-                                                <option value="null" data-i18n="Use global">Use global</option>
-                                                <option value="true" data-i18n="Yes">Yes</option>
-                                                <option value="false" data-i18n="No">No</option>
-                                            </select>
-                                        </div>
-                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Match Character Note">Match Character Note</small>
-                                            <select name="matchCharacterNote" class="text_pole widthNatural margin0 flex1">
-                                                <option value="null" data-i18n="Use global">Use global</option>
-                                                <option value="true" data-i18n="Yes">Yes</option>
-                                                <option value="false" data-i18n="No">No</option>
-                                            </select>
-                                        </div>
-                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Match Scenario">Match Scenario</small>
-                                            <select name="matchScenario" class="text_pole widthNatural margin0 flex1">
-                                                <option value="null" data-i18n="Use global">Use global</option>
-                                                <option value="true" data-i18n="Yes">Yes</option>
-                                                <option value="false" data-i18n="No">No</option>
-                                            </select>
-                                        </div>
-                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Match Creator Notes">Match Creator Notes</small>
-                                            <select name="matchCreatorNotes" class="text_pole widthNatural margin0 flex1">
-                                                <option value="null" data-i18n="Use global">Use global</option>
-                                                <option value="true" data-i18n="Yes">Yes</option>
-                                                <option value="false" data-i18n="No">No</option>
-                                            </select>
-                                        </div>
+                                        <small>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="exclude_recursion" />
+                                                <span data-i18n="Non-recursable (will not be activated by another)">
+                                                    Non-recursable (will not be activated by another)
+                                                </span>
+                                            </label>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="prevent_recursion" />
+                                                <span data-i18n="Prevent further recursion (this entry will not activate others)">
+                                                    Prevent further recursion (will not activate others)
+                                                </span>
+                                            </label>                                            
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="matchPersonaDescription" />
+                                                <span data-i18n="Match Persona Description">
+                                                    Match Persona Description
+                                                </span>
+                                            </label>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="matchCharacterDescription" />
+                                                <span data-i18n="Match Character Description">
+                                                    Match Character Description
+                                                </span>
+                                            </label>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="matchCharacterPersonality" />
+                                                <span data-i18n="Match Character Personality">
+                                                    Match Character Personality
+                                                </span>
+                                            </label>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="matchCharacterNote" />
+                                                <span data-i18n="Match Character Note">
+                                                    Match Character Note
+                                                </span>
+                                            </label>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="matchScenario" />
+                                                <span data-i18n="Match Scenario">
+                                                    Match Scenario
+                                                </span>
+                                            </label>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="matchCreatorNotes" />
+                                                <span data-i18n="Match Creator Notes">
+                                                    Match Creator Notes
+                                                </span>
+                                            </label>
+                                        </small>
                                     </div>
                                 </div>
                             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -4079,7 +4079,7 @@
                                     <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                 </div>
                                 <div class="inline-drawer-content">
-                                    <div id="wiActivationSettings" class="flex-container">
+                                    <div id="wiActivationSettings">
                                         <div id="wiSliders" class="flex2 flex-container">
                                             <div class="alignitemscenter flex-container flexFlowColumn flexGrow flexShrink gap0 flexBasis48p">
                                                 <small>
@@ -4131,31 +4131,12 @@
                                                 <input class="neo-range-slider" type="range" id="world_info_max_recursion_steps" name="world_info_max_recursion_steps" min="0" max="10" step="1">
                                                 <input class="neo-range-input" type="number" min="0" max="10" step="1" data-for="world_info_max_recursion_steps" id="world_info_max_recursion_steps_counter">
                                             </div>
-
-                                            <div class="alignitemscenter flex-container flexFlowColumn flexGrow flexShrink flexBasis48p">
-                                                <small data-i18n="Insertion Strategy">
-                                                    Insertion Strategy
-                                                </small>
-                                                <select id="world_info_character_strategy" class="flexGrow margin0">
-                                                    <option value="0" data-i18n="Sorted Evenly">Sorted Evenly</option>
-                                                    <option value="1" data-i18n="Character Lore First">Character Lore First</option>
-                                                    <option value="2" data-i18n="Global Lore First">Global Lore First</option>
-                                                </select>
-                                            </div>
                                         </div>
-                                        <div id="wiCheckboxes" class="flex1 flex-container flexFlowColumn">
-                                            <label title="Include names with each message into the context for scanning" data-i18n="[title]Include names with each message into the context for scanning" class="checkbox_label flex1">
-                                                <input id="world_info_include_names" type="checkbox" />
-                                                <small data-i18n="Include Names" class="whitespacenowrap flex1">
-                                                    Include Names
-                                                </small>
-                                            </label>
-                                            <label title="Entries can activate other entries by mentioning their keywords" data-i18n="[title]Entries can activate other entries by mentioning their keywords" class="checkbox_label flex1">
-                                                <input id="world_info_recursive" type="checkbox" />
-                                                <small data-i18n="Recursive Scan" class="whitespacenowrap flex1">
-                                                    Recursive Scan
-                                                </small>
-                                            </label>
+                                        <hr class="width100p">
+                                        <div class="flex-container flexFlowColumn flexGrow flexShrink flexBasis48p">
+                                            <small class="textAlignCenter" data-i18n="Matching Strategy">
+                                                Matching Strategy
+                                            </small>
                                             <label title="Lookup for the entry keys in the context will respect the case" data-i18n="[title]Lookup for the entry keys in the context will respect the case" class="checkbox_label flex1">
                                                 <input id="world_info_case_sensitive" type="checkbox" />
                                                 <small data-i18n="Case Sensitive" class="whitespacenowrap flex1">
@@ -4166,6 +4147,61 @@
                                                 <input id="world_info_match_whole_words" type="checkbox" />
                                                 <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
                                                     Match Whole Words
+                                                </small>
+                                            </label>
+                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
+                                                <input id="world_info_match_whole_words" type="checkbox" />
+                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
+                                                    Match Persona Description
+                                                </small>
+                                            </label>
+                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
+                                                <input id="world_info_match_whole_words" type="checkbox" />
+                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
+                                                    Match Character Description
+                                                </small>
+                                            </label>
+                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
+                                                <input id="world_info_match_whole_words" type="checkbox" />
+                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
+                                                    Match Character Personality
+                                                </small>
+                                            </label>
+                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
+                                                <input id="world_info_match_whole_words" type="checkbox" />
+                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
+                                                    Match Character Note
+                                                </small>
+                                            </label>
+                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
+                                                <input id="world_info_match_whole_words" type="checkbox" />
+                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
+                                                    Match Scenario
+                                                </small>
+                                            </label>
+                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
+                                                <input id="world_info_match_characters_metadata" type="checkbox" />
+                                                <small data-i18n="Match Characters Metadata" class="whitespacenowrap flex1">
+                                                    Match Characters Metadata
+                                                </small>
+                                            </label>
+                                        </div>
+
+                                        <hr class="width100p">
+                                        <div class="flex-container flexFlowColumn flexGrow flexShrink flexBasis48p">
+                                            <small class="textAlignCenter" data-i18n="Miscelaneous">
+                                                Miscelaneous
+                                            </small>
+                                            <label title="Include names with each message into the context for scanning" data-i18n="[title]Include names with each message into the context for scanning" class="checkbox_label flex1">
+                                                <input id="world_info_include_names" type="checkbox" />
+                                                <small data-i18n="Include Names" class="whitespacenowrap flex1">
+                                                    Include Names
+                                                </small>
+                                            </label>
+                                            <label title="Entries can activate other entries by mentioning their keywords" data-i18n="[title]Entries can activate other entries by mentioning their keywords" class="checkbox_label flex1">
+                                                <input id="world_info_recursive" type="checkbox" />
+                                                <small data-i18n="Recursive Scan" class="whitespacenowrap flex1">
+                                                    Recursive Scan
                                                 </small>
                                             </label>
                                             <label title="Only the entries with the most number of key matches will be selected for Inclusion Group filtering" data-i18n="[title]Only the entries with the most number of key matches will be selected for Inclusion Group filtering" class="checkbox_label flex1">
@@ -4181,6 +4217,19 @@
                                                 </small>
                                             </label>
                                         </div>
+
+                                        <hr class="width100p">
+                                        <div class="alignitemscenter flex-container flexFlowColumn flexGrow flexShrink flexBasis48p">
+                                            <small data-i18n="Insertion Strategy">
+                                                Insertion Strategy
+                                            </small>
+                                            <select id="world_info_character_strategy" class="flexGrow margin0">
+                                                <option value="0" data-i18n="Sorted Evenly">Sorted Evenly</option>
+                                                <option value="1" data-i18n="Character Lore First">Character Lore First</option>
+                                                <option value="2" data-i18n="Global Lore First">Global Lore First</option>
+                                            </select>
+                                        </div>
+
                                     </div>
                                 </div>
                             </div>
@@ -6087,47 +6136,9 @@
                                         </button>
                                     </div>
                                 </div>
-                                <div name="perEntryOverridesBlock" class="flex-container wide100p alignitemscenter">
-                                    <div class="world_entry_form_control flex1">
-                                        <small class="textAlignCenter" data-i18n="Scan Depth">Scan Depth</small>
-                                        <input class="text_pole margin0" name="scanDepth" type="number" placeholder="Use global setting" data-i18n="[placeholder]Use global setting" max="1000">
-                                    </div>
-                                    <div class="world_entry_form_control flex1">
-                                        <small class="textAlignCenter" data-i18n="Case-Sensitive">Case-Sensitive</small>
-                                        <select name="caseSensitive" class="text_pole widthNatural margin0">
-                                            <option value="null" data-i18n="Use global">Use global</option>
-                                            <option value="true" data-i18n="Yes">Yes</option>
-                                            <option value="false" data-i18n="No">No</option>
-                                        </select>
-                                    </div>
-                                    <div class="world_entry_form_control flex1">
-                                        <small class="textAlignCenter" data-i18n="Whole Words">Whole Words</small>
-                                        <select name="matchWholeWords" class="text_pole widthNatural margin0">
-                                            <option value="null" data-i18n="Use global">Use global</option>
-                                            <option value="true" data-i18n="Yes">Yes</option>
-                                            <option value="false" data-i18n="No">No</option>
-                                        </select>
-                                    </div>
-                                    <div class="world_entry_form_control flex1">
-                                        <small class="textAlignCenter" data-i18n="Group Scoring">Group Scoring</small>
-                                        <select name="useGroupScoring" class="text_pole widthNatural margin0">
-                                            <option value="null" data-i18n="Use global">Use global</option>
-                                            <option value="true" data-i18n="Yes">Yes</option>
-                                            <option value="false" data-i18n="No">No</option>
-                                        </select>
-                                    </div>
-                                    <div class="world_entry_form_control flex1" title="Can be used to automatically activate Quick Replies" data-i18n="[title]Can be used to automatically activate Quick Replies">
-                                        <small class="textAlignCenter" data-i18n="Automation ID">Automation ID</small>
-                                        <input class="text_pole margin0" name="automationId" type="text" placeholder="( None )" data-i18n="[placeholder]( None )">
-                                    </div>
-                                    <div class="world_entry_form_control flex1" title="Defines delay levels for recursive scans.&#13;&#13;Initially, only the first level (smallest number) will match.&#13;Once no matches are found, the next level becomes eligible for matching.&#13;This repeats until all levels are checked.&#13;&#13;Tied to the &quot;Delay until recursion&quot; setting." data-i18n="[title]delay_until_recursion_level">
-                                        <small class="textAlignCenter">
-                                            <span data-i18n="Recursion Level">Recursion Level</span>
-                                            <div class="fa-solid fa-circle-info opacity50p"></div>
-                                        </small>
-                                        <input class="text_pole margin0" name="delayUntilRecursionLevel" type="text" placeholder="1">
-                                    </div>
-                                </div>
+
+
+
                                 <div name="contentAndCharFilterBlock" class="world_entry_thin_controls flex2">
                                     <div class="world_entry_form_control flex1">
                                         <label for="content ">
@@ -6143,26 +6154,6 @@
                                                         (<span data-i18n="extension_token_counter">Tokens:</span>&nbsp; <span class="world_entry_form_token_counter" data-first-run="true">counting...</span>)&nbsp;
                                                         <span class="world_entry_form_uid_value" data-first-run="true"></span>
                                                     </span>
-                                                    <div>
-                                                        <label class="checkbox flex-container alignitemscenter flexNoGap">
-                                                            <input type="checkbox" name="exclude_recursion" />
-                                                            <span data-i18n="Non-recursable (will not be activated by another)">
-                                                                Non-recursable (will not be activated by another)
-                                                            </span>
-                                                        </label>
-                                                        <label class="checkbox flex-container alignitemscenter flexNoGap">
-                                                            <input type="checkbox" name="prevent_recursion" />
-                                                            <span data-i18n="Prevent further recursion (this entry will not activate others)">
-                                                                Prevent further recursion (will not activate others)
-                                                            </span>
-                                                        </label>
-                                                        <label class="checkbox flex-container alignitemscenter flexNoGap">
-                                                            <input type="checkbox" name="delay_until_recursion" />
-                                                            <span data-i18n="Delay until recursion (can only be activated on recursive checking)">
-                                                                Delay until recursion (can only be activated on recursive checking)
-                                                            </span>
-                                                        </label>
-                                                    </div>
                                                 </span>
                                             </small>
                                             <small class="displayNone">
@@ -6177,6 +6168,131 @@
                                 <div class="world_entry_thin_controls commentContainer">
                                 </div>
                             </div>
+
+                            <div class="inline-drawer wide100p flexFlowColumn">
+                                <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable">
+                                    <strong>Activation Settings</strong>
+                                    <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                                </div>
+                                <div class="inline-drawer-content flex-container flexFlowRow flexGap10">
+                                    <div class="flex1 flex-container flexFlowColumn flexGap10">
+                                        <div class="flex-container flexFlowRow alignItemsCenter justifySpaceBetween" title="Can be used to automatically activate Quick Replies" data-i18n="[title]Can be used to automatically activate Quick Replies">
+                                            <small class="flex1" data-i18n="Automation ID">Automation ID</small>
+                                            <input class="flex1 text_pole margin0" name="automationId" type="text" placeholder="( None )" data-i18n="[placeholder]( None )">
+                                        </div>
+                                        <small>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="exclude_recursion" />
+                                                <span data-i18n="Non-recursable (will not be activated by another)">
+                                                    Non-recursable (will not be activated by another)
+                                                </span>
+                                            </label>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="prevent_recursion" />
+                                                <span data-i18n="Prevent further recursion (this entry will not activate others)">
+                                                    Prevent further recursion (will not activate others)
+                                                </span>
+                                            </label>
+                                        </small>
+                                        <div class="flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Scan Depth">Scan Depth</small>
+                                            <input class="text_pole margin0 flex1" name="scanDepth" type="number" placeholder="Use global setting" data-i18n="[placeholder]Use global setting" max="1000">
+                                        </div>
+                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Case-Sensitive">Case-Sensitive</small>
+                                            <select name="caseSensitive" class="text_pole widthNatural margin0 flex1">
+                                                <option value="null" data-i18n="Use global">Use global</option>
+                                                <option value="true" data-i18n="Yes">Yes</option>
+                                                <option value="false" data-i18n="No">No</option>
+                                            </select>
+                                        </div>
+                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Whole Words">Whole Words</small>
+                                            <select name="matchWholeWords" class="text_pole widthNatural margin0 flex1">
+                                                <option value="null" data-i18n="Use global">Use global</option>
+                                                <option value="true" data-i18n="Yes">Yes</option>
+                                                <option value="false" data-i18n="No">No</option>
+                                            </select>
+                                        </div>
+                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Group Scoring">Group Scoring</small>
+                                            <select name="useGroupScoring" class="text_pole widthNatural margin0 flex1">
+                                                <option value="null" data-i18n="Use global">Use global</option>
+                                                <option value="true" data-i18n="Yes">Yes</option>
+                                                <option value="false" data-i18n="No">No</option>
+                                            </select>
+                                        </div>
+
+                                        <small>
+                                            <label class="checkbox flex-container alignItemsCenter flexNoGap">
+                                                <input type="checkbox" name="delay_until_recursion" />
+                                                <span data-i18n="Delay until recursion (can only be activated on recursive checking)">
+                                                    Delay until recursion (can only be activated on recursive checking)
+                                                </span>
+                                            </label>
+                                        </small>
+                                        <div class="world_entry_form_control_recursion_delay flex-container alignItemsCenter" title="Defines delay levels for recursive scans.&#13;&#13;Initially, only the first level (smallest number) will match.&#13;Once no matches are found, the next level becomes eligible for matching.&#13;This repeats until all levels are checked.&#13;&#13;Tied to the &quot;Delay until recursion&quot; setting." data-i18n="[title]delay_until_recursion_level">
+                                            <small class="flex1">
+                                                <span data-i18n="Recursion Level">Recursion Level</span>
+                                                <div class="fa-solid fa-circle-info opacity50p"></div>
+                                            </small>
+                                            <input class="flex1 text_pole margin0" name="delayUntilRecursionLevel" type="text" placeholder="1">
+                                        </div>
+                                    </div>
+
+                                    <div class="flex1 flex-container flexFlowColumn flexGap10">
+                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Match Persona Description">Match Persona Description</small>
+                                            <select name="matchPersonaDescription" class="text_pole widthNatural margin0 flex1">
+                                                <option value="null" data-i18n="Use global">Use global</option>
+                                                <option value="true" data-i18n="Yes">Yes</option>
+                                                <option value="false" data-i18n="No">No</option>
+                                            </select>
+                                        </div>
+                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Match Character Description">Match Character Description</small>
+                                            <select name="matchCharacterDescription" class="text_pole widthNatural margin0 flex1">
+                                                <option value="null" data-i18n="Use global">Use global</option>
+                                                <option value="true" data-i18n="Yes">Yes</option>
+                                                <option value="false" data-i18n="No">No</option>
+                                            </select>
+                                        </div>
+                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Match Character Personality">Match Character Personality</small>
+                                            <select name="matchCharacterPersonality" class="text_pole widthNatural margin0 flex1">
+                                                <option value="null" data-i18n="Use global">Use global</option>
+                                                <option value="true" data-i18n="Yes">Yes</option>
+                                                <option value="false" data-i18n="No">No</option>
+                                            </select>
+                                        </div>
+                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Match Character Note">Match Character Note</small>
+                                            <select name="matchCharacterNote" class="text_pole widthNatural margin0 flex1">
+                                                <option value="null" data-i18n="Use global">Use global</option>
+                                                <option value="true" data-i18n="Yes">Yes</option>
+                                                <option value="false" data-i18n="No">No</option>
+                                            </select>
+                                        </div>
+                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Match Scenario">Match Scenario</small>
+                                            <select name="matchScenario" class="text_pole widthNatural margin0 flex1">
+                                                <option value="null" data-i18n="Use global">Use global</option>
+                                                <option value="true" data-i18n="Yes">Yes</option>
+                                                <option value="false" data-i18n="No">No</option>
+                                            </select>
+                                        </div>
+                                        <div class="checkbox flex-container alignItemsCenter flexNoGap">
+                                            <small class="flex1" data-i18n="Match Character Metadata">Match Character Metadata</small>
+                                            <select name="matchCharacterMetadata" class="text_pole widthNatural margin0 flex1">
+                                                <option value="null" data-i18n="Use global">Use global</option>
+                                                <option value="true" data-i18n="Yes">Yes</option>
+                                                <option value="false" data-i18n="No">No</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
                             <div class="flex-container wide100p flexGap10">
                                 <div class="flex4 flex-container flexFlowColumn flexNoGap">
                                     <div class="flex-container justifySpaceBetween">

--- a/public/index.html
+++ b/public/index.html
@@ -4180,9 +4180,9 @@
                                                 </small>
                                             </label>
                                             <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
-                                                <input id="world_info_match_creators_notes" type="checkbox" />
-                                                <small data-i18n="Match Creator's Notes" class="whitespacenowrap flex1">
-                                                    Match Creator's Notes
+                                                <input id="world_info_match_creator_notes" type="checkbox" />
+                                                <small data-i18n="Match Creator Notes" class="whitespacenowrap flex1">
+                                                    Match Creator Notes
                                                 </small>
                                             </label>
                                         </div>
@@ -6282,8 +6282,8 @@
                                             </select>
                                         </div>
                                         <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Match Creator's Notes">Match Creator's Notes</small>
-                                            <select name="matchCreatorsNotes" class="text_pole widthNatural margin0 flex1">
+                                            <small class="flex1" data-i18n="Match Creator Notes">Match Creator Notes</small>
+                                            <select name="matchCreatorNotes" class="text_pole widthNatural margin0 flex1">
                                                 <option value="null" data-i18n="Use global">Use global</option>
                                                 <option value="true" data-i18n="Yes">Yes</option>
                                                 <option value="false" data-i18n="No">No</option>

--- a/public/index.html
+++ b/public/index.html
@@ -4079,7 +4079,7 @@
                                     <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                                 </div>
                                 <div class="inline-drawer-content">
-                                    <div id="wiActivationSettings">
+                                    <div id="wiActivationSettings" class="flex-container">
                                         <div id="wiSliders" class="flex2 flex-container">
                                             <div class="alignitemscenter flex-container flexFlowColumn flexGrow flexShrink gap0 flexBasis48p">
                                                 <small>
@@ -4131,67 +4131,19 @@
                                                 <input class="neo-range-slider" type="range" id="world_info_max_recursion_steps" name="world_info_max_recursion_steps" min="0" max="10" step="1">
                                                 <input class="neo-range-input" type="number" min="0" max="10" step="1" data-for="world_info_max_recursion_steps" id="world_info_max_recursion_steps_counter">
                                             </div>
-                                        </div>
-                                        <hr class="width100p">
-                                        <div class="flex-container flexFlowColumn flexGrow flexShrink flexBasis48p">
-                                            <small class="textAlignCenter" data-i18n="Matching Strategy">
-                                                Matching Strategy
-                                            </small>
-                                            <label title="Lookup for the entry keys in the context will respect the case" data-i18n="[title]Lookup for the entry keys in the context will respect the case" class="checkbox_label flex1">
-                                                <input id="world_info_case_sensitive" type="checkbox" />
-                                                <small data-i18n="Case Sensitive" class="whitespacenowrap flex1">
-                                                    Case-sensitive
-                                                </small>
-                                            </label>
-                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
-                                                <input id="world_info_match_whole_words" type="checkbox" />
-                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
-                                                    Match Whole Words
-                                                </small>
-                                            </label>
-                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
-                                                <input id="world_info_match_whole_words" type="checkbox" />
-                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
-                                                    Match Persona Description
-                                                </small>
-                                            </label>
-                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
-                                                <input id="world_info_match_whole_words" type="checkbox" />
-                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
-                                                    Match Character Description
-                                                </small>
-                                            </label>
-                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
-                                                <input id="world_info_match_whole_words" type="checkbox" />
-                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
-                                                    Match Character Personality
-                                                </small>
-                                            </label>
-                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
-                                                <input id="world_info_match_whole_words" type="checkbox" />
-                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
-                                                    Match Character Note
-                                                </small>
-                                            </label>
-                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
-                                                <input id="world_info_match_whole_words" type="checkbox" />
-                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
-                                                    Match Scenario
-                                                </small>
-                                            </label>
-                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
-                                                <input id="world_info_match_creator_notes" type="checkbox" />
-                                                <small data-i18n="Match Creator Notes" class="whitespacenowrap flex1">
-                                                    Match Creator Notes
-                                                </small>
-                                            </label>
-                                        </div>
 
-                                        <hr class="width100p">
-                                        <div class="flex-container flexFlowColumn flexGrow flexShrink flexBasis48p">
-                                            <small class="textAlignCenter" data-i18n="Miscelaneous">
-                                                Miscelaneous
-                                            </small>
+                                            <div class="alignitemscenter flex-container flexFlowColumn flexGrow flexShrink flexBasis48p">
+                                                <small data-i18n="Insertion Strategy">
+                                                    Insertion Strategy
+                                                </small>
+                                                <select id="world_info_character_strategy" class="flexGrow margin0">
+                                                    <option value="0" data-i18n="Sorted Evenly">Sorted Evenly</option>
+                                                    <option value="1" data-i18n="Character Lore First">Character Lore First</option>
+                                                    <option value="2" data-i18n="Global Lore First">Global Lore First</option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                        <div id="wiCheckboxes" class="flex1 flex-container flexFlowColumn">
                                             <label title="Include names with each message into the context for scanning" data-i18n="[title]Include names with each message into the context for scanning" class="checkbox_label flex1">
                                                 <input id="world_info_include_names" type="checkbox" />
                                                 <small data-i18n="Include Names" class="whitespacenowrap flex1">
@@ -4202,6 +4154,18 @@
                                                 <input id="world_info_recursive" type="checkbox" />
                                                 <small data-i18n="Recursive Scan" class="whitespacenowrap flex1">
                                                     Recursive Scan
+                                                </small>
+                                            </label>
+                                            <label title="Lookup for the entry keys in the context will respect the case" data-i18n="[title]Lookup for the entry keys in the context will respect the case" class="checkbox_label flex1">
+                                                <input id="world_info_case_sensitive" type="checkbox" />
+                                                <small data-i18n="Case Sensitive" class="whitespacenowrap flex1">
+                                                    Case-sensitive
+                                                </small>
+                                            </label>
+                                            <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
+                                                <input id="world_info_match_whole_words" type="checkbox" />
+                                                <small data-i18n="Match Whole Words" class="whitespacenowrap flex1">
+                                                    Match Whole Words
                                                 </small>
                                             </label>
                                             <label title="Only the entries with the most number of key matches will be selected for Inclusion Group filtering" data-i18n="[title]Only the entries with the most number of key matches will be selected for Inclusion Group filtering" class="checkbox_label flex1">
@@ -4217,19 +4181,6 @@
                                                 </small>
                                             </label>
                                         </div>
-
-                                        <hr class="width100p">
-                                        <div class="alignitemscenter flex-container flexFlowColumn flexGrow flexShrink flexBasis48p">
-                                            <small data-i18n="Insertion Strategy">
-                                                Insertion Strategy
-                                            </small>
-                                            <select id="world_info_character_strategy" class="flexGrow margin0">
-                                                <option value="0" data-i18n="Sorted Evenly">Sorted Evenly</option>
-                                                <option value="1" data-i18n="Character Lore First">Character Lore First</option>
-                                                <option value="2" data-i18n="Global Lore First">Global Lore First</option>
-                                            </select>
-                                        </div>
-
                                     </div>
                                 </div>
                             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -4180,9 +4180,9 @@
                                                 </small>
                                             </label>
                                             <label title="If the entry key consists of only one word, it would not be matched as part of other words" data-i18n="[title]If the entry key consists of only one word, it would not be matched as part of other words" class="checkbox_label flex1">
-                                                <input id="world_info_match_characters_metadata" type="checkbox" />
-                                                <small data-i18n="Match Characters Metadata" class="whitespacenowrap flex1">
-                                                    Match Characters Metadata
+                                                <input id="world_info_match_creators_notes" type="checkbox" />
+                                                <small data-i18n="Match Creator's Notes" class="whitespacenowrap flex1">
+                                                    Match Creator's Notes
                                                 </small>
                                             </label>
                                         </div>
@@ -6282,8 +6282,8 @@
                                             </select>
                                         </div>
                                         <div class="checkbox flex-container alignItemsCenter flexNoGap">
-                                            <small class="flex1" data-i18n="Match Character Metadata">Match Character Metadata</small>
-                                            <select name="matchCharacterMetadata" class="text_pole widthNatural margin0 flex1">
+                                            <small class="flex1" data-i18n="Match Creator's Notes">Match Creator's Notes</small>
+                                            <select name="matchCreatorsNotes" class="text_pole widthNatural margin0 flex1">
                                                 <option value="null" data-i18n="Use global">Use global</option>
                                                 <option value="true" data-i18n="Yes">Yes</option>
                                                 <option value="false" data-i18n="No">No</option>

--- a/public/script.js
+++ b/public/script.js
@@ -2751,6 +2751,7 @@ export function substituteParams(content, _name1, _name2, _original, _group, _re
         environment.charVersion = fields.version || '';
         environment.char_version = fields.version || '';
         environment.charDepthPrompt = fields.charDepthPrompt || '';
+        environment.creatorNotes = fields.creatorNotes || '';
     }
 
     // Must be substituted last so that they're replaced inside {{description}}
@@ -4291,7 +4292,6 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         loreAfter: worldInfoAfter,
         mesExamples: mesExamplesArray.join(''),
         mesExamplesRaw: mesExamplesRawArray.join(''),
-        creatorNotes: creatorNotes,
     };
 
     const storyString = renderStoryString(storyStringParams);

--- a/public/script.js
+++ b/public/script.js
@@ -4155,7 +4155,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         scenario: scenario,
         creatorNotes: creatorNotes,
     };
-    const { worldInfoString, worldInfoBefore, worldInfoAfter, worldInfoExamples, worldInfoDepth } = await getWorldInfoPrompt(globalScanData, chatForWI, this_max_context, dryRun);
+    const { worldInfoString, worldInfoBefore, worldInfoAfter, worldInfoExamples, worldInfoDepth } = await getWorldInfoPrompt(chatForWI, this_max_context, dryRun, globalScanData);
     setExtensionPrompt('QUIET_PROMPT', '', extension_prompt_types.IN_PROMPT, 0, true);
 
     // Add message example WI

--- a/public/script.js
+++ b/public/script.js
@@ -3164,7 +3164,7 @@ export function getCharacterCardFields({ chid = null } = {}) {
     result.jailbreak = power_user.prefer_character_jailbreak ? baseChatReplace(character.data?.post_history_instructions?.trim(), name1, name2) : '';
     result.version = character.data?.character_version ?? '';
     result.charDepthPrompt = baseChatReplace(character.data?.extensions?.depth_prompt?.prompt?.trim(), name1, name2);
-    result.creatorNotes = baseChatReplace(character.creator_notes?.trim(), name1, name2);
+    result.creatorNotes = baseChatReplace(character.data?.creator_notes?.trim(), name1, name2);
 
     if (selected_group) {
         const groupCards = getGroupCharacterCards(selected_group, Number(currentChid));

--- a/public/script.js
+++ b/public/script.js
@@ -4143,7 +4143,8 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     // Make quiet prompt available for WIAN
     setExtensionPrompt('QUIET_PROMPT', quiet_prompt || '', extension_prompt_types.IN_PROMPT, 0, true);
     const chatForWI = coreChat.map(x => world_info_include_names ? `${x.name}: ${x.mes}` : x.mes).reverse();
-    const { worldInfoString, worldInfoBefore, worldInfoAfter, worldInfoExamples, worldInfoDepth } = await getWorldInfoPrompt(chatForWI, this_max_context, dryRun);
+    // TODO: Build globalScanData
+    const { worldInfoString, worldInfoBefore, worldInfoAfter, worldInfoExamples, worldInfoDepth } = await getWorldInfoPrompt(null, chatForWI, this_max_context, dryRun);
     setExtensionPrompt('QUIET_PROMPT', '', extension_prompt_types.IN_PROMPT, 0, true);
 
     // Add message example WI

--- a/public/script.js
+++ b/public/script.js
@@ -3129,6 +3129,7 @@ export function baseChatReplace(value, name1, name2) {
  * @property {string} jailbreak Jailbreak instructions
  * @property {string} version Character version
  * @property {string} charDepthPrompt Character depth note
+ * @property {string} creatorNotes Character creator notes
  * @returns {CharacterCardFields} Character card fields
  */
 export function getCharacterCardFields({ chid = null } = {}) {
@@ -3144,6 +3145,7 @@ export function getCharacterCardFields({ chid = null } = {}) {
         jailbreak: '',
         version: '',
         charDepthPrompt: '',
+        creatorNotes: '',
     };
     result.persona = baseChatReplace(power_user.persona_description?.trim(), name1, name2);
 
@@ -3162,6 +3164,7 @@ export function getCharacterCardFields({ chid = null } = {}) {
     result.jailbreak = power_user.prefer_character_jailbreak ? baseChatReplace(character.data?.post_history_instructions?.trim(), name1, name2) : '';
     result.version = character.data?.character_version ?? '';
     result.charDepthPrompt = baseChatReplace(character.data?.extensions?.depth_prompt?.prompt?.trim(), name1, name2);
+    result.creatorNotes = baseChatReplace(character.creator_notes?.trim(), name1, name2);
 
     if (selected_group) {
         const groupCards = getGroupCharacterCards(selected_group, Number(currentChid));
@@ -3989,6 +3992,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         system,
         jailbreak,
         charDepthPrompt,
+        creatorNotes,
     } = getCharacterCardFields();
 
     if (main_api !== 'openai') {
@@ -4143,8 +4147,15 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     // Make quiet prompt available for WIAN
     setExtensionPrompt('QUIET_PROMPT', quiet_prompt || '', extension_prompt_types.IN_PROMPT, 0, true);
     const chatForWI = coreChat.map(x => world_info_include_names ? `${x.name}: ${x.mes}` : x.mes).reverse();
-    // TODO: Build globalScanData
-    const { worldInfoString, worldInfoBefore, worldInfoAfter, worldInfoExamples, worldInfoDepth } = await getWorldInfoPrompt(null, chatForWI, this_max_context, dryRun);
+    const globalScanData = {
+        personaDescription: persona,
+        characterDescription: description,
+        characterPersonality: personality,
+        characterDepthPrompt: charDepthPrompt,
+        scenario: scenario,
+        creatorNotes: creatorNotes,
+    };
+    const { worldInfoString, worldInfoBefore, worldInfoAfter, worldInfoExamples, worldInfoDepth } = await getWorldInfoPrompt(globalScanData, chatForWI, this_max_context, dryRun);
     setExtensionPrompt('QUIET_PROMPT', '', extension_prompt_types.IN_PROMPT, 0, true);
 
     // Add message example WI

--- a/public/script.js
+++ b/public/script.js
@@ -4291,6 +4291,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         loreAfter: worldInfoAfter,
         mesExamples: mesExamplesArray.join(''),
         mesExamplesRaw: mesExamplesRawArray.join(''),
+        creatorNotes: creatorNotes,
     };
 
     const storyString = renderStoryString(storyStringParams);

--- a/public/scripts/char-data.js
+++ b/public/scripts/char-data.js
@@ -33,6 +33,12 @@
  * @property {number} role - The specific function or purpose of the extension.
  * @property {boolean} vectorized - Indicates if the extension is optimized for vectorized processing.
  * @property {number} display_index - The order in which the extension should be displayed for user interfaces.
+ * @property {boolean} match_persona_description - Wether to match against the persona description.
+ * @property {boolean} match_character_description - Wether to match against the persona description.
+ * @property {boolean} match_character_personality - Wether to match against the character personality.
+ * @property {boolean} match_character_depth_prompt - Wether to match against the character depth prompt.
+ * @property {boolean} match_scenario - Wether to match against the character scenario.
+ * @property {boolean} match_creator_notes - Wether to match against the character creator notes.
  */
 
 /**

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4927,12 +4927,12 @@ export function convertCharacterBook(characterBook) {
             sticky: entry.extensions?.sticky ?? null,
             cooldown: entry.extensions?.cooldown ?? null,
             delay: entry.extensions?.delay ?? null,
-            matchPersonaDescription: entry.extensions?.matchPersonaDescription ?? false,
-            matchCharacterDescription: entry.extensions?.matchCharacterDescription ?? false,
-            matchCharacterPersonality: entry.extensions?.matchCharacterPersonality ?? false,
-            matchCharacterDepthPrompt: entry.extensions?.matchCharacterDepthPrompt ?? false,
-            matchScenario: entry.extensions?.matchScenario ?? false,
-            matchCreatorNotes: entry.extensions?.matchCreatorNotes ?? false,
+            matchPersonaDescription: entry.extensions?.match_persona_description ?? false,
+            matchCharacterDescription: entry.extensions?.match_character_description ?? false,
+            matchCharacterPersonality: entry.extensions?.match_character_personality ?? false,
+            matchCharacterDepthPrompt: entry.extensions?.match_character_depth_prompt ?? false,
+            matchScenario: entry.extensions?.match_scenario ?? false,
+            matchCreatorNotes: entry.extensions?.match_creator_notes ?? false,
             extensions: entry.extensions ?? {},
         };
     });

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -187,10 +187,10 @@ class WorldInfoBuffer {
 
     /**
      * Initialize the buffer with the given messages.
-     * @param {WIGlobalScanData} globalScanData Chat independent context to be scanned
      * @param {string[]} messages Array of messages to add to the buffer
+     * @param {WIGlobalScanData} globalScanData Chat independent context to be scanned
      */
-    constructor(globalScanData, messages) {
+    constructor(messages, globalScanData) {
         this.#initDepthBuffer(messages);
         this.#globalScanDataBuffer = globalScanData;
     }
@@ -796,10 +796,10 @@ export const worldInfoCache = new StructuredCloneMap({ cloneOnGet: true, cloneOn
 
 /**
  * Gets the world info based on chat messages.
- * @param {WIGlobalScanData} globalScanData Chat independent context to be scanned
  * @param {string[]} chat - The chat messages to scan, in reverse order.
  * @param {number} maxContext - The maximum context size of the generation.
  * @param {boolean} isDryRun - If true, the function will not emit any events.
+ * @param {WIGlobalScanData} globalScanData Chat independent context to be scanned
  * @typedef {object} WIPromptResult
  * @property {string} worldInfoString - Complete world info string
  * @property {string} worldInfoBefore - World info that goes before the prompt
@@ -810,10 +810,10 @@ export const worldInfoCache = new StructuredCloneMap({ cloneOnGet: true, cloneOn
  * @property {Array} anAfter - Array of entries after Author's Note
  * @returns {Promise<WIPromptResult>} The world info string and depth.
  */
-export async function getWorldInfoPrompt(globalScanData, chat, maxContext, isDryRun) {
+export async function getWorldInfoPrompt(chat, maxContext, isDryRun, globalScanData) {
     let worldInfoString = '', worldInfoBefore = '', worldInfoAfter = '';
 
-    const activatedWorldInfo = await checkWorldInfo(globalScanData, chat, maxContext, isDryRun);
+    const activatedWorldInfo = await checkWorldInfo(chat, maxContext, isDryRun, globalScanData);
     worldInfoBefore = activatedWorldInfo.worldInfoBefore;
     worldInfoAfter = activatedWorldInfo.worldInfoAfter;
     worldInfoString = worldInfoBefore + worldInfoAfter;
@@ -4053,10 +4053,10 @@ function parseDecorators(content) {
 
 /**
  * Performs a scan on the chat and returns the world info activated.
- * @param {WIGlobalScanData} globalScanData Chat independent context to be scanned
  * @param {string[]} chat The chat messages to scan, in reverse order.
  * @param {number} maxContext The maximum context size of the generation.
  * @param {boolean} isDryRun Whether to perform a dry run.
+ * @param {WIGlobalScanData} globalScanData Chat independent context to be scanned
  * @typedef {object} WIActivated
  * @property {string} worldInfoBefore The world info before the chat.
  * @property {string} worldInfoAfter The world info after the chat.
@@ -4067,9 +4067,9 @@ function parseDecorators(content) {
  * @property {Set<any>} allActivatedEntries All entries.
  * @returns {Promise<WIActivated>} The world info activated.
  */
-export async function checkWorldInfo(globalScanData, chat, maxContext, isDryRun) {
+export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData) {
     const context = getContext();
-    const buffer = new WorldInfoBuffer(globalScanData, chat);
+    const buffer = new WorldInfoBuffer(chat, globalScanData);
 
     console.debug(`[WI] --- START WI SCAN (on ${chat.length} messages)${isDryRun ? ' (DRY RUN)' : ''} ---`);
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3588,6 +3588,7 @@ export const newWorldInfoEntryDefinition = {
     preventRecursion: { default: false, type: 'boolean' },
     matchPersonaDescription: { default: false, type: 'boolean' },
     matchCharacterDescription: { default: false, type: 'boolean' },
+    matchCharacterPersonality: { default: false, type: 'boolean' },
     matchCharacterDepthPrompt: { default: false, type: 'boolean' },
     matchScenario: { default: false, type: 'boolean' },
     matchCreatorNotes: { default: false, type: 'boolean' },

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -101,11 +101,11 @@ const KNOWN_DECORATORS = ['@@activate', '@@dont_activate'];
  * @typedef {object} WIGlobalScanData The chat-independent data to be scanned. Each of
  *     these fields can be enabled for scanning per entry.
  * @property {string} personaDescription User persona description
- * @property {string} characterDescription
- * @property {string} characterPersonality
- * @property {string} characterDepthPrompt
+ * @property {string} characterDescription Character description
+ * @property {string} characterPersonality Character personality
+ * @property {string} characterDepthPrompt Character depth prompt (sometimes referred to as character notes)
  * @property {string} scenario Character defined scenario
- * @property {string} creatorNotes
+ * @property {string} creatorNotes Character creator notes
  */
 
 /**

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3362,15 +3362,15 @@ export async function getWorldEntry(name, data, entry) {
         const key = originalWIDataKeyMap[fieldName];
         const checkBoxElem = template.find(`input[type="checkbox"][name="${fieldName}"]`);
         checkBoxElem.data('uid', entry.uid);
-        checkBoxElem.on('change', async function () {
+        checkBoxElem.on('input', async function () {
             const uid = $(this).data('uid');
-            const isChecked = $(this).is(':checked');
+            const value = $(this).prop('checked');
 
-            data.entries[uid][fieldName] = isChecked;
+            data.entries[uid][fieldName] = value;
             setWIOriginalDataValue(data, uid, key, data.entries[uid][fieldName]);
             await saveWorldInfo(name, data);
         });
-        checkBoxElem.prop('checked', !!entry[name]).trigger('change');
+        checkBoxElem.prop('checked', !!entry[fieldName]).trigger('input');
     }
 
     handleOptionalSelect("matchPersonaDescription");
@@ -3586,6 +3586,11 @@ export const newWorldInfoEntryDefinition = {
     disable: { default: false, type: 'boolean' },
     excludeRecursion: { default: false, type: 'boolean' },
     preventRecursion: { default: false, type: 'boolean' },
+    matchPersonaDescription: { default: false, type: 'boolean' },
+    matchCharacterDescription: { default: false, type: 'boolean' },
+    matchCharacterDepthPrompt: { default: false, type: 'boolean' },
+    matchScenario: { default: false, type: 'boolean' },
+    matchCreatorNotes: { default: false, type: 'boolean' },
     delayUntilRecursion: { default: 0, type: 'number' },
     probability: { default: 100, type: 'number' },
     useProbability: { default: true, type: 'boolean' },

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3373,12 +3373,12 @@ export async function getWorldEntry(name, data, entry) {
         checkBoxElem.prop('checked', !!entry[fieldName]).trigger('input');
     }
 
-    handleOptionalSelect("matchPersonaDescription");
-    handleOptionalSelect("matchCharacterDescription");
-    handleOptionalSelect("matchCharacterPersonality");
-    handleOptionalSelect("matchCharacterDepthPrompt");
-    handleOptionalSelect("matchScenario");
-    handleOptionalSelect("matchCreatorNotes");
+    handleOptionalSelect('matchPersonaDescription');
+    handleOptionalSelect('matchCharacterDescription');
+    handleOptionalSelect('matchCharacterPersonality');
+    handleOptionalSelect('matchCharacterDepthPrompt');
+    handleOptionalSelect('matchScenario');
+    handleOptionalSelect('matchCreatorNotes');
 
     // automation id
     const automationIdInput = template.find('input[name="automationId"]');

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -115,11 +115,11 @@ const KNOWN_DECORATORS = ['@@activate', '@@dont_activate'];
  * @property {boolean} [matchWholeWords] If the scan should match whole words
  * @property {boolean} [useGroupScoring] If the scan should use group scoring
  * @property {boolean} [matchPersonaDescription] If the scan should match against the persona description
- * @property {boolean} [matchCharacterDescription] If the scan should match against the character
- * @property {boolean} [matchCharacterPersonality] If the scan should match against the character
- * @property {boolean} [matchCharacterNote] If the scan should match against the character note
+ * @property {boolean} [matchCharacterDescription] If the scan should match against the character description
+ * @property {boolean} [matchCharacterPersonality] If the scan should match against the character personality
+ * @property {boolean} [matchCharacterDepthPrompt] If the scan should match against the character depth prompt
  * @property {boolean} [matchScenario] If the scan should match against the character scenario
- * @property {boolean} [matchCreatorNotes] If the scan should match against the character metadata
+ * @property {boolean} [matchCreatorNotes] If the scan should match against the creator notes
  * @property {number} [uid] The UID of the entry that triggered the scan
  * @property {string} [world] The world info book of origin of the entry
  * @property {string[]} [key] The primary keys to scan for
@@ -258,7 +258,7 @@ class WorldInfoBuffer {
         if (entry.matchCharacterPersonality) {
             result += JOINER + this.#globalScanDataBuffer.characterPersonality;
         }
-        if (entry.matchCharacterNote) {
+        if (entry.matchCharacterDepthPrompt) {
             result += JOINER + this.#globalScanDataBuffer.characterDepthPrompt;
         }
         if (entry.matchScenario) {

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -158,7 +158,7 @@ class WorldInfoBuffer {
     /**
      * @type {WIGlobalScanData} Chat independent data to be scanned, such as persona and character descriptions
      */
-    #globalScanDataBuffer = null;
+    #globalScanData = null;
 
     /**
      * @type {string[]} Array of messages sorted by ascending depth
@@ -192,7 +192,7 @@ class WorldInfoBuffer {
      */
     constructor(messages, globalScanData) {
         this.#initDepthBuffer(messages);
-        this.#globalScanDataBuffer = globalScanData;
+        this.#globalScanData = globalScanData;
     }
 
     /**
@@ -249,23 +249,23 @@ class WorldInfoBuffer {
         const JOINER = '\n' + MATCHER;
         let result = MATCHER + this.#depthBuffer.slice(this.#startDepth, depth).join(JOINER);
 
-        if (entry.matchPersonaDescription) {
-            result += JOINER + this.#globalScanDataBuffer.personaDescription;
+        if (entry.matchPersonaDescription && this.#globalScanData.personaDescription) {
+            result += JOINER + this.#globalScanData.personaDescription;
         }
-        if (entry.matchCharacterDescription) {
-            result += JOINER + this.#globalScanDataBuffer.characterDescription;
+        if (entry.matchCharacterDescription && this.#globalScanData.characterDescription) {
+            result += JOINER + this.#globalScanData.characterDescription;
         }
-        if (entry.matchCharacterPersonality) {
-            result += JOINER + this.#globalScanDataBuffer.characterPersonality;
+        if (entry.matchCharacterPersonality && this.#globalScanData.characterPersonality) {
+            result += JOINER + this.#globalScanData.characterPersonality;
         }
-        if (entry.matchCharacterDepthPrompt) {
-            result += JOINER + this.#globalScanDataBuffer.characterDepthPrompt;
+        if (entry.matchCharacterDepthPrompt && this.#globalScanData.characterDepthPrompt) {
+            result += JOINER + this.#globalScanData.characterDepthPrompt;
         }
-        if (entry.matchScenario) {
-            result += JOINER + this.#globalScanDataBuffer.scenario;
+        if (entry.matchScenario && this.#globalScanData.scenario) {
+            result += JOINER + this.#globalScanData.scenario;
         }
-        if (entry.matchCreatorNotes) {
-            result += JOINER + this.#globalScanDataBuffer.creatorNotes;
+        if (entry.matchCreatorNotes && this.#globalScanData.creatorNotes) {
+            result += JOINER + this.#globalScanData.creatorNotes;
         }
 
         if (this.#injectBuffer.length > 0) {

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3358,7 +3358,7 @@ export async function getWorldEntry(name, data, entry) {
     });
     useGroupScoringSelect.val((entry.useGroupScoring === null || entry.useGroupScoring === undefined) ? 'null' : entry.useGroupScoring ? 'true' : 'false').trigger('input');
 
-    function handleOptionalSelect(fieldName) {
+    function handleMatchCheckbox(fieldName) {
         const key = originalWIDataKeyMap[fieldName];
         const checkBoxElem = template.find(`input[type="checkbox"][name="${fieldName}"]`);
         checkBoxElem.data('uid', entry.uid);
@@ -3373,12 +3373,12 @@ export async function getWorldEntry(name, data, entry) {
         checkBoxElem.prop('checked', !!entry[fieldName]).trigger('input');
     }
 
-    handleOptionalSelect('matchPersonaDescription');
-    handleOptionalSelect('matchCharacterDescription');
-    handleOptionalSelect('matchCharacterPersonality');
-    handleOptionalSelect('matchCharacterDepthPrompt');
-    handleOptionalSelect('matchScenario');
-    handleOptionalSelect('matchCreatorNotes');
+    handleMatchCheckbox('matchPersonaDescription');
+    handleMatchCheckbox('matchCharacterDescription');
+    handleMatchCheckbox('matchCharacterPersonality');
+    handleMatchCheckbox('matchCharacterDepthPrompt');
+    handleMatchCheckbox('matchScenario');
+    handleMatchCheckbox('matchCreatorNotes');
 
     // automation id
     const automationIdInput = template.find('input[name="automationId"]');

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3358,16 +3358,16 @@ export async function getWorldEntry(name, data, entry) {
     });
     useGroupScoringSelect.val((entry.useGroupScoring === null || entry.useGroupScoring === undefined) ? 'null' : entry.useGroupScoring ? 'true' : 'false').trigger('input');
 
-    function handleOptionalSelect(name) {
-        const key = originalWIDataKeyMap[name];
-        const checkBoxElem = template.find(`input[type="checkbox"][name="${name}"]`);
+    function handleOptionalSelect(fieldName) {
+        const key = originalWIDataKeyMap[fieldName];
+        const checkBoxElem = template.find(`input[type="checkbox"][name="${fieldName}"]`);
         checkBoxElem.data('uid', entry.uid);
         checkBoxElem.on('change', async function () {
             const uid = $(this).data('uid');
             const isChecked = $(this).is(':checked');
 
-            data.entries[uid][name] = isChecked;
-            setWIOriginalDataValue(data, uid, key, data.entries[uid][name]);
+            data.entries[uid][fieldName] = isChecked;
+            setWIOriginalDataValue(data, uid, key, data.entries[uid][fieldName]);
             await saveWorldInfo(name, data);
         });
         checkBoxElem.prop('checked', !!entry[name]).trigger('change');

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4925,6 +4925,12 @@ export function convertCharacterBook(characterBook) {
             sticky: entry.extensions?.sticky ?? null,
             cooldown: entry.extensions?.cooldown ?? null,
             delay: entry.extensions?.delay ?? null,
+            matchPersonaDescription: entry.extensions?.matchPersonaDescription ?? false,
+            matchCharacterDescription: entry.extensions?.matchCharacterDescription ?? false,
+            matchCharacterPersonality: entry.extensions?.matchCharacterPersonality ?? false,
+            matchCharacterDepthPrompt: entry.extensions?.matchCharacterDepthPrompt ?? false,
+            matchScenario: entry.extensions?.matchScenario ?? false,
+            matchCreatorNotes: entry.extensions?.matchCreatorNotes ?? false,
             extensions: entry.extensions ?? {},
         };
     });

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -103,7 +103,7 @@ const KNOWN_DECORATORS = ['@@activate', '@@dont_activate'];
  * @property {string} personaDescription User persona description
  * @property {string} characterDescription
  * @property {string} characterPersonality
- * @property {string} characterNote
+ * @property {string} characterDepthPrompt
  * @property {string} scenario Character defined scenario
  * @property {string} creatorNotes
  */
@@ -259,7 +259,7 @@ class WorldInfoBuffer {
             result += JOINER + this.#globalScanDataBuffer.characterPersonality;
         }
         if (entry.matchCharacterNote) {
-            result += JOINER + this.#globalScanDataBuffer.characterNote;
+            result += JOINER + this.#globalScanDataBuffer.characterDepthPrompt;
         }
         if (entry.matchScenario) {
             result += JOINER + this.#globalScanDataBuffer.scenario;
@@ -2238,7 +2238,7 @@ export const originalWIDataKeyMap = {
     'matchPersonaDescription': 'extensions.match_persona_description',
     'matchCharacterDescription': 'extensions.match_character_description',
     'matchCharacterPersonality': 'extensions.match_character_personality',
-    'matchCharacterNote': 'extensions.match_character_note',
+    'matchCharacterDepthPrompt': 'extensions.match_character_depth_prompt',
     'matchScenario': 'extensions.match_scenario',
     'matchCreatorNotes': 'extensions.match_creator_notes',
     'scanDepth': 'extensions.scan_depth',
@@ -3376,7 +3376,7 @@ export async function getWorldEntry(name, data, entry) {
     handleOptionalSelect("matchPersonaDescription");
     handleOptionalSelect("matchCharacterDescription");
     handleOptionalSelect("matchCharacterPersonality");
-    handleOptionalSelect("matchCharacterNote");
+    handleOptionalSelect("matchCharacterDepthPrompt");
     handleOptionalSelect("matchScenario");
     handleOptionalSelect("matchCreatorNotes");
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4054,6 +4054,7 @@ function parseDecorators(content) {
 /**
  * Performs a scan on the chat and returns the world info activated.
  * @param {WIGlobalScanData} globalScanData Chat independent context to be scanned
+ * @param {string[]} chat The chat messages to scan, in reverse order.
  * @param {number} maxContext The maximum context size of the generation.
  * @param {boolean} isDryRun Whether to perform a dry run.
  * @typedef {object} WIActivated

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -103,6 +103,12 @@ const KNOWN_DECORATORS = ['@@activate', '@@dont_activate'];
  * @property {boolean} [caseSensitive] If the scan is case sensitive
  * @property {boolean} [matchWholeWords] If the scan should match whole words
  * @property {boolean} [useGroupScoring] If the scan should use group scoring
+ * @property {boolean} [matchPersonaDescription] If the scan should match against the persona description
+ * @property {boolean} [matchCharacterDescription] If the scan should match against the character
+ * @property {boolean} [matchCharacterPersonality] If the scan should match against the character
+ * @property {boolean} [matchCharacterNote] If the scan should match against the character note
+ * @property {boolean} [matchScenario] If the scan should match against the character scenario
+ * @property {boolean} [matchCreatorsNotes] If the scan should match against the character metadata
  * @property {number} [uid] The UID of the entry that triggered the scan
  * @property {string} [world] The world info book of origin of the entry
  * @property {string[]} [key] The primary keys to scan for
@@ -2196,7 +2202,7 @@ export const originalWIDataKeyMap = {
     'matchCharacterPersonality': 'extensions.match_character_personality',
     'matchCharacterNote': 'extensions.match_character_note',
     'matchScenario': 'extensions.match_scenario',
-    'matchCharacterMetadata': 'extensions.match_character_metadata',
+    'matchCreatorsNotes': 'extensions.match_creators_notes',
     'scanDepth': 'extensions.scan_depth',
     'automationId': 'extensions.automation_id',
     'vectorized': 'extensions.vectorized',
@@ -3334,7 +3340,7 @@ export async function getWorldEntry(name, data, entry) {
     handleOptionalSelect("matchCharacterPersonality");
     handleOptionalSelect("matchCharacterNote");
     handleOptionalSelect("matchScenario");
-    handleOptionalSelect("matchCharacterMetadata");
+    handleOptionalSelect("matchCreatorsNotes");
 
     // automation id
     const automationIdInput = template.find('input[name="automationId"]');

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -98,6 +98,17 @@ const KNOWN_DECORATORS = ['@@activate', '@@dont_activate'];
 
 // Typedef area
 /**
+ * @typedef {object} WIGlobalScanData The chat-independent data to be scanned. Each of
+ *     these fields can be enabled for scanning per entry.
+ * @property {string} personaDescription User persona description
+ * @property {string} characterDescription
+ * @property {string} characterPersonality
+ * @property {string} characterNote
+ * @property {string} scenario Character defined scenario
+ * @property {string} creatorNotes
+ */
+
+/**
  * @typedef {object} WIScanEntry The entry that triggered the scan
  * @property {number} [scanDepth] The depth of the scan
  * @property {boolean} [caseSensitive] If the scan is case sensitive

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2191,6 +2191,12 @@ export const originalWIDataKeyMap = {
     'matchWholeWords': 'extensions.match_whole_words',
     'useGroupScoring': 'extensions.use_group_scoring',
     'caseSensitive': 'extensions.case_sensitive',
+    'matchPersonaDescription': 'extensions.match_persona_description',
+    'matchCharacterDescription': 'extensions.match_character_description',
+    'matchCharacterPersonality': 'extensions.match_character_personality',
+    'matchCharacterNote': 'extensions.match_character_note',
+    'matchScenario': 'extensions.match_scenario',
+    'matchCharacterMetadata': 'extensions.match_character_metadata',
     'scanDepth': 'extensions.scan_depth',
     'automationId': 'extensions.automation_id',
     'vectorized': 'extensions.vectorized',
@@ -3307,6 +3313,28 @@ export async function getWorldEntry(name, data, entry) {
         await saveWorldInfo(name, data);
     });
     useGroupScoringSelect.val((entry.useGroupScoring === null || entry.useGroupScoring === undefined) ? 'null' : entry.useGroupScoring ? 'true' : 'false').trigger('input');
+
+    function handleOptionalSelect(name) {
+        const key = originalWIDataKeyMap[name];
+        const selectElem = template.find(`select[name="${name}"]`);
+        selectElem.data('uid', entry.uid);
+        selectElem.on('input', async function () {
+            const uid = $(this).data('uid');
+            const value = $(this).val();
+
+            data.entries[uid][name] = value === 'null' ? null : value === 'true';
+            setWIOriginalDataValue(data, uid, key, data.entries[uid][name]);
+            await saveWorldInfo(name, data);
+        });
+        selectElem.val((entry[name] === null || entry[name] === undefined) ? 'null' : entry[name] ? 'true' : 'false').trigger('input');
+    }
+
+    handleOptionalSelect("matchPersonaDescription");
+    handleOptionalSelect("matchCharacterDescription");
+    handleOptionalSelect("matchCharacterPersonality");
+    handleOptionalSelect("matchCharacterNote");
+    handleOptionalSelect("matchScenario");
+    handleOptionalSelect("matchCharacterMetadata");
 
     // automation id
     const automationIdInput = template.find('input[name="automationId"]');

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -108,7 +108,7 @@ const KNOWN_DECORATORS = ['@@activate', '@@dont_activate'];
  * @property {boolean} [matchCharacterPersonality] If the scan should match against the character
  * @property {boolean} [matchCharacterNote] If the scan should match against the character note
  * @property {boolean} [matchScenario] If the scan should match against the character scenario
- * @property {boolean} [matchCreatorsNotes] If the scan should match against the character metadata
+ * @property {boolean} [matchCreatorNotes] If the scan should match against the character metadata
  * @property {number} [uid] The UID of the entry that triggered the scan
  * @property {string} [world] The world info book of origin of the entry
  * @property {string[]} [key] The primary keys to scan for
@@ -2202,7 +2202,7 @@ export const originalWIDataKeyMap = {
     'matchCharacterPersonality': 'extensions.match_character_personality',
     'matchCharacterNote': 'extensions.match_character_note',
     'matchScenario': 'extensions.match_scenario',
-    'matchCreatorsNotes': 'extensions.match_creators_notes',
+    'matchCreatorNotes': 'extensions.match_creator_notes',
     'scanDepth': 'extensions.scan_depth',
     'automationId': 'extensions.automation_id',
     'vectorized': 'extensions.vectorized',
@@ -3340,7 +3340,7 @@ export async function getWorldEntry(name, data, entry) {
     handleOptionalSelect("matchCharacterPersonality");
     handleOptionalSelect("matchCharacterNote");
     handleOptionalSelect("matchScenario");
-    handleOptionalSelect("matchCreatorsNotes");
+    handleOptionalSelect("matchCreatorNotes");
 
     // automation id
     const automationIdInput = template.find('input[name="automationId"]');

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -702,6 +702,12 @@ function convertWorldInfoToCharacterBook(name, entries) {
                 sticky: entry.sticky ?? null,
                 cooldown: entry.cooldown ?? null,
                 delay: entry.delay ?? null,
+                matchPersonaDescription: entry.matchPersonaDescription ?? false,
+                matchCharacterDescription: entry.matchCharacterDescription ?? false,
+                matchCharacterPersonality: entry.matchCharacterPersonality ?? false,
+                matchCharacterDepthPrompt: entry.matchCharacterDepthPrompt ?? false,
+                matchScenario: entry.matchScenario ?? false,
+                matchCreatorNotes: entry.matchCreatorNotes ?? false,
             },
         };
 

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -702,12 +702,12 @@ function convertWorldInfoToCharacterBook(name, entries) {
                 sticky: entry.sticky ?? null,
                 cooldown: entry.cooldown ?? null,
                 delay: entry.delay ?? null,
-                matchPersonaDescription: entry.matchPersonaDescription ?? false,
-                matchCharacterDescription: entry.matchCharacterDescription ?? false,
-                matchCharacterPersonality: entry.matchCharacterPersonality ?? false,
-                matchCharacterDepthPrompt: entry.matchCharacterDepthPrompt ?? false,
-                matchScenario: entry.matchScenario ?? false,
-                matchCreatorNotes: entry.matchCreatorNotes ?? false,
+                match_persona_description: entry.matchPersonaDescription ?? false,
+                match_character_description: entry.matchCharacterDescription ?? false,
+                match_character_personality: entry.matchCharacterPersonality ?? false,
+                match_character_depth_prompt: entry.matchCharacterDepthPrompt ?? false,
+                match_scenario: entry.matchScenario ?? false,
+                match_creator_notes: entry.matchCreatorNotes ?? false,
             },
         };
 


### PR DESCRIPTION
Sometimes it is useful to match World Info entries across character data such as description, personality and so on. This allows for dictionary style Lorebooks with multiple definitions which can be switched on or off according to the character being used. It may also occasionally be useful to match WI Entries on data that is not seen by the LLM, or even on the current user persona.

This feature adds extra World Info Entry options which allow for matching on the following chat-independent data:

- User persona
- Character description
- Character personality
- Character depth prompt (Character's Notes)
- Scenario
- Creator notes

The feature works by adding each of the fields to the World Info scan string, depending on which fields are active. This means that these matches use the exact same mechanism as regular chat matching, which means other options such as trigger chance, cooldown, etc. should work just fine.

To accommodate these new toggles, I have grouped them together under a new **Additional Matching Sources** dropdown:

![image](https://github.com/user-attachments/assets/06ee69ef-b294-4062-bc98-d25b502d1024)

Let me know what you think.

## Arguments against

> Add individual character names / persona name to entries

This doesn't work well in certain cases because every time we create a new character that is supposed to use the lorebook, we have to edit the lorebook to include this character. This is tedious, time consuming, and polutes the Lorebook.

> Use tags instead

Tags should, in my opinion, be used for organization purposes. Having a huge set of tags in one character can hurt character list maintainability, and hinder glance value. With smaller Lorebooks tags could be an appropriate solution, but when you are looking to have 50+ entries it doesn't seem very viable.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
