### PR TITLE
Regex bulkedit select all toggle button add

### DIFF
--- a/public/scripts/extensions/regex/dropdown.html
+++ b/public/scripts/extensions/regex/dropdown.html
@@ -28,6 +28,9 @@
                 </label>
             </div>
             <div class="regex_bulk_operations flex-container justifyCenter">
+                <div id="bulk_select_all_toggle" class="menu_button menu_button_icon" title="Toggle Select All">
+                    <i class="fa-solid fa-check-double"></i>
+                </div>
                 <div id="bulk_enable_regex" class="menu_button menu_button_icon">
                     <i class="fa-solid fa-toggle-on"></i>
                     <small data-i18n="Enable">Enable</small>

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -614,6 +614,23 @@ jQuery(async () => {
         return scripts.filter(script => selectedIds.includes(script.id));
     }
 
+    $('#bulk_select_all_toggle').on('click', async function () {
+        const checkboxes = $('#regex_container .regex_bulk_checkbox');
+        if (checkboxes.length === 0) {
+            return;
+        }
+
+        const allAreChecked = checkboxes.length === checkboxes.filter(':checked').length;
+        const newState = !allAreChecked; // true if we just checked all, false if we just unchecked all
+
+        checkboxes.prop('checked', newState);
+
+        const icon = $(this).find('i');
+        // Toggle the icon shapes
+        icon.toggleClass('fa-check-double', !newState); // Add 'fa-square-check' when deselected
+        icon.toggleClass('fa-minus', newState);  // Add 'fa-square-minus' when selected
+    });
+
     $('#bulk_enable_regex').on('click', async function () {
         const scripts = getSelectedScripts().filter(script => script.disabled);
         if (scripts.length === 0) {

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -115,6 +115,7 @@ async function deleteRegexScript({ id, isScoped }) {
 async function loadRegexScripts() {
     $('#saved_regex_scripts').empty();
     $('#saved_scoped_scripts').empty();
+    setToggleAllIcon(false);
 
     const scriptTemplate = $(await renderExtensionTemplateAsync('regex', 'scriptTemplate'));
 

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -28,6 +28,18 @@ export function getRegexScripts() {
 }
 
 /**
+ * Toggle the icon for the "select all" checkbox in the regex settings.
+ * - Use `fa-check-double` when the checkbox is unchecked (indicating all scripts are not selected).
+ * - Use `fa-minus` when the checkbox is checked (indicating all scripts are selected).
+ * @param {boolean} allAreChecked Should the "select all" icon be in the checked state?
+ */
+function setToggleAllIcon(allAreChecked) {
+    const selectAllIcon = $('#bulk_select_all_toggle').find('i');
+    selectAllIcon.toggleClass('fa-check-double', !allAreChecked);
+    selectAllIcon.toggleClass('fa-minus', allAreChecked);
+}
+
+/**
  * Saves a regex script to the extension settings or character data.
  * @param {import('../../char-data.js').RegexScriptData} regexScript
  * @param {number} existingScriptIndex Index of the existing script
@@ -182,6 +194,11 @@ async function loadRegexScripts() {
 
             await deleteRegexScript({ id: script.id, isScoped });
             await reloadCurrentChat();
+        });
+        scriptHtml.find('.regex_bulk_checkbox').on('change', function () {
+            const checkboxes = $('#regex_container .regex_bulk_checkbox');
+            const allAreChecked = checkboxes.length === checkboxes.filter(':checked').length;
+            setToggleAllIcon(allAreChecked);
         });
 
         $(container).append(scriptHtml);
@@ -624,11 +641,7 @@ jQuery(async () => {
         const newState = !allAreChecked; // true if we just checked all, false if we just unchecked all
 
         checkboxes.prop('checked', newState);
-
-        const icon = $(this).find('i');
-        // Toggle the icon shapes
-        icon.toggleClass('fa-check-double', !newState); // Add 'fa-square-check' when deselected
-        icon.toggleClass('fa-minus', newState);  // Add 'fa-square-minus' when selected
+        setToggleAllIcon(newState);
     });
 
     $('#bulk_enable_regex').on('click', async function () {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

---

# PR for #4169

## What is the reason for a change?
>The problem is that I have 22 regex items, and in order to select all of them in bulk edit mode I have to manually check every single one, and if I accidently move the individual regex card with mouse accidently everything get's unselected.
I want to be able to select everything to export all the regex ones.
Or I want to be able to select everything and uncheck few things and then run disable or enable.


## What did you do to achieve this?

Modified dropdown.html and index.js in public/scripts/extensions/regex.

Dropdown.html, I modified where the other buttons were located, appended a button at the beginning
![image](https://github.com/user-attachments/assets/36adf4f1-0804-4c07-b93d-dabeff5c588f)
![image](https://github.com/user-attachments/assets/fd3b740b-6da1-47ba-ae33-a5d9a53c0867)

Index.js was modified to add a function that will toggle when that button is clicked right above where the previous functions were.


## How would a reviewer test the change?
Open the drop down for Extensions, and Regex, and then have some scripts already imported, or added. Then press the new select all button, press it again to deselect.


## Notes
Used ai to generate the function for toggling.
I ran `npm run lint` and it gave an error for a file I did not modify, so ignored that.
Not sure which icons to use for the selection, so I went with fa-check-double and fa-minus.