### PR TITLE
Added structured output for common APIs

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2330,29 +2330,31 @@ export function getStoppingStrings(isImpersonate, isContinue) {
 
 /**
  * Background generation based on the provided prompt.
- * @param {string} quiet_prompt Instruction prompt for the AI
- * @param {boolean} quietToLoud Whether the message should be sent in a foreground (loud) or background (quiet) mode
- * @param {boolean} skipWIAN whether to skip addition of World Info and Author's Note into the prompt
- * @param {string} quietImage Image to use for the quiet prompt
- * @param {string} quietName Name to use for the quiet prompt (defaults to "System:")
+ * @param {string} quietPrompt Instruction prompt for the AI
+ * @param {boolean} [quietToLoud] Whether the message should be sent in a foreground (loud) or background (quiet) mode
+ * @param {boolean} [skipWIAN] Whether to skip addition of World Info and Author's Note into the prompt
+ * @param {string} [quietImage] Image to use for the quiet prompt
+ * @param {string} [quietName] Name to use for the quiet prompt (defaults to "System:")
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
- * @param {number} force_chid Character ID to use for this generation run. Works in groups only.
- * @returns
+ * @param {number} [forceChId] Character ID to use for this generation run. Works in groups only.
+ * @param {AdditionalRequestOptions} [options={}] Additional generation request options.
+ * @returns {Promise<string>} Generated text. If using structured output, will contain a serialized JSON object.
  */
-export async function generateQuietPrompt(quiet_prompt, quietToLoud, skipWIAN, quietImage = null, quietName = null, responseLength = null, force_chid = null) {
+export async function generateQuietPrompt(quietPrompt, quietToLoud = false, skipWIAN = false, quietImage = null, quietName = null, responseLength = null, forceChId = null, { jsonSchema } = {}) {
     console.log('got into genQuietPrompt');
     const responseLengthCustomized = typeof responseLength === 'number' && responseLength > 0;
     let eventHook = () => { };
     try {
         /** @type {GenerateOptions} */
         const options = {
-            quiet_prompt,
+            quiet_prompt: quietPrompt,
             quietToLoud,
             skipWIAN: skipWIAN,
             force_name2: true,
             quietImage: quietImage,
             quietName: quietName,
-            force_chid: force_chid,
+            force_chid: forceChId,
+            jsonSchema: jsonSchema,
         };
         if (responseLengthCustomized) {
             TempResponseLength.save(main_api, responseLength);
@@ -3340,23 +3342,23 @@ function removeLastMessage() {
 
 /**
  * @typedef {object} JsonSchema
- * @property {string} name
- * @property {object} value
- * @property {string} [description]
- * @property {boolean} [strict]
+ * @property {string} name Name of the schema.
+ * @property {object} value JSON schema value.
+ * @property {string} [description] Description of the schema.
+ * @property {boolean} [strict] If true, the schema will be used in strict mode, meaning that only the fields defined in the schema will be allowed.
  *
  * @typedef {object} GenerateOptions
- * @property {boolean} [automatic_trigger]
- * @property {boolean} [force_name2]
- * @property {string} [quiet_prompt]
- * @property {boolean} [quietToLoud]
- * @property {boolean} [skipWIAN]
- * @property {number} [force_chid]
- * @property {AbortSignal} [signal]
- * @property {string} [quietImage]
- * @property {string} [quietName]
- * @property {number} [depth]
- * @property {JsonSchema} [jsonSchema]
+ * @property {boolean} [automatic_trigger] If the generation was triggered automatically (e.g. group auto mode).
+ * @property {boolean} [force_name2] If a char name should be forced to add to the prompt's last line (Text Completion, non-Instruct only).
+ * @property {string} [quiet_prompt] A system instruction to use for the quiet prompt.
+ * @property {boolean} [quietToLoud] Whether the system instruction should be sent in background (quiet) or a foreground (loud) mode.
+ * @property {boolean} [skipWIAN] Skip adding World Info and Author's Note to the prompt.
+ * @property {number} [force_chid] Force character ID to use for the generation. Only works in groups.
+ * @property {AbortSignal} [signal] Abort signal to cancel the generation. If not provided, will create a new AbortController.
+ * @property {string} [quietImage] Image URL to use for the quiet prompt (defaults to empty string)
+ * @property {string} [quietName] Name to use for the quiet prompt (defaults to "System:")
+ * @property {number} [depth] Recursion depth for the generation. Used to prevent infinite loops in tool calls.
+ * @property {JsonSchema} [jsonSchema] JSON schema to use for the structured generation. Usually requires a special instruction.
  */
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -4511,9 +4511,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 });
             }
         } else {
-            return await sendGenerationRequest(type, generate_data, {
-                jsonSchema,
-            });
+            return await sendGenerationRequest(type, generate_data, { jsonSchema });
         }
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -3127,7 +3127,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
  * @param {boolean} [trimNames] Whether to allow trimming "{{user}}:" and "{{char}}:" from the response.
  * @param {string} [prefill] An optional prefill for the prompt.
- * @param {PureGenerateOptions} [options] Additional options for generation
+ * @param {AdditionalRequestOptions} [options] Additional options for generation
  * @returns {Promise<string>} Generated message
  */
 export async function generateRaw(prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, trimNames = true, prefill = '', options = {}) {
@@ -5120,8 +5120,7 @@ function setInContextMessages(msgInContextCount, type) {
 }
 
 /**
- * Send a chat completion request to backend
- * @typedef {object} PureGenerateOptions
+ * @typedef {object} AdditionalRequestOptions
  * @property {JsonSchema} [jsonSchema]
  */
 
@@ -5129,7 +5128,7 @@ function setInContextMessages(msgInContextCount, type) {
  * Sends a non-streaming request to the API.
  * @param {string} type Generation type
  * @param {object} data Generation data
- * @param {PureGenerateOptions} [options] Additional options for the generation request
+ * @param {AdditionalRequestOptions} [options] Additional options for the generation request
  * @returns {Promise<object>} Response data from the API
  * @throws {Error|object}
  */
@@ -5161,7 +5160,7 @@ export async function sendGenerationRequest(type, data, options = {}) {
  * Sends a streaming request to the API.
  * @param {string} type Generation type
  * @param {object} data Generation data
- * @param {PureGenerateOptions} [options] Additional options for the generation request
+ * @param {AdditionalRequestOptions} [options] Additional options for the generation request
  * @returns {Promise<any>} Streaming generator
  */
 export async function sendStreamingRequest(type, data, options = {}) {

--- a/public/script.js
+++ b/public/script.js
@@ -4548,6 +4548,8 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         }
 
         if (jsonSchema) {
+            unblockGeneration(type);
+            generatedPromptCache = '';
             return extractJsonFromData(data);
         }
 
@@ -5328,20 +5330,41 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
     mainApi = mainApi ?? main_api;
     chatCompletionSource = chatCompletionSource ?? oai_settings.chat_completion_source;
 
-    let result = {};
-    if (data.content) {
-        if (typeof data.content === 'string') {
-            try {
-                result = JSON.parse(data.content);
-            } catch (e) {
-                console.debug('Failed to parse content as JSON.', e);
-            }
-        } else if (mainApi === 'openai' && chatCompletionSource === chat_completion_sources.CLAUDE) {
-            result = data.content.find(x => x.type === 'tool_use')?.input;
+    const tryParse = (/** @type {string} */ value) => {
+        try {
+            return JSON.parse(value);
+        } catch (e) {
+            console.debug('Failed to parse content as JSON.', e);
         }
+    };
+
+    let result = {};
+
+    switch (mainApi) {
+        case 'openai': {
+            switch (chatCompletionSource) {
+                case chat_completion_sources.CLAUDE:
+                    result = data?.content?.find(x => x.type === 'tool_use')?.input;
+                    break;
+                case chat_completion_sources.DEEPSEEK:
+                    result = tryParse(data?.choices?.[0]?.message?.content);
+                    break;
+                case chat_completion_sources.VERTEXAI:
+                case chat_completion_sources.MAKERSUITE:
+                case chat_completion_sources.OPENAI:
+                case chat_completion_sources.OPENROUTER:
+                case chat_completion_sources.MISTRALAI:
+                case chat_completion_sources.CUSTOM:
+                case chat_completion_sources.COHERE:
+                case chat_completion_sources.XAI:
+                default:
+                    result = tryParse(data?.content);
+                    break;
+            }
+        } break;
     }
 
-    return JSON.stringify(result);
+    return JSON.stringify(result ?? {});
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -3209,6 +3209,10 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
             throw new Error(data.response);
         }
 
+        if (options?.jsonSchema) {
+            return extractJsonFromData(data, { mainApi: api });
+        }
+
         // format result, exclude user prompt bias
         const message = cleanUpMessage({
             getMessage: extractMessageFromData(data),
@@ -4543,6 +4547,10 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             throw new Error(data?.response);
         }
 
+        if (jsonSchema) {
+            return extractJsonFromData(data);
+        }
+
         //const getData = await response.json();
         let getMessage = extractMessageFromData(data);
         let title = extractTitleFromData(data);
@@ -5309,6 +5317,31 @@ export function extractMessageFromData(data, activeApi = null) {
         default:
             return '';
     }
+}
+
+/**
+ * Extracts JSON from the response data.
+ * @param {object} data Response data
+ * @returns {string} Extracted JSON string from the response data
+ */
+export function extractJsonFromData(data, { mainApi = null, chatCompletionSource = null } = {}) {
+    mainApi = mainApi ?? main_api;
+    chatCompletionSource = chatCompletionSource ?? oai_settings.chat_completion_source;
+
+    let result = {};
+    if (data.content) {
+        if (typeof data.content === 'string') {
+            try {
+                result = JSON.parse(data.content);
+            } catch (e) {
+                console.debug('Failed to parse content as JSON.', e);
+            }
+        } else if (mainApi === 'openai' && chatCompletionSource === chat_completion_sources.CLAUDE) {
+            result = data.content.find(x => x.type === 'tool_use')?.input;
+        }
+    }
+
+    return JSON.stringify(result);
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -5352,6 +5352,9 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
                 case chat_completion_sources.POLLINATIONS:
                     result = tryParse(data?.choices?.[0]?.message?.content);
                     break;
+                case chat_completion_sources.PERPLEXITY:
+                    result = tryParse(removeReasoningFromString(data?.choices?.[0]?.message?.content));
+                    break;
                 case chat_completion_sources.VERTEXAI:
                 case chat_completion_sources.MAKERSUITE:
                 case chat_completion_sources.OPENAI:

--- a/public/script.js
+++ b/public/script.js
@@ -5348,6 +5348,7 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
                     break;
                 case chat_completion_sources.DEEPSEEK:
                 case chat_completion_sources.AI21:
+                case chat_completion_sources.GROQ:
                     result = tryParse(data?.choices?.[0]?.message?.content);
                     break;
                 case chat_completion_sources.VERTEXAI:

--- a/public/script.js
+++ b/public/script.js
@@ -3117,9 +3117,10 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @param {string} [systemPrompt] System prompt to use. Only Instruct mode or OpenAI.
  * @param {number} [responseLength] Maximum response length. If unset, the global default value is used.
  * @param {boolean} [trimNames] Whether to allow trimming "{{user}}:" and "{{char}}:" from the response.
+ * @param {PureGenerateOptions} [options] Additional options for generation
  * @returns {Promise<string>} Generated message
  */
-export async function generateRaw(prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, trimNames = true) {
+export async function generateRaw(prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, trimNames = true, options = {}) {
     if (!api) {
         api = main_api;
     }
@@ -3171,7 +3172,7 @@ export async function generateRaw(prompt, api, instructOverride, quietToLoud, sy
         if (api === 'koboldhorde') {
             data = await generateHorde(prompt.toString(), generateData, abortController.signal, false);
         } else if (api === 'openai') {
-            data = await sendOpenAIRequest('quiet', generateData, abortController.signal);
+            data = await sendOpenAIRequest('quiet', generateData, abortController.signal, options);
         } else {
             const generateUrl = getGenerateUrl(api);
             const response = await fetch(generateUrl, {
@@ -3328,15 +3329,35 @@ function removeLastMessage() {
 }
 
 /**
+ * @typedef {object} JsonSchema
+ * @property {string} name
+ * @property {object} value
+ * @property {string} [description]
+ * @property {boolean} [strict]
+ *
+ * @typedef {object} GenerateOptions
+ * @property {boolean} [automatic_trigger]
+ * @property {boolean} [force_name2]
+ * @property {string} [quiet_prompt]
+ * @property {boolean} [quietToLoud]
+ * @property {boolean} [skipWIAN]
+ * @property {number} [force_chid]
+ * @property {AbortSignal} [signal]
+ * @property {string} [quietImage]
+ * @property {string} [quietName]
+ * @property {number} [depth]
+ * @property {JsonSchema} [jsonSchema]
+ */
+
+/**
  * MARK:Generate()
  * Runs a generation using the current chat context.
  * @param {string} type Generation type
  * @param {GenerateOptions} options Generation options
  * @param {boolean} dryRun Whether to actually generate a message or just assemble the prompt
  * @returns {Promise<any>} Returns a promise that resolves when the text is done generating.
- * @typedef {{automatic_trigger?: boolean, force_name2?: boolean, quiet_prompt?: string, quietToLoud?: boolean, skipWIAN?: boolean, force_chid?: number, signal?: AbortSignal, quietImage?: string, quietName?: string, depth?: number }} GenerateOptions
  */
-export async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, depth = 0 } = {}, dryRun = false) {
+export async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, jsonSchema = null, depth = 0 } = {}, dryRun = false) {
     console.log('Generate entered');
     setGenerationProgress(0);
     generation_started = new Date();
@@ -4478,7 +4499,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 });
             }
         } else {
-            return await sendGenerationRequest(type, generate_data);
+            return await sendGenerationRequest(type, generate_data, {
+                jsonSchema,
+            });
         }
     }
 
@@ -5087,15 +5110,22 @@ function setInContextMessages(msgInContextCount, type) {
 }
 
 /**
+ * Send a chat completion request to backend
+ * @typedef {object} PureGenerateOptions
+ * @property {JsonSchema} [jsonSchema]
+ */
+
+/**
  * Sends a non-streaming request to the API.
  * @param {string} type Generation type
  * @param {object} data Generation data
+ * @param {PureGenerateOptions} [options] Additional options for the generation request
  * @returns {Promise<object>} Response data from the API
  * @throws {Error|object}
  */
-export async function sendGenerationRequest(type, data) {
+export async function sendGenerationRequest(type, data, options = {}) {
     if (main_api === 'openai') {
-        return await sendOpenAIRequest(type, data.prompt, abortController.signal);
+        return await sendOpenAIRequest(type, data.prompt, abortController.signal, options);
     }
 
     if (main_api === 'koboldhorde') {
@@ -5121,16 +5151,17 @@ export async function sendGenerationRequest(type, data) {
  * Sends a streaming request to the API.
  * @param {string} type Generation type
  * @param {object} data Generation data
+ * @param {PureGenerateOptions} [options] Additional options for the generation request
  * @returns {Promise<any>} Streaming generator
  */
-export async function sendStreamingRequest(type, data) {
+export async function sendStreamingRequest(type, data, options = {}) {
     if (abortController?.signal?.aborted) {
         throw new Error('Generation was aborted.');
     }
 
     switch (main_api) {
         case 'openai':
-            return await sendOpenAIRequest(type, data.prompt, streamingProcessor.abortController.signal);
+            return await sendOpenAIRequest(type, data.prompt, streamingProcessor.abortController.signal, options);
         case 'textgenerationwebui':
             return await generateTextGenWithStreaming(data, streamingProcessor.abortController.signal);
         case 'novel':

--- a/public/script.js
+++ b/public/script.js
@@ -5349,6 +5349,7 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
                 case chat_completion_sources.DEEPSEEK:
                 case chat_completion_sources.AI21:
                 case chat_completion_sources.GROQ:
+                case chat_completion_sources.POLLINATIONS:
                     result = tryParse(data?.choices?.[0]?.message?.content);
                     break;
                 case chat_completion_sources.VERTEXAI:

--- a/public/script.js
+++ b/public/script.js
@@ -5350,6 +5350,7 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
                 case chat_completion_sources.AI21:
                 case chat_completion_sources.GROQ:
                 case chat_completion_sources.POLLINATIONS:
+                case chat_completion_sources.AIMLAPI:
                     result = tryParse(data?.choices?.[0]?.message?.content);
                     break;
                 case chat_completion_sources.PERPLEXITY:

--- a/public/script.js
+++ b/public/script.js
@@ -5347,6 +5347,7 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
                     result = data?.content?.find(x => x.type === 'tool_use')?.input;
                     break;
                 case chat_completion_sources.DEEPSEEK:
+                case chat_completion_sources.AI21:
                     result = tryParse(data?.choices?.[0]?.message?.content);
                     break;
                 case chat_completion_sources.VERTEXAI:

--- a/public/script.js
+++ b/public/script.js
@@ -5342,22 +5342,23 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
 
     switch (mainApi) {
         case 'openai': {
+            const text = extractMessageFromData(data, mainApi);
             switch (chatCompletionSource) {
                 case chat_completion_sources.CLAUDE:
                     result = data?.content?.find(x => x.type === 'tool_use')?.input;
+                    break;
+                case chat_completion_sources.VERTEXAI:
+                case chat_completion_sources.MAKERSUITE:
+                    result = tryParse(data?.content);
+                    break;
+                case chat_completion_sources.PERPLEXITY:
+                    result = tryParse(removeReasoningFromString(text));
                     break;
                 case chat_completion_sources.DEEPSEEK:
                 case chat_completion_sources.AI21:
                 case chat_completion_sources.GROQ:
                 case chat_completion_sources.POLLINATIONS:
                 case chat_completion_sources.AIMLAPI:
-                    result = tryParse(data?.choices?.[0]?.message?.content);
-                    break;
-                case chat_completion_sources.PERPLEXITY:
-                    result = tryParse(removeReasoningFromString(data?.choices?.[0]?.message?.content));
-                    break;
-                case chat_completion_sources.VERTEXAI:
-                case chat_completion_sources.MAKERSUITE:
                 case chat_completion_sources.OPENAI:
                 case chat_completion_sources.OPENROUTER:
                 case chat_completion_sources.MISTRALAI:
@@ -5365,7 +5366,7 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
                 case chat_completion_sources.COHERE:
                 case chat_completion_sources.XAI:
                 default:
-                    result = tryParse(data?.content);
+                    result = tryParse(text);
                     break;
             }
         } break;

--- a/public/script.js
+++ b/public/script.js
@@ -5347,13 +5347,11 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
                 case chat_completion_sources.CLAUDE:
                     result = data?.content?.find(x => x.type === 'tool_use')?.input;
                     break;
-                case chat_completion_sources.VERTEXAI:
-                case chat_completion_sources.MAKERSUITE:
-                    result = tryParse(data?.content);
-                    break;
                 case chat_completion_sources.PERPLEXITY:
                     result = tryParse(removeReasoningFromString(text));
                     break;
+                case chat_completion_sources.VERTEXAI:
+                case chat_completion_sources.MAKERSUITE:
                 case chat_completion_sources.DEEPSEEK:
                 case chat_completion_sources.AI21:
                 case chat_completion_sources.GROQ:

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -480,8 +480,7 @@ export class ChatCompletionService {
                 if (result.content && typeof result.content === 'string') {
                     try {
                         result.content = JSON.parse(result.content);
-                    } catch (e) {
-                    }
+                    } catch (e) { /* empty */ }
                 } else if (data.chat_completion_source === 'claude' && json.content) { // Fuck claude
                     result.content = json.content.find(x => x.type === 'tool_use')?.input;
                 }

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -477,7 +477,7 @@ export class ChatCompletionService {
             };
             // Try parse JSON
             if (data.json_schema) {
-                result.content = extractJsonFromData(json, { mainApi: this.TYPE, chatCompletionSource: data.chat_completion_source });
+                result.content = JSON.parse(extractJsonFromData(json, { mainApi: this.TYPE, chatCompletionSource: data.chat_completion_source }));
             }
             return result;
         }

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -1,5 +1,5 @@
 import { getPresetManager } from './preset-manager.js';
-import { extractMessageFromData, getGenerateUrl, getRequestHeaders } from '../script.js';
+import { extractJsonFromData, extractMessageFromData, getGenerateUrl, getRequestHeaders } from '../script.js';
 import { getTextGenServer } from './textgen-settings.js';
 import { extractReasoningFromData } from './reasoning.js';
 import { formatInstructModeChat, formatInstructModePrompt, getInstructStoppingSequences, names_behavior_types } from './instruct-mode.js';
@@ -477,15 +477,7 @@ export class ChatCompletionService {
             };
             // Try parse JSON
             if (data.json_schema) {
-                if (result.content && typeof result.content === 'string') {
-                    try {
-                        result.content = JSON.parse(result.content);
-                    } catch (e) {
-                        console.debug('Failed to parse content as JSON.', e);
-                    }
-                } else if (data.chat_completion_source === 'claude' && json.content) { // Fuck claude
-                    result.content = json.content.find(x => x.type === 'tool_use')?.input;
-                }
+                result.content = extractJsonFromData(json, { mainApi: this.TYPE, chatCompletionSource: data.chat_completion_source });
             }
             return result;
         }

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -476,11 +476,13 @@ export class ChatCompletionService {
                 }),
             };
             // Try parse JSON
-            if (data._json_schema) {
+            if (data.json_schema) {
                 if (result.content && typeof result.content === 'string') {
                     try {
                         result.content = JSON.parse(result.content);
-                    } catch (e) { /* empty */ }
+                    } catch (e) {
+                        console.debug('Failed to parse content as JSON.', e);
+                    }
                 } else if (data.chat_completion_source === 'claude' && json.content) { // Fuck claude
                     result.content = json.content.find(x => x.type === 'tool_use')?.input;
                 }

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -467,7 +467,7 @@ export class ChatCompletionService {
                 return json;
             }
 
-            return {
+            const result = {
                 content: extractMessageFromData(json, this.TYPE),
                 reasoning: extractReasoningFromData(json, {
                     mainApi: this.TYPE,
@@ -475,6 +475,18 @@ export class ChatCompletionService {
                     ignoreShowThoughts: true,
                 }),
             };
+            // Try parse JSON
+            if (data._json_schema) {
+                if (result.content && typeof result.content === 'string') {
+                    try {
+                        result.content = JSON.parse(result.content);
+                    } catch (e) {
+                    }
+                } else if (data.chat_completion_source === 'claude' && json.content) { // Fuck claude
+                    result.content = json.content.find(x => x.type === 'tool_use')?.input;
+                }
+            }
+            return result;
         }
 
         if (!response.ok) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2465,7 +2465,7 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
     }
 
     if (jsonSchema) {
-        generate_data._json_schema = jsonSchema;
+        generate_data.json_schema = jsonSchema;
     }
 
     await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2187,11 +2187,12 @@ function getReasoningEffort() {
  * @param {string} type (impersonate, quiet, continue, etc)
  * @param {Array} messages
  * @param {AbortSignal?} signal
+ * @param {import('../script.js').PureGenerateOptions} options
  * @returns {Promise<unknown>}
  * @throws {Error}
  */
 
-async function sendOpenAIRequest(type, messages, signal) {
+async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } = {}) {
     // Provide default abort signal
     if (!signal) {
         signal = new AbortController().signal;
@@ -2461,6 +2462,10 @@ async function sendOpenAIRequest(type, messages, signal) {
             delete generate_data.tools;
             delete generate_data.tool_choice;
         }
+    }
+
+    if (jsonSchema) {
+        generate_data._json_schema = jsonSchema;
     }
 
     await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2187,7 +2187,7 @@ function getReasoningEffort() {
  * @param {string} type (impersonate, quiet, continue, etc)
  * @param {Array} messages
  * @param {AbortSignal?} signal
- * @param {import('../script.js').PureGenerateOptions} options
+ * @param {import('../script.js').AdditionalRequestOptions} options
  * @returns {Promise<unknown>}
  * @throws {Error}
  */

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -52,6 +52,7 @@ import {
     getCharacterCardFields,
     swipe_right,
     swipe_left,
+    generateRaw,
 } from '../script.js';
 import {
     extension_settings,
@@ -170,6 +171,7 @@ export function getContext() {
         ModuleWorkerWrapper,
         getTokenizerModel,
         generateQuietPrompt,
+        generateRaw,
         writeExtensionField,
         getThumbnailUrl,
         selectCharacterById,

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1017,15 +1017,15 @@ async function sendXaiRequest(request, response) {
         }
 
         if (request.body._json_schema) {
-        bodyParams['response_format'] = {
-            type: 'json_schema',
-            json_schema: {
-                name: request.body._json_schema.name,
-                strict: request.body._json_schema.strict ?? true,
-                schema: request.body._json_schema.value,
-            }
+            bodyParams['response_format'] = {
+                type: 'json_schema',
+                json_schema: {
+                    name: request.body._json_schema.name,
+                    strict: request.body._json_schema.strict ?? true,
+                    schema: request.body._json_schema.value,
+                },
+            };
         }
-    }
 
         const processedMessages = request.body.messages = convertXAIMessages(request.body.messages, getPromptNames(request));
 
@@ -1546,8 +1546,8 @@ router.post('/generate', function (request, response) {
                     name: request.body._json_schema.name,
                     strict: request.body._json_schema.strict ?? true,
                     schema: request.body._json_schema.value,
-                }
-            }
+                },
+            };
         }
 
         const cachingAtDepth = getConfigValue('claude.cachingAtDepth', -1, 'number');
@@ -1653,8 +1653,8 @@ router.post('/generate', function (request, response) {
                 name: request.body._json_schema.name,
                 strict: request.body._json_schema.strict ?? true,
                 schema: request.body._json_schema.value,
-            }
-        }
+            },
+        };
     }
 
     const requestBody = {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -630,12 +630,23 @@ async function sendAI21Request(request, response) {
         return response.status(400).send({ error: true });
     }
 
+    const bodyParams = {};
     const controller = new AbortController();
-    console.debug(request.body.messages);
     request.socket.removeAllListeners('close');
     request.socket.on('close', function () {
         controller.abort();
     });
+    // Hack to support JSON schema
+    if (request.body.json_schema) {
+        bodyParams.response_format = {
+            type: 'json_object',
+        };
+        const message = {
+            role: 'user',
+            content: `JSON schema for the response:\n${JSON.stringify(request.body.json_schema.value, null, 4)}`,
+        };
+        request.body.messages.push(message);
+    }
     const convertedPrompt = convertAI21Messages(request.body.messages, getPromptNames(request));
     const body = {
         messages: convertedPrompt,
@@ -646,6 +657,7 @@ async function sendAI21Request(request, response) {
         stop: request.body.stop,
         stream: request.body.stream,
         tools: request.body.tools,
+        ...bodyParams,
     };
     const options = {
         method: 'POST',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1442,7 +1442,6 @@ router.post('/generate', function (request, response) {
         request.body.json_schema.value = flattenSchema(request.body.json_schema.value);
     }
 
-
     switch (request.body.chat_completion_source) {
         case CHAT_COMPLETION_SOURCES.CLAUDE: return sendClaudeRequest(request, response);
         case CHAT_COMPLETION_SOURCES.SCALE: return sendScaleRequest(request, response);

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -175,18 +175,14 @@ async function sendClaudeRequest(request, response) {
         }
 
         // Structured output is a forced tool
-        if (request.body._json_schema) {
+        if (request.body.json_schema) {
             const jsonTool = {
-                name: request.body._json_schema.name,
-                description: request.body._json_schema.description || 'Well-formed JSON object',
-                input_schema: request.body._json_schema.value,
+                name: request.body.json_schema.name,
+                description: request.body.json_schema.description || 'Well-formed JSON object',
+                input_schema: request.body.json_schema.value,
             };
-            if (!requestBody.tools) {
-                requestBody.tools = [jsonTool];
-            } else {
-                requestBody.tools.push(jsonTool);
-            }
-            requestBody.tool_choice = { type: 'tool', name: request.body._json_schema.name };
+            requestBody.tools = [...(requestBody.tools || []), jsonTool];
+            requestBody.tool_choice = { type: 'tool', name: request.body.json_schema.name };
         }
 
         if (useWebSearch) {
@@ -379,8 +375,8 @@ async function sendMakerSuiteRequest(request, response) {
     const isGemma = model.includes('gemma');
     const isLearnLM = model.includes('learnlm');
 
-    const responseMimeType = request.body.responseMimeType ?? (request.body._json_schema ? 'application/json' : undefined);
-    const responseSchema = request.body.responseSchema ?? (request.body._json_schema ? request.body._json_schema.value : undefined);
+    const responseMimeType = request.body.responseMimeType ?? (request.body.json_schema ? 'application/json' : undefined);
+    const responseSchema = request.body.responseSchema ?? (request.body.json_schema ? request.body.json_schema.value : undefined);
 
     const generationConfig = {
         stopSequences: request.body.stop,
@@ -820,10 +816,10 @@ async function sendCohereRequest(request, response) {
             requestBody.safety_mode = 'OFF';
         }
 
-        if (request.body._json_schema) {
+        if (request.body.json_schema) {
             requestBody.response_format = {
                 type: 'json_schema',
-                schema: request.body._json_schema.value,
+                schema: request.body.json_schema.value,
             };
         }
 
@@ -1016,13 +1012,13 @@ async function sendXaiRequest(request, response) {
             };
         }
 
-        if (request.body._json_schema) {
+        if (request.body.json_schema) {
             bodyParams['response_format'] = {
                 type: 'json_schema',
                 json_schema: {
-                    name: request.body._json_schema.name,
-                    strict: request.body._json_schema.strict ?? true,
-                    schema: request.body._json_schema.value,
+                    name: request.body.json_schema.name,
+                    strict: request.body.json_schema.strict ?? true,
+                    schema: request.body.json_schema.value,
                 },
             };
         }
@@ -1442,8 +1438,8 @@ router.post('/generate', function (request, response) {
             getPromptNames(request));
     }
 
-    if (request.body._json_schema?.value) {
-        request.body._json_schema.value = flattenSchema(request.body._json_schema.value);
+    if (request.body.json_schema?.value) {
+        request.body.json_schema.value = flattenSchema(request.body.json_schema.value);
     }
 
 
@@ -1522,13 +1518,13 @@ router.post('/generate', function (request, response) {
             bodyParams['reasoning'] = { effort: request.body.reasoning_effort };
         }
 
-        if (request.body._json_schema) {
+        if (request.body.json_schema) {
             bodyParams['response_format'] = {
                 type: 'json_schema',
                 json_schema: {
-                    name: request.body._json_schema.name,
-                    strict: request.body._json_schema.strict ?? true,
-                    schema: request.body._json_schema.value,
+                    name: request.body.json_schema.name,
+                    strict: request.body.json_schema.strict ?? true,
+                    schema: request.body.json_schema.value,
                 },
             };
         }
@@ -1634,13 +1630,13 @@ router.post('/generate', function (request, response) {
         bodyParams['tool_choice'] = request.body.tool_choice;
     }
 
-    if (request.body._json_schema) {
+    if (request.body.json_schema) {
         bodyParams['response_format'] = {
             type: 'json_schema',
             json_schema: {
-                name: request.body._json_schema.name,
-                strict: request.body._json_schema.strict ?? true,
-                schema: request.body._json_schema.value,
+                name: request.body.json_schema.name,
+                strict: request.body.json_schema.strict ?? true,
+                schema: request.body.json_schema.value,
             },
         };
     }

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1605,6 +1605,17 @@ router.post('/generate', function (request, response) {
         apiKey = readSecret(request.user.directories, SECRET_KEYS.GROQ);
         headers = {};
         bodyParams = {};
+        if (request.body.json_schema) {
+            bodyParams['response_format'] = {
+                type: 'json_schema',
+                json_schema: {
+                    name: request.body.json_schema.name,
+                    description: request.body.json_schema.description,
+                    schema: request.body.json_schema.value,
+                    strict: request.body.json_schema.strict ?? true,
+                },
+            };
+        }
     } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.NANOGPT) {
         apiUrl = API_NANOGPT;
         apiKey = readSecret(request.user.directories, SECRET_KEYS.NANOGPT);

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1638,6 +1638,17 @@ router.post('/generate', function (request, response) {
             referrer: 'sillytavern',
             seed: request.body.seed ?? Math.floor(Math.random() * 99999999),
         };
+        // Hack to support JSON schema
+        if (request.body.json_schema) {
+            bodyParams['response_format'] = {
+                type: 'json_object',
+            };
+            const message = {
+                role: 'user',
+                content: `JSON schema for the response:\n${JSON.stringify(request.body.json_schema.value, null, 4)}`,
+            };
+            request.body.messages.push(message);
+        }
     } else {
         console.warn('This chat completion source is not supported yet.');
         return response.status(400).send({ error: true });
@@ -1676,7 +1687,7 @@ router.post('/generate', function (request, response) {
         bodyParams['tool_choice'] = request.body.tool_choice;
     }
 
-    if (request.body.json_schema) {
+    if (request.body.json_schema && !bodyParams['response_format']) {
         bodyParams['response_format'] = {
             type: 'json_schema',
             json_schema: {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -726,6 +726,18 @@ async function sendMistralAIRequest(request, response) {
             requestBody['tool_choice'] = request.body.tool_choice;
         }
 
+        if (request.body.json_schema) {
+            requestBody['response_format'] = {
+                type: 'json_schema',
+                json_schema: {
+                    name: request.body.json_schema.name,
+                    description: request.body.json_schema.description,
+                    schema: request.body.json_schema.value,
+                    strict: request.body.json_schema.strict ?? true,
+                },
+            };
+        }
+
         const config = {
             method: 'POST',
             headers: {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1487,7 +1487,7 @@ router.post('/generate', function (request, response) {
     }
 
     if (request.body.json_schema?.value) {
-        request.body.json_schema.value = flattenSchema(request.body.json_schema.value);
+        request.body.json_schema.value = flattenSchema(request.body.json_schema.value, request.body.chat_completion_source);
     }
 
     switch (request.body.chat_completion_source) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -916,6 +916,18 @@ async function sendDeepSeekRequest(request, response) {
             });
         }
 
+        // Hack to support JSON schema
+        if (request.body.json_schema) {
+            bodyParams.response_format = {
+                type: 'json_object',
+            };
+            const message = {
+                role: 'user',
+                content: `JSON schema for the response:\n${JSON.stringify(request.body.json_schema.value, null, 4)}`,
+            };
+            request.body.messages.push(message);
+        }
+
         const postProcessType = String(request.body.model).endsWith('-reasoner')
             ? PROMPT_PROCESSING_TYPE.STRICT_TOOLS
             : PROMPT_PROCESSING_TYPE.SEMI_TOOLS;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -18,6 +18,7 @@ import {
     excludeKeysByYaml,
     color,
     trimTrailingSlash,
+    flattenSchema,
 } from '../../util.js';
 import {
     convertClaudeMessages,
@@ -171,6 +172,21 @@ async function sendClaudeRequest(request, response) {
             if (enableSystemPromptCache && requestBody.tools.length) {
                 requestBody.tools[requestBody.tools.length - 1]['cache_control'] = { type: 'ephemeral', ttl: cacheTTL };
             }
+        }
+
+        // Structured output is a forced tool
+        if (request.body._json_schema) {
+            const jsonTool = {
+                name: request.body._json_schema.name,
+                description: request.body._json_schema.description || 'Well-formed JSON object',
+                input_schema: request.body._json_schema.value,
+            };
+            if (!requestBody.tools) {
+                requestBody.tools = [jsonTool];
+            } else {
+                requestBody.tools.push(jsonTool);
+            }
+            requestBody.tool_choice = { type: 'tool', name: request.body._json_schema.name };
         }
 
         if (useWebSearch) {
@@ -363,6 +379,9 @@ async function sendMakerSuiteRequest(request, response) {
     const isGemma = model.includes('gemma');
     const isLearnLM = model.includes('learnlm');
 
+    const responseMimeType = request.body.responseMimeType ?? (request.body._json_schema ? 'application/json' : undefined);
+    const responseSchema = request.body.responseSchema ?? (request.body._json_schema ? request.body._json_schema.value : undefined);
+
     const generationConfig = {
         stopSequences: request.body.stop,
         candidateCount: 1,
@@ -370,8 +389,8 @@ async function sendMakerSuiteRequest(request, response) {
         temperature: request.body.temperature,
         topP: request.body.top_p,
         topK: request.body.top_k || undefined,
-        responseMimeType: request.body.responseMimeType,
-        responseSchema: request.body.responseSchema,
+        responseMimeType: responseMimeType,
+        responseSchema: responseSchema,
     };
 
     function getGeminiBody() {
@@ -801,6 +820,13 @@ async function sendCohereRequest(request, response) {
             requestBody.safety_mode = 'OFF';
         }
 
+        if (request.body._json_schema) {
+            requestBody.response_format = {
+                type: 'json_schema',
+                schema: request.body._json_schema.value,
+            };
+        }
+
         console.debug('Cohere request:', requestBody);
 
         const config = {
@@ -989,6 +1015,17 @@ async function sendXaiRequest(request, response) {
                 ],
             };
         }
+
+        if (request.body._json_schema) {
+        bodyParams['response_format'] = {
+            type: 'json_schema',
+            json_schema: {
+                name: request.body._json_schema.name,
+                strict: request.body._json_schema.strict ?? true,
+                schema: request.body._json_schema.value,
+            }
+        }
+    }
 
         const processedMessages = request.body.messages = convertXAIMessages(request.body.messages, getPromptNames(request));
 
@@ -1405,6 +1442,28 @@ router.post('/generate', function (request, response) {
             getPromptNames(request));
     }
 
+    // request.body._json_schema
+    // {
+    //     "name": "WeatherReport",
+    //     "value": {
+    //         "$schema": "http://json-schema.org/draft-04/schema#",
+    //         "type": "object",
+    //         "properties": {
+    //             "Location": {
+    //                 "type": "string"
+    //             }
+    //         },
+    //         "required": [
+    //             "Location"
+    //         ]
+    //     }
+    // }
+
+    if (request.body._json_schema?.value) {
+        request.body._json_schema.value = flattenSchema(request.body._json_schema.value);
+    }
+
+
     switch (request.body.chat_completion_source) {
         case CHAT_COMPLETION_SOURCES.CLAUDE: return sendClaudeRequest(request, response);
         case CHAT_COMPLETION_SOURCES.SCALE: return sendScaleRequest(request, response);
@@ -1478,6 +1537,17 @@ router.post('/generate', function (request, response) {
 
         if (request.body.reasoning_effort) {
             bodyParams['reasoning'] = { effort: request.body.reasoning_effort };
+        }
+
+        if (request.body._json_schema) {
+            bodyParams['response_format'] = {
+                type: 'json_schema',
+                json_schema: {
+                    name: request.body._json_schema.name,
+                    strict: request.body._json_schema.strict ?? true,
+                    schema: request.body._json_schema.value,
+                }
+            }
         }
 
         const cachingAtDepth = getConfigValue('claude.cachingAtDepth', -1, 'number');
@@ -1574,6 +1644,17 @@ router.post('/generate', function (request, response) {
     if (!isTextCompletion && Array.isArray(request.body.tools) && request.body.tools.length > 0) {
         bodyParams['tools'] = request.body.tools;
         bodyParams['tool_choice'] = request.body.tool_choice;
+    }
+
+    if (request.body._json_schema) {
+        bodyParams['response_format'] = {
+            type: 'json_schema',
+            json_schema: {
+                name: request.body._json_schema.name,
+                strict: request.body._json_schema.strict ?? true,
+                schema: request.body._json_schema.value,
+            }
+        }
     }
 
     const requestBody = {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1154,6 +1154,18 @@ async function sendAimlapiRequest(request, response) {
             bodyParams['reasoning_effort'] = request.body.reasoning_effort;
         }
 
+        if (request.body.json_schema) {
+            bodyParams['response_format'] = {
+                type: 'json_schema',
+                json_schema: {
+                    name: request.body.json_schema.name,
+                    description: request.body.json_schema.description,
+                    schema: request.body.json_schema.value,
+                    strict: request.body.json_schema.strict ?? true,
+                },
+            };
+        }
+
         const requestBody = {
             'messages': request.body.messages,
             'model': request.body.model,

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1600,6 +1600,14 @@ router.post('/generate', function (request, response) {
             reasoning_effort: request.body.reasoning_effort,
         };
         request.body.messages = postProcessPrompt(request.body.messages, PROMPT_PROCESSING_TYPE.STRICT, getPromptNames(request));
+        if (request.body.json_schema) {
+            bodyParams['response_format'] = {
+                type: 'json_schema',
+                json_schema: {
+                    schema: request.body.json_schema.value,
+                },
+            };
+        }
     } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.GROQ) {
         apiUrl = API_GROQ;
         apiKey = readSecret(request.user.directories, SECRET_KEYS.GROQ);

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1442,23 +1442,6 @@ router.post('/generate', function (request, response) {
             getPromptNames(request));
     }
 
-    // request.body._json_schema
-    // {
-    //     "name": "WeatherReport",
-    //     "value": {
-    //         "$schema": "http://json-schema.org/draft-04/schema#",
-    //         "type": "object",
-    //         "properties": {
-    //             "Location": {
-    //                 "type": "string"
-    //             }
-    //         },
-    //         "required": [
-    //             "Location"
-    //         ]
-    //     }
-    // }
-
     if (request.body._json_schema?.value) {
         request.body._json_schema.value = flattenSchema(request.body._json_schema.value);
     }

--- a/src/util.js
+++ b/src/util.js
@@ -17,7 +17,7 @@ import mime from 'mime-types';
 import { default as simpleGit } from 'simple-git';
 import chalk from 'chalk';
 import bytes from 'bytes';
-import { LOG_LEVELS } from './constants.js';
+import { LOG_LEVELS, CHAT_COMPLETION_SOURCES } from './constants.js';
 import { serverDirectory } from './server-directory.js';
 
 /**
@@ -1217,9 +1217,10 @@ export function getRequestURL(request) {
 /**
  * Flattens a JSON schema by inlining all definitions and setting additionalProperties to false.
  * @param {object} schema The JSON schema to flatten.
+ * @param {string} api The API source, used to determine how to handle certain properties.
  * @returns {object} The flattened schema.
  */
-export function flattenSchema(schema) {
+export function flattenSchema(schema, api) {
     if (!schema || typeof schema !== 'object') {
         return schema;
     }
@@ -1249,7 +1250,10 @@ export function flattenSchema(schema) {
             }
         }
 
-        if ('properties' in obj) {
+        if (api === CHAT_COMPLETION_SOURCES.MAKERSUITE || api === CHAT_COMPLETION_SOURCES.VERTEXAI) {
+            delete obj.default;
+            delete obj.additionalProperties;
+        } else if ('properties' in obj) {
             if (obj.additionalProperties === undefined || obj.additionalProperties === true) {
                 obj.additionalProperties = false;
             }

--- a/src/util.js
+++ b/src/util.js
@@ -1225,7 +1225,7 @@ export function flattenSchema(schema) {
     }
 
     // Deep clone to avoid modifying the original object.
-    const schemaCopy = JSON.parse(JSON.stringify(schema));
+    const schemaCopy = structuredClone(schema);
 
     const definitions = schemaCopy.$defs || {};
     delete schemaCopy.$defs;
@@ -1245,7 +1245,7 @@ export function flattenSchema(schema) {
         if (obj.$ref && typeof obj.$ref === 'string' && obj.$ref.startsWith('#/$defs/')) {
             const defName = obj.$ref.split('/').pop();
             if (definitions[defName]) {
-                return replaceRefs(JSON.parse(JSON.stringify(definitions[defName])));
+                return replaceRefs(structuredClone(definitions[defName]));
             }
         }
 
@@ -1263,7 +1263,7 @@ export function flattenSchema(schema) {
         return obj;
     }
 
-    let flattenedSchema = replaceRefs(schemaCopy);
+    const flattenedSchema = replaceRefs(schemaCopy);
 
     if (flattenedSchema.$schema) {
         delete flattenedSchema.$schema;

--- a/src/util.js
+++ b/src/util.js
@@ -1213,3 +1213,61 @@ export function getRequestURL(request) {
     }
     throw new TypeError('Invalid request type');
 }
+
+/**
+ * Flattens a JSON schema by inlining all definitions and setting additionalProperties to false.
+ * @param {object} schema The JSON schema to flatten.
+ * @returns {object} The flattened schema.
+ */
+export function flattenSchema(schema) {
+    if (!schema || typeof schema !== 'object') {
+        return schema;
+    }
+
+    // Deep clone to avoid modifying the original object.
+    const schemaCopy = JSON.parse(JSON.stringify(schema));
+
+    const definitions = schemaCopy.$defs || {};
+    delete schemaCopy.$defs;
+
+    function replaceRefs(obj) {
+        if (obj === null || typeof obj !== 'object') {
+            return obj;
+        }
+
+        if (Array.isArray(obj)) {
+            for (let i = 0; i < obj.length; i++) {
+                obj[i] = replaceRefs(obj[i]);
+            }
+            return obj;
+        }
+
+        if (obj.$ref && typeof obj.$ref === 'string' && obj.$ref.startsWith('#/$defs/')) {
+            const defName = obj.$ref.split('/').pop();
+            if (definitions[defName]) {
+                return replaceRefs(JSON.parse(JSON.stringify(definitions[defName])));
+            }
+        }
+
+        if ('properties' in obj) {
+            if (obj.additionalProperties === undefined || obj.additionalProperties === true) {
+                obj.additionalProperties = false;
+            }
+        }
+
+        for (const key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                obj[key] = replaceRefs(obj[key]);
+            }
+        }
+        return obj;
+    }
+
+    let flattenedSchema = replaceRefs(schemaCopy);
+
+    if (flattenedSchema.$schema) {
+        delete flattenedSchema.$schema;
+    }
+
+    return flattenedSchema;
+}


### PR DESCRIPTION
I tested with a simple JSON. It is only for Chat Completion.

- [x] OpenAI
- [x] OpenRouter
- [x] Claude
- [x] Makersuite
- [x] Cohere
- [x] xAI

Of course, there are other APIs such as:
- Deepseek: There is no proper doc with structured output. (It might work OpenAI behavior)
- Mistral: I can't test
- Scale
- AI21
- ai/ml
- Groq
- Perplexity
- Nanogpt
- 01
- Pollinations