### PR TITLE
Added new slash command member-count

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3505,11 +3505,6 @@ async function countGroupMemberCallback() {
         return '';
     }
 
-    if (is_group_generating) {
-        toastr.warning('Cannot run /member-count command while the group reply is generating.');
-        return '';
-    }
-
     return getGroupMembers(selected_group).length;
 }
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -54,7 +54,7 @@ import { getMessageTimeStamp, isMobile } from './RossAscends-mods.js';
 import { hideChatMessageRange } from './chats.js';
 import { getContext, saveMetadataDebounced } from './extensions.js';
 import { getRegexedString, regex_placement } from './extensions/regex/engine.js';
-import { findGroupMemberId, groups, is_group_generating, openGroupById, resetSelectedGroup, saveGroupChat, selected_group } from './group-chats.js';
+import { findGroupMemberId, groups, is_group_generating, openGroupById, resetSelectedGroup, saveGroupChat, selected_group, getGroupMembers } from './group-chats.js';
 import { chat_completion_sources, oai_settings, promptManager } from './openai.js';
 import { user_avatar } from './personas.js';
 import { addEphemeralStoppingString, chat_styles, flushEphemeralStoppingStrings, power_user } from './power-user.js';
@@ -942,6 +942,12 @@ export function initDefaultSlashCommands() {
             </ul>
         </div>
     `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'member-count',
+        callback: countGroupMemberCallback,
+        aliases: ['countmember', 'membercount'],
+        helpString: 'Returns the total number of group members in the group chat list.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'delswipe',
@@ -3491,6 +3497,20 @@ async function peekCallback(_, arg) {
 
     performGroupMemberAction(chid, 'view');
     return '';
+}
+
+async function countGroupMemberCallback() {
+    if (!selected_group) {
+        toastr.warning('Cannot run /member-count command outside of a group chat.');
+        return '';
+    }
+
+    if (is_group_generating) {
+        toastr.warning('Cannot run /member-count command while the group reply is generating.');
+        return '';
+    }
+
+    return getGroupMembers(selected_group).length;
 }
 
 async function removeGroupMemberCallback(_, arg) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).


This commit addresses discussion https://github.com/SillyTavern/SillyTavern/discussions/4133
It adds a member-count slash command that returns the number of members in a group.
This can e. g. be used in combination with member-get in loops, to execute commands for every member of the group.
