### PR TITLE
Fix Typo in Error Message

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1049,7 +1049,7 @@ router.post('/edit', validateAvatarUrlMiddleware, async function (request, respo
         return response.sendStatus(200);
     }
     catch {
-        console.error('An error occured, character edit invalidated.');
+        console.error('An error occurred, character edit invalidated.');
     }
 });
 
@@ -1095,7 +1095,7 @@ router.post('/edit-attribute', validateAvatarUrlMiddleware, async function (requ
         await writeCharacterData(avatarPath, newCharJSON, targetFile, request);
         return response.sendStatus(200);
     } catch (err) {
-        console.error('An error occured, character edit invalidated.', err);
+        console.error('An error occurred, character edit invalidated.', err);
     }
 });
 


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the error messages within the character edit endpoints. The word "occured" has been replaced with the correct spelling "occurred" in two locations in the `src/endpoints/characters.js` file. This change improves the clarity and professionalism of the error logs. No functional code changes were made.