### PR TITLE
Fix FAL.AI models list endpoint

### DIFF
--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -1154,28 +1154,44 @@ const falai = express.Router();
 falai.post('/models', async (_request, response) => {
     try {
         const modelsUrl = new URL('https://fal.ai/api/models?categories=text-to-image');
-        const result = await fetch(modelsUrl);
+        let page = 1;
+        let modelsResponse;
+        let models = [];
 
-        if (!result.ok) {
-            console.warn('FAL.AI returned an error.', result.status, result.statusText);
-            throw new Error('FAL.AI request failed.');
-        }
+        do {
+            modelsUrl.searchParams.set('page', page.toString());
+            const result = await fetch(modelsUrl);
 
-        const data = await result.json();
+            if (!result.ok) {
+                console.warn('FAL.AI returned an error.', result.status, result.statusText);
+                throw new Error('FAL.AI request failed.');
+            }
 
-        if (!Array.isArray(data)) {
-            console.warn('FAL.AI returned invalid data.');
-            throw new Error('FAL.AI request failed.');
-        }
 
-        const models = data
-            .filter(x => !x.title.toLowerCase().includes('inpainting') &&
-                !x.title.toLowerCase().includes('control') &&
-                !x.title.toLowerCase().includes('upscale') &&
-                !x.title.toLowerCase().includes('lora'))
+            modelsResponse = await result.json();
+            if (!('items' in modelsResponse) || !Array.isArray(modelsResponse.items)) {
+                console.warn('FAL.AI returned invalid data.');
+                throw new Error('FAL.AI request failed.');
+            }
+
+            models = models.concat(
+                modelsResponse.items.filter(
+                    x => (
+                        !x.title.toLowerCase().includes('inpainting') &&
+                        !x.title.toLowerCase().includes('control') &&
+                        !x.title.toLowerCase().includes('upscale') &&
+                        !x.title.toLowerCase().includes('lora')
+                    ),
+                ),
+            );
+
+            page = modelsResponse.page + 1;
+        } while (modelsResponse != null && page < modelsResponse.pages);
+
+        const modelOptions = models
             .sort((a, b) => a.title.localeCompare(b.title))
             .map(x => ({ value: x.modelUrl.split('fal-ai/')[1], text: x.title }));
-        return response.send(models);
+        return response.send(modelOptions);
     } catch (error) {
         console.error(error);
         return response.sendStatus(500);


### PR DESCRIPTION
The FAL.AI endpoint seems to have switched to a paginated format where the results are nested under an `items` key. This updates the endpoint handler to fetch all pages and extract the model options correctly.

Example response from `GET https://fal.ai/api/models?categories=text-to-image`: https://gist.github.com/jenrzzz/f4cdedf9bea4521362df2809e2013943
## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
