### PR TITLE
Add gpt-4o-mini-tts model with character voice instructions #3879

### DIFF
--- a/public/scripts/extensions/tts/css/openai-tts.css
+++ b/public/scripts/extensions/tts/css/openai-tts.css
@@ -1,0 +1,11 @@
+#openai-character-instructions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#openai-character-instructions .character-instructions {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -476,7 +476,7 @@ async function tts(text, voiceId, char) {
         await addAudioJob(response, char);
     }
 
-    let response = await ttsProvider.generateTts(text, voiceId);
+    let response = await ttsProvider.generateTts(text, voiceId, char);
 
     // If async generator, process every chunk as it comes in
     if (typeof response[Symbol.asyncIterator] === 'function') {
@@ -1007,7 +1007,7 @@ function getCharacters(unrestricted) {
     return characters.filter(onlyUnique);
 }
 
-function sanitizeId(input) {
+export function sanitizeId(input) {
     // Remove any non-alphanumeric characters except underscore (_) and hyphen (-)
     let sanitized = encodeURIComponent(input).replace(/[^a-zA-Z0-9-_]/g, '');
 

--- a/public/scripts/extensions/tts/openai.js
+++ b/public/scripts/extensions/tts/openai.js
@@ -1,15 +1,18 @@
 import { getRequestHeaders } from '../../../script.js';
-import { saveTtsProviderSettings } from './index.js';
+import { saveTtsProviderSettings, sanitizeId } from './index.js';
 
 export { OpenAITtsProvider };
 
 class OpenAITtsProvider {
     static voices = [
         { name: 'Alloy', voice_id: 'alloy', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/alloy.wav' },
+        { name: 'Ash', voice_id: 'ash', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/ash.wav' },
+        { name: 'Coral', voice_id: 'coral', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/coral.wav' },
         { name: 'Echo', voice_id: 'echo', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/echo.wav' },
         { name: 'Fable', voice_id: 'fable', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/fable.wav' },
         { name: 'Onyx', voice_id: 'onyx', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/onyx.wav' },
         { name: 'Nova', voice_id: 'nova', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/nova.wav' },
+        { name: 'Sage', voice_id: 'sage', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/sage.wav' },
         { name: 'Shimmer', voice_id: 'shimmer', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/shimmer.wav' },
     ];
 
@@ -23,6 +26,7 @@ class OpenAITtsProvider {
         customVoices: [],
         model: 'tts-1',
         speed: 1,
+        characterInstructions: {},
     };
 
     get settingsHtml() {
@@ -35,6 +39,7 @@ class OpenAITtsProvider {
                 <optgroup label="Latest">
                     <option value="tts-1">tts-1</option>
                     <option value="tts-1-hd">tts-1-hd</option>
+                    <option value="gpt-4o-mini-tts">gpt-4o-mini-tts</option>
                 </optgroup>
                 <optgroup label="Snapshots">
                     <option value="tts-1-1106">tts-1-1106</option>
@@ -79,7 +84,31 @@ class OpenAITtsProvider {
         $('#openai-tts-speed-output').text(this.settings.speed);
 
         await this.checkReady();
+        // Initialize UI state based on current model (gpt-4o-mini-tts or other)
+        this.updateInstructionsUI();
+        // Look for voice map changes
+        this.setupVoiceMapObserver();
+
         console.debug('OpenAI TTS: Settings loaded');
+    }
+
+    setupVoiceMapObserver() {
+        if (this.voiceMapObserver) {
+            this.voiceMapObserver.disconnect();
+            this.voiceMapObserver = null;
+        }
+
+        const targetNode = document.getElementById('tts_voicemap_block');
+        if (!targetNode) return;
+
+        const observer = new MutationObserver(() => {
+            if (this.settings.model === 'gpt-4o-mini-tts') {
+                this.populateCharacterInstructions();
+            }
+        });
+
+        observer.observe(targetNode, { childList: true, subtree: true });
+        this.voiceMapObserver = observer;
     }
 
     onSettingsChange() {
@@ -87,6 +116,68 @@ class OpenAITtsProvider {
         this.settings.model = String($('#openai-tts-model').find(':selected').val());
         this.settings.speed = Number($('#openai-tts-speed').val());
         $('#openai-tts-speed-output').text(this.settings.speed);
+        this.updateInstructionsUI();
+        saveTtsProviderSettings();
+    }
+
+    updateInstructionsUI() {
+        if (this.settings.model === 'gpt-4o-mini-tts') {
+            this.createInstructionsContainer();
+            $('#openai-instructions-container').show();
+            this.populateCharacterInstructions();
+        } else {
+            $('#openai-instructions-container').hide();
+            this.voiceMapObserver?.disconnect();
+            this.voiceMapObserver = null;
+        }
+    }
+
+    createInstructionsContainer() {
+        if ($('#openai-instructions-container').length === 0) {
+            const containerHtml = `
+                <div id="openai-instructions-container" style="display: none;">
+                    <span>Voice Instructions (GPT-4o Mini TTS)</span><br>    
+                    <small>Customize how each character speaks</small>
+                    <div id="openai-character-instructions"></div>
+                </div>
+            `;
+            $('#openai-tts-speed').parent().after(containerHtml);
+        }
+    }
+
+    populateCharacterInstructions() {
+
+        const currentCharacters = $('.tts_voicemap_block_char span').map((i, el) => $(el).text()).get();
+
+        $('#openai-character-instructions').empty();
+
+        for (const char of currentCharacters) {
+            if (char === 'SillyTavern System' || char === '[Default Voice]') continue;
+
+            const sanitizedName = sanitizeId(char);
+            const savedInstructions = this.settings.characterInstructions?.[char] || '';
+
+            const html = `
+                <div class="character-instructions" style="margin-bottom: 10px;">
+                    <label for="openai_char_${sanitizedName}">${char}:</label>
+                    <textarea id="openai_char_${sanitizedName}" 
+                            placeholder="e.g., 'Speak cheerfully and energetically'" 
+                            style="width: 100%; height: 60px;">${savedInstructions}</textarea>
+                </div>
+            `;
+
+            $('#openai-character-instructions').append(html);
+            $(`#openai_char_${sanitizedName}`).on('input', () => {
+                this.saveCharacterInstructions(char, $(`#openai_char_${sanitizedName}`).val());
+            });
+        }
+    }
+
+    saveCharacterInstructions(characterName, instructions) {
+        if (!this.settings.characterInstructions) {
+            this.settings.characterInstructions = {};
+        }
+        this.settings.characterInstructions[characterName] = instructions;
         saveTtsProviderSettings();
     }
 
@@ -112,8 +203,8 @@ class OpenAITtsProvider {
         return voice;
     }
 
-    async generateTts(text, voiceId) {
-        const response = await this.fetchTtsGeneration(text, voiceId);
+    async generateTts(text, voiceId, characterName = null) {
+        const response = await this.fetchTtsGeneration(text, voiceId, characterName);
         return response;
     }
 
@@ -125,17 +216,27 @@ class OpenAITtsProvider {
         return;
     }
 
-    async fetchTtsGeneration(inputText, voiceId) {
+    async fetchTtsGeneration(inputText, voiceId, characterName = null) {
         console.info(`Generating new TTS for voice_id ${voiceId}`);
+
+        const requestBody = {
+            'text': inputText,
+            'voice': voiceId,
+            'model': this.settings.model,
+            'speed': this.settings.speed,
+        };
+
+        if (this.settings.model === 'gpt-4o-mini-tts' && characterName) {
+            const instructions = this.settings.characterInstructions?.[characterName];
+            if (instructions && instructions.trim()) {
+                requestBody.instructions = instructions;
+            }
+        }
+
         const response = await fetch('/api/openai/generate-voice', {
             method: 'POST',
             headers: getRequestHeaders(),
-            body: JSON.stringify({
-                'text': inputText,
-                'voice': voiceId,
-                'model': this.settings.model,
-                'speed': this.settings.speed,
-            }),
+            body: JSON.stringify(requestBody),
         });
 
         if (!response.ok) {

--- a/public/scripts/extensions/tts/openai.js
+++ b/public/scripts/extensions/tts/openai.js
@@ -136,7 +136,7 @@ class OpenAITtsProvider {
         if ($('#openai-instructions-container').length === 0) {
             const containerHtml = `
                 <div id="openai-instructions-container" style="display: none;">
-                    <span>Voice Instructions (GPT-4o Mini TTS)</span><br>    
+                    <span>Voice Instructions (GPT-4o Mini TTS)</span><br>
                     <small>Customize how each character speaks</small>
                     <div id="openai-character-instructions"></div>
                 </div>
@@ -157,19 +157,23 @@ class OpenAITtsProvider {
             const sanitizedName = sanitizeId(char);
             const savedInstructions = this.settings.characterInstructions?.[char] || '';
 
-            const html = `
-                <div class="character-instructions" style="margin-bottom: 10px;">
-                    <label for="openai_char_${sanitizedName}">${char}:</label>
-                    <textarea id="openai_char_${sanitizedName}" 
-                            placeholder="e.g., 'Speak cheerfully and energetically'" 
-                            style="width: 100%; height: 60px;">${savedInstructions}</textarea>
-                </div>
-            `;
-
-            $('#openai-character-instructions').append(html);
-            $(`#openai_char_${sanitizedName}`).on('input', () => {
-                this.saveCharacterInstructions(char, $(`#openai_char_${sanitizedName}`).val());
+            const instructionBlock = document.createElement('div');
+            const label = document.createElement('label');
+            const textArea = document.createElement('textarea');
+            instructionBlock.appendChild(label);
+            instructionBlock.appendChild(textArea);
+            instructionBlock.className = 'character-instructions';
+            label.setAttribute('for', `openai_char_${sanitizedName}`);
+            label.innerText = `${char}:`;
+            textArea.id = `openai_char_${sanitizedName}`;
+            textArea.placeholder = 'e.g., "Speak cheerfully and energetically"';
+            textArea.className = 'textarea_compact autoSetHeight';
+            textArea.value = savedInstructions;
+            textArea.addEventListener('input', () => {
+                this.saveCharacterInstructions(char, textArea.value);
             });
+
+            $('#openai-character-instructions').append(instructionBlock);
         }
     }
 

--- a/public/scripts/extensions/tts/style.css
+++ b/public/scripts/extensions/tts/style.css
@@ -1,3 +1,6 @@
+@import './css/minimax-tts.css';
+@import './css/openai-tts.css';
+
 .voice_preview {
     margin: 0.25rem 0.5rem;
     display: flex;
@@ -125,5 +128,3 @@
 #at-status_info {
     color: lightgreen;
 }
-
-@import './css/minimax-tts.css';

--- a/src/endpoints/openai.js
+++ b/src/endpoints/openai.js
@@ -283,6 +283,8 @@ router.post('/generate-voice', async (request, response) => {
             requestBody.instructions = request.body.instructions;
         }
 
+        console.debug('OpenAI TTS request', requestBody);
+
         const result = await fetch('https://api.openai.com/v1/audio/speech', {
             method: 'POST',
             headers: {

--- a/src/endpoints/openai.js
+++ b/src/endpoints/openai.js
@@ -271,19 +271,25 @@ router.post('/generate-voice', async (request, response) => {
             return response.sendStatus(400);
         }
 
+        const requestBody = {
+            input: request.body.text,
+            response_format: 'mp3',
+            voice: request.body.voice ?? 'alloy',
+            speed: request.body.speed ?? 1,
+            model: request.body.model ?? 'tts-1',
+        };
+
+        if (request.body.instructions) {
+            requestBody.instructions = request.body.instructions;
+        }
+
         const result = await fetch('https://api.openai.com/v1/audio/speech', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 Authorization: `Bearer ${key}`,
             },
-            body: JSON.stringify({
-                input: request.body.text,
-                response_format: 'mp3',
-                voice: request.body.voice ?? 'alloy',
-                speed: request.body.speed ?? 1,
-                model: request.body.model ?? 'tts-1',
-            }),
+            body: JSON.stringify(requestBody),
         });
 
         if (!result.ok) {


### PR DESCRIPTION
Added openai gpt-4o-mini-tts model as an option, along with the new voices Ash, Coral and Sage. There are 2 more voices, but I could not find sample audios and they don't work with the other models.
Also added a panel with the option to add one instruction per character when gpt-4o-mini-tts is chosen (the issue also considered the option to have one instruction per message but that seems like a larger change to make). 

To test the change: set an openai api key, open the TTS panel, select OpenAI as a provider/gpt-4o-mini-tts as a model, enter instruction and test it in a chat.


<img width="362" height="1008" alt="image" src="https://github.com/user-attachments/assets/a0311cc0-8f86-4ba3-88c4-b6957daed761" />


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
