### PR TITLE
Add support for characterFilter to getEntryField and setEntryField

### DIFF
--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2367,7 +2367,7 @@ export function findChar({ name = null, allowAvatar = true, insensitive = true, 
 
     // If allowAvatar is true, search by avatar first
     if (allowAvatar && name) {
-        const characterByAvatar = filteredCharacters.find(char => char.avatar === name);
+        const characterByAvatar = filteredCharacters.find(char => char.avatar === name || (!name.endsWith('.png') && char.avatar === `${name}.png`));
         if (characterByAvatar) {
             return characterByAvatar;
         }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1260,10 +1260,15 @@ function registerWorldInfoSlashCommands() {
 
         // handle special cases, otherwise execute default logic
         let tagNames;
+        let charNames;
         switch (field){
             case 'characterFilterNames':
                 createCharacterFilterFieldObjectIfNeeded(entry);
-                entry.characterFilter.names = parseStringArray(value);
+                charNames = parseStringArray(value);
+                entry.characterFilter.names = charNames
+                    .map((name) => getCharaFilename(null, { manualAvatarKey: findChar({ name, allowAvatar: true, preferCurrentChar: false, quiet: true })?.avatar }))
+                    .filter(Boolean)
+                    .filter(onlyUnique);
                 setWIOriginalDataValue(data, uid, 'character_filter', entry.characterFilter);
                 break;
             case 'characterFilterTags':

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1413,7 +1413,7 @@ function registerWorldInfoSlashCommands() {
     const localEnumProviders = {
         /** All possible fields that can be set in a WI entry */
         wiEntryFields: () => Object.entries(newWorldInfoEntryDefinition).map(([key, value]) =>
-            new SlashCommandEnumValue(key, `[${value.type}] default: ${(typeof value.default === 'string' ? `'${value.default}'` : value.default)}`,
+            new SlashCommandEnumValue(key, `[${value.type}] default: ${(typeof value.default === 'string' ? `'${value.default}'` : JSON.stringify(value.default))}`,
                 enumTypes.enum, enumIcons.getDataTypeIcon(value.type))),
 
         /** All existing UIDs based on the file argument as world name */

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1124,6 +1124,7 @@ function registerWorldInfoSlashCommands() {
     async function getEntryFieldCallback(args, uid) {
         const file = args.file;
         const field = args.field || 'content';
+        const tags = getContext().tags;
 
         const entries = await getEntriesFromFile(file);
 
@@ -1143,7 +1144,31 @@ function registerWorldInfoSlashCommands() {
             return '';
         }
 
-        const fieldValue = entry[field];
+        // handle special cases, otherwise execute default logic
+        let fieldValue;
+        switch (field){
+            case 'characterFilterNames':
+                if (entry.characterFilter) {
+                    fieldValue = entry.characterFilter.names;
+                }
+                break;
+            case 'characterFilterTags':
+                if (entry.characterFilter) {
+                    if (!entry.characterFilter.tags) {
+                        return '';
+                    }
+                    //Find the tag objects corresponding to each ID in the array, then return the names
+                    fieldValue = tags.filter((tag) => entry.characterFilter.tags.includes(tag.id)).map((tag) => tag.name);
+                }
+                break;
+            case 'characterFilterExclude':
+                if (entry.characterFilter) {
+                    fieldValue = entry.characterFilter.isExclude;
+                }
+                break;
+            default:
+                fieldValue = entry[field];
+        }
 
         if (fieldValue === undefined) {
             return '';
@@ -1189,6 +1214,23 @@ function registerWorldInfoSlashCommands() {
         const file = args.file;
         const uid = args.uid;
         const field = args.field || 'content';
+        const tags = getContext().tags;
+
+        // characterFilter is an object with internal fields we need to access, which may also may be null and need to be populated
+        const createCharacterFilterfieldObjectIfNeeded = (currentEntry) => {
+            if (!currentEntry.characterFilter) {
+                Object.assign(
+                    currentEntry,
+                    {
+                        characterFilter: {
+                            isExclude: false,
+                            names: [],
+                            tags: [],
+                        },
+                    },
+                );
+            }
+        };
 
         if (value === undefined) {
             toastr.warning('Value is required');
@@ -1216,18 +1258,40 @@ function registerWorldInfoSlashCommands() {
             return '';
         }
 
-        if (Array.isArray(entry[field])) {
-            entry[field] = parseStringArray(value);
-        } else if (typeof entry[field] === 'boolean') {
-            entry[field] = isTrueBoolean(value);
-        } else if (typeof entry[field] === 'number') {
-            entry[field] = Number(value);
-        } else {
-            entry[field] = value;
-        }
+        // handle special cases, otherwise execute default logic
+        let tagNames;
+        switch (field){
+            case 'characterFilterNames':
+                createCharacterFilterfieldObjectIfNeeded(entry);
+                entry.characterFilter.names = parseStringArray(value);
+                setWIOriginalDataValue(data, uid, 'character_filter', entry.characterFilter);
+                break;
+            case 'characterFilterTags':
+                createCharacterFilterfieldObjectIfNeeded(entry);
+                tagNames = parseStringArray(value);
+                //Find the tag objects corresponding to each name in the user array, then return an array of the corresponding IDs
+                entry.characterFilter.tags = tags.filter((tag) => tagNames.includes(tag.name)).map((tag) => tag.id);
+                setWIOriginalDataValue(data, uid, 'character_filter', entry.characterFilter);
+                break;
+            case 'characterFilterExclude':
+                createCharacterFilterfieldObjectIfNeeded(entry);
+                entry.characterFilter.isExclude = isTrueBoolean(value);
+                setWIOriginalDataValue(data, uid, 'character_filter', entry.characterFilter);
+                break;
+            default:
+                if (Array.isArray(entry[field])) {
+                    entry[field] = parseStringArray(value);
+                } else if (typeof entry[field] === 'boolean') {
+                    entry[field] = isTrueBoolean(value);
+                } else if (typeof entry[field] === 'number') {
+                    entry[field] = Number(value);
+                } else {
+                    entry[field] = value;
+                }
 
-        if (originalWIDataKeyMap[field]) {
-            setWIOriginalDataValue(data, uid, originalWIDataKeyMap[field], entry[field]);
+                if (originalWIDataKeyMap[field]) {
+                    setWIOriginalDataValue(data, uid, originalWIDataKeyMap[field], entry[field]);
+                }
         }
 
         await saveWorldInfo(file, data);
@@ -3578,6 +3642,9 @@ export const newWorldInfoEntryDefinition = {
     sticky: { default: null, type: 'number?' },
     cooldown: { default: null, type: 'number?' },
     delay: { default: null, type: 'number?' },
+    characterFilterNames: { default: [], type: 'array' },
+    characterFilterTags: { default: [], type: 'array' },
+    characterFilterExclude: { default: false, type: 'boolean' },
 };
 
 export const newWorldInfoEntryTemplate = Object.fromEntries(

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1217,7 +1217,7 @@ function registerWorldInfoSlashCommands() {
         const tags = getContext().tags;
 
         // characterFilter is an object with internal fields we need to access, which may also may be null and need to be populated
-        const createCharacterFilterfieldObjectIfNeeded = (currentEntry) => {
+        const createCharacterFilterFieldObjectIfNeeded = (currentEntry) => {
             if (!currentEntry.characterFilter) {
                 Object.assign(
                     currentEntry,
@@ -1262,19 +1262,19 @@ function registerWorldInfoSlashCommands() {
         let tagNames;
         switch (field){
             case 'characterFilterNames':
-                createCharacterFilterfieldObjectIfNeeded(entry);
+                createCharacterFilterFieldObjectIfNeeded(entry);
                 entry.characterFilter.names = parseStringArray(value);
                 setWIOriginalDataValue(data, uid, 'character_filter', entry.characterFilter);
                 break;
             case 'characterFilterTags':
-                createCharacterFilterfieldObjectIfNeeded(entry);
+                createCharacterFilterFieldObjectIfNeeded(entry);
                 tagNames = parseStringArray(value);
                 //Find the tag objects corresponding to each name in the user array, then return an array of the corresponding IDs
                 entry.characterFilter.tags = tags.filter((tag) => tagNames.includes(tag.name)).map((tag) => tag.id);
                 setWIOriginalDataValue(data, uid, 'character_filter', entry.characterFilter);
                 break;
             case 'characterFilterExclude':
-                createCharacterFilterfieldObjectIfNeeded(entry);
+                createCharacterFilterFieldObjectIfNeeded(entry);
                 entry.characterFilter.isExclude = isTrueBoolean(value);
                 setWIOriginalDataValue(data, uid, 'character_filter', entry.characterFilter);
                 break;

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -864,7 +864,7 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
             // Search through title and messages of the chat
             const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
             const text = [path.parse(chatFile.path).name,
-            ...messages.map(message => message?.mes)].join('\n').toLowerCase();
+                ...messages.map(message => message?.mes)].join('\n').toLowerCase();
             const hasMatch = fragments.every(fragment => text.includes(fragment));
 
             if (hasMatch) {

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -863,8 +863,7 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
 
             // Search through title and messages of the chat
             const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
-            const text = [path.parse(chatFile.path).name,
-                ...messages.map(message => message?.mes)].join('\n').toLowerCase();
+            const text = [path.parse(chatFile.path).name, ...messages.map(message => message?.mes)].join('\n').toLowerCase();
             const hasMatch = fragments.every(fragment => text.includes(fragment));
 
             if (hasMatch) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Adds support for the character filter fields to getEntryField and setEntryField, which were not previously supported. Should be pretty straightforward, except for tags- these are stored in the WI entry by ID, but need to be converted to  and from names to be usable in STScript. Main logic was to add user-visible field aliases for each sub-field of the characterFilter, then catch these special case fields, create a new characterFilter object if it's not present, and populate it as per the user input. For all other fields, proceed as before. The switch statements should be reusable for any future GUI/data divergences.

Tested locally on good and bad data, and did a smoke test on existing fields. Full testing should include making sure that the newly supported WI fields can be read and written to, and that no existing fields cause issues on these commands.

Also fixed an existing indentation lint error in chats.js, because it was there and somebody had to.