### PR TITLE
Add optional user identifier to OpenRouter requests

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1480,6 +1480,11 @@ router.post('/generate', function (request, response) {
             'include_reasoning': Boolean(request.body.include_reasoning),
         };
 
+        const userIdentifier = getConfigValue('userIdentifier');
+        if (userIdentifier) {
+            bodyParams['user'] = userIdentifier;
+        }
+
         if (request.body.min_p !== undefined) {
             bodyParams['min_p'] = request.body.min_p;
         }

--- a/src/endpoints/openai.js
+++ b/src/endpoints/openai.js
@@ -108,6 +108,10 @@ router.post('/caption-image', async (request, response) => {
         let apiUrl = '';
 
         if (request.body.api === 'openrouter') {
+            const userIdentifier = getConfigValue('userIdentifier');
+            if (userIdentifier) {
+                request.body.user = userIdentifier;
+            }
             apiUrl = 'https://openrouter.ai/api/v1/chat/completions';
             Object.assign(headers, OPENROUTER_HEADERS);
         }


### PR DESCRIPTION
Fully optional and not filled by default. Consciously decided against adding it to the YAML by default.

Allows to track where a given request came from using an API key (to OpenRouter). 
The identifier could be re-used for other APIs that may support if desired, which is why I didn't add it specifically under openrouter.userIdentifier. Would recommend mentioning it on the Wiki.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
