### PR TITLE
Support gzip compression for tokenizer downloads

### DIFF
--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -103,7 +103,7 @@ async function getPathToTokenizer(model, fallbackModel) {
             // If the file was downloaded manually
             if (isCompressed) {
                 const compressedBuffer = await fs.promises.readFile(cachedFile);
-                const decompressedBuffer = await gunzip(new Uint8Array(compressedBuffer).buffer);
+                const decompressedBuffer = await gunzip(new Uint8Array(compressedBuffer));
                 writeFileAtomicSync(uncompressedPath, decompressedBuffer);
                 await fs.promises.unlink(cachedFile);
                 return uncompressedPath;

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -59,6 +59,7 @@ export const TEXT_COMPLETION_MODELS = [
 
 const CHARS_PER_TOKEN = 3.35;
 const IS_DOWNLOAD_ALLOWED = getConfigValue('enableDownloadableTokenizers', true, 'boolean');
+const gunzip = promisify(zlib.gunzip);
 
 /**
  * Gets a path to the tokenizer model. Downloads the model if it's a URL.
@@ -99,6 +100,14 @@ async function getPathToTokenizer(model, fallbackModel) {
 
         const cachedFile = path.join(CACHE_PATH, fileName);
         if (fs.existsSync(cachedFile)) {
+            // If the file was downloaded manually
+            if (isCompressed) {
+                const compressedBuffer = await fs.promises.readFile(cachedFile);
+                const decompressedBuffer = await gunzip(new Uint8Array(compressedBuffer).buffer);
+                writeFileAtomicSync(uncompressedPath, decompressedBuffer);
+                await fs.promises.unlink(cachedFile);
+                return uncompressedPath;
+            }
             return cachedFile;
         }
 
@@ -114,7 +123,6 @@ async function getPathToTokenizer(model, fallbackModel) {
 
         const arrayBuffer = await response.arrayBuffer();
         if (isCompressed) {
-            const gunzip = promisify(zlib.gunzip);
             const decompressedBuffer = await gunzip(arrayBuffer);
             writeFileAtomicSync(uncompressedPath, decompressedBuffer);
             return uncompressedPath;

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { Buffer } from 'node:buffer';
+import zlib from 'node:zlib';
+import { promisify } from 'node:util';
 
 import express from 'express';
 import fetch from 'node-fetch';
@@ -61,7 +63,7 @@ const IS_DOWNLOAD_ALLOWED = getConfigValue('enableDownloadableTokenizers', true,
 /**
  * Gets a path to the tokenizer model. Downloads the model if it's a URL.
  * @param {string} model Model URL or path
- * @param {string|undefined} fallbackModel Fallback model path\
+ * @param {string|undefined} fallbackModel Fallback model path
  * @returns {Promise<string>} Path to the tokenizer model
  */
 async function getPathToTokenizer(model, fallbackModel) {
@@ -87,6 +89,14 @@ async function getPathToTokenizer(model, fallbackModel) {
             fs.mkdirSync(CACHE_PATH, { recursive: true });
         }
 
+        // If an uncompressed version exists, return it
+        const isCompressed = path.extname(fileName) === '.gz';
+        const uncompressedName = path.basename(fileName, '.gz');
+        const uncompressedPath = path.join(CACHE_PATH, uncompressedName);
+        if (isCompressed && fs.existsSync(uncompressedPath)) {
+            return uncompressedPath;
+        }
+
         const cachedFile = path.join(CACHE_PATH, fileName);
         if (fs.existsSync(cachedFile)) {
             return cachedFile;
@@ -103,6 +113,13 @@ async function getPathToTokenizer(model, fallbackModel) {
         }
 
         const arrayBuffer = await response.arrayBuffer();
+        if (isCompressed) {
+            const gunzip = promisify(zlib.gunzip);
+            const decompressedBuffer = await gunzip(arrayBuffer);
+            writeFileAtomicSync(uncompressedPath, decompressedBuffer);
+            return uncompressedPath;
+        }
+
         writeFileAtomicSync(cachedFile, Buffer.from(arrayBuffer));
         return cachedFile;
     } catch (error) {
@@ -203,7 +220,8 @@ class WebTokenizer {
 
         try {
             const pathToModel = await getPathToTokenizer(this.#model, this.#fallbackModel);
-            const arrayBuffer = fs.readFileSync(pathToModel).buffer;
+            const fileBuffer = await fs.promises.readFile(pathToModel);
+            const arrayBuffer = Buffer.from(fileBuffer).buffer;
             this.#instance = await Tokenizer.fromJSON(arrayBuffer);
             console.info('Instantiated the tokenizer for', path.parse(pathToModel).name);
             return this.#instance;
@@ -223,11 +241,11 @@ const spp_gemma = new SentencePieceTokenizer('src/tokenizers/gemma.model');
 const spp_jamba = new SentencePieceTokenizer('src/tokenizers/jamba.model');
 const claude_tokenizer = new WebTokenizer('src/tokenizers/claude.json');
 const llama3_tokenizer = new WebTokenizer('src/tokenizers/llama3.json');
-const commandRTokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/command-r.json', 'src/tokenizers/llama3.json');
-const commandATokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/command-a.json', 'src/tokenizers/llama3.json');
-const qwen2Tokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/qwen2.json', 'src/tokenizers/llama3.json');
-const nemoTokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/nemo.json', 'src/tokenizers/llama3.json');
-const deepseekTokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/deepseek.json', 'src/tokenizers/llama3.json');
+const commandRTokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/command-r.json.gz', 'src/tokenizers/llama3.json');
+const commandATokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/command-a.json.gz', 'src/tokenizers/llama3.json');
+const qwen2Tokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/qwen2.json.gz', 'src/tokenizers/llama3.json');
+const nemoTokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/nemo.json.gz', 'src/tokenizers/llama3.json');
+const deepseekTokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/deepseek.json.gz', 'src/tokenizers/llama3.json');
 
 export const sentencepieceTokenizers = [
     'llama',
@@ -1092,7 +1110,7 @@ router.post('/remote/textgenerationwebui/encode', async function (request, respo
 
         /** @type {any} */
         const data = await result.json();
-        const count =  (data?.length ?? data?.count ?? data?.value ?? data?.tokens?.length);
+        const count = (data?.length ?? data?.count ?? data?.value ?? data?.tokens?.length);
         const ids = (data?.tokens ?? data?.ids ?? []);
 
         return response.send({ count, ids });

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -221,7 +221,7 @@ class WebTokenizer {
         try {
             const pathToModel = await getPathToTokenizer(this.#model, this.#fallbackModel);
             const fileBuffer = await fs.promises.readFile(pathToModel);
-            const arrayBuffer = Buffer.from(fileBuffer).buffer;
+            const arrayBuffer = new Uint8Array(fileBuffer).buffer;
             this.#instance = await Tokenizer.fromJSON(arrayBuffer);
             console.info('Instantiated the tokenizer for', path.parse(pathToModel).name);
             return this.#instance;

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -103,7 +103,7 @@ async function getPathToTokenizer(model, fallbackModel) {
             // If the file was downloaded manually
             if (isCompressed) {
                 const compressedBuffer = await fs.promises.readFile(cachedFile);
-                const decompressedBuffer = await gunzip(new Uint8Array(compressedBuffer));
+                const decompressedBuffer = await gunzip(compressedBuffer);
                 writeFileAtomicSync(uncompressedPath, decompressedBuffer);
                 await fs.promises.unlink(cachedFile);
                 return uncompressedPath;
@@ -229,8 +229,7 @@ class WebTokenizer {
         try {
             const pathToModel = await getPathToTokenizer(this.#model, this.#fallbackModel);
             const fileBuffer = await fs.promises.readFile(pathToModel);
-            const arrayBuffer = new Uint8Array(fileBuffer).buffer;
-            this.#instance = await Tokenizer.fromJSON(arrayBuffer);
+            this.#instance = await Tokenizer.fromJSON(fileBuffer);
             console.info('Instantiated the tokenizer for', path.parse(pathToModel).name);
             return this.#instance;
         } catch (error) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

60% faster downloads!! Files are uncompressed before saving. Existing downloads should also work.

All tokenizers are in the repo. Uncompressed versions left for backwards compatibility.

https://github.com/SillyTavern/SillyTavern-Tokenizers

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
