### PR TITLE
Clean console debugs for group chats

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -436,7 +436,6 @@ export function getGroupDepthPrompts(groupId, characterId) {
  * @returns {{description: string, personality: string, scenario: string, mesExamples: string}} Group character cards combined
  */
 export function getGroupCharacterCards(groupId, characterId) {
-    console.debug('getGroupCharacterCards entered for group: ', groupId);
     const group = groups.find(x => x.id === groupId);
 
     if (!group || !group?.generation_mode || !Array.isArray(group.members) || !group.members.length) {
@@ -507,7 +506,6 @@ export function getGroupCharacterCards(groupId, characterId) {
         }
 
         if (group.disabled_members.includes(member) && characterId !== index && group.generation_mode !== group_generation_mode.APPEND_DISABLED) {
-            console.debug(`Skipping disabled group member: ${member}`);
             continue;
         }
 


### PR DESCRIPTION
Those two debugs always floods the console in group chats, making it imposible to debug anything else, like extensions or activated wi entries.
Ie: You have 2 or 3 group members muted, a wall of `Skipping disabled group member: X` fills the console, making previous logs to get deleted. Even without muted members, `getGroupCharacterCards entered for group: n` was enough to fill console. Tested without extensions.

- [Update](https://github.com/SillyTavern/SillyTavern/commit/34b8b48b52ab9dc8feec488d7e6b683ed480b415) - Clean console debugs for group chats

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
