### PR TITLE
KoboldAI Instruct format preset

### DIFF
--- a/default/content/index.json
+++ b/default/content/index.json
@@ -688,6 +688,10 @@
         "type": "instruct"
     },
     {
+        "filename": "presets/instruct/KoboldAI.json",
+        "type": "instruct"
+    },
+    {
         "filename": "presets/context/Llama-3-Instruct-Names.json",
         "type": "context"
     },

--- a/default/content/presets/instruct/KoboldAI.json
+++ b/default/content/presets/instruct/KoboldAI.json
@@ -1,0 +1,22 @@
+{
+    "input_sequence": "{{[INPUT]}}",
+    "output_sequence": "{{[OUPUT]}}",
+    "last_output_sequence": "",
+    "system_sequence": "{{[SYSTEM]}}",
+    "stop_sequence": "",
+    "wrap": true,
+    "macro": true,
+    "names_behavior": "force",
+    "activation_regex": "",
+    "system_sequence_prefix": "",
+    "system_sequence_suffix": "",
+    "first_output_sequence": "",
+    "skip_examples": false,
+    "output_suffix": "{{[OUTPUT_END]}}",
+    "input_suffix": "{{[INPUT_END]}}",
+    "system_suffix": "{{[SYSTEM_END]}}",
+    "user_alignment_message": "",
+    "system_same_as_user": false,
+    "last_system_sequence": "",
+    "name": "KoboldAI"
+}


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

This is a simple PR bringing KoboldAI's instruct format to SillyTavern's presets. This format has a few unique advantages.
- While currently no models are trained on it most models can handle this format as it was designed to be easy to understand for the LLM and easy to write manually.
- KoboldCpp uses this format as its placeholder format on the backend level, this automatically makes it compatible with every KoboldCpp model without the user having to guess.

Since KoboldCpp 1.94 replace_instruct_placeholders is set to true by default making this format effective on updated KoboldCpp horde workers as well as up to date instances of KoboldCpp. The feature has been around for a while but was not the default, if you like it to be compatible with more KoboldCpp versions you can send replace_instruct_placeholders true in the json call (Horde does not have this but this should be fine once workers update). I left that out in the PR.

Of course we retain the ability to work with the existing formats, but this specific setting should be ideal for text generation on KoboldCpp and Horde moving forward. Non KoboldCpp (or outdated) workers should understand it to a similar degree as alpaca.