### PR TITLE
Fix default emojis expression fallback setting resetting on reload

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1331,7 +1331,7 @@ async function renderFallbackExpressionPicker() {
     defaultPicker.empty();
 
 
-    addOption(OPTION_NO_FALLBACK, '[ No fallback ]', !extension_settings.expressions.fallback_expression);
+    addOption(OPTION_NO_FALLBACK, '[ No fallback ]', !extension_settings.expressions.fallback_expression && !extension_settings.expressions.showDefault);
     addOption(OPTION_EMOJI_FALLBACK, '[ Default emojis ]', !!extension_settings.expressions.showDefault);
 
     for (const expression of expressions) {
@@ -2116,7 +2116,7 @@ function migrateSettings() {
         saveSettingsDebounced();
     }
 
-    if (extension_settings.expressions.showDefault && extension_settings.expressions.fallback_expression !== undefined) {
+    if (extension_settings.expressions.showDefault && extension_settings.expressions.fallback_expression) {
         extension_settings.expressions.showDefault = false;
         saveSettingsDebounced();
     }


### PR DESCRIPTION
Adjusts conditions to properly enforce mutual exclusivity between fallback expression and default emoji settings

- Ensures "[ No fallback ]" option only appears when both settings are inactive
- Updates migration logic to ONLY reset default emoji setting when fallback is active

Fixes #4205

-----

This was an oversight on my part. Mostly stupid because the migration logic fold "old" settings will always reset the "showDefault" flag, which indicates the emojis should be used, because `null` as the fallback expression was different than `undefined`.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
