### PR TITLE
refresh voices upon checkReady in openai-compatible TTS

### DIFF
--- a/public/scripts/extensions/tts/openai-compatible.js
+++ b/public/scripts/extensions/tts/openai-compatible.js
@@ -120,7 +120,7 @@ class OpenAICompatibleTtsProvider {
     }
 
     async checkReady() {
-        await this.fetchTtsVoiceObjects();
+        this.voices = await this.fetchTtsVoiceObjects();
     }
 
     async onRefreshClick() {


### PR DESCRIPTION
Current code checks only for .length == 0 thus once it has been loaded once, you cannot update the list of voices.

The new code will at least "sync" the internal this.voices when the user does the reload. Currently the only way to add voices after generation would be to restart the whole UI.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
