### PR TITLE
Add style pin feature for greeting messages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4778,6 +4778,10 @@
                                     <input id="show_group_chat_queue" type="checkbox" />
                                     <small data-i18n="Show group chat queue">Show group chat queue</small>
                                 </label>
+                                <label class="checkbox_label" for="pin_styles" title="Always render style tags from greetings, even if the message is unloaded due to lazy loading." data-i18n="[title]Always render style tags from greetings, even if the message is unloaded due to lazy loading.">
+                                    <input id="pin_styles" type="checkbox" />
+                                    <small data-i18n="Pin greeting message styles">Pin greeting message styles</small>
+                                </label>
                                 <div class="inline-drawer wide100p flexFlowColumn">
                                     <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable" title="Automatically reject and re-generate AI message based on configurable criteria." data-i18n="[title]Automatically reject and re-generate AI message based on configurable criteria">
                                         <b><span data-i18n="Auto-swipe">Auto-swipe</span></b>

--- a/public/script.js
+++ b/public/script.js
@@ -97,6 +97,7 @@ import {
     forceCharacterEditorTokenize,
     applyPowerUserSettings,
     generatedTextFiltered,
+    applyStylePins,
 } from './scripts/power-user.js';
 
 import {
@@ -1920,6 +1921,7 @@ export async function showMoreMessages(messagesToLoad = null) {
         $('#chat').scrollTop(newHeight - prevHeight);
     }
 
+    applyStylePins();
     await eventSource.emit(event_types.MORE_MESSAGES_LOADED);
 }
 
@@ -1957,6 +1959,7 @@ export async function printMessages() {
     hideSwipeButtons();
     showSwipeButtons();
     scrollChatToBottom();
+    applyStylePins();
 
     function incrementAndCheck() {
         imagesLoaded++;

--- a/public/style.css
+++ b/public/style.css
@@ -1205,6 +1205,17 @@ body .panelControlBar {
     background-color: rgb(102, 0, 0);
 }
 
+#chat .style-pins {
+    visibility: hidden;
+    position: fixed;
+    left: -9999px;
+    top: -9999px;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+}
+
 .mes q:before,
 .mes q:after {
     content: '';


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

This pull request introduces a new feature to "pin" greeting message styles in the chat interface, ensuring that style tags from unloaded greeting messages are always rendered. The changes include updates to the HTML, JavaScript, and CSS files to support this functionality.

### New Feature: Pin Greeting Message Styles

* **HTML Updates**:
  - Added a new checkbox (`#pin_styles`) in the chat settings to enable or disable the "Pin Greeting Message Styles" feature. (`public/index.html`, [public/index.htmlR4781-R4784](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR4781-R4784))

* **JavaScript Updates**:
  - **Functionality**: Introduced the `applyStylePins` function in `public/scripts/power-user.js` to handle the logic for extracting and rendering style tags from the first greeting message. (`public/scripts/power-user.js`, [public/scripts/power-user.jsR1395-R1438](diffhunk://#diff-ec649a74b7de10172508bf497d4c77b0b2c315ee2f3277ab66e43869bd88b692R1395-R1438))
  - **Integration**:
    - Called `applyStylePins` in the `showMoreMessages` and `printMessages` functions to ensure styles are applied during message loading and rendering. (`public/script.js`, [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R1924) [[2]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R1962)
    - Added a listener for the `#pin_styles` checkbox to toggle the feature dynamically and save the setting. (`public/scripts/power-user.js`, [public/scripts/power-user.jsR3926-R3931](diffhunk://#diff-ec649a74b7de10172508bf497d4c77b0b2c315ee2f3277ab66e43869bd88b692R3926-R3931))
  - **Settings**: Added `pin_styles` to the `power_user` settings object and ensured it is loaded and saved correctly. (`public/scripts/power-user.js`, [[1]](diffhunk://#diff-ec649a74b7de10172508bf497d4c77b0b2c315ee2f3277ab66e43869bd88b692R322) [[2]](diffhunk://#diff-ec649a74b7de10172508bf497d4c77b0b2c315ee2f3277ab66e43869bd88b692R1649)

* **CSS Updates**:
  - Added styles for the `.style-pins` container to make it invisible and non-interactive while still rendering the style tags. (`public/style.css`, [public/style.cssR1208-R1218](diffhunk://#diff-46467272678c3da621692b13b96d47ed25128fa8027d8dbedd84684c6336fb51R1208-R1218))

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
