### PR TITLE
[FEATURE] Tailing story string

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3836,6 +3836,12 @@
                                         <input id="context_names_as_stop_strings" type="checkbox" />
                                         <small data-i18n="Names as Stop Strings">Names as Stop Strings</small>
                                     </label>
+                                    <label class="checkbox_label" title="Place the Story String as a system message near the end of the context (at Depth=1), for increased adherence during longer chats." for="context_story_string_tail">
+                                        <input id="context_story_string_tail" type="checkbox" />
+                                        <small data-i18n="Keep Story String Near End of Chat">
+                                            Keep Story String Near End of Chat
+                                        </small>
+                                    </label>
                                 </div>
                             </div>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -3836,12 +3836,17 @@
                                         <input id="context_names_as_stop_strings" type="checkbox" />
                                         <small data-i18n="Names as Stop Strings">Names as Stop Strings</small>
                                     </label>
-                                    <label class="checkbox_label" title="Place the Story String as a system message near the end of the context (at Depth=1), for increased adherence during longer chats." for="context_story_string_tail">
-                                        <input id="context_story_string_tail" type="checkbox" />
-                                        <small data-i18n="Keep Story String Near End of Chat">
-                                            Keep Story String Near End of Chat
-                                        </small>
-                                    </label>
+                                    <div class="flex-container alignitemscenter wide100p">
+                                        <label class="checkbox_label" title="Place the Story String as a system message near the end of the context (at Depth=1), for increased adherence during longer chats." for="context_story_string_tail">
+                                            <input id="context_story_string_tail" type="checkbox" />
+                                            <small data-i18n="Keep Story String Near End of Chat at Depth">
+                                                Keep Story String Near End of Chat at Depth
+                                            </small>
+                                        </label>
+                                        <div class="flex-container flexNoGap">
+                                            <input title="Depth" class="text_pole wideMax100px margin0" type="number" id="context_story_string_tail_depth" data-i18n="[title]Depth" placeholder="" min="0" max="9999" />
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -3837,7 +3837,7 @@
                                         <small data-i18n="Names as Stop Strings">Names as Stop Strings</small>
                                     </label>
                                     <div class="flex-container alignitemscenter wide100p">
-                                        <label class="checkbox_label" title="Place the Story String as a system message near the end of the context (at Depth=1), for increased adherence during longer chats." for="context_story_string_tail">
+                                        <label class="checkbox_label" title="Place the Story String as a system message at the given depth from the end of the context, for increased adherence during longer chats." for="context_story_string_tail">
                                             <input id="context_story_string_tail" type="checkbox" />
                                             <small data-i18n="Keep Story String Near End of Chat at Depth">
                                                 Keep Story String Near End of Chat at Depth

--- a/public/index.html
+++ b/public/index.html
@@ -3839,8 +3839,8 @@
                                     <div class="flex-container alignitemscenter wide100p">
                                         <label class="checkbox_label" title="Place the Story String as a system message at the given depth from the end of the context, for increased adherence during longer chats." for="context_story_string_tail">
                                             <input id="context_story_string_tail" type="checkbox" />
-                                            <small data-i18n="Keep Story String Near End of Chat at Depth">
-                                                Keep Story String Near End of Chat at Depth
+                                            <small data-i18n="Keep Story String At Depth">
+                                                Keep Story String At Depth
                                             </small>
                                         </label>
                                         <div class="flex-container flexNoGap">

--- a/public/script.js
+++ b/public/script.js
@@ -4287,16 +4287,16 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
             let combinedPrompt = (
                 power_user.context.story_string_tail
-                        ?
+                    ?
                 mesExmString +
-                mesSendString.replace("__SILLYTAVERN__STORY_STRING_TAIL__", storyStringWrapped) +
+                mesSendString.replace('__SILLYTAVERN__STORY_STRING_TAIL__', storyStringWrapped) +
                 generatedPromptCache
-                        :
+                    :
                 storyStringWrapped +
                 mesExmString +
                 mesSendString +
                 generatedPromptCache
-            )
+            );
 
             combinedPrompt = combinedPrompt.replace(/\r/gm, '');
 

--- a/public/script.js
+++ b/public/script.js
@@ -3764,6 +3764,11 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         mesExamplesArray = formatInstructModeExamples(mesExamplesArray, name1, name2);
     }
 
+    if (power_user.context.story_string_tail) {
+        // we add a placeholder here and then replace it later
+        setExtensionPrompt('story_string_tail', '__SILLYTAVERN__STORY_STRING_TAIL__', 1, 1, false, extension_prompt_roles.SYSTEM);
+    }
+
     if (skipWIAN !== true) {
         console.log('skipWIAN not active, adding WIAN');
         // Add all depth WI entries to prompt
@@ -4278,12 +4283,20 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             // add chat preamble
             mesSendString = addChatsPreamble(mesSendString);
 
-            let combinedPrompt = beforeScenarioAnchor +
-                storyString +
-                afterScenarioAnchor +
+            const storyStringWrapped = beforeScenarioAnchor + storyString + afterScenarioAnchor;
+
+            let combinedPrompt = (
+                power_user.context.story_string_tail
+                        ?
+                mesExmString +
+                mesSendString.replace("__SILLYTAVERN__STORY_STRING_TAIL__", storyStringWrapped) +
+                generatedPromptCache
+                        :
+                storyStringWrapped +
                 mesExmString +
                 mesSendString +
-                generatedPromptCache;
+                generatedPromptCache
+            )
 
             combinedPrompt = combinedPrompt.replace(/\r/gm, '');
 

--- a/public/script.js
+++ b/public/script.js
@@ -4288,14 +4288,14 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             let combinedPrompt = (
                 power_user.context.story_string_tail
                     ?
-                mesExmString +
-                mesSendString.replace('__SILLYTAVERN__STORY_STRING_TAIL__', storyStringWrapped) +
-                generatedPromptCache
+                    mesExmString +
+                    mesSendString.replace('__SILLYTAVERN__STORY_STRING_TAIL__', storyStringWrapped) +
+                    generatedPromptCache
                     :
-                storyStringWrapped +
-                mesExmString +
-                mesSendString +
-                generatedPromptCache
+                    storyStringWrapped +
+                    mesExmString +
+                    mesSendString +
+                    generatedPromptCache
             );
 
             combinedPrompt = combinedPrompt.replace(/\r/gm, '');

--- a/public/script.js
+++ b/public/script.js
@@ -3764,11 +3764,6 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         mesExamplesArray = formatInstructModeExamples(mesExamplesArray, name1, name2);
     }
 
-    if (power_user.context.story_string_tail) {
-        // we add a placeholder here and then replace it later
-        setExtensionPrompt('story_string_tail', '__SILLYTAVERN__STORY_STRING_TAIL__', 1, 1, false, extension_prompt_roles.SYSTEM);
-    }
-
     if (skipWIAN !== true) {
         console.log('skipWIAN not active, adding WIAN');
         // Add all depth WI entries to prompt
@@ -4274,6 +4269,13 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
         // Flattens the multiple prompt objects to a string.
         const combine = () => {
+            let storyStringWrapped = beforeScenarioAnchor + storyString + afterScenarioAnchor;
+
+            if (power_user.context.story_string_tail) {
+                finalMesSend[finalMesSend.length - 1].extensionPrompts.splice(0, 0, storyStringWrapped);
+                storyStringWrapped = '';
+            }
+
             // Right now, everything is suffixed with a newline
             mesSendString = finalMesSend.map((e) => `${e.extensionPrompts.join('')}${e.message}`).join('');
 
@@ -4283,19 +4285,11 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             // add chat preamble
             mesSendString = addChatsPreamble(mesSendString);
 
-            const storyStringWrapped = beforeScenarioAnchor + storyString + afterScenarioAnchor;
-
             let combinedPrompt = (
-                power_user.context.story_string_tail
-                    ?
-                    mesExmString +
-                    mesSendString.replace('__SILLYTAVERN__STORY_STRING_TAIL__', storyStringWrapped) +
-                    generatedPromptCache
-                    :
-                    storyStringWrapped +
-                    mesExmString +
-                    mesSendString +
-                    generatedPromptCache
+                storyStringWrapped +
+                mesExmString +
+                mesSendString +
+                generatedPromptCache
             );
 
             combinedPrompt = combinedPrompt.replace(/\r/gm, '');

--- a/public/script.js
+++ b/public/script.js
@@ -4272,7 +4272,14 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             let storyStringWrapped = beforeScenarioAnchor + storyString + afterScenarioAnchor;
 
             if (power_user.context.story_string_tail) {
-                finalMesSend[finalMesSend.length - 1].extensionPrompts.splice(0, 0, storyStringWrapped);
+                let insertion_point = finalMesSend.length - power_user.context.story_string_tail_depth;
+                if (insertion_point < 0) {
+                    insertion_point = 0;
+                }
+                if (insertion_point >= finalMesSend.length) {
+                    insertion_point = finalMesSend.length - 1;
+                }
+                finalMesSend[insertion_point].extensionPrompts.splice(0, 0, storyStringWrapped);
                 storyStringWrapped = '';
             }
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -249,6 +249,7 @@ export const power_user = {
         example_separator: defaultExampleSeparator,
         use_stop_strings: true,
         names_as_stop_strings: true,
+        story_string_tail: false,
     },
 
     instruct_derived: false,
@@ -347,6 +348,7 @@ const contextControls = [
     { id: 'context_chat_start', property: 'chat_start', isCheckbox: false, isGlobalSetting: false },
     { id: 'context_use_stop_strings', property: 'use_stop_strings', isCheckbox: true, isGlobalSetting: false, defaultValue: false },
     { id: 'context_names_as_stop_strings', property: 'names_as_stop_strings', isCheckbox: true, isGlobalSetting: false, defaultValue: true },
+    { id: 'context_story_string_tail', property: 'story_string_tail', isCheckbox: true, isGlobalSetting: false, defaultValue: false },
 
     // Existing power user settings
     { id: 'always-force-name2-checkbox', property: 'always_force_name2', isCheckbox: true, isGlobalSetting: true, defaultValue: true },

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -250,6 +250,7 @@ export const power_user = {
         use_stop_strings: true,
         names_as_stop_strings: true,
         story_string_tail: false,
+        story_string_tail_depth: 1,
     },
 
     instruct_derived: false,
@@ -349,6 +350,7 @@ const contextControls = [
     { id: 'context_use_stop_strings', property: 'use_stop_strings', isCheckbox: true, isGlobalSetting: false, defaultValue: false },
     { id: 'context_names_as_stop_strings', property: 'names_as_stop_strings', isCheckbox: true, isGlobalSetting: false, defaultValue: true },
     { id: 'context_story_string_tail', property: 'story_string_tail', isCheckbox: true, isGlobalSetting: false, defaultValue: false },
+    { id: 'context_story_string_tail_depth', property: 'story_string_tail_depth', isCheckbox: false, isGlobalSetting: false },
 
     // Existing power user settings
     { id: 'always-force-name2-checkbox', property: 'always_force_name2', isCheckbox: true, isGlobalSetting: true, defaultValue: true },


### PR DESCRIPTION
People who run long roleplay find system message becomes dilluted and adherence drops over time. This PR proposes a flag which moves the story string to depth 1 (before last user message right before assistant respondse). This seems to help model remember char details and scenario info!

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
