### PR TITLE
Add Local Tags (<local>CONTENT</local>) to allow for in message content that isn't sent to the LLM

### DIFF
--- a/default/content/settings.json
+++ b/default/content/settings.json
@@ -192,6 +192,7 @@
         "custom_stopping_strings_macro": true,
         "fuzzy_search": true,
         "encode_tags": false,
+        "hide_local_tags": false,
         "enableLabMode": false,
         "enableZenSliders": false,
         "ui_mode": 1,

--- a/public/index.html
+++ b/public/index.html
@@ -4993,6 +4993,10 @@
                                     <input id="encode_tags" type="checkbox" />
                                     <small data-i18n="Show tags in responses">Show &lt;tags&gt; in responses</small>
                                 </label>
+                                <label class="checkbox_label" for="hide_local_tags" title="Remove &lt;local&gt; tags and their content from messages sent to the LLM, but still show it in chat." data-i18n="[title]Remove &lt;local&gt; tags and their content from messages sent to the LLM, but still show it in chat.">
+                                    <input id="hide_local_tags" type="checkbox" />
+                                    <small data-i18n="Hide &lt;local&gt; tags from LLM">Hide &lt;local&gt; tags from LLM</small>
+                                </label>                  
                                 <label class="checkbox_label" for="disable_group_trimming" title="Allow AI messages in groups to contain lines spoken by other group members." data-i18n="[title]Allow AI messages in groups to contain lines spoken by other group members">
                                     <input id="disable_group_trimming" type="checkbox" />
                                     <small data-i18n="Relax message trim in Groups">Relax message trim in Groups</small>

--- a/public/script.js
+++ b/public/script.js
@@ -237,7 +237,7 @@ import { getBackgrounds, initBackgrounds, loadBackgroundSettings, background_set
 import { hideLoader, showLoader } from './scripts/loader.js';
 import { BulkEditOverlay } from './scripts/BulkEditOverlay.js';
 import { initTextGenModels } from './scripts/textgen-models.js';
-import { appendFileContent, hasPendingFileAttachment, populateFileAttachment, decodeStyleTags, encodeStyleTags, isExternalMediaAllowed, preserveNeutralChat, restoreNeutralChat, formatCreatorNotes, initChatUtilities, addDOMPurifyHooks } from './scripts/chats.js';
+import { appendFileContent, hasPendingFileAttachment, populateFileAttachment, decodeStyleTags, encodeStyleTags, isExternalMediaAllowed, preserveNeutralChat, restoreNeutralChat, formatCreatorNotes, initChatUtilities, addDOMPurifyHooks,  stripLocalTagsForDisplay,  stripLocalTagsForPrompt } from './scripts/chats.js';
 import { getPresetManager, initPresetManager } from './scripts/preset-manager.js';
 import { evaluateMacros, getLastMessageId, initMacros } from './scripts/macros.js';
 import { currentUser, setUserControls } from './scripts/user.js';
@@ -1533,6 +1533,9 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         }
     }
 
+    // —— strip <local>…</local> tags from display (keep inner text) ——  
+    mes = stripLocalTagsForDisplay(mes, power_user.hide_local_tags);
+    
     mesForShowdownParse = mes;
 
     // Force isSystem = false on comment messages so they get formatted properly
@@ -4333,6 +4336,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     const eventData = { prompt: finalPrompt, dryRun: dryRun };
     await eventSource.emit(event_types.GENERATE_AFTER_COMBINE_PROMPTS, eventData);
     finalPrompt = eventData.prompt;
+    
+    // strip ALL <local>…</local> blocks if the user has that toggle on
+    finalPrompt = stripLocalTagsForPrompt(finalPrompt, power_user.hide_local_tags)
 
     let maxLength = Number(amount_gen); // how many tokens the AI will be requested to generate
     let thisPromptBits = [];
@@ -4391,6 +4397,14 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 messages: oaiMessages,
                 messageExamples: oaiMessageExamples,
             }, dryRun);
+
+            // if the toggle is on, strip all <local>…</local> from each content
+            prompt = prompt.map(m => ({
+            ...m,
+            content: stripLocalTagsForPrompt(m.content, power_user.hide_local_tags)
+            }));
+        
+            
             generate_data = { prompt: prompt };
 
             // TODO: move these side-effects somewhere else, so this switch-case solely sets generate_data

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -483,6 +483,27 @@ export function encodeStyleTags(text) {
 }
 
 /**
+ * Handles <local>...</local> tag processing based on context.
+ * - `stripLocalTagsForDisplay`: Removes only the <local> and </local> tags, keeping inner content visible to the user.
+ * - `stripLocalTagsForPrompt`: Removes the entire <local>...</local> block so it's not sent to the LLM.
+ * @param {string} text - The message content.
+ * @param {boolean} enabled - Whether to strip local tags or blocks.
+ * @returns {string} - The processed message text for the given context.
+ * @author https://github.com/route-404-gh/
+ */
+export function stripLocalTagsForDisplay(text, enabled) {
+    if (!enabled) return text;
+    return text.replace(/<local>([\s\S]*?)<\/local>/gi, '$1');
+}
+
+export function stripLocalTagsForPrompt(text, enabled) {
+    if (!enabled) return text;
+    // <local> with optional attrs/whitespace, any content, </local>, plus trailing space/newline
+    const re = /<\s*local\b[^>]*>[\s\S]*?<\s*\/\s*local\s*>\s*/gi;
+    return text.replace(re, '');
+  }
+
+/**
  * Sanitizes custom style tags in the message text to prevent DOM pollution.
  * @param {string} text Message text
  * @param {object} options Options object

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -293,6 +293,7 @@ export const power_user = {
     custom_stopping_strings_macro: true,
     fuzzy_search: false,
     encode_tags: false,
+    hide_local_tags: true,
     servers: [],
     bogus_folders: false,
     zoomed_avatar_magnification: false,
@@ -1591,6 +1592,7 @@ export async function loadPowerUserSettings(settings, data) {
     $('#persona_allow_multi_connections').prop('checked', power_user.persona_allow_multi_connections);
     $('#persona_auto_lock').prop('checked', power_user.persona_auto_lock);
     $('#encode_tags').prop('checked', power_user.encode_tags);
+    $('#hide_local_tags').prop('checked', power_user.hide_local_tags);
     $('#example_messages_behavior').val(getExampleMessagesBehavior());
     $(`#example_messages_behavior option[value="${getExampleMessagesBehavior()}"]`).prop('selected', true);
     $('#instruct_derived').parent().find('i').toggleClass('toggleEnabled', !!power_user.instruct_derived);
@@ -3862,6 +3864,12 @@ jQuery(() => {
 
     $('#encode_tags').on('input', async function () {
         power_user.encode_tags = !!$(this).prop('checked');
+        await reloadCurrentChat();
+        saveSettingsDebounced();
+    });
+
+    $('#hide_local_tags').on('input', async function () {
+        power_user.hide_local_tags = !!$(this).prop('checked');
         await reloadCurrentChat();
         saveSettingsDebounced();
     });


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

---

## Description

This PR introduces a way to annotate parts of a message as “local only” by wrapping them in `<local>…</local>`. When the user enables **Hide tags from LLM** (`hide_local_tags`), those sections will:

- Still appear in the chat UI (inner content only, with tags removed)
- Be completely omitted from the payload sent to the language model

**Screenshot**:

<img width="1867" height="951" alt="image" src="https://github.com/user-attachments/assets/7c4dea66-8215-4427-b76b-2fd5222e6225" />


---

## What’s Changed
**New helper functions in public/scripts/chats.js**
- export function stripLocalTagsForDisplay(text, enabled) { … }
- export function stripLocalTagsForPrompt(text, enabled) { … }
    
**Application of helper functions in public/script.js**
- In "messageFormatting()" applied "stripLocalTagsForDisplay()" to mes
- In "getCombinedPrompt()" applied "stripLocalTagsForPrompt() to finalPrompt & to prompt.map messages for openAI

**Add** Toggle/Settings to public/scripts/power-user.js , default/content/settings.json, and public/index.html
- Added appropriate settings options and UI elements to handle toggling of function, Off by default

---

## Why

**Formatting/Privacy control**: By wrapping content in tags users can keep certain content from reaching the LLM which may otherwise guide the LLM to formatting content in certain ways in responses, such as including a title/header in first message or alternative greetings.

---

## How to Test

1. **Enable the Feature**
- Go to **Settings → “Hide tags from LLM”** and turn it on.

2. **UI Check**
- Send the message:
     `Hello, <local>this is private</local> world!`
- In the chat window, it should display:
     `Hello, this is private world!`

3. **Prompt Inspection**
- Open the terminal/PowerShell
- Trigger a generation
- Inspect the request body
- Confirm:
     * No `<local>` tags
     * No “this is private” content
     * You should see: `"Hello, world!"` in the payload

4. **Toggle Off & Repeat**

- Go back to Settings and turn **Hide tags from LLM** off
- Repeat steps 2–3
- Verify that both the UI and API payload include the raw `<local>…</local>` markers

> **Note:** If you have "Show `<tags>` in responses" also turned on, you will not see the tags.
