### PR TITLE
chat templates: add Kimi K2 (Moonshot AI) chat template derivation

### DIFF
--- a/public/scripts/chat-templates.js
+++ b/public/scripts/chat-templates.js
@@ -96,7 +96,7 @@ const substr_derivations = [
     ['Moonshot AI', ['<|im_user|>user<|im_middle|>', '<|im_assistant|>assistant<|im_middle|>', '<|im_end|>']],
 
     // Generic cases
-    ['ChatML', '<|im_start|>'],
+    ['ChatML', ['<|im_start|>user', '<|im_start|>assistant', '<|im_end|>']],
 ];
 
 const parse_derivation = derivation => (typeof derivation === 'string') ? {

--- a/public/scripts/chat-templates.js
+++ b/public/scripts/chat-templates.js
@@ -85,11 +85,19 @@ const hash_derivations = {
     '854b703e44ca06bdb196cc471c728d15dbab61e744fe6cdce980086b61646ed1':
         'GLM-4'
     ,
+
+    // Kimi K2, ...
+    'aab20feb9bc6881f941ea649356130ffbc4943b3c2577c0991e1fba90de5a0fc':
+        'Moonshot AI'
+    ,
 };
 
-const substr_derivations = {
-    '<|im_start|>': 'ChatML', // qwen2.5, ...
-};
+const substr_derivations = [
+    ['Moonshot AI', ['<|im_user|>user<|im_middle|>', '<|im_assistant|>assistant<|im_middle|>', '<|im_end|>']],
+
+    // Generic cases
+    ['ChatML', '<|im_start|>'],
+];
 
 const parse_derivation = derivation => (typeof derivation === 'string') ? {
     'context': derivation,
@@ -109,8 +117,8 @@ export async function deriveTemplatesFromChatTemplate(chat_template, hash) {
     }
 
     // heuristics
-    for (const [substr, derivation] of Object.entries(substr_derivations) ) {
-        if (chat_template.includes(substr)) {
+    for (const [derivation, substr] of substr_derivations) {
+        if ([substr].flat().every(str => chat_template.includes(str))) {
             return parse_derivation(derivation);
         }
     }


### PR DESCRIPTION
Auto-detect Moonshot AI model.

This also rearranges the derivation stuff, and adds support for multi-string (match all) search. Tentatively this is moving away from using the chat template hash and instead using search strings like [`AutoGuess` in koboldcpp](https://github.com/LostRuins/koboldcpp/blob/concedo/kcpp_adapters/AutoGuess.json).

Currently it's a NOP because the hash is included as well.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
