### PR TITLE
Fix continuation suffix trimming

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4235,12 +4235,20 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
         // Do not suffix the message for continuation
         if (i === 0 && isContinue) {
+            // Pick something that's very unlikely to be in a message
+            const FORMAT_TOKEN = '\u0000\ufffc\u0000\ufffd';
+
             if (isInstruct) {
+                const originalMessage = String(coreChat[j].mes ?? '');
+                coreChat[j].mes = originalMessage.replaceAll(FORMAT_TOKEN, '') + FORMAT_TOKEN;
                 // Reformat with the last output sequence (if any)
                 chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.LAST);
+                coreChat[j].mes = originalMessage;
             }
 
-            chat2[i] = chat2[i].slice(0, chat2[i].lastIndexOf(coreChat[j].mes) + coreChat[j].mes.length);
+            chat2[i] = chat2[i].includes(FORMAT_TOKEN)
+                ? chat2[i].slice(0, chat2[i].lastIndexOf(FORMAT_TOKEN))
+                : chat2[i].slice(0, chat2[i].lastIndexOf(coreChat[j].mes) + coreChat[j].mes.length);
             continue_mag = coreChat[j].mes;
         }
 


### PR DESCRIPTION
Fixes #3901

Quite an elaborate way, but I haven't been able to think something to fix that tiny corner case without rewriting the entire TC prompt builder.

<!-- Put X in the box below to confirm -->

## Yap

This pull request introduces a change to the `Generate` function in `public/script.js` to improve how continuation messages are handled when formatting chat history. The update ensures that a unique token is used to mark and manage message boundaries without interfering with the original message content.

Key change:

* Introduced a `FORMAT_TOKEN` constant (`\u0000\ufffc\u0000\ufffd`) to act as a unique marker for message boundaries. This token is temporarily appended to messages during processing and removed afterward to ensure clean formatting of continuation messages. The logic for slicing messages was updated to account for the presence of this token.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
