### PR TITLE
Update: Disabled VertexAI api option in the Gemini TTS settings

### DIFF
--- a/public/scripts/extensions/tts/google-native.js
+++ b/public/scripts/extensions/tts/google-native.js
@@ -24,7 +24,7 @@ export class GoogleNativeTtsProvider {
                 <label for="google-tts-api-type">API Type:</label>
                 <select id="google-tts-api-type">
                     <option value="makersuite">Google AI Studio (MakerSuite)</option>
-                    <option value="vertexai">Google Vertex AI</option>
+                    <option value="vertexai" disabled>Google Vertex AI (unsupported)</option>
                 </select>
             </div>
             <div>


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

just a follow up to the recently merged Google Native Speech feature #4163 . TTS support is extremely limited in VertexAI as of today.

https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-2.0-flash-001 