### PR TITLE
Select2 visual bug fix

### DIFF
--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -251,34 +251,3 @@ span.select2.select2-container .select2-selection__choice__remove:hover {
     flex-wrap: wrap;
     row-gap: 5px;
 }
-
-.select2_multi_sameline+span.select2-container .select2-selection--multiple .select2-selection__choice {
-    margin-top: 0px;
-}
-
-.select2_multi_sameline+span.select2-container .select2-selection--multiple .select2-search__field {
-    /* Min height to reserve spacing */
-    min-height: calc(var(--mainFontSize) + 13px);
-    /* Min width to be clickable */
-    min-width: 4em;
-    align-content: center;
-    /* Fix search textarea alignment issue with UL elements */
-    margin-top: 0px;
-    height: unset;
-    /* Prevent height from jumping around when input is focused */
-    line-height: 1;
-}
-
-.select2_multi_sameline+span.select2-container .select2-selection--multiple .select2-selection__rendered {
-    /* Min height to reserve spacing */
-    min-height: calc(var(--mainFontSize) + 13px);
-}
-
-/* Make search bar invisible unless the select2 is active, to save space */
-.select2_multi_sameline+span.select2-container .select2-selection--multiple .select2-search--inline {
-    height: 1px;
-}
-
-.select2_multi_sameline+span.select2-container.select2-container--focus .select2-selection--multiple .select2-search--inline {
-    height: unset;
-}

--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -24,8 +24,9 @@
     margin-top: 0;  /* compensate for the increased font size */
 }
 
-.select2-container .select2-search__field {
+.select2-container .select2-search--inline textarea.select2-search__field {
     opacity: 0.8;
+    margin-top: 7px;  /* get placeholder text to the center */
 }
 
 .select2-selection--single .select2-selection__placeholder {
@@ -93,7 +94,6 @@
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 7px;
     font-family: var(--mainFontFamily);
-    padding-top: 2px;  /* keep placeholder text aligned */
 }
 
 .select2-container.select2-container--focus .select2-selection--multiple,

--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -19,10 +19,9 @@
 .select2-container .select2-selection .select2-selection__clear {
     color: var(--SmartThemeBodyColor);
     font-size: 20px;
-    padding: 0;
     position: absolute;
     right: 5px;
-    top: 0;
+    margin-top: 0;  /* compensate for the increased font size */
 }
 
 .select2-container .select2-search__field {
@@ -63,9 +62,11 @@
     background-color: var(--black30a);
     color: var(--SmartThemeBodyColor);
     border: 1px solid var(--SmartThemeBorderColor);
-    border-radius: 7px;
     font-family: var(--mainFontFamily);
     padding: 3px 5px;
+    display: unset;  /* override the ST textarea display style */
+    line-height: 1.4;  /* get placeholder text to the center */
+    border-radius: 0;  /* border radius was interfering with cursor */
 }
 
 /* Customize the selected option */
@@ -93,7 +94,6 @@
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 7px;
     font-family: var(--mainFontFamily);
-    padding: 3px 5px;
 }
 
 .select2-container.select2-container--focus .select2-selection--multiple,
@@ -229,25 +229,4 @@ span.select2.select2-container .select2-selection__choice__remove:hover {
 
 .select2_choice_clickable_buttonstyle+span.select2-container .select2-selection__choice__display:hover {
     background-color: var(--white30a);
-}
-
-/* Custom class to support same line multi inputs of select2 controls */
-.select2_multi_sameline+span.select2-container .select2-selection--multiple {
-    display: flex;
-    flex-wrap: wrap;
-}
-
-.select2_multi_sameline+span.select2-container .select2-selection--multiple .select2-search--inline {
-    /* Allow search placeholder to take up all space if needed */
-    flex-grow: 1;
-}
-
-.select2_multi_sameline+span.select2-container .select2-selection--multiple .select2-selection__rendered {
-    /* Fix weird styling choice or huge margin around selected options */
-    margin-block-start: 2px;
-    margin-block-end: 2px;
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    row-gap: 5px;
 }

--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -65,7 +65,6 @@
     font-family: var(--mainFontFamily);
     padding: 3px 5px;
     display: unset;  /* override the ST textarea display style */
-    line-height: 1.4;  /* get placeholder text to the center */
     border-radius: 0;  /* border radius was interfering with cursor */
 }
 
@@ -94,6 +93,7 @@
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 7px;
     font-family: var(--mainFontFamily);
+    padding-top: 2px;  /* keep placeholder text aligned */
 }
 
 .select2-container.select2-container--focus .select2-selection--multiple,

--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -107,7 +107,6 @@
     height: auto;
     margin-top: 0;
     margin-bottom: 0;
-    min-height: calc(var(--mainFontSize) + 14px);
 }
 
 .delete_entry_button {

--- a/public/index.html
+++ b/public/index.html
@@ -4307,7 +4307,7 @@
                                 </span>
                             </div>
                             <div class="range-block-range">
-                                <select id="world_info" class="select2_multi_sameline" multiple>
+                                <select id="world_info" multiple>
                                     <option value="" data-i18n="-- World Info not found --">-- World Info not found -- </option>
                                 </select>
                             </div>
@@ -6273,7 +6273,7 @@
                                 </span>
                             </small>
                             <small class="textAlignCenter" data-i18n="Primary Keywords">Primary Keywords</small>
-                            <select class="keyprimaryselect keyselect select2_multi_sameline" name="key" data-i18n="[placeholder]Keywords or Regexes" placeholder="Keywords or Regexes" multiple="multiple"></select>
+                            <select class="keyprimaryselect keyselect" name="key" data-i18n="[placeholder]Keywords or Regexes" placeholder="Keywords or Regexes" multiple="multiple"></select>
                             <textarea class="text_pole keyprimarytextpole mobile" name="key" rows="1" data-i18n="[placeholder]Comma separated list" placeholder="Comma separated list" style="display: none;"></textarea>
                             <button type="button" class="switch_input_type_icon" tabindex="-1" title="Switch to plaintext mode" data-i18n="[title]Switch to plaintext mode" data-icon-on="✨" data-icon-off="⌨️" data-tooltip-on="Switch to fancy mode" data-tooltip-off="Switch to plaintext mode">
                                 ⌨️
@@ -6295,7 +6295,7 @@
                                 </span>
                             </small>
                             <small class="textAlignCenter" data-i18n="Optional Filter">Optional Filter</small>
-                            <select class="keysecondaryselect keyselect select2_multi_sameline" name="keysecondary" data-i18n="[placeholder]Keywords or Regexes (ignored if empty)" placeholder="Keywords or Regexes (ignored if empty)" multiple="multiple"></select>
+                            <select class="keysecondaryselect keyselect" name="keysecondary" data-i18n="[placeholder]Keywords or Regexes (ignored if empty)" placeholder="Keywords or Regexes (ignored if empty)" multiple="multiple"></select>
                             <textarea class="text_pole keysecondarytextpole mobile" name="keysecondary" rows="1" data-i18n="[placeholder]Comma separated list (ignored if empty)" placeholder="Comma separated list (ignored if empty)" style="display: none;"></textarea>
                             <button type="button" class="switch_input_type_icon" tabindex="-1" title="Switch to plaintext mode" data-i18n="[title]Switch to plaintext mode" data-icon-on="✨" data-icon-off="⌨️" data-tooltip-on="Switch to fancy mode" data-tooltip-off="Switch to plaintext mode">
                                 ⌨️
@@ -6482,7 +6482,7 @@
                             </label>
                         </div>
                         <div class="range-block-range">
-                            <select name="characterFilter" class="select2_multi_sameline" multiple>
+                            <select name="characterFilter" multiple>
                                 <option value="" data-i18n="-- Characters not found --">
                                     -- Characters not found --
                                 </option>


### PR DESCRIPTION
## Description

I noticed a formatting issue with Select2 elements causing placeholder text to be vertically offset from center. This is slightly noticeable on Chrom/IE, and very noticeable on FF:

Firefox (v140.0):
![ff_before](https://github.com/user-attachments/assets/37953fb9-342d-4064-89c4-f0b8f3fe4947)

Chrome (v138.0.7204.50) / IE (v137.0.3296.93):
![chrome_before](https://github.com/user-attachments/assets/ea4d001e-99d8-4453-9d53-7de9acf27acd)

This PR fixes the issue, shown below:

Firefox:
![ff_after](https://github.com/user-attachments/assets/ec7fd85b-0a93-4196-921b-9e66d376684f)

Chrome/IE: 
![chrome_after](https://github.com/user-attachments/assets/dacacf87-d5b2-408d-b943-83bcc201cd83)


## Method

It took me awhile to track down what was causing this problem, but I was able to find the exact commit by going back until I no longer noticed the issue. This was the commit that introduced the bug: 70a2f71e33c338323234a3b4a62880e1fb0facb9
This commit is from over a year ago, but I've only recently noticed this problem so I have to assume that this is caused by the browsers changing since then, but I can't be sure.

Regardless, this commit appears to be solving a different issue where the select2 elements had a large margin at the bottom when adding items to it:

![old_issue](https://github.com/user-attachments/assets/9241f936-22f3-4e2b-a7cb-7d9af97ebf45)

The commit accomplishes this by assigning a class to all select2 elements (`select2_multi_sameline`) and overriding a bunch of select2 CSS. This overridden CSS is what causes the present issue.

However, I found that the original issue tackled by that commit is actually caused by the ST textarea CSS, which bled into the select2 textarea. Specifically, ST sets all textareas to `display: block` ([here](https://github.com/SillyTavern/SillyTavern/blob/28f5b74cc7b1834329d26e3798cc6b5fb22677a9/public/style.css#L1491C1-L1491C20)), which causes the extra line in the select2 element. Adding `display: unset` to the select2 textarea completely fixes that issue.

Consequently, all the extra CSS added in that commit to work around the problem was no longer necessary, and in fact removing it solved the present issue (with a few tweaks).

## Additional
- I do not have access to a mac, so this would need to be tested on Safari.
- Please let me know if there are other things that commit from a year ago solved that need to be addressed

## Checklist:
- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).