### PR TITLE
/inject: auto-generate ID and fix argument description

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2270,7 +2270,7 @@ export function initDefaultSlashCommands() {
         namedArgumentList: [
             SlashCommandNamedArgument.fromProps({
                 name: 'id',
-                description: 'injection ID or variable name pointing to ID',
+                description: 'injection ID',
                 typeList: [ARGUMENT_TYPE.STRING],
                 isRequired: true,
                 enumProvider: commonEnumProviders.injects,
@@ -2311,7 +2311,7 @@ export function initDefaultSlashCommands() {
                 'text', [ARGUMENT_TYPE.STRING], false,
             ),
         ],
-        helpString: 'Injects a text into the LLM prompt for the current chat. Requires a unique injection ID. Positions: "before" main prompt, "after" main prompt, in-"chat", hidden with "none" (default: after). Depth: injection depth for the prompt (default: 4). Role: role for in-chat injections (default: system). Scan: include injection content into World Info scans (default: false). Hidden injects in "none" position are not inserted into the prompt but can be used for triggering WI entries.',
+        helpString: 'Injects a text into the LLM prompt for the current chat. Requires a unique injection ID (will be auto-generated if not provided). Positions: "before" main prompt, "after" main prompt, in-"chat", hidden with "none" (default: after). Depth: injection depth for the prompt (default: 4). Role: role for in-chat injections (default: system). Scan: include injection content into World Info scans (default: false). Hidden injects in "none" position are not inserted into the prompt but can be used for triggering WI entries.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'listinjects',
@@ -2987,14 +2987,8 @@ function injectCallback(args, value) {
         'assistant': extension_prompt_roles.ASSISTANT,
     };
 
-    const id = String(args?.id ?? '');
+    const id = String(args?.id ?? '') || Math.random().toString(36).substring(2);
     const ephemeral = isTrueBoolean(String(args?.ephemeral ?? ''));
-
-    if (!id) {
-        console.warn('WARN: No ID provided for /inject command');
-        toastr.warning('No ID provided for /inject command');
-        return '';
-    }
 
     const defaultPosition = 'after';
     const defaultDepth = 4;

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2994,10 +2994,10 @@ function injectCallback(args, value) {
     const defaultDepth = 4;
     const positionValue = args?.position ?? defaultPosition;
     const position = positions[positionValue] ?? positions[defaultPosition];
-    const depthValue = Number(args?.depth) ?? defaultDepth;
+    const depthValue = Number(args?.depth ?? defaultDepth);
     const depth = isNaN(depthValue) ? defaultDepth : depthValue;
     const roleValue = typeof args?.role === 'string' ? args.role.toLowerCase().trim() : Number(args?.role ?? extension_prompt_roles.SYSTEM);
-    const role = roles[roleValue] ?? roles[extension_prompt_roles.SYSTEM];
+    const role = roles[roleValue] ?? extension_prompt_roles.SYSTEM;
     const scan = isTrueBoolean(String(args?.scan));
     const filter = args?.filter instanceof SlashCommandClosure ? args.filter.rawText : null;
     const filterFunction = args?.filter instanceof SlashCommandClosure ? closureToFilter(args.filter) : null;

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2266,13 +2266,14 @@ export function initDefaultSlashCommands() {
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'inject',
+        returns: 'injection ID',
         callback: injectCallback,
         namedArgumentList: [
             SlashCommandNamedArgument.fromProps({
                 name: 'id',
                 description: 'injection ID',
                 typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
+                isRequired: false,
                 enumProvider: commonEnumProviders.injects,
             }),
             new SlashCommandNamedArgument(
@@ -2311,7 +2312,7 @@ export function initDefaultSlashCommands() {
                 'text', [ARGUMENT_TYPE.STRING], false,
             ),
         ],
-        helpString: 'Injects a text into the LLM prompt for the current chat. Requires a unique injection ID (will be auto-generated if not provided). Positions: "before" main prompt, "after" main prompt, in-"chat", hidden with "none" (default: after). Depth: injection depth for the prompt (default: 4). Role: role for in-chat injections (default: system). Scan: include injection content into World Info scans (default: false). Hidden injects in "none" position are not inserted into the prompt but can be used for triggering WI entries.',
+        helpString: 'Injects a text into the LLM prompt for the current chat. Requires a unique injection ID (will be auto-generated if not provided). Positions: "before" main prompt, "after" main prompt, in-"chat", hidden with "none" (default: after). Depth: injection depth for the prompt (default: 4). Role: role for in-chat injections (default: system). Scan: include injection content into World Info scans (default: false). Hidden injects in "none" position are not inserted into the prompt but can be used for triggering WI entries. Returns the injection ID.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'listinjects',
@@ -3039,7 +3040,7 @@ function injectCallback(args, value) {
         eventSource.once(event_types.GENERATION_STOPPED, unsetInject);
     }
 
-    return '';
+    return id;
 }
 
 async function listInjectsCallback(args) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. It may be hard to come up with a clever name if you're doing a one-time ephemeral injection.
2. We stopped accepting variable names as IDs long ago.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
