### PR TITLE
Added: Separate tabs for Parameters and Prompt in Chat Completion Pre…

### DIFF
--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -220,13 +220,11 @@
     flex-direction: row;
     justify-content: space-between;
     color: var(--white50a);
-    margin-top: 0.5em;
     padding: 0 0.25em;
     width: 100%
 }
 
 #completion_prompt_manager .completion_prompt_manager_header div {
-    margin-top: 0.5em;
     width: fit-content;
 }
 

--- a/public/script.js
+++ b/public/script.js
@@ -12326,10 +12326,10 @@ class OpenAITabManager {
         presetDiv.insertAdjacentHTML('afterend', `
             <div class="openai-tab-buttons">
                 <button id="openai-tab-btn-parameters" class="openai-tab-button active">
-                    <i class="fa-solid fa-vial"></i>Parameters
+                    <i class="fa-solid fa-vial"></i><span data-i18n="Parameters">Parameters</span>
                 </button>
                 <button id="openai-tab-btn-prompts" class="openai-tab-button">
-                    <i class="fa-solid fa-file-edit"></i>Prompts
+                    <i class="fa-solid fa-file-edit"></i><span data-i18n="Prompts">Prompts</span>
                 </button>
             </div>
         `);

--- a/public/script.js
+++ b/public/script.js
@@ -12289,3 +12289,204 @@ jQuery(async function () {
         }
     });
 });
+
+/**
+ * OpenAI Settings Tab Manager
+ * When using the Chat Completion API, add separate tabs for Parameters and Prompt.
+ */
+class OpenAITabManager {
+    constructor() {
+        this.activeTab = 'parameters';
+        this.tabButtonsContainer = null;
+        this.isTabsCreated = false;
+        this.init();
+    }
+
+    init() {
+        setTimeout(() => this.checkApiAndInitialize(), 300);
+        setInterval(() => this.checkApiAndInitialize(), 2000);
+    }
+
+    checkApiAndInitialize() {
+        const shouldShowTabs = typeof main_api !== 'undefined' &&
+                              main_api === 'openai' &&
+                              typeof oai_settings !== 'undefined';
+
+        if (shouldShowTabs && !this.isTabsCreated) {
+            this.createTabs();
+        } else if (!shouldShowTabs && this.isTabsCreated) {
+            this.removeTabs();
+        }
+    }
+
+    createTabs() {
+        const presetDiv = document.querySelector('#openai_api-presets > div');
+        if (!presetDiv) return;
+
+        presetDiv.insertAdjacentHTML('afterend', `
+            <div class="openai-tab-buttons">
+                <button id="openai-tab-btn-parameters" class="openai-tab-button active">
+                    <i class="fa-solid fa-vial"></i>Parameters
+                </button>
+                <button id="openai-tab-btn-prompts" class="openai-tab-button">
+                    <i class="fa-solid fa-file-edit"></i>Prompts
+                </button>
+            </div>
+        `);
+
+        this.tabButtonsContainer = document.querySelector('.openai-tab-buttons');
+        this.organizeContent();
+        this.bindEvents();
+        this.setInitialState();
+        this.isTabsCreated = true;
+    }
+
+    organizeContent() {
+        const tabButtons = this.tabButtonsContainer;
+
+        // Create tab containers
+        tabButtons.insertAdjacentHTML('afterend',
+            `<div id="openai-tab-content-parameters" class="openai-tab-content active"></div>
+             <div id="openai-tab-content-prompts" class="openai-tab-content"></div>`
+        );
+
+        const parametersTab = document.querySelector('#openai-tab-content-parameters');
+        const promptsTab = document.querySelector('#openai-tab-content-prompts');
+
+        // Move parameters content
+        [
+            '#range_block_openai',
+            '#openai_settings',
+            '#logit_bias_openai'
+        ].forEach(selector => {
+            const element = document.querySelector(selector);
+            if (element) {
+                const container = element.closest('.range-block') || element;
+                parametersTab.appendChild(container);
+            }
+        });
+
+        // Move additional openai blocks
+        document.querySelectorAll('[data-source*="openai"]:not(.openai-tab-content):not(.openai-tab-buttons)')
+            .forEach(block => {
+                const rangeBlock = block.closest('.range-block');
+                if (rangeBlock && !parametersTab.contains(block)) {
+                    parametersTab.appendChild(rangeBlock);
+                }
+            });
+
+        // Move prompts content
+        const completionManager = document.querySelector('#completion_prompt_manager');
+        if (completionManager) {
+            let wrapper = completionManager.closest('.range-block');
+            if (!wrapper) {
+                wrapper = document.createElement('div');
+                wrapper.className = 'range-block m-b-1';
+                completionManager.parentNode.insertBefore(wrapper, completionManager);
+                wrapper.appendChild(completionManager);
+            }
+            promptsTab.appendChild(wrapper);
+        }
+    }
+
+    removeTabs() {
+        if (this.tabButtonsContainer) {
+            this.tabButtonsContainer.remove();
+            this.tabButtonsContainer = null;
+        }
+
+        const openaiContainer = document.querySelector('#openai_api-presets');
+        ['#openai-tab-content-parameters', '#openai-tab-content-prompts'].forEach(selector => {
+            const tab = document.querySelector(selector);
+            if (tab) {
+                while (tab.firstChild) {
+                    openaiContainer.appendChild(tab.firstChild);
+                }
+                tab.remove();
+            }
+        });
+
+        this.isTabsCreated = false;
+    }
+
+    bindEvents() {
+        document.querySelectorAll('.openai-tab-button').forEach(button => {
+            button.addEventListener('click', (e) => {
+                e.preventDefault();
+                const tabId = e.target.closest('.openai-tab-button').id.replace('openai-tab-btn-', '');
+                this.switchTab(tabId);
+            });
+        });
+    }
+
+    switchTab(tabId) {
+        if (!['parameters', 'prompts'].includes(tabId)) return;
+
+        // Update buttons
+        document.querySelectorAll('.openai-tab-button').forEach(button => {
+            button.classList.toggle('active', button.id.includes(tabId));
+        });
+
+        // Update content
+        document.querySelectorAll('.openai-tab-content').forEach(content => {
+            const isActive = content.id.includes(tabId);
+            content.classList.toggle('active', isActive);
+            content.style.display = isActive ? 'block' : 'none';
+        });
+
+        // Scroll left panel to top
+        const leftPanel = document.querySelector('#left-nav-panel .scrollableInner');
+        if (leftPanel) {
+            leftPanel.scrollTop = 0;
+        }
+
+        this.activeTab = tabId;
+        this.saveTabPreference(tabId);
+    }
+
+    setInitialState() {
+        const savedTab = this.loadTabPreference();
+        const initialTab = ['parameters', 'prompts'].includes(savedTab) ? savedTab : 'parameters';
+        this.switchTab(initialTab);
+    }
+
+    saveTabPreference(tabId) {
+        try {
+            localStorage.setItem('openai-active-tab', tabId);
+        } catch (error) {
+            // Silent fail
+        }
+    }
+
+    loadTabPreference() {
+        try {
+            return localStorage.getItem('openai-active-tab');
+        } catch (error) {
+            return null;
+        }
+    }
+
+    refreshTabs() {
+        this.checkApiAndInitialize();
+    }
+}
+
+// Global instance and initialization
+let openAITabManager = null;
+
+function initializeOpenAITabs() {
+    if (!openAITabManager) {
+        openAITabManager = new OpenAITabManager();
+        return true;
+    }
+    return false;
+}
+
+function onApiChange() {
+    openAITabManager?.refreshTabs();
+}
+
+// Initialize
+$(document).ready(initializeOpenAITabs);
+setTimeout(initializeOpenAITabs, 1000);
+setTimeout(initializeOpenAITabs, 3000);

--- a/public/script.js
+++ b/public/script.js
@@ -12347,7 +12347,7 @@ class OpenAITabManager {
         // Create tab containers
         tabButtons.insertAdjacentHTML('afterend',
             `<div id="openai-tab-content-parameters" class="openai-tab-content active"></div>
-             <div id="openai-tab-content-prompts" class="openai-tab-content"></div>`
+             <div id="openai-tab-content-prompts" class="openai-tab-content"></div>`,
         );
 
         const parametersTab = document.querySelector('#openai-tab-content-parameters');

--- a/public/script.js
+++ b/public/script.js
@@ -12357,7 +12357,7 @@ class OpenAITabManager {
         [
             '#range_block_openai',
             '#openai_settings',
-            '#logit_bias_openai'
+            '#logit_bias_openai',
         ].forEach(selector => {
             const element = document.querySelector(selector);
             if (element) {
@@ -12480,10 +12480,6 @@ function initializeOpenAITabs() {
         return true;
     }
     return false;
-}
-
-function onApiChange() {
-    openAITabManager?.refreshTabs();
 }
 
 // Initialize

--- a/public/style.css
+++ b/public/style.css
@@ -6105,3 +6105,54 @@ body:not(.movingUI) .drawer-content.maximized {
     border-color: var(--error-color, #e87f7f);
     background-color: rgba(241, 163, 163, 0.2);
 }
+
+/* OpenAI Settings Tab Navigation */
+.openai-tab-buttons {
+    display: flex;
+    position: sticky;
+    top: 0;
+    margin-top: 0.5em;
+    margin-bottom: 0.8em;
+    padding: 2px;
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--SmartThemeBlurTintColor);
+    backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
+    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBodyColor) 25%, transparent);
+    z-index: 1000;
+}
+.openai-tab-button {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: 2px;
+    padding: 6px;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: var(--SmartThemeBodyColor);
+    font-size: calc(var(--mainFontSize) * 0.9);
+    font-weight: 500;
+    cursor: pointer;
+    position: relative;
+    opacity: 0.5;
+    transition: all var(--animation-duration-slow) ease-in-out;
+}
+.openai-tab-button:hover {
+    opacity: 1;
+}
+.openai-tab-button.active {
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 15%, transparent);
+    color: var(--SmartThemeBodyColor);
+    opacity: 1;
+}
+/* Tab Content */
+.openai-tab-content {
+    display: none;
+}
+.openai-tab-content.active {
+    display: block;
+}


### PR DESCRIPTION
Chat Completion Presets often contain lengthy content, making them hard to use on mobile devices—and even on desktop, scrolling can be tedious. This update introduces a tabbed menu with “Parameters” and “Prompt” sections, fixed at the top for easy switching.

<img width="442" alt="截圖 2025-05-28 下午6 40 00" src="https://github.com/user-attachments/assets/2e76b136-198e-47c9-a2bd-4a5c46aed47c" />

<!-- Put X in the box below to confirm -->

## Checklist:
- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
