### PR TITLE
Preset Manager: Add methods for reading/writing custom data

### DIFF
--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -44,6 +44,7 @@ export const kai_settings = {
     seed: -1,
     api_server: '',
     preset_settings: 'gui',
+    extensions: {},
 };
 
 /**
@@ -130,6 +131,11 @@ export function loadKoboldSettings(data, preset, settings) {
 
 function loadKoboldSettingsFromPreset(preset) {
     for (const name of Object.keys(kai_settings)) {
+        if (name === 'extensions') {
+            kai_settings.extensions = preset.extensions || {};
+            continue;
+        }
+
         const value = preset[name] ?? defaultValues[name];
         const slider = sliders.find(x => x.name === name);
 

--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -56,6 +56,7 @@ export const nai_settings = {
     banned_tokens: '',
     order: default_order,
     logit_bias: [],
+    extensions: {},
 };
 
 const nai_tiers = {
@@ -205,6 +206,7 @@ export function loadNovelPreset(preset) {
     nai_settings.math1_temp = preset.math1_temp || 1;
     nai_settings.math1_quad = preset.math1_quad || 0;
     nai_settings.math1_quad_entropy_scale = preset.math1_quad_entropy_scale || 0;
+    nai_settings.extensions = preset.extensions || {};
     loadNovelSettingsUi(nai_settings);
 }
 

--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -141,6 +141,7 @@ export function convertNovelPreset(data) {
         math1_quad_entropy_scale: data.parameters.math1_quad_entropy_scale,
         min_p: data.parameters.min_p,
         order: Array.isArray(data.parameters.order) ? data.parameters.order.filter(s => s.enabled && Object.keys(samplers).includes(s.id)).map(s => samplers[s.id]) : default_order,
+        extensions: {},
     };
 }
 

--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -260,6 +260,7 @@ export function loadNovelSettings(data, settings) {
     nai_settings.math1_temp = settings.math1_temp || 1;
     nai_settings.math1_quad = settings.math1_quad || 0;
     nai_settings.math1_quad_entropy_scale = settings.math1_quad_entropy_scale || 0;
+    nai_settings.extensions = settings.extensions || {};
     loadNovelSettingsUi(nai_settings);
 }
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -332,6 +332,7 @@ export const settingsToUpdate = {
     n: ['#n_openai', 'n', false, false],
     bypass_status_check: ['#openai_bypass_status_check', 'bypass_status_check', true, true],
     request_images: ['#openai_request_images', 'request_images', true, false],
+    extensions: ['#NULL_SELECTOR', 'extensions', false, false],
 };
 
 const default_settings = {
@@ -421,6 +422,7 @@ const default_settings = {
     seed: -1,
     n: 1,
     bind_preset_to_connection: true,
+    extensions: {},
 };
 
 const oai_settings = {
@@ -510,6 +512,7 @@ const oai_settings = {
     seed: -1,
     n: 1,
     bind_preset_to_connection: true,
+    extensions: {},
 };
 
 export let proxies = [
@@ -3582,6 +3585,7 @@ function loadOpenAISettings(data, settings) {
     oai_settings.function_calling = settings.function_calling ?? default_settings.function_calling;
     oai_settings.openrouter_providers = settings.openrouter_providers ?? default_settings.openrouter_providers;
     oai_settings.bind_preset_to_connection = settings.bind_preset_to_connection ?? default_settings.bind_preset_to_connection;
+    oai_settings.extensions = settings.extensions ?? default_settings.extensions;
 
     // Migrate from old settings
     if (settings.names_in_completion === true) {
@@ -4007,6 +4011,7 @@ async function saveOpenAIPreset(name, settings, triggerUi = true) {
         request_images: settings.request_images,
         seed: settings.seed,
         n: settings.n,
+        extensions: settings.extensions,
     };
 
     const savePresetSettings = await fetch('/api/presets/save', {
@@ -4448,6 +4453,12 @@ function onSettingsPresetChange() {
 
         for (const [key, [selector, setting, isCheckbox, isConnection]] of Object.entries(settingsToUpdate)) {
             if (isConnection && !oai_settings.bind_preset_to_connection) {
+                continue;
+            }
+
+            // Extensions don't need UI updates and shouldn't fallback to current settings
+            if (key === 'extensions') {
+                oai_settings.extensions = preset.extensions || {};
                 continue;
             }
 

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -37,7 +37,7 @@ import {
     textgenerationwebui_presets,
     textgenerationwebui_settings as textgen_settings,
 } from './textgen-settings.js';
-import { download, equalsIgnoreCaseAndAccents, getSanitizedFilename, parseJsonFile, waitUntilCondition } from './utils.js';
+import { download, ensurePlainObject, equalsIgnoreCaseAndAccents, getSanitizedFilename, parseJsonFile, waitUntilCondition } from './utils.js';
 import { t } from './i18n.js';
 import { reasoning_templates } from './reasoning.js';
 
@@ -103,19 +103,6 @@ function registerPresetManagers() {
             presetManagers[apiId] = new PresetManager($(e), apiId);
         }
     });
-}
-
-/**
- * Ensures that the provided object is a plain object.
- * @param {object} obj Object to ensure is a plain object
- * @return {object} A plain object, or an empty object if the input is not an object.
- */
-function ensurePlainObject(obj) {
-    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
-        return {};
-    }
-
-    return obj;
 }
 
 class PresetManager {

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -1,4 +1,4 @@
-import { Fuse } from '../lib.js';
+import { Fuse, lodash } from '../lib.js';
 
 import {
     amount_gen,
@@ -14,6 +14,7 @@ import {
     novelai_setting_names,
     novelai_settings,
     online_status,
+    saveSettings,
     saveSettingsDebounced,
     this_chid,
 } from '../script.js';
@@ -102,6 +103,19 @@ function registerPresetManagers() {
             presetManagers[apiId] = new PresetManager($(e), apiId);
         }
     });
+}
+
+/**
+ * Ensures that the provided object is a plain object.
+ * @param {object} obj Object to ensure is a plain object
+ * @return {object} A plain object, or an empty object if the input is not an object.
+ */
+function ensurePlainObject(obj) {
+    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+        return {};
+    }
+
+    return obj;
 }
 
 class PresetManager {
@@ -391,6 +405,9 @@ class PresetManager {
         $(this.select).val(value).trigger('change');
     }
 
+    /**
+     * Updates the preset select element with the current API presets.
+     */
     async updatePreset() {
         const selected = $(this.select).find('option:selected');
         console.log(selected);
@@ -407,6 +424,9 @@ class PresetManager {
         toastr.success(successToast);
     }
 
+    /**
+     * Saves the currently selected preset with a new name.
+     */
     async savePresetAs() {
         const inputValue = this.getSelectedPresetName();
         const popupText = !this.isAdvancedFormatting() ? '<h4>' + t`Hint: Use a character/group name to bind preset to a specific chat.` + '</h4>' : '';
@@ -423,7 +443,14 @@ class PresetManager {
         toastr.success(successToast);
     }
 
-    async savePreset(name, settings) {
+    /**
+     * Saves a preset with the given name and settings.
+     * @param {string} name Name of the preset to save
+     * @param {object} [settings] Settings to save as the preset. If not provided, uses the current preset settings.
+     * @param {object} [options] Options for saving the preset
+     * @param {boolean} [options.skipUpdate=false] If true, skips updating the preset list after saving.
+     */
+    async savePreset(name, settings, { skipUpdate = false } = {}) {
         if (this.apiId === 'instruct' && settings) {
             await checkForSystemPromptInInstructTemplate(name, settings);
         }
@@ -449,9 +476,18 @@ class PresetManager {
         const data = await response.json();
         name = data.name;
 
+        if (skipUpdate) {
+            console.debug(`Preset ${name} saved, but not updating the list`);
+            return;
+        }
+
         this.updateList(name, preset);
     }
 
+    /**
+     * Renames the currently selected preset.
+     * @param {string} newName New name for the preset
+     */
     async renamePreset(newName) {
         const oldName = this.getSelectedPresetName();
         if (equalsIgnoreCaseAndAccents(oldName, newName)) {
@@ -468,9 +504,15 @@ class PresetManager {
 
     }
 
+    /**
+     * Gets a list of presets for the API.
+     * @param {string} [api] API ID. If not specified, uses the current API ID.
+     * @returns {{presets: any[], preset_names: object, settings: object}}
+     */
     getPresetList(api) {
         let presets = [];
         let preset_names = {};
+        let settings = {};
 
         // If no API specified, use the current API
         if (api === undefined) {
@@ -482,50 +524,69 @@ class PresetManager {
             case 'kobold':
                 presets = koboldai_settings;
                 preset_names = koboldai_setting_names;
+                settings = kai_settings;
                 break;
             case 'novel':
                 presets = novelai_settings;
                 preset_names = novelai_setting_names;
+                settings = nai_settings;
                 break;
             case 'textgenerationwebui':
                 presets = textgenerationwebui_presets;
                 preset_names = textgenerationwebui_preset_names;
+                settings = textgen_settings;
                 break;
             case 'openai':
                 presets = openai_settings;
                 preset_names = openai_setting_names;
+                settings = openai_settings;
                 break;
             case 'context':
                 presets = context_presets;
                 preset_names = context_presets.map(x => x.name);
+                settings = power_user.context;
                 break;
             case 'instruct':
                 presets = instruct_presets;
                 preset_names = instruct_presets.map(x => x.name);
+                settings = power_user.instruct;
                 break;
             case 'sysprompt':
                 presets = system_prompts;
                 preset_names = system_prompts.map(x => x.name);
+                settings = power_user.sysprompt;
                 break;
             case 'reasoning':
                 presets = reasoning_templates;
                 preset_names = reasoning_templates.map(x => x.name);
+                settings = power_user.reasoning;
                 break;
             default:
                 console.warn(`Unknown API ID ${api}`);
         }
 
-        return { presets, preset_names };
+        return { presets, preset_names, settings };
     }
 
+    /**
+     * Returns true if the API is keyed, meaning it uses a name to identify presets.
+     */
     isKeyedApi() {
         return this.apiId == 'textgenerationwebui' || this.isAdvancedFormatting();
     }
 
+    /**
+     * Returns true if the API is from Advanced Formatting group.
+     */
     isAdvancedFormatting() {
-        return  ['context', 'instruct', 'sysprompt', 'reasoning'].includes(this.apiId);
+        return ['context', 'instruct', 'sysprompt', 'reasoning'].includes(this.apiId);
     }
 
+    /**
+     * Updates the preset list with a new or existing preset.
+     * @param {string} name Name of the preset
+     * @param {object} preset Preset object
+     */
     updateList(name, preset) {
         const { presets, preset_names } = this.getPresetList();
         const presetExists = this.isKeyedApi() ? preset_names.includes(name) : Object.keys(preset_names).includes(name);
@@ -561,6 +622,11 @@ class PresetManager {
         }
     }
 
+    /**
+     * Gets the preset settings for the given name.
+     * @param {string} name Name of the preset
+     * @returns {object} Preset settings object for the given name
+     */
     getPresetSettings(name) {
         function getSettingsByApiId(apiId) {
             switch (apiId) {
@@ -655,7 +721,7 @@ class PresetManager {
             }
         }
 
-        if (!this.isAdvancedFormatting()) {
+        if (!this.isAdvancedFormatting() && this.apiId !== 'openai') {
             settings['genamt'] = amount_gen;
             settings['max_length'] = max_context;
         }
@@ -663,6 +729,11 @@ class PresetManager {
         return settings;
     }
 
+    /**
+     * Retrieves a completion preset by name.
+     * @param {string} name Name of the preset to retrieve
+     * @returns {any} Preset object if found, otherwise undefined
+     */
     getCompletionPresetByName(name) {
         // Retrieve a completion preset by name. Return undefined if not found.
         let { presets, preset_names } = this.getPresetList();
@@ -687,7 +758,10 @@ class PresetManager {
         return preset;
     }
 
-    // pass no arguments to delete current preset
+    /**
+     * Deletes a preset by name. If not provided, deletes the currently selected preset.
+     * @param {string} [name] Name of the preset to delete.
+     */
     async deletePreset(name) {
         const { preset_names, presets } = this.getPresetList();
         const value = name ? (this.isKeyedApi() ? this.findPreset(name) : name) : this.getSelectedPreset();
@@ -728,6 +802,11 @@ class PresetManager {
         return response.ok;
     }
 
+    /**
+     * Retrieves the default preset for the API from the server.
+     * @param {string} name Name of the preset to restore
+     * @returns {Promise<any>} Default preset object, or undefined if the request fails
+     */
     async getDefaultPreset(name) {
         const response = await fetch('/api/presets/restore', {
             method: 'POST',
@@ -742,6 +821,70 @@ class PresetManager {
         }
 
         return await response.json();
+    }
+
+    /**
+     * Reads a preset extension field from the preset.
+     * @param {object} options
+     * @param {string} [options.name] Name of the preset. If not provided, uses the currently selected preset name.
+     * @param {string} options.path Path to the preset extension field, e.g. 'myextension.data'.
+     * @return {any} The value of the preset extension field, or null if not found.
+     */
+    readPresetExtensionField({ name, path }) {
+        const { settings } = this.getPresetList();
+        const selectedName = this.getSelectedPresetName();
+        const presetName = name || selectedName;
+
+        // Read from settings if the selected preset is the same as the provided name
+        if (settings && selectedName === presetName) {
+            const settingsExtensions = ensurePlainObject(settings.extensions || {});
+            return lodash.get(settingsExtensions, path, null);
+        }
+
+        // Otherwise, read from the preset by name
+        const preset = this.getCompletionPresetByName(presetName);
+        if (!preset) {
+            return null;
+        }
+
+        const presetExtensions = ensurePlainObject(preset.extensions || {});
+        const value = lodash.get(presetExtensions, path, null);
+        return value;
+    }
+
+    /**
+     * Writes a value to a preset extension field.
+     * @param {object} options
+     * @param {string} [options.name] Name of the preset. If not provided, uses the currently selected preset name.
+     * @param {string} options.path Path to the preset extension field, e.g. 'myextension.data'.
+     * @param {any} options.value Value to write to the preset extension field.
+     * @return {Promise<void>} Resolves when the preset is saved.
+     */
+    async writePresetExtensionField({ name, path, value }) {
+        const { settings } = this.getPresetList();
+        const selectedName = this.getSelectedPresetName();
+        const presetName = name || selectedName;
+
+        // Write to settings if the selected preset is the same as the provided name
+        if (settings && selectedName === presetName) {
+            // Set the value at the specified path
+            settings.extensions = ensurePlainObject(settings.extensions || {});
+            lodash.set(settings.extensions, path, value);
+            await saveSettings();
+        }
+
+        // Also update the preset by name
+        const preset = this.getCompletionPresetByName(presetName);
+        if (!preset) {
+            return;
+        }
+
+        // Set the value at the specified path
+        preset.extensions = ensurePlainObject(preset.extensions || {});
+        lodash.set(preset.extensions, path, value);
+
+        // Save the updated preset
+        await this.savePreset(presetName, preset, { skipUpdate: true });
     }
 }
 

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -224,6 +224,7 @@ const settings = {
     min_keep: 0,
     featherless_model: '',
     generic_model: '',
+    extensions: {},
 };
 
 export {
@@ -306,6 +307,7 @@ export const setting_names = [
     'nsigma',
     'min_keep',
     'generic_model',
+    'extensions',
 ];
 
 const DYNATEMP_BLOCK = document.getElementById('dynatemp_block_ooba');
@@ -1098,6 +1100,12 @@ function insertMissingArrayItems(source, target) {
 }
 
 function setSettingByName(setting, value, trigger) {
+    if ('extensions' === setting) {
+        value = value || {};
+        settings.extensions = value;
+        return;
+    }
+
     if (value === null || value === undefined) {
         return;
     }

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -102,6 +102,19 @@ export function deepMerge(target, source) {
     return output;
 }
 
+/**
+ * Ensures that the provided object is a plain object.
+ * @param {object} obj Object to ensure is a plain object
+ * @return {object} A plain object, or an empty object if the input is not an object.
+ */
+export function ensurePlainObject(obj) {
+    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+        return {};
+    }
+
+    return obj;
+}
+
 export function escapeHtml(str) {
     return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Split from #4216

Adds an ability to write custom data to/from preset settings by using PresetManager methods:

* writePresetExtensionField
* readPresetExtensionField

How to use:

```js
const ctx = SillyTavern.getContext();
const pm = ctx.getPresetManager();
await pm.writePresetExtensionField({ path: 'test', value: 'test' });
console.log(pm.readPresetExtensionField({ path: 'test' }));
```

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
