### PR TITLE
Fix markdown exclusion extension to use macros

### DIFF
--- a/public/scripts/showdown-exclusion.js
+++ b/public/scripts/showdown-exclusion.js
@@ -1,40 +1,39 @@
 import { power_user } from './power-user.js';
+import { substituteParams } from '../script.js';
 
-// Showdown extension to make chat separators (dinkuses) ignore markdown formatting
+/**
+ * Showdown extension to make chat separators (dinkuses) ignore markdown formatting
+ * @returns {import('showdown').ShowdownExtension[]} An array of Showdown extensions
+ */
 export const markdownExclusionExt = () => {
     if (!power_user) {
         console.log('Showdown-dinkus extension: power_user wasn\'t found! Returning.');
         return [];
     }
 
-    let combinedExcludeString = '';
-    if (power_user.context.chat_start) {
-        combinedExcludeString += `${power_user.context.chat_start},`;
-    }
-
-    if (power_user.context.example_separator) {
-        combinedExcludeString += `${power_user.context.example_separator},`;
-    }
-
-    if (power_user.markdown_escape_strings) {
-        combinedExcludeString += power_user.markdown_escape_strings;
-    }
-
-    const escapedExclusions = combinedExcludeString
-        .split(',')
-        .filter((element) => element.length > 0)
-        .map((element) => `(${element.split('').map((char) => `\\${char}`).join('')})`);
-
-
-    // No exclusions? No extension!
-    if (!combinedExcludeString || combinedExcludeString.length === 0 || escapedExclusions.length === 0) {
+    // The extension will only be applied if the user has non-empty "Non-markdown strings"
+    // Changing the string in the UI reloads the processor, so we don't need to worry about it
+    if (!power_user.markdown_escape_strings) {
         return [];
     }
 
-    const replaceRegex = new RegExp(`^(${escapedExclusions.join('|')})\n`, 'gm');
+    // Escape the strings to be excluded from markdown parsing
+    // Function is evaluated every time, so we don't care about stale macros in the strings
     return [{
         type: 'lang',
-        regex: replaceRegex,
-        replace: ((match) => match.replace(replaceRegex, `\u0000${match} \n`)),
+        filter: (text) => {
+            const escapedExclusions = substituteParams(power_user.markdown_escape_strings)
+                .split(',')
+                .filter((element) => element.length > 0)
+                .map((element) => `(${element.split('').map((char) => `\\${char}`).join('')})`);
+
+            // No exclusions? No extension!
+            if (escapedExclusions.length === 0) {
+                return text;
+            }
+
+            const replaceRegex = new RegExp(`^(${escapedExclusions.join('|')})\n`, 'gm');
+            return text.replace(replaceRegex, ((match) => match.replace(replaceRegex, `\u0000${match} \n`)));
+        },
     }];
 };


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->
(AI generated summary below)

## Problem

The current implementation of markdown exclusion for chat separators (dinkuses) has several issues:

* It automatically applies exclusions based on `chat_start` and `example_separator` settings, which can unexpectedly break formatting without clear indication to users
* It doesn't properly handle macros in the exclusion strings

## Changes

* Refactored to only apply exclusions from the explicit `markdown_escape_strings` setting
* Added support for macros in exclusion strings by using `substituteParams()`
* Switched from regex replacement to a filter function for better control
* Removed unnecessary concatenation of settings that were causing confusion

## Testing

Test with various separator strings including ***, ###, and --- to ensure they remain unformatted while preserving normal markdown formatting elsewhere in the text.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
