### PR TITLE
Ability to specify multiple messages and roles in generateRaw()

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3066,7 +3066,10 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
 
     // If the prompt was given as a string, convert to a message-style object assuming user role
     if (typeof prompt === 'string') {
-        prompt = [{ role: 'user', content: prompt.trim() }];
+        const message = api === 'openai'
+            ? { role: 'user', content: prompt.trim() }
+            : { role: 'system', content: prompt };
+        prompt = [message];
     } else {  // checks for message-style object
         if (prompt.length === 0 && !systemPrompt) throw Error('No messages provided');
     }

--- a/public/script.js
+++ b/public/script.js
@@ -3053,8 +3053,60 @@ class StreamingProcessor {
 }
 
 /**
+ * Constructs a prompt to be used for either Text Completion or Chat Completion. Input is format-agnostic.
+ * @param {string | object[]} prompt Input prompt. Can be a string or an array of chat-style messages, i.e. [{role: '', content: ''}, ...]
+ * @param {string} api API to use.
+ * @param {boolean} instructOverride true to override instruct mode, false to use the default value
+ * @param {boolean} quietToLoud true to generate a message in system mode, false to generate a message in character mode
+ * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
+ * @returns {string | object[]} Prompt ready for use in generation. If using TC, this will be a string. If using CC, this will be an array of chat-style messages.
+ */
+export function createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt) {
+    const isInstruct = power_user.instruct.enabled && api !== 'openai' && api !== 'novel' && !instructOverride;
+
+    // If the prompt was given as a string, convert to a message-style object assuming user role
+    if (typeof prompt === 'string') {
+        prompt = [{role: 'user', content: prompt.trim()}]
+    } else {  // checks for message-style object
+        if (prompt.length === 0) throw Error("No messages provided")
+    }
+
+    // Format each message in the prompt, accounting for the provided roles
+    for (let message of prompt) {
+        message.content = substituteParams(message.content ?? '');
+        if (api === 'novel') message.content = adjustNovelInstructionPrompt(message.content);
+        let name = '';
+        if (isInstruct) {
+            if (message.role === 'user') name = message.name ?? name1;
+            if (message.role === 'assistant') name = message.name ?? name2;
+            if (message.role === 'system') name = message.name ?? '';
+            let isUser = message.role === 'user';
+            let isNarrator = message.role === 'system';
+            message.content = formatInstructModeChat(name, message.content, isUser, isNarrator, '', name1, name2, false);
+        }
+    }
+
+    // prepend system prompt, if provided
+    if (systemPrompt) {
+        systemPrompt = substituteParams(systemPrompt);
+        if (isInstruct) systemPrompt = formatInstructModeSystemPrompt(systemPrompt) + '\n'
+        prompt.unshift({role: 'system', content: systemPrompt.trim()});
+    }
+
+    // If text completion, convert to text prompt by concatenating all message contents
+    if (api !== 'openai') {
+        prompt = prompt.map(message => message.content).join('');
+        prompt = prompt + (isInstruct ? formatInstructModePrompt(name2, false, '', name1, name2, true, quietToLoud) : '\n')  // add last line
+    }
+
+    return prompt
+}
+
+
+/**
  * Generates a message using the provided prompt.
- * @param {string} prompt Prompt to generate a message from
+ * If the prompt is an array of chat-style messages and not using chat completion, it will be converted to a text prompt.
+ * @param {string | object[]} prompt Prompt to generate a message from. Can be a string or an array of chat-style messages, i.e. [{role: '', content: ''}, ...]
  * @param {string} api API to use. Main API is used if not specified.
  * @param {boolean} instructOverride true to override instruct mode, false to use the default value
  * @param {boolean} quietToLoud true to generate a message in system mode, false to generate a message in character mode
@@ -3070,20 +3122,10 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
 
     const abortController = new AbortController();
     const responseLengthCustomized = typeof responseLength === 'number' && responseLength > 0;
-    const isInstruct = power_user.instruct.enabled && api !== 'openai' && api !== 'novel' && !instructOverride;
-    const isQuiet = true;
     let eventHook = () => { };
 
-    if (systemPrompt) {
-        systemPrompt = substituteParams(systemPrompt);
-        systemPrompt = isInstruct ? formatInstructModeSystemPrompt(systemPrompt) : systemPrompt;
-        prompt = api === 'openai' ? prompt : `${systemPrompt}\n${prompt}`;
-    }
-
-    prompt = substituteParams(prompt);
-    prompt = api == 'novel' ? adjustNovelInstructionPrompt(prompt) : prompt;
-    prompt = isInstruct ? formatInstructModeChat(name1, prompt, false, true, '', name1, name2, false) : prompt;
-    prompt = isInstruct ? (prompt + formatInstructModePrompt(name2, false, '', name1, name2, isQuiet, quietToLoud)) : (prompt + '\n');
+    // construct final prompt from the input
+    prompt = createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt)
 
     try {
         if (responseLengthCustomized) {
@@ -3115,10 +3157,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
                 TempResponseLength.restore(api);
                 break;
             case 'openai': {
-                generateData = [{ role: 'user', content: prompt.trim() }];
-                if (systemPrompt) {
-                    generateData.unshift({ role: 'system', content: systemPrompt.trim() });
-                }
+                generateData = prompt  // generateData is just the chat message object
                 eventHook = TempResponseLength.setupEventHook(api);
             } break;
         }

--- a/public/script.js
+++ b/public/script.js
@@ -3066,9 +3066,9 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
 
     // If the prompt was given as a string, convert to a message-style object assuming user role
     if (typeof prompt === 'string') {
-        prompt = [{role: 'user', content: prompt.trim()}]
+        prompt = [{ role: 'user', content: prompt.trim() }];
     } else {  // checks for message-style object
-        if (prompt.length === 0) throw Error("No messages provided")
+        if (prompt.length === 0) throw Error('No messages provided');
     }
 
     // Format each message in the prompt, accounting for the provided roles
@@ -3089,17 +3089,17 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
     // prepend system prompt, if provided
     if (systemPrompt) {
         systemPrompt = substituteParams(systemPrompt);
-        if (isInstruct) systemPrompt = formatInstructModeSystemPrompt(systemPrompt) + '\n'
-        prompt.unshift({role: 'system', content: systemPrompt.trim()});
+        if (isInstruct) systemPrompt = formatInstructModeSystemPrompt(systemPrompt) + '\n';
+        prompt.unshift({ role: 'system', content: systemPrompt.trim() });
     }
 
     // If text completion, convert to text prompt by concatenating all message contents
     if (api !== 'openai') {
         prompt = prompt.map(message => message.content).join('');
-        prompt = prompt + (isInstruct ? formatInstructModePrompt(name2, false, '', name1, name2, true, quietToLoud) : '\n')  // add last line
+        prompt = prompt + (isInstruct ? formatInstructModePrompt(name2, false, '', name1, name2, true, quietToLoud) : '\n');  // add last line
     }
 
-    return prompt
+    return prompt;
 }
 
 
@@ -3125,7 +3125,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
     let eventHook = () => { };
 
     // construct final prompt from the input
-    prompt = createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt)
+    prompt = createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt);
 
     try {
         if (responseLengthCustomized) {
@@ -3157,7 +3157,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
                 TempResponseLength.restore(api);
                 break;
             case 'openai': {
-                generateData = prompt  // generateData is just the chat message object
+                generateData = prompt;  // generateData is just the chat message object
                 eventHook = TempResponseLength.setupEventHook(api);
             } break;
         }

--- a/public/script.js
+++ b/public/script.js
@@ -3092,8 +3092,8 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
     // prepend system prompt, if provided
     if (systemPrompt) {
         systemPrompt = substituteParams(systemPrompt);
-        if (isInstruct) systemPrompt = formatInstructModeSystemPrompt(systemPrompt) + '\n';
-        prompt.unshift({ role: 'system', content: systemPrompt.trim() });
+        systemPrompt = isInstruct ? formatInstructModeSystemPrompt(systemPrompt) : systemPrompt.trim();
+        prompt.unshift({ role: 'system', content: systemPrompt });
     }
 
     // If text completion, convert to text prompt by concatenating all message contents

--- a/public/script.js
+++ b/public/script.js
@@ -3080,7 +3080,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
         if (message.role === 'user') name = message.name ?? name1;
         if (message.role === 'assistant') name = message.name ?? name2;
         if (message.role === 'system') name = message.name ?? '';
-        const prefix = isInstruct ? '' : (name ? `${name}: ` : '');
+        const prefix = isInstruct || api === 'openai' ? '' : (name ? `${name}: ` : '');
         message.content = prefix + substituteParams(message.content ?? '');
         if (isInstruct) {  // instruct formatting for text completion
             const isUser = message.role === 'user';

--- a/public/script.js
+++ b/public/script.js
@@ -3068,20 +3068,23 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
     if (typeof prompt === 'string') {
         prompt = [{ role: 'user', content: prompt.trim() }];
     } else {  // checks for message-style object
-        if (prompt.length === 0) throw Error('No messages provided');
+        if (prompt.length === 0 && !systemPrompt) throw Error('No messages provided');
     }
 
     // Format each message in the prompt, accounting for the provided roles
-    for (let message of prompt) {
+    for (const message of prompt) {
         message.content = substituteParams(message.content ?? '');
-        if (api === 'novel') message.content = adjustNovelInstructionPrompt(message.content);
+        const isLastMessage = prompt.indexOf(message) === prompt.length - 1;
+        if (api === 'novel' && isLastMessage) {
+            message.content = adjustNovelInstructionPrompt(message.content);
+        }
         if (isInstruct) {  // instruct formatting for text completion
             let name = '';
             if (message.role === 'user') name = message.name ?? name1;
             if (message.role === 'assistant') name = message.name ?? name2;
             if (message.role === 'system') name = message.name ?? '';
-            let isUser = message.role === 'user';
-            let isNarrator = message.role === 'system';
+            const isUser = message.role === 'user';
+            const isNarrator = message.role === 'system';
             message.content = formatInstructModeChat(name, message.content, isUser, isNarrator, '', name1, name2, false);
         }
     }
@@ -3101,7 +3104,6 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
 
     return prompt;
 }
-
 
 /**
  * Generates a message using the provided prompt.
@@ -3142,7 +3144,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
                 } else {
                     const isHorde = api === 'koboldhorde';
                     const koboldSettings = koboldai_settings[koboldai_setting_names[kai_settings.preset_settings]];
-                    generateData = getKoboldGenerationData(prompt, koboldSettings, amount_gen, max_context, isHorde, 'quiet');
+                    generateData = getKoboldGenerationData(prompt.toString(), koboldSettings, amount_gen, max_context, isHorde, 'quiet');
                 }
                 TempResponseLength.restore(api);
                 break;
@@ -3165,7 +3167,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
         let data = {};
 
         if (api === 'koboldhorde') {
-            data = await generateHorde(prompt, generateData, abortController.signal, false);
+            data = await generateHorde(prompt.toString(), generateData, abortController.signal, false);
         } else if (api === 'openai') {
             data = await sendOpenAIRequest('quiet', generateData, abortController.signal);
         } else {

--- a/public/script.js
+++ b/public/script.js
@@ -3098,7 +3098,8 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
 
     // If text completion, convert to text prompt by concatenating all message contents
     if (api !== 'openai') {
-        prompt = prompt.map(message => message.content).join('');
+        const joiner = isInstruct ? '' : '\n';
+        prompt = prompt.map(message => message.content).join(joiner);
         prompt = prompt + (isInstruct ? formatInstructModePrompt(name2, false, '', name1, name2, true, quietToLoud) : '\n');  // add last line
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -3075,8 +3075,8 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
     for (let message of prompt) {
         message.content = substituteParams(message.content ?? '');
         if (api === 'novel') message.content = adjustNovelInstructionPrompt(message.content);
-        let name = '';
-        if (isInstruct) {
+        if (isInstruct) {  // instruct formatting for text completion
+            let name = '';
             if (message.role === 'user') name = message.name ?? name1;
             if (message.role === 'assistant') name = message.name ?? name2;
             if (message.role === 'system') name = message.name ?? '';
@@ -3124,7 +3124,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
     const responseLengthCustomized = typeof responseLength === 'number' && responseLength > 0;
     let eventHook = () => { };
 
-    // construct final prompt from the input
+    // construct final prompt from the input. Can either be a string or an array of chat-style messages.
     prompt = createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt);
 
     try {

--- a/public/script.js
+++ b/public/script.js
@@ -3073,16 +3073,13 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
 
     // Format each message in the prompt, accounting for the provided roles
     for (const message of prompt) {
-        message.content = substituteParams(message.content ?? '');
-        const isLastMessage = prompt.indexOf(message) === prompt.length - 1;
-        if (api === 'novel' && isLastMessage) {
-            message.content = adjustNovelInstructionPrompt(message.content);
-        }
+        let name = '';
+        if (message.role === 'user') name = message.name ?? name1;
+        if (message.role === 'assistant') name = message.name ?? name2;
+        if (message.role === 'system') name = message.name ?? '';
+        const prefix = isInstruct ? '' : (name ? `${name}: ` : '');
+        message.content = prefix + substituteParams(message.content ?? '');
         if (isInstruct) {  // instruct formatting for text completion
-            let name = '';
-            if (message.role === 'user') name = message.name ?? name1;
-            if (message.role === 'assistant') name = message.name ?? name2;
-            if (message.role === 'system') name = message.name ?? '';
             const isUser = message.role === 'user';
             const isNarrator = message.role === 'system';
             message.content = formatInstructModeChat(name, message.content, isUser, isNarrator, '', name1, name2, false);
@@ -3100,6 +3097,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
     if (api !== 'openai') {
         const joiner = isInstruct ? '' : '\n';
         prompt = prompt.map(message => message.content).join(joiner);
+        prompt = api === 'novel' ? adjustNovelInstructionPrompt(prompt) : prompt;
         prompt = prompt + (isInstruct ? formatInstructModePrompt(name2, false, '', name1, name2, true, quietToLoud) : '\n');  // add last line
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -3092,7 +3092,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
     // prepend system prompt, if provided
     if (systemPrompt) {
         systemPrompt = substituteParams(systemPrompt);
-        systemPrompt = isInstruct ? formatInstructModeSystemPrompt(systemPrompt) : systemPrompt.trim();
+        systemPrompt = isInstruct ? (formatInstructModeSystemPrompt(systemPrompt) + '\n') : systemPrompt.trim();
         prompt.unshift({ role: 'system', content: systemPrompt });
     }
 


### PR DESCRIPTION
## Motivation

Currently, using `generateRaw()` with Chat Completion uses a hard-coded role and provides no way to add additional chat messages. This makes it impossible to add assistant messages, multiple messages, or prefills with Chat Completion.

## Description

This change allows the `prompt` parameter of `generateRaw()` to be either a string or an array of chat-style message objects, allowing you to completely customize the prompt for Chat Completion.

Additionally, if you pass in an array of chat-style message objects while using Text Completion, it will get converted to a text prompt while respecting the provided roles for the instruct templates. Previously you would have to do this manually.

This change potentially makes the `systemPrompt` parameter redundant, since you can now just pass in your own system prompt in both TC and CC. I kept it in to maintain backward comparability.

## Method

First, I've moved the prompt creation itself out of `generateRaw()` and into a new function `createRawPrompt()`. This is so you can call `createRawPrompt()` in isolation to see what your prompt will look like without sending it.

Instead of handling each of the 4 possible scenarios separately (CC + string, CC + messages, TC + string, TC + messages), I instead convert string input into chat-style messages, with the role assumed to be `user` (the current default for both CC and TC). All TC instruct formatting is then done on each message individually taking the specified role into account, then concatenating them all together.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
