### PR TITLE
Add URL support to set bg command

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -4204,7 +4204,13 @@ async function setBackgroundCallback(_, bg) {
         const isAbsoluteUrl = isValidUrl(bg);
 
         if (isAbsoluteUrl) {
-            const isExternal = new URL(bg, window.location.origin).origin !== window.location.origin;
+            const parsedUrl = new URL(bg);
+            const isValidProtocol = ['http:', 'https:', 'data:'].includes(parsedUrl.protocol);
+            if (!isValidProtocol) {
+                toastr.error('Invalid protocol for background URL.');
+                return '';
+            }
+            const isExternal = parsedUrl.origin !== window.location.origin;
             const externalMediaAllowed = isExternalMediaAllowed();
             if (isExternal && !externalMediaAllowed) {
                 toastr.error('External media is not allowed. Please enable it in the settings to use this background.');

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2462,3 +2462,22 @@ export function clearInfoBlock(target) {
         infoBlock.innerHTML = '';
     }
 }
+
+/**
+ * Checks if a URL is fetchable by making a HEAD request.
+ * @param {string|URL} url - The URL to check for fetchability
+ * @returns {Promise<boolean>} Returns true if the URL is fetchable, false otherwise.
+ */
+export async function isFetchableUrl(url) {
+    try {
+        const result = await fetch(url, {
+            method: 'HEAD',
+            cache: 'force-cache',
+        });
+
+        return result.ok;
+    } catch (error) {
+        console.error(`Error checking fetchability of ${url}:`, error);
+        return false;
+    }
+}


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

More juice for the `/bg` command:

1. Allow data URI images
2. Allow same origin URLs
3. Allow external URLs if a toggle is properly set

All 3 types save to the chat backgrounds list, but since they can't be copied directly, they will be opened for download in a new tab instead.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
