### PR TITLE
Prompt Manager: add source display of pulled prompts

### DIFF
--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -359,10 +359,15 @@
     content: attr(external_piece_text);
     display: block;
     width: 100%;
-    font-weight: 600;
+    font-weight: 500;
     text-align: center;
 }
 
 .completion_prompt_manager_popup_entry_form_control #completion_prompt_manager_popup_entry_form_prompt:disabled {
     visibility: hidden;
+}
+
+#completion_prompt_manager_popup_entry_source_block {
+    display: flex;
+    justify-content: center;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -6477,6 +6477,11 @@
                                     </label>
                                 </div>
                             </div>
+                            <div id="completion_prompt_manager_popup_entry_source_block">
+                                <b data-i18n="Source:">Source:</b>
+                                <span>&nbsp;</span>
+                                <span id="completion_prompt_manager_popup_entry_source"></span>
+                            </div>
                             <textarea id="completion_prompt_manager_popup_entry_form_prompt" class="text_pole" name="prompt">
                         </textarea>
                         </div>

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -419,6 +419,7 @@ class PromptManager {
         this.handleResetPrompt = (event) => {
             const promptId = event.target.dataset.pmPrompt;
             const prompt = this.getPromptById(promptId);
+            const isPulledPrompt = Object.keys(this.promptSources).includes(promptId);
 
             switch (promptId) {
                 case 'main':
@@ -450,9 +451,9 @@ class PromptManager {
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_forbid_overrides').checked = prompt.forbid_overrides ?? false;
             document.getElementById(this.configuration.prefix + 'prompt_manager_forbid_overrides_block').style.visibility = this.overridablePrompts.includes(prompt.identifier) ? 'visible' : 'hidden';
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_prompt').disabled = prompt.marker ?? false;
-            document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source_block').style.display = Object.keys(this.promptSources).includes(promptId) ? '' : 'none';
+            document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source_block').style.display = isPulledPrompt ? '' : 'none';
 
-            if (prompt.marker) {
+            if (isPulledPrompt) {
                 const sourceName = this.promptSources[promptId];
                 document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source').textContent = sourceName;
             }
@@ -1226,6 +1227,7 @@ class PromptManager {
         const forbidOverridesBlock = document.getElementById(this.configuration.prefix + 'prompt_manager_forbid_overrides_block');
         const entrySourceBlock = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source_block');
         const entrySource = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source');
+        const isPulledPrompt = Object.keys(this.promptSources).includes(prompt.identifier);
 
         nameField.value = prompt.name ?? '';
         roleField.value = prompt.role || 'system';
@@ -1237,9 +1239,9 @@ class PromptManager {
         injectionPositionField.removeAttribute('disabled');
         forbidOverridesField.checked = prompt.forbid_overrides ?? false;
         forbidOverridesBlock.style.visibility = this.overridablePrompts.includes(prompt.identifier) ? 'visible' : 'hidden';
-        entrySourceBlock.style.display = prompt.marker ? '' : 'none';
+        entrySourceBlock.style.display = isPulledPrompt ? '' : 'none';
 
-        if (prompt.marker) {
+        if (isPulledPrompt) {
             const sourceName = this.promptSources[prompt.identifier];
             entrySource.textContent = sourceName;
         }

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -196,6 +196,17 @@ export class PromptCollection {
 }
 
 class PromptManager {
+    get promptSources() {
+        return {
+            charDescription: t`Character Description`,
+            charPersonality: t`Character Personality`,
+            scenario: t`Character Scenario`,
+            personaDescription: t`Persona Description`,
+            worldInfoBefore: t`World Info (↑Char)`,
+            worldInfoAfter: t`World Info (↓Char)`,
+        };
+    }
+
     constructor() {
         this.systemPrompts = [
             'main',
@@ -439,6 +450,12 @@ class PromptManager {
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_forbid_overrides').checked = prompt.forbid_overrides ?? false;
             document.getElementById(this.configuration.prefix + 'prompt_manager_forbid_overrides_block').style.visibility = this.overridablePrompts.includes(prompt.identifier) ? 'visible' : 'hidden';
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_prompt').disabled = prompt.marker ?? false;
+            document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source_block').style.display = Object.keys(this.promptSources).includes(promptId) ? '' : 'none';
+
+            if (prompt.marker) {
+                const sourceName = this.promptSources[promptId];
+                document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source').textContent = sourceName;
+            }
 
             if (!this.systemPrompts.includes(promptId)) {
                 document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_injection_position').removeAttribute('disabled');
@@ -1207,6 +1224,8 @@ class PromptManager {
         const injectionDepthBlock = document.getElementById(this.configuration.prefix + 'prompt_manager_depth_block');
         const forbidOverridesField = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_forbid_overrides');
         const forbidOverridesBlock = document.getElementById(this.configuration.prefix + 'prompt_manager_forbid_overrides_block');
+        const entrySourceBlock = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source_block');
+        const entrySource = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source');
 
         nameField.value = prompt.name ?? '';
         roleField.value = prompt.role || 'system';
@@ -1218,6 +1237,12 @@ class PromptManager {
         injectionPositionField.removeAttribute('disabled');
         forbidOverridesField.checked = prompt.forbid_overrides ?? false;
         forbidOverridesBlock.style.visibility = this.overridablePrompts.includes(prompt.identifier) ? 'visible' : 'hidden';
+        entrySourceBlock.style.display = prompt.marker ? '' : 'none';
+
+        if (prompt.marker) {
+            const sourceName = this.promptSources[prompt.identifier];
+            entrySource.textContent = sourceName;
+        }
 
         if (this.systemPrompts.includes(prompt.identifier)) {
             injectionPositionField.setAttribute('disabled', 'disabled');
@@ -1303,6 +1328,8 @@ class PromptManager {
         const injectionDepthBlock = document.getElementById(this.configuration.prefix + 'prompt_manager_depth_block');
         const forbidOverridesField = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_forbid_overrides');
         const forbidOverridesBlock = document.getElementById(this.configuration.prefix + 'prompt_manager_forbid_overrides_block');
+        const entrySourceBlock = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source_block');
+        const entrySource = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_source');
 
         nameField.value = '';
         roleField.selectedIndex = 0;
@@ -1314,6 +1341,8 @@ class PromptManager {
         injectionDepthBlock.style.visibility = 'unset';
         forbidOverridesBlock.style.visibility = 'unset';
         forbidOverridesField.checked = false;
+        entrySourceBlock.style.display = 'none';
+        entrySource.textContent = '';
 
         roleField.disabled = false;
     }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Adds a source display for these prompts. Prompts that pull their contents elsewhere can be renamed, so its source may be unclear.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
