### PR TITLE
Allow extensions to know if lorebooks can be saved

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -86,7 +86,7 @@ const saveSettingsDebounced = debounce(() => {
 }, debounce_timeout.relaxed);
 const sortFn = (a, b) => b.order - a.order;
 let updateEditor = (navigation, flashOnNav = true) => { console.debug('Triggered WI navigation', navigation, flashOnNav); };
-let isSaveWorldInfoDisabled = false;
+export let isSaveWorldInfoDisabled = false;
 
 // Do not optimize. updateEditor is a function that is updated by the displayWorldEntries with new data.
 export const worldInfoFilter = new FilterHelper(() => updateEditor());
@@ -3567,6 +3567,24 @@ async function _save(name, data) {
     await eventSource.emit(event_types.WORLDINFO_UPDATED, name, data);
 }
 
+/**
+ * Wait until lorebooks can be saved
+ * @param {number} intervalTime - Time in miliseconds to await for each check of isSaveWorldInfoDisabled (def = 100)
+ * @return {Promise<void>} A promise that resolves when lorebooks can be saved
+ */
+export async function waitForWIDisabled(intervalTime = 100) {
+    if (!isSaveWorldInfoDisabled) return;
+
+    await new Promise(resolve => {
+        const interval = setInterval(() => {
+            if (!isSaveWorldInfoDisabled) {
+                clearInterval(interval);
+                resolve();
+            }
+            console.debug('Waiting for isSaveWorldInfoDisabled to be false');
+        }, intervalTime);
+    });
+}
 
 /**
  * Saves the world info

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3572,7 +3572,7 @@ async function _save(name, data) {
  * @param {number} intervalTime - Time in miliseconds to await for each check of isSaveWorldInfoDisabled (def = 100)
  * @return {Promise<void>} A promise that resolves when lorebooks can be saved
  */
-export async function waitForWIDisabled(intervalTime = 100) {
+export async function waitDuringWIDisabled(intervalTime = 100) {
     if (!isSaveWorldInfoDisabled) return;
 
     await new Promise(resolve => {


### PR DESCRIPTION
What is the reason for a change?
With the new changes to lorebooks, calling `moveWorldInfoEntry` repeatedly or making anything that implies constant update of lorebooks from extensions breaks (Like `WI-Bulk-Mover`). The cause is changes to pagination blocking `saveWorldInfo` when the pagination refreshes.

![image](https://github.com/user-attachments/assets/c9ae097e-1db9-4e02-b6ae-9f018bbc0d8f)

Solution: Allowing extensions check `isSaveWorldInfoDisabled` and giving them `waitDuringWIDisabled` to `await` until lorebooks can be saved.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
