### PR TITLE
Adds a check for jailbreaks existing in new TC PHI

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4214,12 +4214,15 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             ? substituteParams(jailbreak, name1, name2, (power_user.sysprompt.post_history ?? ''))
             : baseChatReplace(power_user.sysprompt.post_history, name1, name2);
 
-        // When continuing generation of previous output, last user message precedes the message to continue
-        if (isContinue) {
-            coreChat.splice(coreChat.length - 1, 0, { mes: jailbreak, is_user: true });
-        }
-        else {
-            coreChat.push({ mes: jailbreak, is_user: true });
+        // Only inject the jb if there is one
+        if (jailbreak && typeof(jailbreak) != 'undefined') {
+            // When continuing generation of previous output, last user message precedes the message to continue
+            if (isContinue) {
+                coreChat.splice(coreChat.length - 1, 0, { mes: jailbreak, is_user: true });
+            }
+            else {
+                coreChat.push({ mes: jailbreak, is_user: true });
+            }
         }
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -4215,7 +4215,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             : baseChatReplace(power_user.sysprompt.post_history, name1, name2);
 
         // Only inject the jb if there is one
-        if (jailbreak && typeof(jailbreak) != 'undefined') {
+        if (jailbreak) {
             // When continuing generation of previous output, last user message precedes the message to continue
             if (isContinue) {
                 coreChat.splice(coreChat.length - 1, 0, { mes: jailbreak, is_user: true });


### PR DESCRIPTION
Fixes an issue where an empty or undefined PHI from the new prompt field still gets injected in Text Completion.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
