### PR TITLE
Refactor saveBase64AsFile uploads

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -43,6 +43,7 @@ import {
     extractTextFromOffice,
     download,
     getFileText,
+    getFileExtension,
 } from './utils.js';
 import { extension_settings, renderExtensionTemplateAsync, saveMetadataDebounced } from './extensions.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
@@ -204,7 +205,7 @@ export async function populateFileAttachment(message, inputId = 'file_form_input
         const fileNamePrefix = `${Date.now()}_${slug}`;
         const fileBase64 = await getBase64Async(file);
         let base64Data = fileBase64.split(',')[1];
-        const extension = file.name.substring((file.name.lastIndexOf('.') + file.name.length) % file.name.length + 1);
+        const extension = getFileExtension(file);
 
         // If file is image
         if (file.type.startsWith('image/')) {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -247,6 +247,7 @@ export async function populateFileAttachment(message, inputId = 'file_form_input
 
     } catch (error) {
         console.error('Could not upload file', error);
+        toastr.error(t`Either the file is corrupted or its format is not supported.`, t`Could not upload the file`);
     } finally {
         $('#file_form').trigger('reset');
     }

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -27,4 +27,4 @@ export const IGNORE_SYMBOL = Symbol.for('ignore');
  * Common video file extensions. Should be the same as supported by Gemini.
  * https://ai.google.dev/gemini-api/docs/video-understanding#supported-formats
  */
-export const VIDEO_EXTENSIONS = ['mp4', 'avi', 'mov', 'wmv', 'flv', 'webm', '3gp', 'mkv'];
+export const VIDEO_EXTENSIONS = ['mp4', 'avi', 'mov', 'wmv', 'flv', 'webm', '3gp', 'mkv', 'mpg'];

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -1,4 +1,4 @@
-import { ensureImageFormatSupported, getBase64Async, isTrueBoolean, saveBase64AsFile } from '../../utils.js';
+import { ensureImageFormatSupported, getBase64Async, getFileExtension, isTrueBoolean, saveBase64AsFile } from '../../utils.js';
 import { getContext, getApiUrl, doExtrasFetch, extension_settings, modules, renderExtensionTemplateAsync } from '../../extensions.js';
 import { appendMediaToMessage, eventSource, event_types, getRequestHeaders, saveChatConditional, saveSettingsDebounced, substituteParamsExtended } from '../../../script.js';
 import { getMessageTimeStamp } from '../../RossAscends-mods.js';
@@ -327,11 +327,11 @@ async function getCaptionForFile(file, prompt, quiet) {
         setSpinnerIcon();
         const context = getContext();
         const fileData = await getBase64Async(await ensureImageFormatSupported(file));
-        const base64Format = fileData.split(',')[0].split(';')[0].split('/')[1];
+        const extension = getFileExtension(file);
         const base64Data = fileData.split(',')[1];
         const { caption } = await doCaptionRequest(base64Data, fileData, prompt);
         if (!quiet) {
-            const imagePath = await saveBase64AsFile(base64Data, context.name2, '', base64Format);
+            const imagePath = await saveBase64AsFile(base64Data, context.name2, '', extension);
             await sendCaptionedMessage(caption, imagePath);
         }
         return caption;

--- a/public/scripts/extensions/gallery/index.js
+++ b/public/scripts/extensions/gallery/index.js
@@ -8,7 +8,7 @@ import {
     animation_easing,
 } from '../../../script.js';
 import { groups, selected_group } from '../../group-chats.js';
-import { loadFileToDocument, delay, getBase64Async, getSanitizedFilename } from '../../utils.js';
+import { loadFileToDocument, delay, getBase64Async, getSanitizedFilename, saveBase64AsFile, getFileExtension } from '../../utils.js';
 import { loadMovingUIState } from '../../power-user.js';
 import { dragElement } from '../../RossAscends-mods.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
@@ -341,27 +341,12 @@ async function showCharGallery(deleteModeState = false) {
 async function uploadFile(file, url) {
     try {
         // Convert the file to a base64 string
-        const base64Data = await getBase64Async(file);
+        const fileBase64 = await getBase64Async(file);
+        const base64Data = fileBase64.split(',')[1];
+        const extension = getFileExtension(file);
+        const path = await saveBase64AsFile(base64Data, url, '', extension);
 
-        // Create the payload
-        const payload = {
-            image: base64Data,
-            ch_name: url,
-        };
-
-        const response = await fetch('/api/images/upload', {
-            method: 'POST',
-            headers: getRequestHeaders(),
-            body: JSON.stringify(payload),
-        });
-
-        if (!response.ok) {
-            throw new Error(`HTTP error! Status: ${response.status}`);
-        }
-
-        const result = await response.json();
-
-        toastr.success(t`File uploaded successfully. Saved at: ${result.path}`);
+        toastr.success(t`File uploaded successfully. Saved at: ${path}`);
     } catch (error) {
         console.error('There was an issue uploading the file:', error);
 

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -38,10 +38,14 @@ export async function getMultimodalCaption(base64Img, prompt) {
     const isVllm = extension_settings.caption.multimodal_api === 'vllm';
     const base64Bytes = base64Img.length * 0.75;
     const compressionLimit = 2 * 1024 * 1024;
+    const safeMimeTypes = ['image/jpeg', 'image/png', 'image/webp'];
+    const mimeType = base64Img?.split(';')?.[0]?.split(':')?.[1];
     const thumbnailNeeded = ['google', 'openrouter', 'mistral', 'groq', 'vertexai'].includes(extension_settings.caption.multimodal_api);
     if ((thumbnailNeeded && base64Bytes > compressionLimit) || isOoba || isKoboldCpp) {
-        const maxSide = 1024;
-        base64Img = await createThumbnail(base64Img, maxSide, maxSide, 'image/jpeg');
+        const maxSide = 2048;
+        base64Img = await createThumbnail(base64Img, maxSide, maxSide);
+    } else if (!safeMimeTypes.includes(mimeType)) {
+        base64Img = await createThumbnail(base64Img, null, null);
     }
 
     const proxyUrl = useReverseProxy ? oai_settings.reverse_proxy : '';

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2949,13 +2949,15 @@ class Message {
             chat_completion_sources.MISTRALAI,
             chat_completion_sources.VERTEXAI,
         ];
-        if (compressImageSources.includes(oai_settings.chat_completion_source)) {
-            const sizeThreshold = 2 * 1024 * 1024;
-            const dataSize = image.length * 0.75;
-            const maxSide = 1024;
-            if (dataSize > sizeThreshold) {
-                image = await createThumbnail(image, maxSide);
-            }
+        const sizeThreshold = 2 * 1024 * 1024;
+        const dataSize = image.length * 0.75;
+        const safeMimeTypes = ['image/jpeg', 'image/png', 'image/webp'];
+        const mimeType = image?.split(';')?.[0]?.split(':')?.[1];
+        if (compressImageSources.includes(oai_settings.chat_completion_source) && dataSize > sizeThreshold) {
+            const maxSide = 2048;
+            image = await createThumbnail(image, maxSide, maxSide);
+        } else if (!safeMimeTypes.includes(mimeType)) {
+            image = await createThumbnail(image, null, null);
         }
         return image;
     }

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1410,32 +1410,27 @@ export async function getSanitizedFilename(fileName) {
  * Sends a base64 encoded image to the backend to be saved as a file.
  *
  * @param {string} base64Data - The base64 encoded image data.
- * @param {string} characterName - The character name to determine the sub-directory for saving.
- * @param {string} ext - The file extension for the image (e.g., 'jpg', 'png', 'webp').
+ * @param {string} subFolder - The character name to determine the sub-directory for saving.
+ * @param {string} fileName - The name of the file to save the image as (without extension).
+ * @param {string} extension - The file extension for the image (e.g., 'jpg', 'png', 'webp').
  *
  * @returns {Promise<string>} - Resolves to the saved image's path on the server.
  *                              Rejects with an error if the upload fails.
  */
-export async function saveBase64AsFile(base64Data, characterName, filename = '', ext) {
-    // Construct the full data URL
-    const format = ext; // Extract the file extension (jpg, png, webp)
-    const dataURL = `data:image/${format};base64,${base64Data}`;
-
+export async function saveBase64AsFile(base64Data, subFolder, fileName, extension) {
     // Prepare the request body
     const requestBody = {
-        image: dataURL,
-        ch_name: characterName,
-        filename: String(filename).replace(/\./g, '_'),
+        image: base64Data,
+        format: extension,
+        ch_name: subFolder,
+        filename: String(fileName).replace(/\./g, '_'),
     };
 
     // Send the data URL to your backend using fetch
     const response = await fetch('/api/images/upload', {
         method: 'POST',
+        headers: getRequestHeaders(),
         body: JSON.stringify(requestBody),
-        headers: {
-            ...getRequestHeaders(),
-            'Content-Type': 'application/json',
-        },
     });
 
     // If the response is successful, get the saved image path from the server's response
@@ -1446,6 +1441,15 @@ export async function saveBase64AsFile(base64Data, characterName, filename = '',
         const errorData = await response.json();
         throw new Error(errorData.error || 'Failed to upload the image to the server');
     }
+}
+
+/**
+ * Gets the file extension from a File object.
+ * @param {File} file The file to get the extension from
+ * @returns {string} The file extension of the given file
+ */
+export function getFileExtension(file) {
+    return file.name.substring((file.name.lastIndexOf('.') + file.name.length) % file.name.length + 1);
 }
 
 /**

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1558,10 +1558,16 @@ export function createThumbnail(dataUrl, maxWidth = null, maxHeight = null, type
                 maxHeight = img.height;
             }
 
-            if (img.width > img.height) {
-                thumbnailHeight = maxWidth / aspectRatio;
+            // Do not upscale if image is already smaller than max dimensions
+            if (img.width <= maxWidth && img.height <= maxHeight) {
+                thumbnailWidth = img.width;
+                thumbnailHeight = img.height;
             } else {
-                thumbnailWidth = maxHeight * aspectRatio;
+                if (img.width > img.height) {
+                    thumbnailHeight = maxWidth / aspectRatio;
+                } else {
+                    thumbnailWidth = maxHeight * aspectRatio;
+                }
             }
 
             // Set the canvas dimensions and draw the resized image

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1573,6 +1573,10 @@ export function createThumbnail(dataUrl, maxWidth = null, maxHeight = null, type
             // Set the canvas dimensions and draw the resized image
             canvas.width = thumbnailWidth;
             canvas.height = thumbnailHeight;
+            ctx.imageSmoothingEnabled = true;
+            ctx.imageSmoothingQuality = 'high';
+            ctx.fillStyle = 'white';
+            ctx.fillRect(0, 0, thumbnailWidth, thumbnailHeight);
             ctx.drawImage(img, 0, 0, thumbnailWidth, thumbnailHeight);
 
             // Convert the canvas to a data URL and resolve the promise

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1449,7 +1449,7 @@ export async function saveBase64AsFile(base64Data, subFolder, fileName, extensio
  * @returns {string} The file extension of the given file
  */
 export function getFileExtension(file) {
-    return file.name.substring((file.name.lastIndexOf('.') + file.name.length) % file.name.length + 1);
+    return file.name.substring((file.name.lastIndexOf('.') + file.name.length) % file.name.length + 1).toLowerCase().trim();
 }
 
 /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -412,3 +412,24 @@ export const LOG_LEVELS = {
     WARN: 2,
     ERROR: 3,
 };
+
+/**
+ * An array of supported media file extensions.
+ * This is used to validate file uploads and ensure that only supported media types are processed.
+ */
+export const MEDIA_EXTENSIONS = [
+    'png',
+    'jpg',
+    'webp',
+    'jpeg',
+    'gif',
+    'mp4',
+    'avi',
+    'mov',
+    'wmv',
+    'flv',
+    'webm',
+    '3gp',
+    'mkv',
+    'mpg',
+];

--- a/src/constants.js
+++ b/src/constants.js
@@ -418,6 +418,7 @@ export const LOG_LEVELS = {
  * This is used to validate file uploads and ensure that only supported media types are processed.
  */
 export const MEDIA_EXTENSIONS = [
+    'bmp',
     'png',
     'jpg',
     'webp',

--- a/src/constants.js
+++ b/src/constants.js
@@ -422,6 +422,7 @@ export const MEDIA_EXTENSIONS = [
     'jpg',
     'webp',
     'jpeg',
+    'jfif',
     'gif',
     'mp4',
     'avi',

--- a/src/endpoints/images.js
+++ b/src/endpoints/images.js
@@ -6,6 +6,7 @@ import express from 'express';
 import sanitize from 'sanitize-filename';
 
 import { clientRelativePath, removeFileExtension, getImages, isPathUnderParent } from '../util.js';
+import { MEDIA_EXTENSIONS } from '../constants.js';
 
 /**
  * Ensure the directory for the provided file path exists.
@@ -47,7 +48,7 @@ router.post('/upload', async (request, response) => {
             return response.status(400).send({ error: 'No image data provided' });
         }
 
-        const validFormat = ['png', 'jpg', 'webp', 'jpeg', 'gif', 'mp4', 'avi', 'mov', 'wmv', 'flv', 'webm', '3gp', 'mkv'].includes(format);
+        const validFormat = MEDIA_EXTENSIONS.includes(format);
         if (!validFormat) {
             return response.status(400).send({ error: 'Invalid image format' });
         }

--- a/src/endpoints/images.js
+++ b/src/endpoints/images.js
@@ -36,16 +36,13 @@ export const router = express.Router();
  * @returns {Object} response - The response object containing the path where the image was saved.
  */
 router.post('/upload', async (request, response) => {
-    // Check for image data
-    if (!request.body || !request.body.image) {
-        return response.status(400).send({ error: 'No image data provided' });
-    }
-
     try {
-        // Extracting the base64 data and the image format
-        const splitParts = request.body.image.split(',');
-        const format = splitParts[0].split(';')[0].split('/')[1];
-        const base64Data = splitParts[1];
+        const { image, format } = request.body;
+
+        if (!image) {
+            return response.status(400).send({ error: 'No image data provided' });
+        }
+
         const validFormat = ['png', 'jpg', 'webp', 'jpeg', 'gif', 'mp4', 'avi', 'mov', 'wmv', 'flv', 'webm', '3gp', 'mkv'].includes(format);
         if (!validFormat) {
             return response.status(400).send({ error: 'Invalid image format' });
@@ -66,7 +63,7 @@ router.post('/upload', async (request, response) => {
         }
 
         ensureDirectoryExistence(pathToNewFile);
-        const imageBuffer = Buffer.from(base64Data, 'base64');
+        const imageBuffer = Buffer.from(image, 'base64');
         await fs.promises.writeFile(pathToNewFile, new Uint8Array(imageBuffer));
         response.send({ path: clientRelativePath(request.user.directories.root, pathToNewFile) });
     } catch (error) {

--- a/src/endpoints/images.js
+++ b/src/endpoints/images.js
@@ -37,6 +37,10 @@ export const router = express.Router();
  */
 router.post('/upload', async (request, response) => {
     try {
+        if (!request.body) {
+            return response.status(400).send({ error: 'No data provided' });
+        }
+
         const { image, format } = request.body;
 
         if (!image) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Unifies the use of saveBase64AsFile and its related endpoint:

1. Move get file extension to a shared util
2. Update payload format to reduce string slicing
3. Reuse the saveBase64AsFile in gallery uploads

Affected areas:

1. Gallery upload
5. Image captioning
6. Regular chat media attachments

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
