### PR TITLE
Feature: Allow tools to accept arrays of values as an array

### DIFF
--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -60,6 +60,9 @@ function assignNestedVariables(scope, arg, prefix) {
     Object.entries(arg).forEach(([key, value]) => {
         const newPrefix = `${prefix}.${key}`;
         if (typeof value === 'object' && value !== null) {
+            if (Array.isArray(value)) {
+                scope.letVariable(newPrefix, JSON.stringify(value));
+            }
             assignNestedVariables(scope, value, newPrefix);
         } else {
             scope.letVariable(newPrefix, value);


### PR DESCRIPTION
Previously, a tool that that registered itself as having an array parameter had each element of the array registered as a variable, but it did not register the array parameter itself. 

This meant that it was only really useful with fixed length arrays. While structures are not super easy to handle with stscript, lalib largely resolves this, and I expect this was also limiting javascript implementations.

This patch adds a variable for the array itself that lives alongside the existing args.  I don't expect this to have any backward compatiblity concerns.

Repro:

```stscript
// this requires lalib to function |
/let key=schema {
    "$schema": "http://json-schema.org/draft-04/schema#",
    "type": "string",
    "properties": {
        "example": {
            "type": "array",
            "contains": {
                "type": "string"
            }
        }
    },
    "required": [
        "example"
    ]
} ||
/tools-register name=YourFunc description="filler" parameters={{var::schema}} {:
    /let ex {: /try {: /return {{var::arg.example}} :} :}() | /= ex.isException | /if rule=not left={{pipe}} else={:
        /console-log {{var::ex}}
    :} {:
        /console-log "arg.example: {{var::arg.example}}" |
        /foreach {{var::arg.example}} {: /console-log "#{{var::index}}: {{var::item}}" :}
    :} |
    /try {: /return {{var::arg.example.0}} :}  | /console-log "arg.example.0: {{pipe}}" |
    /try {: /return {{var::arg.example.1}} :}  | /console-log "arg.example.1: {{pipe}}" |
    /try {: /return {{var::arg.example.2}} :}  | /console-log "arg.example.2: {{pipe}}" |
    /try {: /return {{var::arg.example.3}} :}  | /console-log "arg.example.3: {{pipe}}" |
:} ||
/let key=params {
    "example": [
    	"test1", "test2", "test3"
    ]
} |
/tools-invoke parameters={{var::params}} YourFunc
```
Currently produces:

```
[/console-log] arg.example: {"isException":true,"exception":"No such variable: \"arg.example\""}
[/console-log] arg.example.0: {"isException":false,"result":"test1"} 
[/console-log] arg.example.1: {"isException":false,"result":"test2"}
[/console-log] arg.example.2: {"isException":false,"result":"test3"}
[/console-log] arg.example.3: {"isException":true,"exception":"No such variable: \"arg.example.3\""}
```
With this patch it produces:

```
[/console-log] arg.example: ["test1","test2","test3"]
[/console-log] #0: test1
[/console-log] #1: test2
[/console-log] #2: test3
[/console-log] arg.example.0: {"isException":false,"result":"test1"}
[/console-log] arg.example.1: {"isException":false,"result":"test2"}
[/console-log] arg.example.2: {"isException":false,"result":"test3"}
[/console-log] arg.example.3: {"isException":true,"exception":"No such variable: \"arg.example.3\""}
```
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
