### PR TITLE
apply gemini safety settings as extra_body in OpenRouter requests

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -140,10 +140,6 @@ export const UNSAFE_EXTENSIONS = [
 
 export const GEMINI_SAFETY = [
     {
-        category: 'HARM_CATEGORY_UNSPECIFIED',
-        threshold: 'OFF',
-    },
-    {
         category: 'HARM_CATEGORY_HARASSMENT',
         threshold: 'OFF',
     },

--- a/src/constants.js
+++ b/src/constants.js
@@ -140,6 +140,10 @@ export const UNSAFE_EXTENSIONS = [
 
 export const GEMINI_SAFETY = [
     {
+        category: 'HARM_CATEGORY_UNSPECIFIED',
+        threshold: 'OFF',
+    },
+    {
         category: 'HARM_CATEGORY_HARASSMENT',
         threshold: 'OFF',
     },

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1487,14 +1487,9 @@ router.post('/generate', function (request, response) {
             cachingAtDepthForOpenRouterClaude(request.body.messages, cachingAtDepth, cacheTTL);
         }
 
-        // when using a gemini model, we can pass the Gemini safety settings as extra_body
-        const isGemini = /gemini/.test(request.body.model);
+        const isGemini = /google\/gemini/.test(request.body.model);
         if (isGemini) {
-            bodyParams['extra_body'] = {
-                google: {
-                    safety_settings: GEMINI_SAFETY,
-                },
-            };
+            bodyParams['safety_settings'] = GEMINI_SAFETY;
         }
     } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM) {
         apiUrl = request.body.custom_url;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1486,6 +1486,16 @@ router.post('/generate', function (request, response) {
         if (Number.isInteger(cachingAtDepth) && cachingAtDepth >= 0 && isClaude3or4) {
             cachingAtDepthForOpenRouterClaude(request.body.messages, cachingAtDepth, cacheTTL);
         }
+
+        // when using a gemini model, we can pass the Gemini safety settings as extra_body
+        const isGemini = /gemini/.test(request.body.model);
+        if (isGemini) {
+            bodyParams['extra_body'] = {
+                google: {
+                    safety_settings: GEMINI_SAFETY,
+                },
+            };
+        }
     } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM) {
         apiUrl = request.body.custom_url;
         apiKey = readSecret(request.user.directories, SECRET_KEYS.CUSTOM);


### PR DESCRIPTION
Right now, Gemini Safety Settings are only passed in the request when using the Google AI connection directly.
When using a Gemini model via OpenRouter, they are not sent.

According to [this documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/migrate/openai/overview?hl=de#extra_body_features), when using the Vertex provider, the safety settings can be passed in `extra_body`.

So this pull request:
- Adds an `extra_body` to the `bodyParams`:
```
{
  google: {
    safety_settings: GEMINI_SAFETY,
  },
}
```
- Adds `HARM_CATEGORY_UNSPECIFIED` to `GEMINI_SAFETY`(according to [HarmCategory Documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/HarmCategory))

Sadly I was not able to validate if it's even working properly, since I wasn't able to figure out the right prompts to trigger them. Technically it should be correct and would be a great benefit for people using Gemini via OpenRouter, but I'd appreciate a validation from more experience people very much.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
