### PR TITLE
Add regex option for first greeting message only

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2100,7 +2100,11 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
                 } else if (chat[messageId]?.extra?.type === 'narrator') {
                     return regex_placement.SLASH_COMMAND;
                 } else {
-                    return regex_placement.AI_OUTPUT;
+                    if (Number(messageId) === 0) {
+                        return regex_placement.GREETING;
+                    } else {
+                        return regex_placement.AI_OUTPUT;
+                    }
                 }
             } catch {
                 return regex_placement.AI_OUTPUT;
@@ -4053,7 +4057,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
     coreChat = await Promise.all(coreChat.map(async (chatItem, index) => {
         let message = chatItem.mes;
-        let regexType = chatItem.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT;
+        let regexType = chatItem.is_user ? regex_placement.USER_INPUT : (index === 0 ? regex_placement.GREETING : regex_placement.AI_OUTPUT);
         let options = { isPrompt: true, depth: (coreChat.length - index - (isContinue ? 2 : 1)) };
 
         let regexedMessage = getRegexedString(message, regexType, options);
@@ -7250,12 +7254,12 @@ function getFirstMessage() {
         is_user: false,
         is_system: false,
         send_date: getMessageTimeStamp(),
-        mes: getRegexedString(firstMes, regex_placement.AI_OUTPUT),
+        mes: getRegexedString(firstMes, regex_placement.GREETING),
         extra: {},
     };
 
     if (Array.isArray(alternateGreetings) && alternateGreetings.length > 0) {
-        const swipes = [message.mes, ...(alternateGreetings.map(greeting => getRegexedString(greeting, regex_placement.AI_OUTPUT)))];
+        const swipes = [message.mes, ...(alternateGreetings.map(greeting => getRegexedString(greeting, regex_placement.GREETING)))];
 
         if (!message.mes) {
             swipes.shift();
@@ -7734,7 +7738,11 @@ function updateMessage(div) {
     } else if (mes.extra?.type === 'narrator') {
         regexPlacement = regex_placement.SLASH_COMMAND;
     } else {
-        regexPlacement = regex_placement.AI_OUTPUT;
+        if (Number(mesElement.attr('mesid')) === 0) {
+            regexPlacement = regex_placement.GREETING;
+        } else {
+            regexPlacement = regex_placement.AI_OUTPUT;
+        }
     }
 
     // Ignore character override if sent as system

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -77,6 +77,12 @@
         <div class="flex-container">
             <div class="flex1 wi-enter-footer-text flex-container flexFlowColumn flexNoGap alignitemsstart">
                 <small data-i18n="ext_regex_affects">Affects</small>
+                <div data-i18n="[title]ext_regex_greetingOnly_desc" title="Greeting message.">
+                    <label class="checkbox flex-container">
+                        <input type="checkbox" name="replace_position" value="4">
+                        <span data-i18n="Greeting">Greeting Message</span>
+                    </label>
+                </div>
                 <div data-i18n="[title]ext_regex_user_input_desc" title="Messages sent by the user.">
                     <label class="checkbox flex-container">
                         <input type="checkbox" name="replace_position" value="1">

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -77,6 +77,12 @@
         <div class="flex-container">
             <div class="flex1 wi-enter-footer-text flex-container flexFlowColumn flexNoGap alignitemsstart">
                 <small data-i18n="ext_regex_affects">Affects</small>
+                <div data-i18n="[title]ext_regex_greetingOnly_desc" title="Greeting message.">
+                    <label class="checkbox flex-container">
+                        <input type="checkbox" name="replace_position" value="4">
+                        <span data-i18n="Greeting">Greeting Message</span>
+                    </label>
+                </div>
                 <div data-i18n="[title]ext_regex_user_input_desc" title="Messages sent by the user.">
                     <label class="checkbox flex-container">
                         <input type="checkbox" name="replace_position" value="1">
@@ -93,12 +99,6 @@
                     <label class="checkbox flex-container">
                         <input type="checkbox" name="replace_position" value="3">
                         <span data-i18n="Slash Commands">Slash Commands</span>
-                    </label>
-                </div>
-                <div data-i18n="[title]ext_regex_greetingOnly_desc" title="Greeting message.">
-                    <label class="checkbox flex-container">
-                        <input type="checkbox" name="replace_position" value="4">
-                        <span data-i18n="Greeting">Greeting Message</span>
                     </label>
                 </div>
                 <div data-i18n="[title]ext_regex_wi_desc" title="Lorebook/World Info entry contents. Requires 'Only Format Prompt' to be checked!">

--- a/public/scripts/extensions/regex/editor.html
+++ b/public/scripts/extensions/regex/editor.html
@@ -77,12 +77,6 @@
         <div class="flex-container">
             <div class="flex1 wi-enter-footer-text flex-container flexFlowColumn flexNoGap alignitemsstart">
                 <small data-i18n="ext_regex_affects">Affects</small>
-                <div data-i18n="[title]ext_regex_greetingOnly_desc" title="Greeting message.">
-                    <label class="checkbox flex-container">
-                        <input type="checkbox" name="replace_position" value="4">
-                        <span data-i18n="Greeting">Greeting Message</span>
-                    </label>
-                </div>
                 <div data-i18n="[title]ext_regex_user_input_desc" title="Messages sent by the user.">
                     <label class="checkbox flex-container">
                         <input type="checkbox" name="replace_position" value="1">
@@ -99,6 +93,12 @@
                     <label class="checkbox flex-container">
                         <input type="checkbox" name="replace_position" value="3">
                         <span data-i18n="Slash Commands">Slash Commands</span>
+                    </label>
+                </div>
+                <div data-i18n="[title]ext_regex_greetingOnly_desc" title="Greeting message.">
+                    <label class="checkbox flex-container">
+                        <input type="checkbox" name="replace_position" value="4">
+                        <span data-i18n="Greeting">Greeting Message</span>
                     </label>
                 </div>
                 <div data-i18n="[title]ext_regex_wi_desc" title="Lorebook/World Info entry contents. Requires 'Only Format Prompt' to be checked!">

--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -18,6 +18,7 @@ const regex_placement = {
     USER_INPUT: 1,
     AI_OUTPUT: 2,
     SLASH_COMMAND: 3,
+    GREETING: 4,
     // 4 - sendAs (legacy)
     WORLD_INFO: 5,
     REASONING: 6,

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -361,13 +361,13 @@ function migrateSettings() {
 
         // Old system and sendas placement migration
         // 4 - sendAs
-        if (script.placement.includes(4)) {
-            script.placement = script.placement.length === 1 ?
-                [regex_placement.SLASH_COMMAND] :
-                script.placement = script.placement.filter((e) => e !== 4);
-
-            performSave = true;
-        }
+        // if (script.placement.includes(4)) {
+        //     script.placement = script.placement.length === 1 ?
+        //         [regex_placement.SLASH_COMMAND] :
+        //         script.placement = script.placement.filter((e) => e !== 4);
+        //
+        //     performSave = true;
+        // }
     });
 
     if (!extension_settings.character_allowed_regex) {


### PR DESCRIPTION
This PR adds the option to run a specified Regex on Greetings only:
![image](https://github.com/user-attachments/assets/d619f49e-5873-414f-b5a4-11a172e792c3)

Intended use is to allow an easy way to conform pre-existing greeting messages to whatever markdown an user has setup for themselves. In above image i.e. all Asterisks are removed by default as I personally use them for "whispering-markdown" in dialogue.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
