### PR TITLE
fixes #4324: injectedIndices becomes invalidated with a off-by-one in…

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3799,7 +3799,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 // This operation will result in the injectedIndices indexes being off by one
                 coreChat.push({ mes: jailbreak, is_user: true });
                 // Add +1 to the elements to correct for the new PHI/Jailbreak message.
-                injectedIndices.forEach((e,idx) => injectedIndices[idx] = e + 1);
+                injectedIndices.forEach((e, idx) => injectedIndices[idx] = e + 1);
             }
         }
     }

--- a/public/script.js
+++ b/public/script.js
@@ -3796,7 +3796,10 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 coreChat.splice(coreChat.length - 1, 0, { mes: jailbreak, is_user: true });
             }
             else {
+                // This operation will result in the injectedIndices indexes being off by one
                 coreChat.push({ mes: jailbreak, is_user: true });
+                // Add +1 to the elements to correct for the new PHI/Jailbreak message.
+                injectedIndices.forEach((e,idx) => injectedIndices[idx] = e + 1);
             }
         }
     }

--- a/public/script.js
+++ b/public/script.js
@@ -4760,7 +4760,7 @@ async function doChatInject(messages, isContinue) {
 
         if (roleMessages.length) {
             const depth = isContinue && i === 0 ? 1 : i;
-            const injectIdx = depth + totalInsertedMessages;
+            const injectIdx = Math.min(depth + totalInsertedMessages, messages.length);
             messages.splice(injectIdx, 0, ...roleMessages);
             totalInsertedMessages += roleMessages.length;
             injectedIndices.push(...Array.from({ length: roleMessages.length }, (_, i) => injectIdx + i));


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).


## Info
injectedIndices OOB error can cause injected elements to be dropped erroneously under certain conditions, when tokenCount is close to context size. main_api != 'openai' only.

public/script.js contains the code.

Refer to Bug #4324 for the full description.

Have tested the code as far as I understand it can happen, but there may be some cases I don't understand yet.

