### PR TITLE
feat(elevenlabs): add new models and deprecate old ones

### DIFF
--- a/public/scripts/extensions/tts/elevenlabs.js
+++ b/public/scripts/extensions/tts/elevenlabs.js
@@ -17,7 +17,7 @@ class ElevenLabsTtsProvider {
         style_exaggeration: 0.00,
         speaker_boost: true,
         apiKey: '',
-        model: 'eleven_monolingual_v1',
+        model: 'eleven_turbo_v2_5',
         voiceMap: {},
     };
 
@@ -70,7 +70,14 @@ class ElevenLabsTtsProvider {
     }
 
     shouldInvolveExtendedSettings() {
-        return this.settings.model === 'eleven_multilingual_v2';
+        // Models that support extended settings (style_exaggeration, speaker_boost)
+        const modelsWithExtendedSettings = [
+            'eleven_v3',
+            'eleven_ttv_v3',
+            'eleven_multilingual_v2',
+            'eleven_multilingual_ttv_v2',
+        ];
+        return modelsWithExtendedSettings.includes(this.settings.model);
     }
 
     onSettingsChange() {

--- a/public/scripts/extensions/tts/elevenlabs.js
+++ b/public/scripts/extensions/tts/elevenlabs.js
@@ -28,10 +28,15 @@ class ElevenLabsTtsProvider {
             <input id="elevenlabs_tts_api_key" type="text" class="text_pole" placeholder="<API Key>"/>
             <label for="elevenlabs_tts_model">Model</label>
             <select id="elevenlabs_tts_model" class="text_pole">
-                <option value="eleven_monolingual_v1">English v1</option>
-                <option value="eleven_multilingual_v1">Multilingual v1</option>
+                <option value="eleven_v3">Eleven v3</option>
+                <option value="eleven_ttv_v3">Eleven ttv v3</option>
                 <option value="eleven_multilingual_v2">Multilingual v2</option>
-                <option value="eleven_turbo_v2">Turbo v2</option>
+                <option value="eleven_flash_v2_5">Eleven Flash v2.5</option>
+                <option value="eleven_turbo_v2_5">Turbo v2.5</option>
+                <option value="eleven_multilingual_ttv_v2">Multilingual ttv v2</option>
+                <option value="eleven_monolingual_v1">English v1 (Old)</option>
+                <option value="eleven_multilingual_v1">Multilingual v1 (Old)</option>
+                <option value="eleven_turbo_v2">Turbo v2 (Old)</option>
             </select>
             <input id="eleven_labs_connect" class="menu_button" type="button" value="Connect" />
             <label for="elevenlabs_tts_stability">Stability: <span id="elevenlabs_tts_stability_output"></span></label>


### PR DESCRIPTION
## Add New ElevenLabs TTS Models and Reorganize Model Selection

### What is the reason for this change?
ElevenLabs has released several new and improved TTS models that offer better quality, speed, and functionality compared to the older models. Users should have access to these newer models while still being able to use the legacy ones if needed.

https://elevenlabs.io/docs/models

### What did you do to achieve this?
- **Added new ElevenLabs models:**
  - `eleven_v3` - Eleven v3 (latest general-purpose model)
  - `eleven_ttv_v3` - Eleven ttv v3 (text-to-voice optimized)
  - `eleven_flash_v2_5` - Eleven Flash v2.5 (fast generation)
  - `eleven_turbo_v2_5` - Turbo v2.5 (updated turbo model)
  - `eleven_multilingual_ttv_v2` - Multilingual ttv v2 (multilingual text-to-voice)

- **Reorganized model dropdown:**
  - Moved newer, recommended models to the top
  - Added "(Old)" suffix to legacy models (`eleven_monolingual_v1`, `eleven_multilingual_v1`, `eleven_turbo_v2`)
  - Maintained backward compatibility - all existing models still available

### How can a reviewer test this change?
1. Navigate to **Extensions** → **TTS** → **ElevenLabs**
2. Open the **Model** dropdown
3. Verify that:
   - New models appear at the top of the list
   - Old models are marked with "(Old)" and appear at the bottom
   - All models are selectable and functional
   - Existing user configurations continue to work

### Additional Notes
- This change maintains full backward compatibility
- Users with existing configurations using older models will continue to work seamlessly
- The reorganization provides better UX by presenting the best options first

---

**Target Branch:** `staging` (as per contributing guidelines for new features)

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
