### PR TITLE
Console access log output is now controlled by enableAccessLog

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -100,7 +100,7 @@ disableCsrfProtection: false
 securityOverride: false
 # -- LOGGING CONFIGURATION --
 logging:
-  # Enable access logging to access.log file
+  # Enable access logging to access.log file and console output
   # Records new connections with timestamp, IP address and user agent
   enableAccessLog: true
   # Minimum log level to display in the terminal (DEBUG = 0, INFO = 1, WARN = 2, ERROR = 3)

--- a/src/middleware/accessLogWriter.js
+++ b/src/middleware/accessLogWriter.js
@@ -37,11 +37,11 @@ export default function accessLoggerMiddleware() {
 
         if (!knownIPs.has(clientIp)) {
             // Log new connection
-            console.info(color.yellow(`New connection from ${clientIp}; User Agent: ${userAgent}\n`));
             knownIPs.add(clientIp);
 
             // Write to access log if enabled
             if (enableAccessLog) {
+                console.info(color.yellow(`New connection from ${clientIp}; User Agent: ${userAgent}\n`));
                 const logPath = getAccessLogPath();
                 const timestamp = new Date().toISOString();
                 const log = `${timestamp} ${clientIp} ${userAgent}\n`;


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Previously, the enableAccessLog setting did not control the console's access log output. Even when enableAccessLog was set to False, a large volume of access logs would still be printed to the console. This caused significant screen flooding for users accessing SillyTavern, particularly when the site was hosted on Cloudflare with its proxy enabled.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
