### PR TITLE
Check for `error` as well when parsing streaming responses

### DIFF
--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1146,7 +1146,7 @@ function tryParseStreamingError(response, decoded) {
         // No JSON. Do nothing.
     }
 
-    const message = data?.error?.message || data?.message || data?.detail;
+    const message = data?.error?.message || data?.error || data?.message || data?.detail;
 
     if (message) {
         toastr.error(message, 'Text Completion API');


### PR DESCRIPTION
# Explanation

I asked Cohee and he said to PR in. To put it simply, featherless returns errors as strings and does not contain a `message` object inside. This added or switch check will catch that case as well.

Here's an example of an error that would be accepted before the change:
```json
{
    "error": {
        "message": "Error Goes here"
    }
}
```

New error type that would be accepted (featherless.ai specific)
```json
{
    "error": "no data in 30000ms"
}
```

Recently, a particular issue on featherless meant that users might be getting empty responses when they are actually sent with an error message. This check ensures that toast notifications alerts the user of the error.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
