### PR TITLE
Assorted Claude adjustments

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1963,7 +1963,7 @@
                                             </span>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="makersuite,openrouter">
+                                    <div class="range-block" data-source="makersuite,openrouter,claude">
                                         <label for="openai_enable_web_search" class="checkbox_label flexWrap widthFreeExpand">
                                             <input id="openai_enable_web_search" type="checkbox" />
                                             <span data-i18n="Enable web search">Enable web search</span>

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -200,11 +200,12 @@ async function sendClaudeRequest(request, response) {
             betaHeaders.push('prompt-caching-2024-07-31');
         }
 
-        if (useThinking) {
+        const reasoningEffort = request.body.reasoning_effort;
+        const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream);
+
+        if (useThinking && Number.isInteger(budgetTokens)) {
             // No prefill when thinking
             voidPrefill = true;
-            const reasoningEffort = request.body.reasoning_effort;
-            const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream);
             const minThinkTokens = 1024;
             if (requestBody.max_tokens <= minThinkTokens) {
                 const newValue = requestBody.max_tokens + minThinkTokens;

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -917,19 +917,20 @@ export function cachingAtDepthForOpenRouterClaude(messages, cachingAtDepth) {
  * @param {number} maxTokens Maximum tokens
  * @param {string} reasoningEffort Reasoning effort
  * @param {boolean} stream If streaming is enabled
- * @returns {number} Budget tokens
+ * @returns {number?} Budget tokens
  */
 export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream) {
     let budgetTokens = 0;
 
     switch (reasoningEffort) {
+        case REASONING_EFFORT.auto:
+            return null;
         case REASONING_EFFORT.min:
             budgetTokens = 1024;
             break;
         case REASONING_EFFORT.low:
             budgetTokens = Math.floor(maxTokens * 0.1);
             break;
-        case REASONING_EFFORT.auto:
         case REASONING_EFFORT.medium:
             budgetTokens = Math.floor(maxTokens * 0.25);
             break;


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Adds recently released web search tool for Cl. 3.5/3.7 (closes #3968). Uses an existing checkbox, just works.
2. Changes reasoning effort "Auto" to "no thinking" to match OpenRouter. @cloak1505 said it's fine.
3. Removes prefill voiding for tools. Prefill is no longer forbidden when using tools.
4. For thinking, instead of appending a zero-width space, a prefill message will be flipped to user role. Prefills with thinking are still [explicitly not allowed](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#preserving-thinking-blocks:~:text=You%20cannot%20pre%2Dfill%20responses%20when%20thinking%20is%20enabled.), but hopefully this will prevent a side effect some users are experiencing when Claude interprets an empty user message as an empty user message (sic) instead of silently ignoring it.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
