### PR TITLE
Updates/fixes for llama.cpp textgen settings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1313,8 +1313,8 @@
                                             <span data-i18n="Top nsigma">Top nsigma</span>
                                             <div class="fa-solid fa-circle-info opacity50p" title="A sampling method that filters logits based on their statistical properties. It keeps tokens within n standard deviations of the maximum logit value, providing a simpler alternative to top-p/top-k sampling while maintaining sampling stability across different temperatures."></div>
                                         </small>
-                                        <input class="neo-range-slider" type="range" id="nsigma_textgenerationwebui" name="volume" min="-0.01" max="5" step="0.01">
-                                        <input class="neo-range-input" type="number" min="-0.01" max="5" step="0.01" data-for="nsigma_textgenerationwebui" id="nsigma_counter_textgenerationwebui">
+                                        <input class="neo-range-slider" type="range" id="nsigma_textgenerationwebui" name="volume" min="0" max="5" step="0.01">
+                                        <input class="neo-range-input" type="number" min="0" max="5" step="0.01" data-for="nsigma_textgenerationwebui" id="nsigma_counter_textgenerationwebui">
                                     </div>
                                     <div data-tg-type="llamacpp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>

--- a/public/index.html
+++ b/public/index.html
@@ -1284,7 +1284,7 @@
                                         <input class="neo-range-slider" type="range" id="min_p_textgenerationwebui" name="volume" min="0" max="1" step="0.001">
                                         <input class="neo-range-input" type="number" min="0" max="1" step="0.001" data-for="min_p_textgenerationwebui" id="min_p_counter_textgenerationwebui">
                                     </div>
-                                    <div data-tg-type-mode="except" data-tg-type="generic" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-tg-type-mode="except" data-tg-type="generic,llamacpp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Top A">Top A</span>
                                             <div class="fa-solid fa-circle-info opacity50p" title="Top A sets a threshold for token selection based on the square of the highest token probability.&#13;E.g if the Top-A value is 0.2 and the top token's probability is 50%, tokens with probabilities below 5% (0.2 * 0.5^2) are excluded.&#13;Set to 0 to disable." data-i18n="[title]Top_A_desc"></div>
@@ -1292,7 +1292,7 @@
                                         <input class="neo-range-slider" type="range" id="top_a_textgenerationwebui" name="volume" min="0" max="1" step="0.01">
                                         <input class="neo-range-input" type="number" min="0" max="1" step="0.01" data-for="top_a_textgenerationwebui" id="top_a_counter_textgenerationwebui">
                                     </div>
-                                    <div data-tg-type-mode="except" data-tg-type="generic" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-tg-type-mode="except" data-tg-type="generic,llamacpp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="TFS">TFS</span>
                                             <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Tail_Free_Sampling_desc" title="Tail-Free Sampling (TFS) searches for a tail of low-probability tokens in the distribution,&#13;by analyzing the rate of change in token probabilities using derivatives. It retains tokens up to a threshold (e.g., 0.3) based on the normalized second derivative.&#13;The closer to 0, the more discarded tokens. Set to 1.0 to disable."></div>
@@ -1308,13 +1308,21 @@
                                         <input class="neo-range-slider" type="range" id="epsilon_cutoff_textgenerationwebui" name="volume" min="0" max="9" step="0.01">
                                         <input class="neo-range-input" type="number" min="0" max="9" step="0.01" data-for="epsilon_cutoff_textgenerationwebui" id="epsilon_cutoff_counter_textgenerationwebui">
                                     </div>
-                                    <div data-tg-type="aphrodite,koboldcpp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-tg-type="aphrodite,koboldcpp,llamacpp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Top nsigma">Top nsigma</span>
                                             <div class="fa-solid fa-circle-info opacity50p" title="A sampling method that filters logits based on their statistical properties. It keeps tokens within n standard deviations of the maximum logit value, providing a simpler alternative to top-p/top-k sampling while maintaining sampling stability across different temperatures."></div>
                                         </small>
-                                        <input class="neo-range-slider" type="range" id="nsigma_textgenerationwebui" name="volume" min="0" max="5" step="0.01">
-                                        <input class="neo-range-input" type="number" min="0" max="5" step="0.01" data-for="nsigma_textgenerationwebui" id="nsigma_counter_textgenerationwebui">
+                                        <input class="neo-range-slider" type="range" id="nsigma_textgenerationwebui" name="volume" min="-0.01" max="5" step="0.01">
+                                        <input class="neo-range-input" type="number" min="-0.01" max="5" step="0.01" data-for="nsigma_textgenerationwebui" id="nsigma_counter_textgenerationwebui">
+                                    </div>
+                                    <div data-tg-type="llamacpp" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                        <small>
+                                            <span data-i18n="Min Keep">Min Keep</span>
+                                            <div class="fa-solid fa-circle-info opacity50p" title="A sampling modifier that ensures that truncation samplers such as top-p, min-p, typical-p, and xtc return at least this many tokens. Set to 0 to disable."></div>
+                                        </small>
+                                        <input class="neo-range-slider" type="range" id="min_keep_textgenerationwebui" name="volume" min="0" max="50" step="1">
+                                        <input class="neo-range-input" type="number" min="0" max="50" step="1" data-for="min_keep_textgenerationwebui" id="min_keep_counter_textgenerationwebui">
                                     </div>
                                     <div data-tg-type="ooba,mancer,aphrodite" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
@@ -1769,11 +1777,12 @@
                                             <div data-name="temperature" draggable="true"><span>Temperature</span><small></small></div>
                                             <div data-name="top_k" draggable="true"><span>Top K</span><small></small></div>
                                             <div data-name="top_p" draggable="true"><span>Top P</span><small></small></div>
-                                            <div data-name="typical_p" draggable="true"><span>Typical P</span><small></small></div>
-                                            <div data-name="tfs_z" draggable="true"><span>Tail Free Sampling</span><small></small></div>
+                                            <div data-name="typ_p" draggable="true"><span>Typical P</span><small></small></div>
                                             <div data-name="min_p" draggable="true"><span>Min P</span><small></small></div>
                                             <div data-name="xtc" draggable="true"><span>Exclude Top Choices</span><small></small></div>
                                             <div data-name="dry" draggable="true"><span>DRY</span><small></small></div>
+                                            <div data-name="penalties" draggable="true"><span>Rep/Freq/Pres Penalties</span><small></small></div>
+                                            <div data-name="top_n_sigma" draggable="true"><span>Top N-Sigma</span><small></small></div>
                                         </div>
                                         <div id="llamacpp_samplers_default_order" class="menu_button menu_button_icon">
                                             <span data-i18n="Load default order">Load default order</span>

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -806,7 +806,7 @@ jQuery(function () {
             'dry_penalty_last_n_textgenerationwebui': 0,
             'xtc_threshold_textgenerationwebui': 0.1,
             'xtc_probability_textgenerationwebui': 0,
-            'nsigma_textgenerationwebui': [LLAMACPP].includes(settings.type) ? -0.01 : 0,
+            'nsigma_textgenerationwebui': 0,
             'min_keep_textgenerationwebui': 0,
         };
 
@@ -1335,8 +1335,8 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         'sampler_order': settings.type === textgen_types.KOBOLDCPP ? settings.sampler_order : undefined,
         'xtc_threshold': settings.xtc_threshold,
         'xtc_probability': settings.xtc_probability,
-        'nsigma': settings.nsigma,
-        'top_n_sigma': settings.nsigma,
+        'nsigma': [LLAMACPP].includes(settings.type) && settings.nsigma === 0 ? -1 : settings.nsigma,
+        'top_n_sigma': [LLAMACPP].includes(settings.type) && settings.nsigma === 0 ? -1 : settings.nsigma,
         'min_keep': settings.min_keep,
     };
     const nonAphroditeParams = {

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -56,10 +56,11 @@ const {
 } = textgen_types;
 
 const LLAMACPP_DEFAULT_ORDER = [
+    'penalties',
     'dry',
+    'top_n_sigma',
     'top_k',
-    'tfs_z',
-    'typical_p',
+    'typ_p',
     'top_p',
     'min_p',
     'xtc',
@@ -212,6 +213,7 @@ const settings = {
     xtc_threshold: 0.1,
     xtc_probability: 0,
     nsigma: 0.0,
+    min_keep: 0,
     featherless_model: '',
     generic_model: '',
 };
@@ -294,6 +296,7 @@ export const setting_names = [
     'xtc_threshold',
     'xtc_probability',
     'nsigma',
+    'min_keep',
     'generic_model',
 ];
 
@@ -803,7 +806,8 @@ jQuery(function () {
             'dry_penalty_last_n_textgenerationwebui': 0,
             'xtc_threshold_textgenerationwebui': 0.1,
             'xtc_probability_textgenerationwebui': 0,
-            'nsigma_textgenerationwebui': 0,
+            'nsigma_textgenerationwebui': [LLAMACPP].includes(settings.type) ? -0.01 : 0,
+            'min_keep_textgenerationwebui': 0,
         };
 
         for (const [id, value] of Object.entries(inputs)) {
@@ -1332,6 +1336,8 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         'xtc_threshold': settings.xtc_threshold,
         'xtc_probability': settings.xtc_probability,
         'nsigma': settings.nsigma,
+        'top_n_sigma': settings.nsigma,
+        'min_keep': settings.min_keep,
     };
     const nonAphroditeParams = {
         'rep_pen': settings.rep_pen,

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1357,7 +1357,6 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         'json_schema': [TABBY, LLAMACPP].includes(settings.type) ? settings.json_schema : undefined,
         // llama.cpp aliases. In case someone wants to use LM Studio as Text Completion API
         'repeat_penalty': settings.rep_pen,
-        'tfs_z': settings.tfs,
         'repeat_last_n': settings.rep_pen_range,
         'n_predict': maxTokens,
         'num_predict': maxTokens,

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1335,8 +1335,8 @@ export async function getTextGenGenerationData(finalPrompt, maxTokens, isImperso
         'sampler_order': settings.type === textgen_types.KOBOLDCPP ? settings.sampler_order : undefined,
         'xtc_threshold': settings.xtc_threshold,
         'xtc_probability': settings.xtc_probability,
-        'nsigma': [LLAMACPP].includes(settings.type) && settings.nsigma === 0 ? -1 : settings.nsigma,
-        'top_n_sigma': [LLAMACPP].includes(settings.type) && settings.nsigma === 0 ? -1 : settings.nsigma,
+        'nsigma': settings.nsigma,
+        'top_n_sigma': settings.nsigma,
         'min_keep': settings.min_keep,
     };
     const nonAphroditeParams = {


### PR DESCRIPTION
## Several changes to the llama.cpp textgen settings:

* Add the llama.cpp-exclusive [`min_keep`](https://github.com/ggml-org/llama.cpp/blob/15a28ec8c705b188ebe178170966d1dcc36fe151/common/common.h#L133) parameter that constrains the effect of truncation samplers.
* Add penalties (rep pen, freq pen, and pres pen) to the llama.cpp sampler order block, allowing them to actually be applied.
* Add support for `nsigma` for llama.cpp (https://github.com/ggml-org/llama.cpp/pull/13264)
    - Addresses https://github.com/SillyTavern/SillyTavern/issues/3960
    - Add `nsigma` to the sampler order block.
    - Add the llama.cpp alias `top_n_sigma` for `nsigma`.
    - Add the ability to set `nsigma` to a negative value, as this represents "disabled" in llama.cpp (https://github.com/ggml-org/llama.cpp/pull/13264/commits/9152659426e2c6d8141d11d447ae9a1463b76f7f). 0 behaves as deterministic in llama.cpp. I chose the negative value -0.01 instead of -1 to avoid extending the slider too far into negative territory, but yeah it's ugly lol. Not sure if there is a better solution.
* Remove [`tfs`](https://github.com/ggml-org/llama.cpp/pull/10071) and `top_a` for llama.cpp as these samplers are not supported.
    - Remove the llama.cpp-specific alias for `tfs`, `tfs_z`.
* Correct the identification string for `typical_p` to the canonical `typ_p` in the llama.cpp sampler order block, allowing it to actually be applied. The [valid options](https://github.com/ggml-org/llama.cpp/blob/a7366faa5bb2fff97b9fb43340d853709f52d8c9/common/sampling.cpp#L501-L528) are `typ_p`, `typical-p`, `typical`, `typ-p`, and `typ`, but not... `typical_p`.


## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
