### PR TITLE
feature: essential strategy, ignoring budget caps

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6572,7 +6572,8 @@
                                             <textarea class="text_pole" rows="1" name="comment" data-i18n="[placeholder]Entry Title/Memo" placeholder="Entry Title/Memo"></textarea>
                                         </div>
                                         <!-- <span class="world_entry_form_position_value"></span> -->
-                                        <select data-i18n="[title]WI Entry Status:🔵 Constant🟢 Normal🔗 Vectorized" title="WI Entry Status:&#13;🔵 Constant&#13;🟢 Normal&#13;🔗 Vectorized" name="entryStateSelector" class="text_pole widthNatural margin0">
+                                        <select data-i18n="[title]WI Entry Status:🟣 Essential🔵 Constant🟢 Normal🔗 Vectorized" title="WI Entry Status:&#13;🟣 Essential (constant, ignore context budget caps)&#13;🔵 Constant (skipped if budget cap exceeded)&#13;🟢 Normal&#13;🔗 Vectorized" name="entryStateSelector" class="text_pole widthNatural margin0">
+                                            <option value="essential" title="Essential" data-i18n="[title]WI_Entry_Status_Essential">🟣</option>
                                             <option value="constant" title="Constant" data-i18n="[title]WI_Entry_Status_Constant">🔵</option>
                                             <option value="normal" title="Normal" data-i18n="[title]WI_Entry_Status_Normal">🟢</option>
                                             <option value="vectorized" title="Vectorized" data-i18n="[title]WI_Entry_Status_Vectorized">🔗</option>

--- a/public/scripts/slash-commands/SlashCommandCommonEnumsProvider.js
+++ b/public/scripts/slash-commands/SlashCommandCommonEnumsProvider.js
@@ -61,6 +61,7 @@ export const enumIcons = {
     assistant: '🤖',
 
     // WI Icons
+    essential: '🟣',
     constant: '🔵',
     normal: '🟢',
     disabled: '❌',
@@ -83,6 +84,7 @@ export const enumIcons = {
      * @returns {string} The corresponding WI icon
      */
     getWiStatusIcon: (entry) => {
+        if (entry.essential) return enumIcons.essential;
         if (entry.constant) return enumIcons.constant;
         if (entry.disable) return enumIcons.disabled;
         if (entry.vectorized) return enumIcons.vectorized;

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2023,8 +2023,8 @@ export function sortWorldInfoEntries(data, { customSort = null } = {}) {
     } else if (sortRule === 'priority') {
         // First constant, then normal, then disabled.
         primarySort = (a, b) => {
-            const aValue = a.disable ? 2 : a.constant ? 0 : 1;
-            const bValue = b.disable ? 2 : b.constant ? 0 : 1;
+            const aValue = a.disable ? 2 : a.constant || a.essential ? 0 : 1;
+            const bValue = b.disable ? 2 : b.constant || a.essential ? 0 : 1;
             return aValue - bValue;
         };
     } else {
@@ -3038,29 +3038,15 @@ function handleEntryStateSelectorHelper({ entryStateSelector, entry, data, name 
     entryStateSelector.on('input', async function (_, { noSave = false } = {}) {
         const uid = entry.uid;
         const value = $(this).val();
-        switch (value) {
-            case 'constant':
-                data.entries[uid].constant = true;
-                data.entries[uid].vectorized = false;
-                setWIOriginalDataValue(data, uid, 'constant', true);
-                setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
-                break;
-            case 'normal':
-                data.entries[uid].constant = false;
-                data.entries[uid].vectorized = false;
-                setWIOriginalDataValue(data, uid, 'constant', false);
-                setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
-                break;
-            case 'vectorized':
-                data.entries[uid].constant = false;
-                data.entries[uid].vectorized = true;
-                setWIOriginalDataValue(data, uid, 'constant', false);
-                setWIOriginalDataValue(data, uid, 'extensions.vectorized', true);
-                break;
-        }
+        data.entries[uid].essential  = value === 'essential';
+        data.entries[uid].constant   = value === 'constant';
+        data.entries[uid].vectorized = value === 'vectorized';
+        setWIOriginalDataValue(data, uid, 'essential',             value === 'essential');
+        setWIOriginalDataValue(data, uid, 'constant',              value === 'constant');
+        setWIOriginalDataValue(data, uid, 'extensions.vectorized', value === 'vectorized');
         !noSave && await saveWorldInfo(name, data);
     });
-    const entryState = () => entry.constant === true ? 'constant' : entry.vectorized === true ? 'vectorized' : 'normal';
+    const entryState = () => entry.essential === true ? 'essential' : entry.constant === true ? 'constant' : entry.vectorized === true ? 'vectorized' : 'normal';
     entryStateSelector.find(`option[value=${entryState()}]`).prop('selected', true).trigger('input', { noSave: true });
 }
 
@@ -4296,6 +4282,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
         // Loop and find all entries that can activate here
         let activatedNow = new Set();
+        let essentialNow = new Set();
 
         for (const entry of sortedEntries) {
             // Logging preparation
@@ -4405,6 +4392,13 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
             }
 
             // Now do checks for immediate activations
+            if (entry.essential) {
+                log('activated because of essential');
+                essentialNow.add(entry);
+                activatedNow.add(entry);
+                continue;
+            }
+
             if (entry.constant) {
                 log('activated because of constant');
                 activatedNow.add(entry);
@@ -4568,8 +4562,18 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
                 break;
             }
 
+            essentialNow.delete(entry);
             allActivatedEntries.set(`${entry.world}.${entry.uid}`, entry);
             console.debug(`[WI] Entry ${entry.uid} activation successful, adding to prompt`, entry);
+        }
+
+        // Add missing essential entries
+        for (const entry of essentialNow) {
+            // Substitute macros inline, for both this checking and also future processing
+            entry.content = substituteParams(entry.content);
+            newContent += `${entry.content}\n`;
+            allActivatedEntries.set(`${entry.world}.${entry.uid}`, entry);
+            console.debug(`[WI] Essential Entry ${entry.uid} activation successful, adding to prompt`, entry);
         }
 
         const successfulNewEntries = newEntries.filter(x => !failedProbabilityChecks.has(x));
@@ -5066,6 +5070,7 @@ export function convertCharacterBook(characterBook) {
             keysecondary: entry.secondary_keys || [],
             comment: entry.comment || '',
             content: entry.content,
+            essential: entry.essential || false,
             constant: entry.constant || false,
             selective: entry.selective || false,
             order: entry.insertion_order,

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -673,6 +673,7 @@ function convertWorldInfoToCharacterBook(name, entries) {
             secondary_keys: entry.keysecondary,
             comment: entry.comment,
             content: entry.content,
+            essential: entry.essential,
             constant: entry.constant,
             selective: entry.selective,
             insertion_order: entry.order,


### PR DESCRIPTION
The budget cap default at 25% is a big gotcha at the start of chats, as a person may assume that a constant lore book entry will always be present, no matter what. This pull request adds a new 'essential' strategy which ignores the budget cap and always includes the lore book entry. It also adds clarification to the existing 'constant' entry.

_Note to users: if you had constant lorebook entries *sometimes* not appearing during chats, especially during the start, changing them to "essential" may fix. Reason: if the lorebook-to-chat size is just around 1:4 ratio (the default "context % budget" for lorebook), each swipe may change the outcome slightly, i.e. if the previous assistant message was short, a lorebook entry may be missing from the next swipe compared to if the previous assistant message was long(er)._

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
