### PR TITLE
Print full Google response

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -499,7 +499,7 @@ async function sendMakerSuiteRequest(request, response) {
             const responseContent = candidates[0].content ?? candidates[0].output;
             const functionCall = (candidates?.[0]?.content?.parts ?? []).some(part => part.functionCall);
             const inlineData = (candidates?.[0]?.content?.parts ?? []).some(part => part.inlineData);
-            console.warn('Google AI Studio response:', util.inspect(generateResponseJson, {depth: 6, colors: true}));
+            console.warn('Google AI Studio response:', util.inspect(generateResponseJson, {depth: 5, colors: true}));
 
             const responseText = typeof responseContent === 'string' ? responseContent : responseContent?.parts?.filter(part => !part.thought)?.map(part => part.text)?.join('\n\n');
             if (!responseText && !functionCall && !inlineData) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1,6 +1,7 @@
 import process from 'node:process';
 import express from 'express';
 import fetch from 'node-fetch';
+import util from 'node:util';
 
 import {
     CHAT_COMPLETION_SOURCES,
@@ -498,7 +499,7 @@ async function sendMakerSuiteRequest(request, response) {
             const responseContent = candidates[0].content ?? candidates[0].output;
             const functionCall = (candidates?.[0]?.content?.parts ?? []).some(part => part.functionCall);
             const inlineData = (candidates?.[0]?.content?.parts ?? []).some(part => part.inlineData);
-            console.warn('Google AI Studio response:', responseContent);
+            console.warn('Google AI Studio response:', util.inspect(generateResponseJson, {depth: 6, colors: true}));
 
             const responseText = typeof responseContent === 'string' ? responseContent : responseContent?.parts?.filter(part => !part.thought)?.map(part => part.text)?.join('\n\n');
             if (!responseText && !functionCall && !inlineData) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -499,7 +499,7 @@ async function sendMakerSuiteRequest(request, response) {
             const responseContent = candidates[0].content ?? candidates[0].output;
             const functionCall = (candidates?.[0]?.content?.parts ?? []).some(part => part.functionCall);
             const inlineData = (candidates?.[0]?.content?.parts ?? []).some(part => part.inlineData);
-            console.warn('Google AI Studio response:', util.inspect(generateResponseJson, {depth: 5, colors: true}));
+            console.warn('Google AI Studio response:', util.inspect(generateResponseJson, { depth: 5, colors: true }));
 
             const responseText = typeof responseContent === 'string' ? responseContent : responseContent?.parts?.filter(part => !part.thought)?.map(part => part.text)?.join('\n\n');
             if (!responseText && !functionCall && !inlineData) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1,7 +1,7 @@
 import process from 'node:process';
+import util from 'node:util';
 import express from 'express';
 import fetch from 'node-fetch';
-import util from 'node:util';
 
 import {
     CHAT_COMPLETION_SOURCES,
@@ -499,7 +499,7 @@ async function sendMakerSuiteRequest(request, response) {
             const responseContent = candidates[0].content ?? candidates[0].output;
             const functionCall = (candidates?.[0]?.content?.parts ?? []).some(part => part.functionCall);
             const inlineData = (candidates?.[0]?.content?.parts ?? []).some(part => part.inlineData);
-            console.warn('Google AI Studio response:', util.inspect(generateResponseJson, { depth: 5, colors: true }));
+            console.debug('Google AI Studio response:', util.inspect(generateResponseJson, { depth: 5, colors: true }));
 
             const responseText = typeof responseContent === 'string' ? responseContent : responseContent?.parts?.filter(part => !part.thought)?.map(part => part.text)?.join('\n\n');
             if (!responseText && !functionCall && !inlineData) {


### PR DESCRIPTION
Inspect depth 5 will print `inlineData: [Object]` so a generated image string doesn't take up the whole terminal.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
