### PR TITLE
ZIP extraction error handling

### DIFF
--- a/src/endpoints/novelai.js
+++ b/src/endpoints/novelai.js
@@ -394,7 +394,8 @@ router.post('/generate-image', async (request, response) => {
             });
 
             if (!upscaleResult.ok) {
-                throw new Error('NovelAI returned an error.');
+                const text = await upscaleResult.text();
+                throw new Error('NovelAI returned an error.', { cause: text });
             }
 
             const upscaledArchiveBuffer = await upscaleResult.arrayBuffer();
@@ -408,7 +409,7 @@ router.post('/generate-image', async (request, response) => {
 
             return response.send(upscaledBase64);
         } catch (error) {
-            console.warn('NovelAI generated an image, but upscaling failed. Returning original image.');
+            console.warn('NovelAI generated an image, but upscaling failed. Returning original image.', error);
             return response.send(originalBase64);
         }
     } catch (error) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Improve server-side dealing with corrupted ZIP files (such as CharX archives).

Also add more console logs when NovelAI image upscaling fails.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
