### PR TITLE
Decouple "click to edit" from document mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4498,10 +4498,11 @@
                                     <small data-i18n="Tags as Folders">Tags as Folders</small>
                                     <i title="Recent change: Tags must be marked as folders in the Tag Management menu to appear as such. Click here to bring it up." data-i18n="[title]Tags_as_Folders_desc" class="tags_view right_menu_button fa-solid fa-circle-exclamation"></i>
                                 </label>
-
+                                <label for="click_to_edit" class="checkbox_label" title="Click the message text in the chat log to edit it." data-i18n="[title]Click the message text in the chat log to edit it.">
+                                    <input id="click_to_edit" type="checkbox" />
+                                    <small data-i18n="Click to Edit">Click to Edit</small>
+                                </label>
                             </div>
-
-
                         </div>
                     </div>
                     <div name="UserSettingsSecondColumn" id="UI-Customization" class="flex-container flexFlowColumn wide100p flexNoGap flex1">

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -1576,7 +1576,8 @@ jQuery(function () {
         await callGenericPopup(wrapper, POPUP_TYPE.TEXT, '', { wide: true, large: true });
     });
 
-    $(document).on('click', 'body.documentstyle .mes .mes_text', function () {
+    $(document).on('click', 'body .mes .mes_text', function () {
+        if (!power_user.click_to_edit) return;
         if (window.getSelection().toString()) return;
         if ($('.edit_textarea').length) return;
         $(this).closest('.mes').find('.mes_edit').trigger('click');

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1459,6 +1459,10 @@ async function loadPowerUserSettings(settings, data) {
     const defaultStscript = JSON.parse(JSON.stringify(power_user.stscript));
     // Load from settings.json
     if (settings.power_user !== undefined) {
+        // Migrate old preference to a new setting
+        if (settings.power_user.click_to_edit === undefined && settings.power_user.chat_display === chat_styles.DOCUMENT) {
+            settings.power_user.click_to_edit = true;
+        }
         Object.assign(power_user, settings.power_user);
     }
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -320,6 +320,7 @@ let power_user = {
     external_media_allowed_overrides: [],
     external_media_forbidden_overrides: [],
     pin_styles: true,
+    click_to_edit: false,
 };
 
 let themes = [];
@@ -1322,6 +1323,12 @@ function applyTheme(name) {
                 switchSwipeNumAllMessages();
             },
         },
+        {
+            key: 'click_to_edit',
+            action: () => {
+                $('#click_to_edit').prop('checked', power_user.click_to_edit);
+            },
+        },
     ];
 
     for (const { key, selector, type, action } of themeProperties) {
@@ -1647,6 +1654,7 @@ async function loadPowerUserSettings(settings, data) {
     $('#auto-load-chat-checkbox').prop('checked', power_user.auto_load_chat);
     $('#forbid_external_media').prop('checked', power_user.forbid_external_media);
     $('#pin_styles').prop('checked', power_user.pin_styles);
+    $('#click_to_edit').prop('checked', power_user.click_to_edit);
 
     for (const theme of themes) {
         const option = document.createElement('option');
@@ -2379,6 +2387,7 @@ function getThemeObject(name) {
         reduced_motion: power_user.reduced_motion,
         compact_input_area: power_user.compact_input_area,
         show_swipe_num_all_messages: power_user.show_swipe_num_all_messages,
+        click_to_edit: power_user.click_to_edit,
     };
 }
 
@@ -3927,6 +3936,11 @@ $(document).ready(() => {
         power_user.pin_styles = !!$(this).prop('checked');
         saveSettingsDebounced();
         applyStylePins();
+    });
+
+    $('#click_to_edit').on('input', function () {
+        power_user.click_to_edit = !!$(this).prop('checked');
+        saveSettingsDebounced();
     });
 
     $('#ui_preset_import_button').on('click', function () {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Sometimes you want to click to edit when in chat mode. Sometimes you don't want to click to edit when in document mode. This helps both, hopefully.

---

This pull request introduces a new "Click to Edit" feature for chat messages, allowing users to enable or disable the ability to edit messages directly from the chat log. The changes include updates to the user interface, event handling, and settings management.

### User Interface Updates:
* Added a new checkbox labeled "Click to Edit" in the UI, allowing users to toggle the feature on or off. (`public/index.html`, [public/index.htmlL4501-L4504](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL4501-L4504))

### Event Handling:
* Updated the click event handler for chat messages to respect the new `click_to_edit` setting, ensuring the feature is only active when enabled. (`public/scripts/chats.js`, [public/scripts/chats.jsL1579-R1580](diffhunk://#diff-a4e2bb42942b7497efce08c9278c128574525ac0ea1ce0d7fa231cdcd949f8dfL1579-R1580))

### Settings Management:
* Introduced a new `click_to_edit` property in the `power_user` settings object, defaulting to `false`. (`public/scripts/power-user.js`, [public/scripts/power-user.jsR323](diffhunk://#diff-ec649a74b7de10172508bf497d4c77b0b2c315ee2f3277ab66e43869bd88b692R323))
* Added logic to apply the `click_to_edit` setting when themes are loaded and updated the theme object to include this property. (`public/scripts/power-user.js`, [[1]](diffhunk://#diff-ec649a74b7de10172508bf497d4c77b0b2c315ee2f3277ab66e43869bd88b692R1326-R1331) [[2]](diffhunk://#diff-ec649a74b7de10172508bf497d4c77b0b2c315ee2f3277ab66e43869bd88b692R2390)
* Implemented an event listener to save changes to the `click_to_edit` setting when toggled in the UI. (`public/scripts/power-user.js`, [public/scripts/power-user.jsR3941-R3945](diffhunk://#diff-ec649a74b7de10172508bf497d4c77b0b2c315ee2f3277ab66e43869bd88b692R3941-R3945))
* Ensured the `click_to_edit` checkbox reflects the current setting when power user settings are loaded. (`public/scripts/power-user.js`, [public/scripts/power-user.jsR1657](diffhunk://#diff-ec649a74b7de10172508bf497d4c77b0b2c315ee2f3277ab66e43869bd88b692R1657))

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
