### PR TITLE
Fix video attachment for MKV files

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -214,7 +214,11 @@ export async function populateFileAttachment(message, inputId = 'file_form_input
         }
         // If file is video
         else if (file.type.startsWith('video/')) {
-            const extension = file.type.split('/')[1];
+            let extension = file.type.split('/')[1];
+            // Special handling for MKV files, as the server expects 'mkv' not 'x-matroska'.
+            if (extension === 'x-matroska') {
+                extension = 'mkv';
+            }
             const videoUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
             message.extra.video = videoUrl;
         } else {


### PR DESCRIPTION
**1. Reason for the change**
Previously, MKV video files failed to upload as attachments. This was due to a mismatch between the client-side and server-side handling of MKV file extensions. The client-side code, when processing a `video/x-matroska` MIME type (common for MKV files), extracted the extension as `x-matroska`. However, the server-side validation in `src/endpoints/images.js` only recognized and accepted `mkv` as a valid format for Matroska video files. This discrepancy led to upload failures for all MKV files.

**2. What was done to achieve this**
The `populateFileAttachment` function in [`public/scripts/chats.js`](public/scripts/chats.js) has been modified. Specifically, within the `else if (file.type.startsWith('video/'))` block, a conditional check was added. If the extracted `extension` is `x-matroska`, it is now explicitly converted to `mkv` before being sent to the server via the `saveBase64AsFile` function. This ensures that the server receives the expected `mkv` extension, allowing the upload to proceed successfully.

**3. How to test the change**
To test this change, follow these steps:
*   Navigate to the chat interface.
*   Attempt to upload an MKV video file as an attachment.
*   Verify that the MKV file uploads successfully and is displayed correctly in the chat.
*   (Optional) Test with other supported video formats (e.g., MP4, AVI) to ensure existing functionality is not regressed.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
