### PR TITLE
Bugfix - Clicking on tag view list toggles checkbox

### DIFF
--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -2012,7 +2012,12 @@ export function initTags() {
     $(document).on('click', '#rm_button_group_chats', onGroupCreateClick);
     $(document).on('click', '.tag_remove', onTagRemoveClick);
     $(document).on('input', '.tag_input', onTagInput);
-    $(document).on('click', '.tags_view', onViewTagsListClick);
+    $(document).on('click', '.tags_view', function (event) {
+        // 1. Prevent the label from toggling the checkbox
+        event.preventDefault();
+        // 2. Open the guide dialog
+        onViewTagsListClick();
+    });
     $(document).on('click', '.tag_delete', onTagDeleteClick);
     $(document).on('click', '.tag_as_folder', onTagAsFolderClick);
     $(document).on('input', '.tag_view_name', onTagRenameInput);

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -2015,7 +2015,7 @@ export function initTags() {
     $(document).on('click', '.tags_view', function (event) {
         // 1. Prevent the label from toggling the checkbox
         event.preventDefault();
-        // 2. Open the guide dialog
+        // 2. Open the tag view list dialog
         onViewTagsListClick();
     });
     $(document).on('click', '.tag_delete', onTagDeleteClick);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

---

# What is the reason for a change?

There is a bug that if you click on the button next to 'Tags as Folders' it will both open the dialog and also toggle the checkbox. This makes it so both can be activated independently, as is expected.

According to Jeremy:

"The issue you're facing is due to the default behavior of the <label> element, which triggers its associated input when clicked anywhere within its bounds."

# What did you do to achieve this?

Changed the function to call event.preventDefault(); before calling the function to call the popup.

# How would a reviewer test the change?

Click on the button next to it and see if the dialog opens without toggling the checkbox.

![image](https://github.com/user-attachments/assets/b6f807cc-d789-4583-8a19-4af21843f059)

