### PR TITLE
Removes memory heap bloat by improving DOM and JQUI datacache clearing when swapping WI in the editor, and all other 'reloadEditor' calls via slashcommands etc.

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1942,7 +1942,6 @@ function clearEntryList() {
     console.time('clearEntryList');
     const $list = $('#world_popup_entries_list');
 
-
     if (!$list.children().length) {
         console.debug('List already empty, skipping cleanup.');
         console.timeEnd('clearEntryList');
@@ -1977,7 +1976,6 @@ function clearEntryList() {
 
         $select.off();
         $.cleanData([$select[0]]);
-
     });
 
     // Step 3: Clean <div>, <span>, <input>
@@ -1993,13 +1991,12 @@ function clearEntryList() {
         $list.sortable('destroy');
     }
 
-    let totalElementsOfanyKindLeftInList = $list.children().length;
+    const totalElementsOfAnyKindLeftInList = $list.children().length;
 
     // Final cleanup
-    if (totalElementsOfanyKindLeftInList !== 0) {
+    if (totalElementsOfAnyKindLeftInList) {
         console.time('empty');
         $list.empty();
-        totalElementsOfanyKindLeftInList = $list.children().length;
         console.timeEnd('empty');
     }
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1986,11 +1986,6 @@ function clearEntryList() {
         $elem.remove();
     });
 
-    // Destroy Sortable
-    if ($list.sortable('instance')) {
-        $list.sortable('destroy');
-    }
-
     const totalElementsOfAnyKindLeftInList = $list.children().length;
 
     // Final cleanup

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2301,7 +2301,7 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
     });
 
     worldEntriesList.css('opacity', '1');
-    //remove inline CSS on the list
+    await delay(250);
     worldEntriesList.removeAttr('style');
 
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1943,23 +1943,20 @@ function clearEntryList() {
 
 
     if (!$list.children().length) {
-        console.warn('List already empty, skipping cleanup.');
+        console.debug('List already empty, skipping cleanup.');
         console.timeEnd('clearEntryList');
         return;
     }
 
     // Step 1: Clean all <option> elements within <select>
-    console.warn(`Before cleaning: ${$list.find('option').length} options in list`);
     $list.find('option').each(function () {
         const $option = $(this);
         $option.off();
         $.cleanData([$option[0]]);
         $option.remove();
     });
-    console.warn(`Post-clean: ${$list.find('option').length} options in list`);
 
     // Step 2: Clean all <select> elements
-    console.warn(`Before cleaning: ${$list.find('select').length} selects in list`);
     $list.find('select').each(function () {
         const $select = $(this);
         // Remove Select2-related data and container if present
@@ -1967,7 +1964,7 @@ function clearEntryList() {
             try {
                 $select.select2('destroy');
             } catch (e) {
-                console.warn('Select2 destroy failed:', e);
+                console.debug('Select2 destroy failed:', e);
             }
         }
         const $container = $select.parent();
@@ -1975,47 +1972,34 @@ function clearEntryList() {
             $container.find('*').off();
             $.cleanData($container.find('*').get());
             $container.remove();
-        } else {
-            console.warn('container not found');
-            console.warn($select.parent().html());
         }
-        // Destroy Select2 if applicable
 
         $select.off();
         $.cleanData([$select[0]]);
 
     });
-    console.warn(`Post-clean: ${$list.find('select').length} selects in list`);
 
     // Step 3: Clean <div>, <span>, <input>
-    console.warn(`Before cleaning: ${$list.find('div, span, input').length} divs, spans, inputs in list`);
     $list.find('div, span, input').each(function () {
         const $elem = $(this);
         $elem.off();
         $.cleanData([$elem[0]]);
         $elem.remove();
     });
-    console.warn(`Post-clean: ${$list.find('div, span, input').length} divs, spans, inputs in list`);
 
     // Destroy Sortable
-    console.warn(`Before cleaning: ${$list.sortable('instance') ? 1 : 0} sortable instance in list`);
     if ($list.sortable('instance')) {
         $list.sortable('destroy');
     }
-    console.warn(`Post-cleaning: ${$list.sortable('instance') ? 1 : 0} sortable instance in list`);
 
     let totalElementsOfanyKindLeftInList = $list.children().length;
 
     // Final cleanup
     if (totalElementsOfanyKindLeftInList !== 0) {
         console.time('empty');
-        console.warn(`Before .empty(): ${totalElementsOfanyKindLeftInList} elements left in list`);
         $list.empty();
         totalElementsOfanyKindLeftInList = $list.children().length;
-        console.warn(`After .empty(): ${totalElementsOfanyKindLeftInList} elements left in list`);
         console.timeEnd('empty');
-    } else {
-        console.warn('Entry List is already totally empty, no need to call .empty()');
     }
 
     console.timeEnd('clearEntryList');

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1960,7 +1960,7 @@ function clearEntryList() {
     $list.find('select').each(function () {
         const $select = $(this);
         // Remove Select2-related data and container if present
-        if ($select.hasClass('select2-hidden-accessible')) {
+        if ($select.data('select2')) {
             try {
                 $select.select2('destroy');
             } catch (e) {

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -5631,9 +5631,12 @@ export function initWorldInfo() {
         select2ChoiceClickSubscribe($('#world_info'), target => {
             const name = $(target).text();
             const selectedIndex = world_names.indexOf(name);
-            if (selectedIndex !== -1) {
+            const alreadySelectedInEditor = $('#world_editor_select option:selected').text() === name;
+            if (selectedIndex !== -1 && !alreadySelectedInEditor) {
                 $('#world_editor_select').val(selectedIndex).trigger('change');
                 console.log('Quick selection of world', name);
+            } else {
+                console.warn('lets not reload an already loaded list yes?');
             }
         }, { buttonStyle: true, closeDrawer: true });
     }


### PR DESCRIPTION
Improved DOM cleanup and JQUI data cache clearing when reloading WI Editor display during manual swap, and any other call that makes the editorReload happen (such as /setentryfield command). 

This fixes the memory heap bloating out and prevents long-term slowdown.

It does results in a slight delay depending on entries visible via pagination (almost instant for 10 visible entries, and about 2s for 50), but I added a pleasant fade transition to make it feel organic.

Aside from this, the only real fix to this is to optimize the WI entry DOM tree. The select element for "characterfilter" is particular heinous. 

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
