### PR TITLE
Add Gemini 2.5 models to BLOCK_NONE override

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -373,6 +373,8 @@ async function sendMakerSuiteRequest(request, response) {
 
         // These models do not support setting the threshold to OFF at all.
         const blockNoneModels = [
+            'gemini-2.5-pro-exp-03-25',
+            'gemini-2.5-flash-preview-04-17',
             'gemini-1.5-pro-001',
             'gemini-1.5-flash-001',
             'gemini-1.5-flash-8b-exp-0827',


### PR DESCRIPTION
What is the reason for a change?

Starting with the Gemini 2.5 series, setting "threshold": "OFF" in safetySettings no longer disables content filtering as it did previously. The API now requires BLOCK_NONE to fully remove automated blocking. This change has led to unexpected filtering behavior when using these models.


What did you do to achieve this?

I updated the chat-completions.js file to include all Gemini 2.5 model identifiers in the list of models that enforce BLOCK_NONE across all safety categories. This ensures consistent behavior with previous model versions and prevents unintended content filtering.


How would a reviewer test the change?

Apply the proposed changes to chat-completions.js.

Run the application and initiate requests using Gemini 2.5 models (e.g., gemini-2.5-pro, gemini-2.5-flash).

Observe that content previously blocked when using "threshold": "OFF" is now returned unfiltered, confirming that BLOCK_NONE is effectively disabling the safety filters.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
