### PR TITLE
Allow extensions to specify minimum ST client version

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1,6 +1,6 @@
 import { DOMPurify, Popper } from '../lib.js';
 
-import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration } from '../script.js';
+import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration, CLIENT_VERSION } from '../script.js';
 import { showLoader } from './loader.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
@@ -382,11 +382,40 @@ async function getManifests(names) {
 }
 
 /**
+ * Compares two semantic version strings.
+ * @param {string} v1
+ * @param {string} v2
+ * @returns {number} If v1 > v2, returns 1; if v1 < v2, returns -1; if v1 === v2, returns 0.
+ */
+function compareSemanticVersions(v1, v2){
+    var v1p = v1.split('.');
+    var v2p = v2.split('.');
+
+    for (var i = 0; i < v1p.length; ++i) {
+        if (v2p.length === i) {
+            return 1;
+        }
+        if (v1p[i] === v2p[i]) {
+            continue;
+        }
+        if (v1p[i] > v2p[i]) {
+            return 1;
+        }
+        return -1;
+    }
+    if (v1.length !== v2.length) {
+        return -1;
+    }
+    return 0;
+}
+
+/**
  * Tries to activate all available extensions that are not already active.
  * @returns {Promise<void>}
  */
 async function activateExtensions() {
     extensionLoadErrors.clear();
+    const clientVersion = CLIENT_VERSION.split(':')[1];
     const extensions = Object.entries(manifests).sort((a, b) => sortManifestsByOrder(a[1], b[1]));
     const extensionNames = extensions.map(x => x[0]);
     const promises = [];
@@ -396,10 +425,16 @@ async function activateExtensions() {
         const manifest = entry[1];
         const extrasRequirements = manifest.requires;
         const extensionDependencies = manifest.dependencies;
+        const minClientVersion = manifest.minimum_client_version;
         const displayName = manifest.display_name || name;
 
         if (activeExtensions.has(name)) {
             continue;
+        }
+        // Client version requirement: pass if 'minimum_client_version' is undefined or null.
+        let meetsClientMinimumVersion = true;
+        if (minClientVersion !== undefined) {
+            meetsClientMinimumVersion = compareSemanticVersions(clientVersion, minClientVersion) >= 0;
         }
 
         // Module requirements: pass if 'requires' is undefined, null, or not an array; check subset if it's an array
@@ -438,7 +473,7 @@ async function activateExtensions() {
 
         const isDisabled = extension_settings.disabledExtensions.includes(name);
 
-        if (meetsModuleRequirements && meetsExtensionDeps && !isDisabled) {
+        if (meetsModuleRequirements && meetsExtensionDeps && meetsClientMinimumVersion && !isDisabled) {
             try {
                 console.debug('Activating extension', name);
                 const promise = addExtensionLocale(name, manifest).finally(() =>
@@ -465,6 +500,9 @@ async function activateExtensions() {
                 console.warn(t`Extension "${name}" did not load. Missing required extensions: "${missingDependencies.join(', ')}"`);
                 extensionLoadErrors.add(t`Extension "${displayName}" did not load. Missing required extensions: "${missingDependencies.join(', ')}"`);
             }
+        } else if (!meetsClientMinimumVersion && !isDisabled) {
+            console.warn(t`Extension "${name}" did not load. Requires ST client version ${minClientVersion}, but current version is ${clientVersion}.`);
+            extensionLoadErrors.add(t`Extension "${displayName}" did not load. Requires ST client version ${minClientVersion}, but current version is ${clientVersion}.`);
         }
     }
 

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -10,6 +10,7 @@ import { isAdmin } from './user.js';
 import { addLocaleData, getCurrentLocale, t } from './i18n.js';
 import { debounce_timeout } from './constants.js';
 import { accountStorage } from './util/AccountStorage.js';
+import { versionCompare } from './kai-settings.js';
 
 export {
     getContext,
@@ -381,33 +382,6 @@ async function getManifests(names) {
     return obj;
 }
 
-/**
- * Compares two semantic version strings.
- * @param {string} v1
- * @param {string} v2
- * @returns {number} If v1 > v2, returns 1; if v1 < v2, returns -1; if v1 === v2, returns 0.
- */
-function compareSemanticVersions(v1, v2){
-    var v1p = v1.split('.');
-    var v2p = v2.split('.');
-
-    for (var i = 0; i < v1p.length; ++i) {
-        if (v2p.length === i) {
-            return 1;
-        }
-        if (v1p[i] === v2p[i]) {
-            continue;
-        }
-        if (v1p[i] > v2p[i]) {
-            return 1;
-        }
-        return -1;
-    }
-    if (v1.length !== v2.length) {
-        return -1;
-    }
-    return 0;
-}
 
 /**
  * Tries to activate all available extensions that are not already active.
@@ -434,7 +408,7 @@ async function activateExtensions() {
         // Client version requirement: pass if 'minimum_client_version' is undefined or null.
         let meetsClientMinimumVersion = true;
         if (minClientVersion !== undefined) {
-            meetsClientMinimumVersion = compareSemanticVersions(clientVersion, minClientVersion) >= 0;
+            meetsClientMinimumVersion = versionCompare(clientVersion, minClientVersion);
         }
 
         // Module requirements: pass if 'requires' is undefined, null, or not an array; check subset if it's an array

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -4,13 +4,12 @@ import { eventSource, event_types, saveSettings, saveSettingsDebounced, getReque
 import { showLoader } from './loader.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
-import { delay, isSubsetOf, sanitizeSelector, setValueByPath } from './utils.js';
+import { delay, isSubsetOf, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';
 import { getContext } from './st-context.js';
 import { isAdmin } from './user.js';
 import { addLocaleData, getCurrentLocale, t } from './i18n.js';
 import { debounce_timeout } from './constants.js';
 import { accountStorage } from './util/AccountStorage.js';
-import { versionCompare } from './kai-settings.js';
 
 export {
     getContext,
@@ -381,7 +380,6 @@ async function getManifests(names) {
     await Promise.allSettled(promises);
     return obj;
 }
-
 
 /**
  * Tries to activate all available extensions that are not already active.

--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -20,7 +20,7 @@ import {
     power_user,
 } from './power-user.js';
 import { getEventSourceStream } from './sse-stream.js';
-import { getSortableDelay } from './utils.js';
+import { getSortableDelay, versionCompare } from './utils.js';
 
 export let koboldai_settings;
 export let koboldai_setting_names;
@@ -386,16 +386,6 @@ export function setKoboldFlags(koboldUnitedVersion, koboldCppVersion) {
     kai_flags.can_use_min_p = versionCompare(koboldCppVersion, MIN_MIN_P_KCPPVERSION);
     const isKoboldCpp = versionCompare(koboldCppVersion, '1.0.0');
     $('#koboldcpp_hint').toggleClass('displayNone', !isKoboldCpp);
-}
-
-/**
- * Compares two version numbers, returning true if srcVersion >= minVersion
- * @param {string} srcVersion The current version.
- * @param {string} minVersion The target version number to test against
- * @returns {boolean} True if srcVersion >= minVersion, false if not
- */
-export function versionCompare(srcVersion, minVersion) {
-    return (srcVersion || '0.0.0').localeCompare(minVersion, undefined, { numeric: true, sensitivity: 'base' }) > -1;
 }
 
 /**

--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -394,7 +394,7 @@ export function setKoboldFlags(koboldUnitedVersion, koboldCppVersion) {
  * @param {string} minVersion The target version number to test against
  * @returns {boolean} True if srcVersion >= minVersion, false if not
  */
-function versionCompare(srcVersion, minVersion) {
+export function versionCompare(srcVersion, minVersion) {
     return (srcVersion || '0.0.0').localeCompare(minVersion, undefined, { numeric: true, sensitivity: 'base' }) > -1;
 }
 

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2550,3 +2550,13 @@ export function textValueMatcher(params, data) {
     // If it doesn't contain the term, don't return anything
     return null;
 }
+
+/**
+ * Compares two version numbers, returning true if srcVersion >= minVersion
+ * @param {string} srcVersion The current version.
+ * @param {string} minVersion The target version number to test against
+ * @returns {boolean} True if srcVersion >= minVersion, false if not
+ */
+export function versionCompare(srcVersion, minVersion) {
+    return (srcVersion || '0.0.0').localeCompare(minVersion, undefined, { numeric: true, sensitivity: 'base' }) > -1;
+}


### PR DESCRIPTION
### Description

This allows extensions to optionally specify a minimum ST client semantic version requirement in `manifest.json` using the field `minimum_client_version`.

### Motivation

Currently, extensions must perform their own version checking to ensure comparability with the ST client. This typically relies on checking the client for particular features or functionality, rather than the standardized semantic version. It is also difficult when an extension relies on an import that fails on past versions of the client; an invalid static import will cause an error, thus preventing the extension from running its version check in the first place.

### Method

I have added a check for the optional manifest field which is expected to be a semantic version string for the minimum ST version required. If the version of ST is less than this, the extension fails to load with an appropriate error.

### Notes
- I just used a standard semantic version comparison function, though I am aware packages like semver exist. I just didn't want to mess with dependencies.
- In order to get the current client version, I used `CLIENT_VERSION.split(':')[1]`, but if there is a more reliable way that would be preferable.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
