### PR TITLE
fix: lowercase remote-user header in authelia auto-login procedure

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -70,7 +70,7 @@ enableDiscreetLogin: false
 # https://www.authelia.com/
 # This will use auto login to an account with the same username
 # as that used for authlia. (Ensure the username in authlia
-# is an exact match with that in sillytavern)
+# is an exact match in lowercase with that in sillytavern)
 autheliaAuth: false
 # If `basicAuthMode` and this are enabled then
 # the username and passwords for basic auth are the same as those

--- a/src/users.js
+++ b/src/users.js
@@ -760,7 +760,7 @@ async function autheliaUserLogin(request) {
 
     const userHandles = await getAllUserHandles();
     for (const userHandle of userHandles) {
-        if (remoteUser === userHandle) {
+        if (remoteUser.toLowerCase() === userHandle) {
             const user = await storage.getItem(toKey(userHandle));
             if (user && user.enabled) {
                 request.session.handle = userHandle;


### PR DESCRIPTION
### Problem
Authelia supports case-sensitive usernames (e.g., `Test`), while SillyTavern expects lowercase usernames only (e.g., `test`). This mismatch prevents successful auto-login when the remote-user header contains a username with differing case, causing authentication failures.

### Solution
This PR modifies the auto-login procedure in Authelia to lowercase the `Remote-User` header before comparison. This ensures case-insensitive matching, resolving compatibility issues with SillyTavern and similar downstream services.

### Changes
Updated the auto-login middleware to convert the `Remote-User` header to lowercase during authentication.

### Impact
Fixes authentication failures due to case mismatches between Authelia and SillyTavern.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
