### PR TITLE
Reverse CC prompt manager's injection order of "Order" to match World Info

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6488,7 +6488,7 @@
                                     <span data-i18n="prompt_manager_order">Order</span>
                                 </label>
                                 <input id="completion_prompt_manager_popup_entry_form_injection_order" class="text_pole" type="number" name="injection_order" min="0" max="9999" value="0" />
-                                <div class="text_muted" data-i18n="Ordered from high/top to low/bottom, and at same order: System, User, Assistant.">Ordered from high/top to low/bottom, and at same order: System, User, Assistant.</div>
+                                <div class="text_muted" data-i18n="Ordered from low/top to high/bottom, and at same order: Assistant, User, System.">Ordered from low/top to high/bottom, and at same order: Assistant, User, System.</div>
                             </div>
                         </div>
                         <div class="completion_prompt_manager_popup_entry_form_control">

--- a/public/index.html
+++ b/public/index.html
@@ -6486,6 +6486,7 @@
                             <div id="completion_prompt_manager_order_block" class="completion_prompt_manager_popup_entry_form_control flex1">
                                 <label for="completion_prompt_manager_popup_entry_form_injection_order">
                                     <span data-i18n="prompt_manager_order">Order</span>
+                                    <i class="fas fa-info-circle" title="Prompt injections from other sources (World Info, Author's Note, etc.) always have a default order of 100." data-i18n="[title]prompt_manager_order_note"></i>
                                 </label>
                                 <input id="completion_prompt_manager_popup_entry_form_injection_order" class="text_pole" type="number" name="injection_order" min="0" max="9999" value="100" />
                                 <div class="text_muted" data-i18n="Ordered from low/top to high/bottom, and at same order: Assistant, User, System.">Ordered from low/top to high/bottom, and at same order: Assistant, User, System.</div>

--- a/public/index.html
+++ b/public/index.html
@@ -6487,7 +6487,7 @@
                                 <label for="completion_prompt_manager_popup_entry_form_injection_order">
                                     <span data-i18n="prompt_manager_order">Order</span>
                                 </label>
-                                <input id="completion_prompt_manager_popup_entry_form_injection_order" class="text_pole" type="number" name="injection_order" min="0" max="9999" value="0" />
+                                <input id="completion_prompt_manager_popup_entry_form_injection_order" class="text_pole" type="number" name="injection_order" min="0" max="9999" value="100" />
                                 <div class="text_muted" data-i18n="Ordered from low/top to high/bottom, and at same order: Assistant, User, System.">Ordered from low/top to high/bottom, and at same order: Assistant, User, System.</div>
                             </div>
                         </div>

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -106,7 +106,7 @@ class Prompt {
         this.injection_position = injection_position;
         this.forbid_overrides = forbid_overrides;
         this.extension = extension ?? false;
-        this.injection_order = injection_order ?? 0;
+        this.injection_order = injection_order ?? 100;
     }
 }
 
@@ -449,7 +449,7 @@ class PromptManager {
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_prompt').value = prompt.content ?? '';
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_injection_position').value = prompt.injection_position ?? 0;
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_injection_depth').value = prompt.injection_depth ?? DEFAULT_DEPTH;
-            document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_injection_order').value = prompt.injection_order ?? 0;
+            document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_injection_order').value = prompt.injection_order ?? 100;
             document.getElementById(this.configuration.prefix + 'prompt_manager_depth_block').style.visibility = prompt.injection_position === INJECTION_POSITION.ABSOLUTE ? 'visible' : 'hidden';
             document.getElementById(this.configuration.prefix + 'prompt_manager_order_block').style.visibility = prompt.injection_position === INJECTION_POSITION.ABSOLUTE ? 'visible' : 'hidden';
             document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_forbid_overrides').checked = prompt.forbid_overrides ?? false;
@@ -1242,7 +1242,7 @@ class PromptManager {
         promptField.disabled = prompt.marker ?? false;
         injectionPositionField.value = prompt.injection_position ?? INJECTION_POSITION.RELATIVE;
         injectionDepthField.value = prompt.injection_depth ?? DEFAULT_DEPTH;
-        injectionOrderField.value = prompt.injection_order ?? 0;
+        injectionOrderField.value = prompt.injection_order ?? 100;
         injectionDepthBlock.style.visibility = prompt.injection_position === INJECTION_POSITION.ABSOLUTE ? 'visible' : 'hidden';
         injectionOrderBlock.style.visibility = prompt.injection_position === INJECTION_POSITION.ABSOLUTE ? 'visible' : 'hidden';
         injectionPositionField.removeAttribute('disabled');

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -770,7 +770,7 @@ async function populationInjectionPrompts(prompts, messages) {
             [extensionPromptsOrder]: [],
         };
         for (const prompt of depthPrompts) {
-            const order = prompt.injection_order || 0;
+            const order = prompt.injection_order ?? 100;
             if (!orderGroups[order]) {
                 orderGroups[order] = [];
             }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -765,7 +765,7 @@ async function populationInjectionPrompts(prompts, messages) {
         const wrap = false;
 
         // Group prompts by priority
-        const extensionPromptsOrder = '0';
+        const extensionPromptsOrder = '100';
         const orderGroups = {
             [extensionPromptsOrder]: [],
         };

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -778,7 +778,7 @@ async function populationInjectionPrompts(prompts, messages) {
         }
 
         // Process each order group in order (b - a = low to high ; a - b = high to low)
-        const orders = Object.keys(orderGroups).sort((a, b) => +a - +b);
+        const orders = Object.keys(orderGroups).sort((a, b) => +b - +a);
         for (const order of orders) {
             const orderPrompts = orderGroups[order];
 


### PR DESCRIPTION
Follow-up of #3978 (@Dakraid)

This PR reverses the Order order of depth injections in CC's prompt manager. Role behavior remains unchanged, but description is adjusted to match the top-to-bottom reading of Order order.

World Info / Lorebook's Order has always been low number toward top and high number toward bottom. Don't believe me? Run release branch, not that LB logic has changed, and notice high order LB entry appears below low order. Also, from the [Docs](https://docs.sillytavern.app/usage/core-concepts/worldinfo/#insertion-order):

> #### Insertion Order
>
> Numeric value. Defines a priority of the entry if multiple were activated at once. Entries with higher order numbers will be inserted closer to the end of the context as they will have more impact on the output.

More accurately, Order simply defines chronological order of same-depth parts as you would physically read them.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
