### PR TITLE
Implement lazy loading for background menu

### DIFF
--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -9,12 +9,11 @@ import { Popup } from './popup.js';
 
 const BG_METADATA_KEY = 'custom_background';
 const LIST_METADATA_KEY = 'chat_backgrounds';
-const DEBUG_BACKGROUND_LOADING = false;
-const PLACEHOLDER_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 // A single transparent PNG pixel used as a placeholder for errored backgrounds
 const PNG_PIXEL = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 const PNG_PIXEL_BLOB = new Blob([Uint8Array.from(atob(PNG_PIXEL), c => c.charCodeAt(0))], { type: 'image/png' });
+const PLACEHOLDER_IMAGE = `url('data:image/png;base64,${PNG_PIXEL}')`;
 
 /**
  * Storage for frontend-generated background thumbnails.
@@ -97,7 +96,6 @@ async function getChatBackgroundsList() {
         const template = await getBackgroundFromTemplate(bg, true);
         $('#bg_custom_content').append(template);
     }
-    if (DEBUG_BACKGROUND_LOADING) console.log('Calling activateLazyLoader from getChatBackgroundsList');
     activateLazyLoader();
 }
 
@@ -438,45 +436,32 @@ export async function getBackgrounds() {
     const response = await fetch('/api/backgrounds/all', {
         method: 'POST',
         headers: getRequestHeaders(),
-        body: JSON.stringify({
-            '': '',
-        }),
+        body: JSON.stringify({}),
     });
     if (response.ok) {
         const getData = await response.json();
-        //background = getData;
-        //console.log(getData.length);
         $('#bg_menu_content').children('div').remove();
         for (const bg of getData) {
             const template = await getBackgroundFromTemplate(bg, false);
             $('#bg_menu_content').append(template);
         }
-        if (DEBUG_BACKGROUND_LOADING) console.log('Calling activateLazyLoader from getBackgrounds');
         activateLazyLoader();
     }
 }
 
 function activateLazyLoader() {
-    if (DEBUG_BACKGROUND_LOADING) console.log('activateLazyLoader function started.');
     const lazyLoadElements = document.querySelectorAll('.lazy-load-background');
-    if (DEBUG_BACKGROUND_LOADING) console.log('activateLazyLoader called. Found elements:', lazyLoadElements.length);
 
     const options = {
         root: null,
         rootMargin: '200px',
         threshold: 0.01,
     };
-    if (DEBUG_BACKGROUND_LOADING) console.log('IntersectionObserver options:', options);
 
     const observer = new IntersectionObserver((entries, observer) => {
         entries.forEach(entry => {
-            if (DEBUG_BACKGROUND_LOADING) console.log('IntersectionObserver callback triggered for:', entry.target, 'Is intersecting:', entry.isIntersecting);
-            if (entry.isIntersecting) {
+            if (entry.target instanceof HTMLElement && entry.isIntersecting) {
                 const imageUrl = entry.target.dataset.bgSrc;
-                if (!imageUrl) {
-                    if (DEBUG_BACKGROUND_LOADING) console.warn('No bgSrc found for', entry.target);
-                }
-                if (DEBUG_BACKGROUND_LOADING) console.log('Loading image for:', entry.target, 'with URL:', imageUrl);
                 if (imageUrl) {
                     entry.target.style.backgroundImage = `url('${imageUrl}')`;
                 }
@@ -529,7 +514,7 @@ async function getBackgroundFromTemplate(bg, isCustom) {
     template.data('url', url);
     template.attr('data-bg-src', thumbnailUrl);
     template.addClass('lazy-load-background');
-    template.css('background-image', `url('${PLACEHOLDER_IMAGE}')`);
+    template.css('background-image', PLACEHOLDER_IMAGE);
     template.find('.BGSampleTitle').text(friendlyTitle);
     return template;
 }

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -21,7 +21,7 @@ export let background_settings = {
 
 export function loadBackgroundSettings(settings) {
     let backgroundSettings = settings.background;
-    if (!backgroundSettings || !backgroundSettings.name || !backgroundSettings.name) {
+    if (!backgroundSettings || !backgroundSettings.name || !backgroundSettings.url) {
         backgroundSettings = background_settings;
     }
     if (!backgroundSettings.fitting) {

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -402,11 +402,23 @@ export async function getBackgrounds() {
 
 function activateLazyLoader() {
     const lazyLoadElements = document.querySelectorAll('.lazy-load-background');
+    console.log('activateLazyLoader called. Found elements:', lazyLoadElements.length);
+
+    const options = {
+      root: document.getElementById('Backgrounds'), // Assuming 'Backgrounds' is the ID of the scrollable container
+      rootMargin: '0px',
+      threshold: 0.1 // Trigger when 10% of the item is visible
+    };
 
     const observer = new IntersectionObserver((entries, observer) => {
         entries.forEach(entry => {
+            console.log('IntersectionObserver callback triggered for:', entry.target, 'Is intersecting:', entry.isIntersecting);
             if (entry.isIntersecting) {
                 const imageUrl = entry.target.dataset.bgSrc;
+                if (!imageUrl) {
+                    console.warn('No bgSrc found for', entry.target);
+                }
+                console.log('Loading image for:', entry.target, 'with URL:', imageUrl);
                 if (imageUrl) {
                     entry.target.style.backgroundImage = `url('${imageUrl}')`;
                 }
@@ -414,7 +426,7 @@ function activateLazyLoader() {
                 observer.unobserve(entry.target);
             }
         });
-    });
+    }, options);
 
     lazyLoadElements.forEach(element => {
         observer.observe(element);

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -75,6 +75,11 @@ function getChatBackgroundsList() {
         const template = getBackgroundFromTemplate(bg, true);
         $('#bg_custom_content').append(template);
     }
+<<<<<<< HEAD
+=======
+    console.log('Calling activateLazyLoader from getChatBackgroundsList');
+    activateLazyLoader();
+>>>>>>> a7e749524 (debug: Enhance logging for IntersectionObserver and root element)
 }
 
 function getBackgroundPath(fileUrl) {
@@ -368,6 +373,11 @@ async function autoBackgroundCommand() {
     return '';
 }
 
+/**
+ * Gets the CSS URL of the background
+ * @param {Element} block
+ * @returns {string} URL of the background
+ */
 export async function getBackgrounds() {
     const response = await fetch('/api/backgrounds/all', {
         method: 'POST',
@@ -385,7 +395,54 @@ export async function getBackgrounds() {
             const template = getBackgroundFromTemplate(bg, false);
             $('#bg_menu_content').append(template);
         }
+        console.log('Calling activateLazyLoader from getBackgrounds');
+        activateLazyLoader();
     }
+}
+
+function activateLazyLoader() {
+    console.log('activateLazyLoader function started.');
+    const lazyLoadElements = document.querySelectorAll('.lazy-load-background');
+    console.log('activateLazyLoader called. Found elements:', lazyLoadElements.length);
+
+    const rootElement = document.getElementById('Backgrounds');
+    if (!rootElement) {
+        console.error('#Backgrounds element not found!');
+        // Fallback to viewport if #Backgrounds is not found, or handle error
+        // For now, we'll let it proceed and potentially fail in observer creation if null,
+        // or you could default to `root: null` to use the viewport.
+    } else {
+        console.log('#Backgrounds element found:', rootElement);
+    }
+
+    const options = {
+      root: rootElement, // This will be null if not found, defaulting to viewport
+      rootMargin: '0px',
+      threshold: 0.1 // Trigger when 10% of the item is visible
+    };
+    console.log('IntersectionObserver options:', options);
+
+    const observer = new IntersectionObserver((entries, observer) => {
+        entries.forEach(entry => {
+            console.log('IntersectionObserver callback triggered for:', entry.target, 'Is intersecting:', entry.isIntersecting);
+            if (entry.isIntersecting) {
+                const imageUrl = entry.target.dataset.bgSrc;
+                if (!imageUrl) {
+                    console.warn('No bgSrc found for', entry.target);
+                }
+                console.log('Loading image for:', entry.target, 'with URL:', imageUrl);
+                if (imageUrl) {
+                    entry.target.style.backgroundImage = `url('${imageUrl}')`;
+                }
+                entry.target.classList.remove('lazy-load-background');
+                observer.unobserve(entry.target);
+            }
+        });
+    }, options);
+
+    lazyLoadElements.forEach(element => {
+        observer.observe(element);
+    });
 }
 
 /**

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -61,6 +61,9 @@ async function onChatChanged() {
 }
 
 function getChatBackgroundsList() {
+    if ($('#bg_custom_content').children('.bg_example').length > 0) {
+        return;
+    }
     const list = chat_metadata[LIST_METADATA_KEY];
     const listEmpty = !Array.isArray(list) || list.length === 0;
 
@@ -75,11 +78,7 @@ function getChatBackgroundsList() {
         const template = getBackgroundFromTemplate(bg, true);
         $('#bg_custom_content').append(template);
     }
-<<<<<<< HEAD
-=======
-    console.log('Calling activateLazyLoader from getChatBackgroundsList');
-    activateLazyLoader();
->>>>>>> a7e749524 (debug: Enhance logging for IntersectionObserver and root element)
+activateLazyLoader();
 }
 
 function getBackgroundPath(fileUrl) {
@@ -379,6 +378,9 @@ async function autoBackgroundCommand() {
  * @returns {string} URL of the background
  */
 export async function getBackgrounds() {
+    if ($('#bg_menu_content').children('.bg_example').length > 0) {
+        return;
+    }
     const response = await fetch('/api/backgrounds/all', {
         method: 'POST',
         headers: getRequestHeaders(),
@@ -395,42 +397,16 @@ export async function getBackgrounds() {
             const template = getBackgroundFromTemplate(bg, false);
             $('#bg_menu_content').append(template);
         }
-        console.log('Calling activateLazyLoader from getBackgrounds');
-        activateLazyLoader();
-    }
+    activateLazyLoader();
 }
 
 function activateLazyLoader() {
-    console.log('activateLazyLoader function started.');
     const lazyLoadElements = document.querySelectorAll('.lazy-load-background');
-    console.log('activateLazyLoader called. Found elements:', lazyLoadElements.length);
-
-    const rootElement = document.getElementById('Backgrounds');
-    if (!rootElement) {
-        console.error('#Backgrounds element not found!');
-        // Fallback to viewport if #Backgrounds is not found, or handle error
-        // For now, we'll let it proceed and potentially fail in observer creation if null,
-        // or you could default to `root: null` to use the viewport.
-    } else {
-        console.log('#Backgrounds element found:', rootElement);
-    }
-
-    const options = {
-      root: rootElement, // This will be null if not found, defaulting to viewport
-      rootMargin: '0px',
-      threshold: 0.1 // Trigger when 10% of the item is visible
-    };
-    console.log('IntersectionObserver options:', options);
 
     const observer = new IntersectionObserver((entries, observer) => {
         entries.forEach(entry => {
-            console.log('IntersectionObserver callback triggered for:', entry.target, 'Is intersecting:', entry.isIntersecting);
             if (entry.isIntersecting) {
                 const imageUrl = entry.target.dataset.bgSrc;
-                if (!imageUrl) {
-                    console.warn('No bgSrc found for', entry.target);
-                }
-                console.log('Loading image for:', entry.target, 'with URL:', imageUrl);
                 if (imageUrl) {
                     entry.target.style.backgroundImage = `url('${imageUrl}')`;
                 }
@@ -438,7 +414,7 @@ function activateLazyLoader() {
                 observer.unobserve(entry.target);
             }
         });
-    }, options);
+    });
 
     lazyLoadElements.forEach(element => {
         observer.observe(element);
@@ -474,7 +450,9 @@ function getBackgroundFromTemplate(bg, isCustom) {
     template.attr('bgfile', bg);
     template.attr('custom', String(isCustom));
     template.data('url', url);
-    template.css('background-image', `url('${thumbPath}')`);
+    template.attr('data-bg-src', thumbPath);
+    template.addClass('lazy-load-background');
+    template.css('background-image', 'none');
     template.find('.BGSampleTitle').text(friendlyTitle);
     return template;
 }

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -1,5 +1,7 @@
 import { Fuse } from '../lib.js';
 
+const DEBUG_BACKGROUND_LOADING = false;
+
 import { chat_metadata, eventSource, event_types, generateQuietPrompt, getCurrentChatId, getRequestHeaders, getThumbnailUrl, saveSettingsDebounced } from '../script.js';
 import { openThirdPartyExtensionMenu, saveMetadataDebounced } from './extensions.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
@@ -78,7 +80,8 @@ function getChatBackgroundsList() {
         const template = getBackgroundFromTemplate(bg, true);
         $('#bg_custom_content').append(template);
     }
-activateLazyLoader();
+    if (DEBUG_BACKGROUND_LOADING) console.log('Calling activateLazyLoader from getChatBackgroundsList');
+    activateLazyLoader();
 }
 
 function getBackgroundPath(fileUrl) {
@@ -397,28 +400,42 @@ export async function getBackgrounds() {
             const template = getBackgroundFromTemplate(bg, false);
             $('#bg_menu_content').append(template);
         }
-    activateLazyLoader();
+        if (DEBUG_BACKGROUND_LOADING) console.log('Calling activateLazyLoader from getBackgrounds');
+        activateLazyLoader();
+    }
 }
 
 function activateLazyLoader() {
+    if (DEBUG_BACKGROUND_LOADING) console.log('activateLazyLoader function started.');
     const lazyLoadElements = document.querySelectorAll('.lazy-load-background');
-    console.log('activateLazyLoader called. Found elements:', lazyLoadElements.length);
+    if (DEBUG_BACKGROUND_LOADING) console.log('activateLazyLoader called. Found elements:', lazyLoadElements.length);
+
+    const rootElement = document.getElementById('Backgrounds');
+    if (!rootElement) {
+        if (DEBUG_BACKGROUND_LOADING) console.error('#Backgrounds element not found!');
+        // Fallback to viewport if #Backgrounds is not found, or handle error
+        // For now, we'll let it proceed and potentially fail in observer creation if null,
+        // or you could default to `root: null` to use the viewport.
+    } else {
+        if (DEBUG_BACKGROUND_LOADING) console.log('#Backgrounds element found:', rootElement);
+    }
 
     const options = {
       root: document.getElementById('Backgrounds'), // Assuming 'Backgrounds' is the ID of the scrollable container
       rootMargin: '0px',
       threshold: 0.1 // Trigger when 10% of the item is visible
     };
+    if (DEBUG_BACKGROUND_LOADING) console.log('IntersectionObserver options:', options);
 
     const observer = new IntersectionObserver((entries, observer) => {
         entries.forEach(entry => {
-            console.log('IntersectionObserver callback triggered for:', entry.target, 'Is intersecting:', entry.isIntersecting);
+            if (DEBUG_BACKGROUND_LOADING) console.log('IntersectionObserver callback triggered for:', entry.target, 'Is intersecting:', entry.isIntersecting);
             if (entry.isIntersecting) {
                 const imageUrl = entry.target.dataset.bgSrc;
                 if (!imageUrl) {
-                    console.warn('No bgSrc found for', entry.target);
+                    if (DEBUG_BACKGROUND_LOADING) console.warn('No bgSrc found for', entry.target);
                 }
-                console.log('Loading image for:', entry.target, 'with URL:', imageUrl);
+                if (DEBUG_BACKGROUND_LOADING) console.log('Loading image for:', entry.target, 'with URL:', imageUrl);
                 if (imageUrl) {
                     entry.target.style.backgroundImage = `url('${imageUrl}')`;
                 }
@@ -640,4 +657,48 @@ export function initBackgrounds() {
         setFittingClass(background_settings.fitting);
         saveSettingsDebounced();
     });
+
+    // START MutationObserver for #Backgrounds
+    const backgroundsElement = document.getElementById('Backgrounds');
+
+    if (backgroundsElement) {
+        const observer = new MutationObserver((mutationsList) => {
+            for (const mutation of mutationsList) {
+                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                    const isOpened = !backgroundsElement.classList.contains('closedDrawer');
+                    handleBackgroundMenuToggle(isOpened);
+                }
+            }
+        });
+
+        observer.observe(backgroundsElement, { attributes: true });
+    } else {
+        if (DEBUG_BACKGROUND_LOADING) console.error('#Backgrounds element not found for MutationObserver');
+    }
+    // END MutationObserver for #Backgrounds
+}
+
+// New function to handle background menu toggle
+function handleBackgroundMenuToggle(isOpened) {
+    if (isOpened) {
+        if (DEBUG_BACKGROUND_LOADING) console.log('Background menu opened. Repopulating background lists.');
+        getBackgrounds();
+        getChatBackgroundsList();
+    } else {
+        if (DEBUG_BACKGROUND_LOADING) console.log('Background menu closed. Unloading unused images.');
+        const bgMenuContent = document.querySelectorAll('#bg_menu_content > div.bg_example');
+        const bgCustomContent = document.querySelectorAll('#bg_custom_content > div.bg_example');
+        const backgroundElements = [...bgMenuContent, ...bgCustomContent];
+
+        const currentMainBgUrl = background_settings.url;
+        const currentChatBgUrl = chat_metadata[BG_METADATA_KEY];
+
+        backgroundElements.forEach(element => {
+            const elementUrl = element.dataset.url;
+
+            if (elementUrl !== currentMainBgUrl && elementUrl !== currentChatBgUrl) {
+                element.style.backgroundImage = 'none';
+            }
+        });
+    }
 }

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -1,7 +1,5 @@
 import { Fuse } from '../lib.js';
 
-const DEBUG_BACKGROUND_LOADING = false;
-
 import { chat_metadata, eventSource, event_types, generateQuietPrompt, getCurrentChatId, getRequestHeaders, getThumbnailUrl, saveSettingsDebounced } from '../script.js';
 import { openThirdPartyExtensionMenu, saveMetadataDebounced } from './extensions.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
@@ -12,6 +10,8 @@ import { Popup } from './popup.js';
 
 const BG_METADATA_KEY = 'custom_background';
 const LIST_METADATA_KEY = 'chat_backgrounds';
+const DEBUG_BACKGROUND_LOADING = false;
+const PLACEHOLDER_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 export let background_settings = {
     name: '__transparent.png',
@@ -21,7 +21,7 @@ export let background_settings = {
 
 export function loadBackgroundSettings(settings) {
     let backgroundSettings = settings.background;
-    if (!backgroundSettings || !backgroundSettings.name || !backgroundSettings.url) {
+    if (!backgroundSettings || !backgroundSettings.name || !backgroundSettings.name) {
         backgroundSettings = background_settings;
     }
     if (!backgroundSettings.fitting) {
@@ -63,9 +63,6 @@ async function onChatChanged() {
 }
 
 function getChatBackgroundsList() {
-    if ($('#bg_custom_content').children('.bg_example').length > 0) {
-        return;
-    }
     const list = chat_metadata[LIST_METADATA_KEY];
     const listEmpty = !Array.isArray(list) || list.length === 0;
 
@@ -375,15 +372,7 @@ async function autoBackgroundCommand() {
     return '';
 }
 
-/**
- * Gets the CSS URL of the background
- * @param {Element} block
- * @returns {string} URL of the background
- */
 export async function getBackgrounds() {
-    if ($('#bg_menu_content').children('.bg_example').length > 0) {
-        return;
-    }
     const response = await fetch('/api/backgrounds/all', {
         method: 'POST',
         headers: getRequestHeaders(),
@@ -410,20 +399,10 @@ function activateLazyLoader() {
     const lazyLoadElements = document.querySelectorAll('.lazy-load-background');
     if (DEBUG_BACKGROUND_LOADING) console.log('activateLazyLoader called. Found elements:', lazyLoadElements.length);
 
-    const rootElement = document.getElementById('Backgrounds');
-    if (!rootElement) {
-        if (DEBUG_BACKGROUND_LOADING) console.error('#Backgrounds element not found!');
-        // Fallback to viewport if #Backgrounds is not found, or handle error
-        // For now, we'll let it proceed and potentially fail in observer creation if null,
-        // or you could default to `root: null` to use the viewport.
-    } else {
-        if (DEBUG_BACKGROUND_LOADING) console.log('#Backgrounds element found:', rootElement);
-    }
-
     const options = {
-      root: document.getElementById('Backgrounds'), // Assuming 'Backgrounds' is the ID of the scrollable container
-      rootMargin: '0px',
-      threshold: 0.1 // Trigger when 10% of the item is visible
+      root: null,
+      rootMargin: '200px',
+      threshold: 0.01
     };
     if (DEBUG_BACKGROUND_LOADING) console.log('IntersectionObserver options:', options);
 
@@ -481,7 +460,7 @@ function getBackgroundFromTemplate(bg, isCustom) {
     template.data('url', url);
     template.attr('data-bg-src', thumbPath);
     template.addClass('lazy-load-background');
-    template.css('background-image', 'none');
+    template.css('background-image', `url('${PLACEHOLDER_IMAGE}')`);
     template.find('.BGSampleTitle').text(friendlyTitle);
     return template;
 }
@@ -657,48 +636,4 @@ export function initBackgrounds() {
         setFittingClass(background_settings.fitting);
         saveSettingsDebounced();
     });
-
-    // START MutationObserver for #Backgrounds
-    const backgroundsElement = document.getElementById('Backgrounds');
-
-    if (backgroundsElement) {
-        const observer = new MutationObserver((mutationsList) => {
-            for (const mutation of mutationsList) {
-                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-                    const isOpened = !backgroundsElement.classList.contains('closedDrawer');
-                    handleBackgroundMenuToggle(isOpened);
-                }
-            }
-        });
-
-        observer.observe(backgroundsElement, { attributes: true });
-    } else {
-        if (DEBUG_BACKGROUND_LOADING) console.error('#Backgrounds element not found for MutationObserver');
-    }
-    // END MutationObserver for #Backgrounds
-}
-
-// New function to handle background menu toggle
-function handleBackgroundMenuToggle(isOpened) {
-    if (isOpened) {
-        if (DEBUG_BACKGROUND_LOADING) console.log('Background menu opened. Repopulating background lists.');
-        getBackgrounds();
-        getChatBackgroundsList();
-    } else {
-        if (DEBUG_BACKGROUND_LOADING) console.log('Background menu closed. Unloading unused images.');
-        const bgMenuContent = document.querySelectorAll('#bg_menu_content > div.bg_example');
-        const bgCustomContent = document.querySelectorAll('#bg_custom_content > div.bg_example');
-        const backgroundElements = [...bgMenuContent, ...bgCustomContent];
-
-        const currentMainBgUrl = background_settings.url;
-        const currentChatBgUrl = chat_metadata[BG_METADATA_KEY];
-
-        backgroundElements.forEach(element => {
-            const elementUrl = element.dataset.url;
-
-            if (elementUrl !== currentMainBgUrl && elementUrl !== currentChatBgUrl) {
-                element.style.backgroundImage = 'none';
-            }
-        });
-    }
 }

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -400,9 +400,9 @@ function activateLazyLoader() {
     if (DEBUG_BACKGROUND_LOADING) console.log('activateLazyLoader called. Found elements:', lazyLoadElements.length);
 
     const options = {
-      root: null,
-      rootMargin: '200px',
-      threshold: 0.01
+        root: null,
+        rootMargin: '200px',
+        threshold: 0.01,
     };
     if (DEBUG_BACKGROUND_LOADING) console.log('IntersectionObserver options:', options);
 

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -27,6 +27,12 @@ const THUMBNAIL_STORAGE = localforage.createInstance({ name: 'SillyTavern_Thumbn
  */
 const THUMBNAIL_BLOBS = new Map();
 
+/**
+ * Global IntersectionObserver instance for lazy loading backgrounds
+ * @type {IntersectionObserver|null}
+ */
+let lazyLoadObserver = null;
+
 export let background_settings = {
     name: '__transparent.png',
     url: generateUrlParameter('__transparent.png', false),
@@ -450,6 +456,12 @@ export async function getBackgrounds() {
 }
 
 function activateLazyLoader() {
+    // Disconnect previous observer to prevent memory leaks
+    if (lazyLoadObserver) {
+        lazyLoadObserver.disconnect();
+        lazyLoadObserver = null;
+    }
+
     const lazyLoadElements = document.querySelectorAll('.lazy-load-background');
 
     const options = {
@@ -458,7 +470,7 @@ function activateLazyLoader() {
         threshold: 0.01,
     };
 
-    const observer = new IntersectionObserver((entries, observer) => {
+    lazyLoadObserver = new IntersectionObserver((entries, observer) => {
         entries.forEach(entry => {
             if (entry.target instanceof HTMLElement && entry.isIntersecting) {
                 const imageUrl = entry.target.dataset.bgSrc;
@@ -472,7 +484,7 @@ function activateLazyLoader() {
     }, options);
 
     lazyLoadElements.forEach(element => {
-        observer.observe(element);
+        lazyLoadObserver.observe(element);
     });
 }
 


### PR DESCRIPTION
This PR introduces a lazy-loading mechanism for the background image thumbnails to significantly improve performance and reduce initial load times, especially for users with a large number of backgrounds.

#### What is the problem?
Currently, the "Backgrounds" menu loads all thumbnail images at once upon opening. This can cause a noticeable delay and high memory usage, creating a poor user experience for anyone with a substantial collection of backgrounds.

#### How does this PR solve it?
This implementation uses a modern web API, the `IntersectionObserver`, to defer the loading of each thumbnail until it is about to enter the user's viewport.

**How it works:**
1.  When the background menu is populated, each thumbnail element is initially given a tiny, 1x1 transparent placeholder image. This is a critical step that ensures the element has dimensions and is "visible" to the browser's layout engine.
2.  The real path to the thumbnail is stored in a `data-bg-src` attribute on the element.
3.  An `IntersectionObserver` is created to watch all these thumbnail elements.
4.  When a user scrolls and a thumbnail enters the viewport (plus a 200px margin to ensure smooth loading), the observer's callback fires.
5.  The callback reads the `data-bg-src` attribute and sets it as the element's actual `background-image`, triggering the image download.
6.  The observer then stops watching that specific element, as its job is done.

This ensures that only the visible (and soon-to-be-visible) thumbnails are ever loaded, drastically cutting down on initial network requests and memory footprint.

#### Key Changes:
*   **`activateLazyLoader()`:** A new function that sets up the `IntersectionObserver` to watch for `.lazy-load-background` elements.
*   **`getBackgroundFromTemplate()`:** Modified to apply the 1x1 transparent placeholder image and store the real image path in a `data-bg-src` attribute.
*   **`getBackgrounds()` & `getChatBackgroundsList()`:** Removed a premature optimization check to ensure the lists are always rebuilt and the lazy loader is re-initialized correctly every time the menu is opened.

#### How to Test:
1.  Go to the "Backgrounds" menu.
2.  Open your browser's developer tools and switch to the **Network** tab.
3.  Slowly scroll down the list of backgrounds.
4.  **Expected:** You should see that the image files for the thumbnails are only requested in the Network tab as they become visible on the screen, not all at once.
5.  Close and re-open the menu. The lazy-loading behavior should work correctly again.

This PR resolves the issues from previous attempts and provides a stable, working implementation for this feature.
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).