### PR TITLE
Check instruct activation regex before selecting context template

### DIFF
--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -208,37 +208,39 @@ export function autoSelectInstructPreset(modelId) {
 
     // Select matching instruct preset
     let foundMatch = false;
-    for (const instruct_preset of instruct_presets) {
-        // If instruct preset matches the context template
-        if (power_user.instruct.bind_to_context && instruct_preset.name === power_user.context.preset) {
-            foundMatch = true;
-            selectInstructPreset(instruct_preset.name, { isAuto: true });
-            break;
-        }
-    }
-    // If no match was found, auto-select instruct preset
-    if (!foundMatch) {
-        for (const preset of instruct_presets) {
-            // If activation regex is set, check if it matches the model id
-            if (preset.activation_regex) {
-                try {
-                    const regex = regexFromString(preset.activation_regex);
 
-                    // Stop on first match so it won't cycle back and forth between presets if multiple regexes match
-                    if (regex instanceof RegExp && regex.test(modelId)) {
-                        selectInstructPreset(preset.name, { isAuto: true });
+    for (const preset of instruct_presets) {
+        // If activation regex is set, check if it matches the model id
+        if (preset.activation_regex) {
+            try {
+                const regex = regexFromString(preset.activation_regex);
 
-                        return true;
-                    }
-                } catch {
-                    // If regex is invalid, ignore it
-                    console.warn(`Invalid instruct activation regex in preset "${preset.name}"`);
+                // Stop on first match so it won't cycle back and forth between presets if multiple regexes match
+                if (regex instanceof RegExp && regex.test(modelId)) {
+                    selectInstructPreset(preset.name, { isAuto: true });
+                    foundMatch = true;
+                    break;
                 }
+            } catch {
+                // If regex is invalid, ignore it
+                console.warn(`Invalid instruct activation regex in preset "${preset.name}"`);
             }
         }
     }
 
-    return false;
+    // If no match was found, auto-select instruct preset
+    if (!foundMatch && power_user.instruct.bind_to_context) {
+        for (const instruct_preset of instruct_presets) {
+            // If instruct preset matches the context template
+            if (instruct_preset.name === power_user.context.preset) {
+                selectInstructPreset(instruct_preset.name, { isAuto: true });
+                foundMatch = true;
+                break;
+            }
+        }
+    }
+
+    return foundMatch;
 }
 
 /**


### PR DESCRIPTION
> Well but right now the regex matching doesn't seem to affect the instruct preset at all if the bind to context option is set. So its not just that it doesn't switch to the matching context, its that the instruct preset also doesn't change

Cause context name matches were done before a regex would ever evaluate, essentially rendering instruct matching impossible if you have context binding enabled.

---

This pull request refactors the `autoSelectInstructPreset` function in `public/scripts/instruct-mode.js` to improve the logic for selecting an instruct preset. The changes streamline the preset selection process and ensure that context-based presets are only selected when no regex matches are found.

### Refactoring of `autoSelectInstructPreset`:

* Removed the initial loop that prioritized context-based presets and integrated it as a fallback after checking regex-based matches. This simplifies the flow and avoids redundant checks. [[1]](diffhunk://#diff-776b7a0b7ce63c8ca4b6d681c31b8cf56cc0a9ce758106e13eb789a5397e2939L211-R211) [[2]](diffhunk://#diff-776b7a0b7ce63c8ca4b6d681c31b8cf56cc0a9ce758106e13eb789a5397e2939L230-R243)
* Adjusted the logic to set `foundMatch` to `true` only when a regex match or a context-based preset match is found, ensuring accurate return values.
* Added a final fallback to auto-select context-based presets only if no regex matches are found and `bind_to_context` is enabled. This ensures the correct preset is selected in edge cases.
* Updated the return value to reflect whether a match was successfully found, improving the function's usability and clarity.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
