### PR TITLE
Remove last message role restriction for Cohere

### DIFF
--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -351,11 +351,6 @@ export function convertCohereMessages(messages, names) {
         }
     });
 
-    // A prompt should end with a user/tool message
-    if (messages.length && !['user', 'tool'].includes(messages[messages.length - 1].role)) {
-        messages[messages.length - 1].role = 'user';
-    }
-
     return { chatHistory: messages };
 }
 


### PR DESCRIPTION
Closes #3692.

I debated with myself whether to allow last as assistant. We can let users find out for themselves that prefilling doesn't work. The request itself works on all models, and the restriction was originally in place to prevent API errors. Responses aren't much different when I tested it.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
