### PR TITLE
Increase <hr>'s opacity from 0.2 to 0.4

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -712,7 +712,7 @@ hr {
     height: 1px;
     min-height: 1px;
     border: 0;
-    opacity: 0.2;
+    opacity: 0.4;
 }
 
 #bg1,


### PR DESCRIPTION
The default horizontal rule is insanely light. This will increase visibility without making it stand out too much.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
