### PR TITLE
When the server returns EventStream, it is also forwarded in EventStream mode

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1731,8 +1731,9 @@ router.post('/generate', function (request, response) {
         try {
             controller.signal.throwIfAborted();
             const fetchResponse = await fetch(endpointUrl, config);
+            const contentType = fetchResponse.headers.get('Content-Type')?.toLowerCase() || '';
 
-            if (request.body.stream) {
+            if (request.body.stream || contentType.includes('text/event-stream')) {
                 console.info('Streaming request in progress');
                 forwardFetchResponse(fetchResponse, response);
                 return;


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Using EventStream can prevent connections from being terminated by the CDN due to timeouts, even if no errors occurred.