### PR TITLE
adding prefill parameter to generateRaw()

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3059,9 +3059,10 @@ class StreamingProcessor {
  * @param {boolean} instructOverride true to override instruct mode, false to use the default value
  * @param {boolean} quietToLoud true to generate a message in system mode, false to generate a message in character mode
  * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
+ * @param {string} [prefill] Prefill for the prompt
  * @returns {string | object[]} Prompt ready for use in generation. If using TC, this will be a string. If using CC, this will be an array of chat-style messages.
  */
-export function createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt) {
+export function createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt, prefill) {
     const isInstruct = power_user.instruct.enabled && api !== 'openai' && api !== 'novel' && !instructOverride;
 
     // If the prompt was given as a string, convert to a message-style object assuming user role
@@ -3097,11 +3098,14 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
     }
 
     // If text completion, convert to text prompt by concatenating all message contents
+    if (api === 'openai' && prefill) {  // with Chat Completion, the prefill is an additional assistant message at the end.
+        prompt.push({ role: 'assistant', content: prefill });
+    }
     if (api !== 'openai') {
         const joiner = isInstruct ? '' : '\n';
         prompt = prompt.map(message => message.content).join(joiner);
         prompt = api === 'novel' ? adjustNovelInstructionPrompt(prompt) : prompt;
-        prompt = prompt + (isInstruct ? formatInstructModePrompt(name2, false, '', name1, name2, true, quietToLoud) : '\n');  // add last line
+        prompt = prompt + (isInstruct ? formatInstructModePrompt(name2, false, prefill, name1, name2, true, quietToLoud) : '\n');  // add last line
     }
 
     return prompt;
@@ -3117,9 +3121,10 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
  * @param {boolean} [trimNames] Whether to allow trimming "{{user}}:" and "{{char}}:" from the response.
+ * @param {string} [prefill] An optional prefill.
  * @returns {Promise<string>} Generated message
  */
-export async function generateRaw(prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, trimNames = true) {
+export async function generateRaw(prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, trimNames = true, prefill = '') {
     if (!api) {
         api = main_api;
     }
@@ -3129,7 +3134,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
     let eventHook = () => { };
 
     // construct final prompt from the input. Can either be a string or an array of chat-style messages.
-    prompt = createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt);
+    prompt = createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt, prefill);
 
     try {
         if (responseLengthCustomized) {

--- a/public/script.js
+++ b/public/script.js
@@ -3059,7 +3059,7 @@ class StreamingProcessor {
  * @param {boolean} instructOverride true to override instruct mode, false to use the default value
  * @param {boolean} quietToLoud true to generate a message in system mode, false to generate a message in character mode
  * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
- * @param {string} [prefill] Prefill for the prompt
+ * @param {string} [prefill] Prefill for the prompt (only applied for text completion when instructOverride is false).
  * @returns {string | object[]} Prompt ready for use in generation. If using TC, this will be a string. If using CC, this will be an array of chat-style messages.
  */
 export function createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt, prefill) {
@@ -3097,10 +3097,12 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
         prompt.unshift({ role: 'system', content: systemPrompt });
     }
 
-    // If text completion, convert to text prompt by concatenating all message contents
-    if (api === 'openai' && prefill) {  // with Chat Completion, the prefill is an additional assistant message at the end.
+    // with Chat Completion, the prefill is an additional assistant message at the end.
+    if (api === 'openai' && prefill) {
         prompt.push({ role: 'assistant', content: prefill });
     }
+
+    // if text completion, convert to text prompt by concatenating all message contents and adding the prefill as a promptBias.
     if (api !== 'openai') {
         const joiner = isInstruct ? '' : '\n';
         prompt = prompt.map(message => message.content).join(joiner);
@@ -3121,7 +3123,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
  * @param {boolean} [trimNames] Whether to allow trimming "{{user}}:" and "{{char}}:" from the response.
- * @param {string} [prefill] An optional prefill.
+ * @param {string} [prefill] An optional prefill (only applied for text completion when instructOverride is false).
  * @returns {Promise<string>} Generated message
  */
 export async function generateRaw(prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, trimNames = true, prefill = '') {

--- a/public/script.js
+++ b/public/script.js
@@ -3126,7 +3126,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
  * @param {boolean} [trimNames] Whether to allow trimming "{{user}}:" and "{{char}}:" from the response.
- * @param {string} [prefill] An optional prefill (only applied for text completion when instructOverride is false).
+ * @param {string} [prefill] An optional prefill for the prompt.
  * @returns {Promise<string>} Generated message
  */
 export async function generateRaw(prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, trimNames = true, prefill = '') {

--- a/public/script.js
+++ b/public/script.js
@@ -3058,7 +3058,7 @@ class StreamingProcessor {
  * @param {string} api API to use.
  * @param {boolean} instructOverride true to override instruct mode, false to use the default value
  * @param {boolean} quietToLoud true to generate a message in system mode, false to generate a message in character mode
- * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
+ * @param {string} [systemPrompt] System prompt to use.
  * @param {string} [prefill] Prefill for the prompt.
  * @returns {string | object[]} Prompt ready for use in generation. If using TC, this will be a string. If using CC, this will be an array of chat-style messages.
  */
@@ -3123,7 +3123,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @param {string} api API to use. Main API is used if not specified.
  * @param {boolean} instructOverride true to override instruct mode, false to use the default value
  * @param {boolean} quietToLoud true to generate a message in system mode, false to generate a message in character mode
- * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
+ * @param {string} [systemPrompt] System prompt to use.
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
  * @param {boolean} [trimNames] Whether to allow trimming "{{user}}:" and "{{char}}:" from the response.
  * @param {string} [prefill] An optional prefill for the prompt.

--- a/public/script.js
+++ b/public/script.js
@@ -3075,6 +3075,9 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
         if (prompt.length === 0 && !systemPrompt) throw Error('No messages provided');
     }
 
+    // Substitute the prefill if provided
+    prefill = substituteParams(prefill ?? '');
+
     // Format each message in the prompt, accounting for the provided roles
     for (const message of prompt) {
         let name = '';
@@ -3107,7 +3110,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
         const joiner = isInstruct ? '' : '\n';
         prompt = prompt.map(message => message.content).join(joiner);
         prompt = api === 'novel' ? adjustNovelInstructionPrompt(prompt) : prompt;
-        prompt = prompt + (isInstruct ? formatInstructModePrompt(name2, false, prefill, name1, name2, true, quietToLoud) : '\n');  // add last line
+        prompt = prompt + (isInstruct ? formatInstructModePrompt(name2, false, prefill, name1, name2, true, quietToLoud) : `\n${prefill}`);  // add last line
     }
 
     return prompt;

--- a/public/script.js
+++ b/public/script.js
@@ -3059,7 +3059,7 @@ class StreamingProcessor {
  * @param {boolean} instructOverride true to override instruct mode, false to use the default value
  * @param {boolean} quietToLoud true to generate a message in system mode, false to generate a message in character mode
  * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
- * @param {string} [prefill] Prefill for the prompt (only applied for text completion when instructOverride is false).
+ * @param {string} [prefill] Prefill for the prompt.
  * @returns {string | object[]} Prompt ready for use in generation. If using TC, this will be a string. If using CC, this will be an array of chat-style messages.
  */
 export function createRawPrompt(prompt, api, instructOverride, quietToLoud, systemPrompt, prefill) {


### PR DESCRIPTION
## Motivation

In https://github.com/SillyTavern/SillyTavern/pull/4264, we added the ability to pass in a chat-style array of messages to `generateRaw()`, allowing customization of roles and number of messages when using CC. This implicitly allows you to add a CC prefill by just adding an assistant message at the end. However, this does not work when using TC because that message would be completely wrapped in the instruct template. 

## Description

In order to maintain parity between TC and CC, I've added a `prefill` parameter to `generateRaw()` which will add a prefill appropriately for either mode. For CC, an extra assistant message is added at the end. For TC, the prefill is passed to the `promptBias` parameter of `formatInstructModePrompt()`.

I am not fully familiar with how different models handle prefills, so let me know if there are other methods of creating prefills that need to be addressed (or if I've gotten these wrong).

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
