### PR TITLE
Non-streaming narrate by paragraphs setting now actually works automatically regardless of streaming-related settings. Resolves #4228.

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -866,7 +866,7 @@ async function onMessageEvent(messageId, lastCharIndex) {
 
     console.debug(`Adding message from ${message.name} for TTS processing: "${message.mes}"`);
 
-    if (extension_settings.tts.periodic_auto_generation) {
+    if (extension_settings.tts.periodic_auto_generation && isStreamingEnabled()) {
         ttsJobQueue.push(message);
     } else {
         processAndQueueTtsMessage(message);


### PR DESCRIPTION
Non-streaming narrate by paragraphs setting now actually works automatically regardless of streaming-related settings. Resolves #4228.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
