### PR TITLE
Update links to ollama gihub

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2622,8 +2622,8 @@
                             </div>
                             <div data-tg-type="ollama">
                                 <div class="flex-container flexFlowColumn">
-                                    <a href="https://github.com/jmorganca/ollama" target="_blank">
-                                        jmorganca/ollama
+                                    <a href="https://github.com/ollama/ollama" target="_blank">
+                                        ollama/ollama
                                     </a>
                                 </div>
                                 <div class="flex1">

--- a/src/constants.js
+++ b/src/constants.js
@@ -284,7 +284,7 @@ export const TOGETHERAI_KEYS = [
     'stop',
 ];
 
-// https://github.com/jmorganca/ollama/blob/main/docs/api.md#request-with-options
+// https://github.com/ollama/ollama/blob/main/docs/api.md#request-with-options
 export const OLLAMA_KEYS = [
     'num_predict',
     'num_ctx',


### PR DESCRIPTION
Ollama has moved from the jmorganca namespace to the ollama namespace. This PR updates the ollama links.

## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
