### PR TITLE
Add toggle and user agent filter for CacheBuster middleware

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -151,6 +151,15 @@ performance:
   # Enables disk caching for character cards. Improves performances with large card libraries.
   useDiskCache: true
 
+# CACHE BUSTER CONFIGURATION
+# IMPORTANT: Requires localhost or a domain with HTTPS, otherwise will not work!
+cacheBuster:
+  # Clear browser cache on first load or after uploading image files
+  enabled: false
+  # Only clear cache for the specified user agent regex pattern
+  # Example: 'firefox|safari' (case-insensitive)
+  userAgentPattern: ''
+
 # Allow secret keys exposure via API
 allowKeysExposure: false
 # Skip new default content checks

--- a/src/byaf.js
+++ b/src/byaf.js
@@ -1,4 +1,3 @@
-
 import sanitize from 'sanitize-filename';
 import { promises as fsPromises } from 'node:fs';
 import path from 'node:path';

--- a/src/endpoints/avatars.js
+++ b/src/endpoints/avatars.js
@@ -10,6 +10,7 @@ import { getImages, tryParse } from '../util.js';
 import { getFileNameValidationFunction } from '../middleware/validateFileName.js';
 import { applyAvatarCropResize } from './characters.js';
 import { invalidateThumbnail } from './thumbnails.js';
+import { CacheBuster } from '../middleware/cacheBuster.js';
 
 export const router = express.Router();
 
@@ -49,7 +50,7 @@ router.post('/upload', getFileNameValidationFunction('overwrite_name'), async (r
         // Remove previous thumbnail and bust cache if overwriting
         if (request.body.overwrite_name) {
             invalidateThumbnail(request.user.directories, 'persona', sanitize(request.body.overwrite_name));
-            response.setHeader('Clear-Site-Data', '"cache"');
+            new CacheBuster().bust(request, response);
         }
 
         const filename = request.body.overwrite_name || `${Date.now()}.png`;

--- a/src/endpoints/avatars.js
+++ b/src/endpoints/avatars.js
@@ -10,7 +10,7 @@ import { getImages, tryParse } from '../util.js';
 import { getFileNameValidationFunction } from '../middleware/validateFileName.js';
 import { applyAvatarCropResize } from './characters.js';
 import { invalidateThumbnail } from './thumbnails.js';
-import { CacheBuster } from '../middleware/cacheBuster.js';
+import cacheBuster from '../middleware/cacheBuster.js';
 
 export const router = express.Router();
 
@@ -50,7 +50,7 @@ router.post('/upload', getFileNameValidationFunction('overwrite_name'), async (r
         // Remove previous thumbnail and bust cache if overwriting
         if (request.body.overwrite_name) {
             invalidateThumbnail(request.user.directories, 'persona', sanitize(request.body.overwrite_name));
-            new CacheBuster().bust(request, response);
+            cacheBuster.bust(request, response);
         }
 
         const filename = request.body.overwrite_name || `${Date.now()}.png`;

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -23,6 +23,7 @@ import { importRisuSprites } from './sprites.js';
 import { getUserDirectories } from '../users.js';
 import { getChatInfo } from './chats.js';
 import { formatByafAsCharacterCard, getCharacterFromByafManifest, getImageBufferFromByafCharacter, getScenarioFromByafManifest } from '../byaf.js';
+import { CacheBuster } from '../middleware/cacheBuster.js';
 
 // With 100 MB limit it would take roughly 3000 characters to reach this limit
 const memoryCacheCapacity = getConfigValue('performance.memoryCacheCapacity', '100mb');
@@ -1065,7 +1066,7 @@ router.post('/edit', validateAvatarUrlMiddleware, async function (request, respo
             fs.unlinkSync(newAvatarPath);
 
             // Bust cache to reload the new avatar
-            response.setHeader('Clear-Site-Data', '"cache"');
+            new CacheBuster().bust(request, response);
         }
 
         return response.sendStatus(200);

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -23,7 +23,7 @@ import { importRisuSprites } from './sprites.js';
 import { getUserDirectories } from '../users.js';
 import { getChatInfo } from './chats.js';
 import { formatByafAsCharacterCard, getCharacterFromByafManifest, getImageBufferFromByafCharacter, getScenarioFromByafManifest } from '../byaf.js';
-import { CacheBuster } from '../middleware/cacheBuster.js';
+import cacheBuster from '../middleware/cacheBuster.js';
 
 // With 100 MB limit it would take roughly 3000 characters to reach this limit
 const memoryCacheCapacity = getConfigValue('performance.memoryCacheCapacity', '100mb');
@@ -1066,7 +1066,7 @@ router.post('/edit', validateAvatarUrlMiddleware, async function (request, respo
             fs.unlinkSync(newAvatarPath);
 
             // Bust cache to reload the new avatar
-            new CacheBuster().bust(request, response);
+            cacheBuster.bust(request, response);
         }
 
         return response.sendStatus(200);

--- a/src/middleware/cacheBuster.js
+++ b/src/middleware/cacheBuster.js
@@ -30,8 +30,8 @@ class CacheBuster {
         if (userAgentPattern) {
             try {
                 this.#userAgentRegex = new RegExp(userAgentPattern, 'i');
-            } catch (error) {
-                console.error('Cache Buster: Invalid user agent pattern:', userAgentPattern, error);
+            } catch {
+                console.error('[Cache Buster] Invalid user agent pattern:', userAgentPattern);
             }
         }
     }
@@ -50,7 +50,7 @@ class CacheBuster {
 
         // If response headers are already sent or response is ended
         if (response.headersSent || response.writableEnded) {
-            console.warn('Cache Buster: Response ended or headers already sent');
+            console.warn('[Cache Buster] Response ended or headers already sent');
             return false;
         }
 

--- a/src/middleware/cacheBuster.js
+++ b/src/middleware/cacheBuster.js
@@ -2,7 +2,15 @@ import crypto from 'node:crypto';
 import { DEFAULT_USER } from '../constants.js';
 import { getConfigValue } from '../util.js';
 
-export class CacheBuster {
+/**
+ * Sets the Clear-Site-Data header to bust the browser cache.
+ */
+class CacheBuster {
+    /**
+     * @type {Set<string>} Handles/User-Agents that have already been busted.
+     */
+    #keys = new Set();
+
     /**
      * Check if the cache buster is enabled based on the configuration.
      * @returns {boolean} Whether the cache buster is enabled.
@@ -49,28 +57,29 @@ export class CacheBuster {
 
     /**
      * Middleware to bust the browser cache for the current user.
-     * @returns {import('express').RequestHandler}
+     * @type {import('express').RequestHandler}
+     */
+    #middleware(request, response, next) {
+        const handle = request.user?.profile?.handle || DEFAULT_USER.handle;
+        const userAgent = request.headers['user-agent'] || '';
+        const hash = crypto.createHash('sha256').update(userAgent).digest('hex');
+        const key = `${handle}-${hash}`;
+
+        if (this.#keys.has(key)) {
+            return next();
+        }
+
+        this.#keys.add(key);
+        this.bust(request, response);
+        next();
+    }
+
+    /**
+     * Middleware to bust the browser cache for the current user.
+     * @returns {import('express').RequestHandler} The middleware function.
      */
     get middleware() {
-        /**
-         * @type {Set<string>} Handles/User-Agents that have already been busted.
-         */
-        const keys = new Set();
-
-        return (request, response, next) => {
-            const handle = request.user?.profile?.handle || DEFAULT_USER.handle;
-            const userAgent = request.headers['user-agent'] || '';
-            const hash = crypto.createHash('sha256').update(userAgent).digest('hex');
-            const key = `${handle}-${hash}`;
-
-            if (keys.has(key)) {
-                return next();
-            }
-
-            keys.add(key);
-            this.bust(request, response);
-            next();
-        };
+        return this.#middleware.bind(this);
     }
 
     /**
@@ -85,3 +94,7 @@ export class CacheBuster {
         }
     }
 }
+
+// Export a single instance for the entire application
+const instance = new CacheBuster();
+export default instance;

--- a/src/middleware/cacheBuster.js
+++ b/src/middleware/cacheBuster.js
@@ -7,16 +7,33 @@ import { getConfigValue } from '../util.js';
  */
 class CacheBuster {
     /**
-     * @type {Set<string>} Handles/User-Agents that have already been busted.
+     * Handles/User-Agents that have already been busted.
+     * @type {Set<string>}
      */
     #keys = new Set();
 
     /**
-     * Check if the cache buster is enabled based on the configuration.
-     * @returns {boolean} Whether the cache buster is enabled.
+     * User agent regex to match against requests.
+     * @type {RegExp | null}
      */
-    isEnabled() {
-        return !!getConfigValue('cacheBuster.enabled', false, 'boolean');
+    #userAgentRegex = null;
+
+    /**
+     * Whether the cache buster is enabled.
+     * @type {boolean | null}
+     */
+    #isEnabled = null;
+
+    constructor() {
+        this.#isEnabled = !!getConfigValue('cacheBuster.enabled', false, 'boolean');
+        const userAgentPattern = getConfigValue('cacheBuster.userAgentPattern', '');
+        if (userAgentPattern) {
+            try {
+                this.#userAgentRegex = new RegExp(userAgentPattern, 'i');
+            } catch (error) {
+                console.error('Cache Buster: Invalid user agent pattern:', userAgentPattern, error);
+            }
+        }
     }
 
     /**
@@ -27,7 +44,7 @@ class CacheBuster {
      */
     shouldBust(request, response) {
         // If disabled with config, don't do anything
-        if (!this.isEnabled()) {
+        if (!this.#isEnabled) {
             return false;
         }
 
@@ -38,21 +55,14 @@ class CacheBuster {
         }
 
         // Check if the user agent matches the configured pattern
-        const userAgentPattern = getConfigValue('cacheBuster.userAgentPattern', '');
         const userAgent = request.headers['user-agent'] || '';
 
         // Bust cache for all requests if no pattern is set
-        if (!userAgentPattern) {
+        if (!this.#userAgentRegex) {
             return true;
         }
 
-        try {
-            const regex = new RegExp(userAgentPattern, 'i');
-            return regex.test(userAgent);
-        } catch (error) {
-            console.error('Cache Buster: Invalid user agent pattern:', userAgentPattern, error);
-            return false;
-        }
+        return this.#userAgentRegex.test(userAgent);
     }
 
     /**

--- a/src/middleware/cacheBuster.js
+++ b/src/middleware/cacheBuster.js
@@ -1,28 +1,87 @@
 import crypto from 'node:crypto';
 import { DEFAULT_USER } from '../constants.js';
+import { getConfigValue } from '../util.js';
 
-/**
- * Middleware to bust the browser cache for the current user.
- * @returns {import('express').RequestHandler}
- */
-export default function getCacheBusterMiddleware() {
+export class CacheBuster {
     /**
-     * @type {Set<string>} Handles/User-Agents that have already been busted.
+     * Check if the cache buster is enabled based on the configuration.
+     * @returns {boolean} Whether the cache buster is enabled.
      */
-    const keys = new Set();
+    isEnabled() {
+        return !!getConfigValue('cacheBuster.enabled', false, 'boolean');
+    }
 
-    return (request, response, next) => {
-        const handle = request.user?.profile?.handle || DEFAULT_USER.handle;
-        const userAgent = request.headers['user-agent'] || '';
-        const hash = crypto.createHash('sha256').update(userAgent).digest('hex');
-        const key = `${handle}-${hash}`;
-
-        if (keys.has(key)) {
-            return next();
+    /**
+     * Check if the cache should be busted for the given request.
+     * @param {import('express').Request} request Express request object.
+     * @param {import('express').Response} response Express response object.
+     * @returns {boolean} Whether the cache should be busted.
+     */
+    shouldBust(request, response) {
+        // If disabled with config, don't do anything
+        if (!this.isEnabled()) {
+            return false;
         }
 
-        keys.add(key);
-        response.setHeader('Clear-Site-Data', '"cache"');
-        next();
-    };
+        // If response headers are already sent or response is ended
+        if (response.headersSent || response.writableEnded) {
+            console.warn('Cache Buster: Response ended or headers already sent');
+            return false;
+        }
+
+        // Check if the user agent matches the configured pattern
+        const userAgentPattern = getConfigValue('cacheBuster.userAgentPattern', '');
+        const userAgent = request.headers['user-agent'] || '';
+
+        // Bust cache for all requests if no pattern is set
+        if (!userAgentPattern) {
+            return true;
+        }
+
+        try {
+            const regex = new RegExp(userAgentPattern, 'i');
+            return regex.test(userAgent);
+        } catch (error) {
+            console.error('Cache Buster: Invalid user agent pattern:', userAgentPattern, error);
+            return false;
+        }
+    }
+
+    /**
+     * Middleware to bust the browser cache for the current user.
+     * @returns {import('express').RequestHandler}
+     */
+    get middleware() {
+        /**
+         * @type {Set<string>} Handles/User-Agents that have already been busted.
+         */
+        const keys = new Set();
+
+        return (request, response, next) => {
+            const handle = request.user?.profile?.handle || DEFAULT_USER.handle;
+            const userAgent = request.headers['user-agent'] || '';
+            const hash = crypto.createHash('sha256').update(userAgent).digest('hex');
+            const key = `${handle}-${hash}`;
+
+            if (keys.has(key)) {
+                return next();
+            }
+
+            keys.add(key);
+            this.bust(request, response);
+            next();
+        };
+    }
+
+    /**
+     * Bust the cache for the given response.
+     * @param {import('express').Request} request Express request object.
+     * @param {import('express').Response} response Express response object.
+     * @returns {void}
+     */
+    bust(request, response) {
+        if (this.shouldBust(request, response)) {
+            response.setHeader('Clear-Site-Data', '"cache"');
+        }
+    }
 }

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -44,7 +44,7 @@ import getWhitelistMiddleware from './middleware/whitelist.js';
 import accessLoggerMiddleware, { getAccessLogPath, migrateAccessLog } from './middleware/accessLogWriter.js';
 import multerMonkeyPatch from './middleware/multerMonkeyPatch.js';
 import initRequestProxy from './request-proxy.js';
-import getCacheBusterMiddleware from './middleware/cacheBuster.js';
+import { CacheBuster } from './middleware/cacheBuster.js';
 import corsProxyMiddleware from './middleware/corsProxy.js';
 import {
     getVersion,
@@ -185,7 +185,7 @@ if (!cliArgs.disableCsrf) {
 
 // Static files
 // Host index page
-app.get('/', getCacheBusterMiddleware(), (request, response) => {
+app.get('/', new CacheBuster().middleware, (request, response) => {
     if (shouldRedirectToLogin(request)) {
         const query = request.url.split('?')[1];
         const redirectUrl = query ? `/login?${query}` : '/login';

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -44,7 +44,7 @@ import getWhitelistMiddleware from './middleware/whitelist.js';
 import accessLoggerMiddleware, { getAccessLogPath, migrateAccessLog } from './middleware/accessLogWriter.js';
 import multerMonkeyPatch from './middleware/multerMonkeyPatch.js';
 import initRequestProxy from './request-proxy.js';
-import { CacheBuster } from './middleware/cacheBuster.js';
+import cacheBuster from './middleware/cacheBuster.js';
 import corsProxyMiddleware from './middleware/corsProxy.js';
 import {
     getVersion,
@@ -185,7 +185,7 @@ if (!cliArgs.disableCsrf) {
 
 // Static files
 // Host index page
-app.get('/', new CacheBuster().middleware, (request, response) => {
+app.get('/', cacheBuster.middleware, (request, response) => {
     if (shouldRedirectToLogin(request)) {
         const query = request.url.split('?')[1];
         const redirectUrl = query ? `/login?${query}` : '/login';


### PR DESCRIPTION
Closes #4290 [BUG] SillyTavern takes ~45 seconds to load initially

Adds a feature toggle (disabled by default) for CacheBuster and a user agent filter (empty by default). The middleware exists primarily for browsers with overly aggressive caching like Safari and Firefox, but causes problems on Chrome.

'Clear-Site-Data' header is very slow in Chrome due to a bug: https://issues.chromium.org/issues/40233601

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
