### PR TITLE
Add both `test` and `match` regex commands

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2138,7 +2138,7 @@ export function initDefaultSlashCommands() {
             if (!pattern) {
                 throw new Error('Argument of \'pattern=\' cannot be empty');
             }
-            let re = regexFromString(pattern.toString());
+            const re = regexFromString(pattern.toString());
             if (!re) {
                 throw new Error('The value of \'pattern\' argument is not a valid regular expression.');
             }

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2134,10 +2134,13 @@ export function initDefaultSlashCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'test',
         callback: (({ pattern }, text) => {
-            if (pattern === '') {
+            if (!pattern) {
                 throw new Error('Argument of \'pattern=\' cannot be empty');
             }
             let re = regexFromString(pattern.toString());
+            if (!re) {
+                throw new Error('The value of \'pattern\' argument is not a valid regular expression.');
+            }
             return JSON.stringify(re.test(text.toString()));
         }),
         returns: 'true | false',
@@ -2170,10 +2173,13 @@ export function initDefaultSlashCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'match',
         callback: (({ pattern }, text) => {
-            if (pattern === '') {
+            if (!pattern) {
                 throw new Error('Argument of \'pattern=\' cannot be empty');
             }
             let re = regexFromString(pattern.toString());
+            if (!re) {
+                throw new Error('The value of \'pattern\' argument is not a valid regular expression.');
+            }
             if (re.flags.includes('g')) {
                 return JSON.stringify([...text.toString().matchAll(re)]);
             } else {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2163,10 +2163,10 @@ export function initDefaultSlashCommands() {
             </div>
             <div>
                 <strong>Example:</strong>
-                <pre>/let x Blue house and green car                         ||</pre>
-                <pre>/test pattern="green" {{var::x}}    | /echo  |/# true   ||</pre>
-                <pre>/test pattern="blue" {{var::x}}     | /echo  |/# false  ||</pre>
-                <pre>/test pattern="/blue/i" {{var::x}}  | /echo  |/# true   ||</pre>
+                <pre><code class="language-stscript">/let x Blue house and green car                         ||</code></pre>
+                <pre><code class="language-stscript">/test pattern="green" {{var::x}}    | /echo  |/# true   ||</code></pre>
+                <pre><code class="language-stscript">/test pattern="blue" {{var::x}}     | /echo  |/# false  ||</code></pre>
+                <pre><code class="language-stscript">/test pattern="/blue/i" {{var::x}}  | /echo  |/# true   ||</code></pre>
             </div>
         `,
     }));
@@ -2208,12 +2208,12 @@ export function initDefaultSlashCommands() {
             </div>
             <div>
                 <strong>Example:</strong>
-                <pre>/let x color_green green lamp color_blue                                                                            ||</pre>
-                <pre>/match pattern="green" {{var::x}}            | /echo  |/# [ "green" ]                                               ||</pre>
-                <pre>/match pattern="color_(\\w+)" {{var::x}}     | /echo  |/# [ "color_green", "green" ]                                ||</pre>
-                <pre>/match pattern="/color_(\\w+)/g" {{var::x}}  | /echo  |/# [ [ "color_green", "green" ], [ "color_blue", "blue" ] ]  ||</pre>
-                <pre>/match pattern="orange" {{var::x}}           | /echo  |/# null                                                      ||</pre>
-                <pre>/match pattern="/orange/g" {{var::x}}        | /echo  |/# []                                                        ||</pre>
+                <pre><code class="language-stscript">/let x color_green green lamp color_blue                                                                            ||</code></pre>
+                <pre><code class="language-stscript">/match pattern="green" {{var::x}}            | /echo  |/# [ "green" ]                                               ||</code></pre>
+                <pre><code class="language-stscript">/match pattern="color_(\\w+)" {{var::x}}      | /echo  |/# [ "color_green", "green" ]                                ||</code></pre>
+                <pre><code class="language-stscript">/match pattern="/color_(\\w+)/g" {{var::x}}   | /echo  |/# [ [ "color_green", "green" ], [ "color_blue", "blue" ] ]  ||</code></pre>
+                <pre><code class="language-stscript">/match pattern="orange" {{var::x}}           | /echo  |/# null                                                      ||</code></pre>
+                <pre><code class="language-stscript">/match pattern="/orange/g" {{var::x}}        | /echo  |/# []                                                        ||</code></pre>
             </div>
         `,
     }));

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2131,6 +2131,86 @@ export function initDefaultSlashCommands() {
             </div>
         `,
     }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'test',
+        callback: (({ pattern }, text) => {
+            if (pattern === '') {
+                throw new Error('Argument of \'pattern=\' cannot be empty');
+            }
+            let re = regexFromString(pattern.toString());
+            return JSON.stringify(re.test(text.toString()));
+        }),
+        returns: 'true | false',
+        namedArgumentList: [
+            new SlashCommandNamedArgument(
+                'pattern', 'pattern to find', [ARGUMENT_TYPE.STRING], true, false,
+            ),
+        ],
+        unnamedArgumentList: [
+            new SlashCommandArgument(
+                'text to test', [ARGUMENT_TYPE.STRING], true, false,
+            ),
+        ],
+        helpString: `
+            <div>
+                Tests text for a regular expression match.
+            </div>
+            <div>
+                Returns <code>true</code> if the match is found, <code>false</code> otherwise.
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <pre>/let x Blue house and green car                         ||</pre>
+                <pre>/test pattern="green" {{var::x}}    | /echo  |/# true   ||</pre>
+                <pre>/test pattern="blue" {{var::x}}     | /echo  |/# false  ||</pre>
+                <pre>/test pattern="/blue/i" {{var::x}}  | /echo  |/# true   ||</pre>
+            </div>
+        `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'match',
+        callback: (({ pattern }, text) => {
+            if (pattern === '') {
+                throw new Error('Argument of \'pattern=\' cannot be empty');
+            }
+            let re = regexFromString(pattern.toString());
+            if (re.flags.includes('g')) {
+                return JSON.stringify([...text.toString().matchAll(re)]);
+            } else {
+                return JSON.stringify(text.toString().match(re));
+            }
+        }),
+        returns: 'group array for each match',
+        namedArgumentList: [
+            new SlashCommandNamedArgument(
+                'pattern', 'pattern to find', [ARGUMENT_TYPE.STRING], true, false,
+            ),
+        ],
+        unnamedArgumentList: [
+            new SlashCommandArgument(
+                'text to match against', [ARGUMENT_TYPE.STRING], true, false,
+            ),
+        ],
+        helpString: `
+            <div>
+                Retrieves regular expression matches in the given text
+            </div>
+            <div>
+                Returns an array of groups (with the first group being the full match). If the regex contains the global flag (i.e. <code>/g</code>),
+                multiple nested arrays are returned for each match. If the regex is global, returns <code>[]</code> if no matches are found,
+                otherwise it returns null.
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <pre>/let x color_green green lamp color_blue                                                                            ||</pre>
+                <pre>/match pattern="green" {{var::x}}            | /echo  |/# [ "green" ]                                               ||</pre>
+                <pre>/match pattern="color_(\\w+)" {{var::x}}     | /echo  |/# [ "color_green", "green" ]                                ||</pre>
+                <pre>/match pattern="/color_(\\w+)/g" {{var::x}}  | /echo  |/# [ [ "color_green", "green" ], [ "color_blue", "blue" ] ]  ||</pre>
+                <pre>/match pattern="orange" {{var::x}}           | /echo  |/# null                                                      ||</pre>
+                <pre>/match pattern="/orange/g" {{var::x}}        | /echo  |/# []                                                        ||</pre>
+            </div>
+        `,
+    }));
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'chat-jump',

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2177,14 +2177,15 @@ export function initDefaultSlashCommands() {
             if (!pattern) {
                 throw new Error('Argument of \'pattern=\' cannot be empty');
             }
-            let re = regexFromString(pattern.toString());
+            const re = regexFromString(pattern.toString());
             if (!re) {
                 throw new Error('The value of \'pattern\' argument is not a valid regular expression.');
             }
             if (re.flags.includes('g')) {
                 return JSON.stringify([...text.toString().matchAll(re)]);
             } else {
-                return JSON.stringify(text.toString().match(re));
+                const match = text.toString().match(re);
+                return match ? JSON.stringify(match) : '';
             }
         }),
         returns: 'group array for each match',
@@ -2205,7 +2206,7 @@ export function initDefaultSlashCommands() {
             <div>
                 Returns an array of groups (with the first group being the full match). If the regex contains the global flag (i.e. <code>/g</code>),
                 multiple nested arrays are returned for each match. If the regex is global, returns <code>[]</code> if no matches are found,
-                otherwise it returns null.
+                otherwise it returns an empty string.
             </div>
             <div>
                 <strong>Example:</strong>
@@ -2213,7 +2214,7 @@ export function initDefaultSlashCommands() {
                 <pre><code class="language-stscript">/match pattern="green" {{var::x}}            | /echo  |/# [ "green" ]                                               ||</code></pre>
                 <pre><code class="language-stscript">/match pattern="color_(\\w+)" {{var::x}}      | /echo  |/# [ "color_green", "green" ]                                ||</code></pre>
                 <pre><code class="language-stscript">/match pattern="/color_(\\w+)/g" {{var::x}}   | /echo  |/# [ [ "color_green", "green" ], [ "color_blue", "blue" ] ]  ||</code></pre>
-                <pre><code class="language-stscript">/match pattern="orange" {{var::x}}           | /echo  |/# null                                                      ||</code></pre>
+                <pre><code class="language-stscript">/match pattern="orange" {{var::x}}           | /echo  |/#                                                           ||</code></pre>
                 <pre><code class="language-stscript">/match pattern="/orange/g" {{var::x}}        | /echo  |/# []                                                        ||</code></pre>
             </div>
         `,

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2124,11 +2124,11 @@ export function initDefaultSlashCommands() {
             </div>
             <div>
                 <strong>Example:</strong>
-                <pre>/let x Blue house and blue car ||                                                                        </pre>
-                <pre>/replace pattern="blue" {{var::x}}                                | /echo  |/# Blue house and  car     ||</pre>
-                <pre>/replace pattern="blue" replacer="red" {{var::x}}                 | /echo  |/# Blue house and red car  ||</pre>
-                <pre>/replace mode=regex pattern="/blue/i" replacer="red" {{var::x}}   | /echo  |/# red house and blue car  ||</pre>
-                <pre>/replace mode=regex pattern="/blue/gi" replacer="red" {{var::x}}  | /echo  |/# red house and red car   ||</pre>
+                <pre><code class="language-stscript">/let x Blue house and blue car ||                                                                        </code></pre>
+                <pre><code class="language-stscript">/replace pattern="blue" {{var::x}}                                | /echo  |/# Blue house and  car     ||</code></pre>
+                <pre><code class="language-stscript">/replace pattern="blue" replacer="red" {{var::x}}                 | /echo  |/# Blue house and red car  ||</code></pre>
+                <pre><code class="language-stscript">/replace mode=regex pattern="/blue/i" replacer="red" {{var::x}}   | /echo  |/# red house and blue car  ||</code></pre>
+                <pre><code class="language-stscript">/replace mode=regex pattern="/blue/gi" replacer="red" {{var::x}}  | /echo  |/# red house and red car   ||</code></pre>
             </div>
         `,
     }));

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2079,8 +2079,9 @@ export function initDefaultSlashCommands() {
         name: 'replace',
         aliases: ['re'],
         callback: (async ({ mode = 'literal', pattern, replacer = '' }, text) => {
-            if (pattern === '')
+            if (!pattern) {
                 throw new Error('Argument of \'pattern=\' cannot be empty');
+            }
             switch (mode) {
                 case 'literal':
                     return text.replaceAll(pattern, replacer);


### PR DESCRIPTION
At the moment we have access to `/replace` through STscript, which allows us to replace strings based on a regular expression. This is very useful, however it would sometimes be useful to have the ability to simply test against a text to verify if some value can be found, or to retrieve matches and groups from a text for convenient value extraction.

This adds two new commands to the core STscript command set, `/test` and `/match`. They are analogues to the functions with the same name in javascript (with `/match` specifically condensing both `String.match()` and `String.matchAll()` into one command). 

With these new commands we could do things like test for flags in responses, retrieve arguments from functions, count occurrences of a certain pattern, etc.

Here are some examples of how to use both (these are included with the command documentation as well):

```
/let x Blue house and green car                         ||
/test pattern="green" {{var::x}}    | /echo  |/# true   ||
/test pattern="blue" {{var::x}}     | /echo  |/# false  ||
/test pattern="/blue/i" {{var::x}}  | /echo  |/# true   ||
```

```
/let x color_green green lamp color_blue                                                                            ||
/match pattern="green" {{var::x}}            | /echo  |/# [ "green" ]                                               ||
/match pattern="color_(\w+)" {{var::x}}      | /echo  |/# [ "color_green", "green" ]                                ||
/match pattern="/color_(\w+)/g" {{var::x}}   | /echo  |/# [ [ "color_green", "green" ], [ "color_blue", "blue" ] ]  ||
/match pattern="orange" {{var::x}}           | /echo  |/#                                                           ||
/match pattern="/orange/g" {{var::x}}        | /echo  |/# []                                                        ||
```

---

> Why not an extension instead

Regex matching and testing seems like such a core feature that I believe it should be included in the core package. These are also simple features to implement, and complement the already existing `/replace` nicely.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
