### PR TITLE
Fix Soulkyn import

### DIFF
--- a/public/locales/ar-sa.json
+++ b/public/locales/ar-sa.json
@@ -1376,7 +1376,6 @@
     "char_import_6": "رابط PNG المباشر (راجع",
     "char_import_7": "للمضيفين المسموح بهم)",
     "char_import_8": "شخصية RisuRealm (رابط مباشر)",
-    "char_import_9": "شخصية Soulkyn (رابط مباشر)",
     "char_import_10": "شخصية Perchance (رابط مباشر أو UUID + .gz)",
     "Supports importing multiple characters.": "يدعم استيراد أحرف متعددة.",
     "Write each URL or ID into a new line.": "اكتب كل عنوان URL أو معرف في سطر جديد.",

--- a/public/locales/de-de.json
+++ b/public/locales/de-de.json
@@ -1376,7 +1376,6 @@
     "char_import_6": "Direkter PNG-Link (siehe",
     "char_import_7": "für erlaubte Hosts)",
     "char_import_8": "RisuRealm-Charakter (Direktlink)",
-    "char_import_9": "Soulkyn-Charakter (Direktlink)",
     "char_import_10": "Perchance-Charakter (Direktlink oder UUID + .gz)",
     "Supports importing multiple characters.": "Unterstützt den Import mehrerer Zeichen.",
     "Write each URL or ID into a new line.": "Schreiben Sie jede URL oder ID in eine neue Zeile.",

--- a/public/locales/es-es.json
+++ b/public/locales/es-es.json
@@ -1376,7 +1376,6 @@
     "char_import_6": "Enlace PNG directo (consulte",
     "char_import_7": "para hosts permitidos)",
     "char_import_8": "Personaje RisuRealm (Enlace directo)",
-    "char_import_9": "Personaje Soulkyn (Enlace directo)",
     "char_import_10": "Personaje Perchance (enlace directo o UUID + .gz)",
     "Supports importing multiple characters.": "Admite la importación de múltiples caracteres.",
     "Write each URL or ID into a new line.": "Escriba cada URL o ID en una nueva línea.",

--- a/public/locales/fr-fr.json
+++ b/public/locales/fr-fr.json
@@ -1298,7 +1298,6 @@
     "char_import_6": "Lien PNG direct (voir",
     "char_import_7": "pour les hôtes autorisés)",
     "char_import_8": "Personnage de RisuRealm (lien direct)",
-    "char_import_9": "Personnage de Soulkyn (lien direct)",
     "char_import_10": "Personnage de Perchance (lien direct ou UUID + .gz)",
     "Supports importing multiple characters.": "Prend en charge l'importation de plusieurs caractères.",
     "Write each URL or ID into a new line.": "Écrivez chaque URL ou identifiant dans une nouvelle ligne.",

--- a/public/locales/is-is.json
+++ b/public/locales/is-is.json
@@ -1376,7 +1376,6 @@
     "char_import_6": "Beinn PNG hlekkur (sjá",
     "char_import_7": "fyrir leyfilega gestgjafa)",
     "char_import_8": "RisuRealm karakter (beinn hlekkur)",
-    "char_import_9": "Soulkyn karakter (beinn hlekkur)",
     "char_import_10": "Perchance karakter (beinn hlekkur eða UUID + .gz)",
     "Supports importing multiple characters.": "Styður innflutning á mörgum stöfum.",
     "Write each URL or ID into a new line.": "Skrifaðu hverja vefslóð eða auðkenni í nýja línu.",

--- a/public/locales/it-it.json
+++ b/public/locales/it-it.json
@@ -1376,7 +1376,6 @@
     "char_import_6": "Collegamento PNG diretto (fare riferimento a",
     "char_import_7": "per gli host consentiti)",
     "char_import_8": "Personaggio RisuRealm (collegamento diretto)",
-    "char_import_9": "Personaggio Soulkyn (collegamento diretto)",
     "char_import_10": "Perchance Personaggio (collegamento diretto o UUID + .gz)",
     "Supports importing multiple characters.": "Supporta l'importazione di più caratteri.",
     "Write each URL or ID into a new line.": "Scrivi ogni URL o ID in una nuova riga.",

--- a/public/locales/ja-jp.json
+++ b/public/locales/ja-jp.json
@@ -1378,7 +1378,6 @@
     "char_import_6": "直接PNGリンク（参照",
     "char_import_7": "許可されたホストの場合)",
     "char_import_8": "RisuRealm キャラクター (直接リンク)",
-    "char_import_9": "Soulkyn キャラクター (直接リンク)",
     "char_import_10": "Perchance キャラクター (直接リンクまたは UUID + .gz)",
     "Supports importing multiple characters.": "複数のキャラクターのインポートをサポートします。",
     "Write each URL or ID into a new line.": "各 URL または ID を新しい行に入力します。",

--- a/public/locales/ko-kr.json
+++ b/public/locales/ko-kr.json
@@ -1395,7 +1395,6 @@
     "char_import_6": "직접 PNG 링크(참조",
     "char_import_7": "허용된 호스트의 경우)",
     "char_import_8": "RisuRealm 캐릭터 (직접링크)",
-    "char_import_9": "Soulkyn 캐릭터 (직접링크)",
     "char_import_10": "Perchance 캐릭터 (직접 링크 또는 UUID + .gz)",
     "Supports importing multiple characters.": "여러 문자 가져오기를 지원합니다.",
     "Write each URL or ID into a new line.": "각 URL 또는 ID를 새 줄에 작성합니다.",

--- a/public/locales/nl-nl.json
+++ b/public/locales/nl-nl.json
@@ -1376,7 +1376,6 @@
     "char_import_6": "Directe PNG-link (zie",
     "char_import_7": "voor toegestane hosts)",
     "char_import_8": "RisuRealm-personage (directe link)",
-    "char_import_9": "Soulkyn-personage (directe link)",
     "char_import_10": "Perchance-personage (directe link of UUID + .gz)",
     "Supports importing multiple characters.": "Ondersteunt het importeren van meerdere tekens.",
     "Write each URL or ID into a new line.": "Schrijf elke URL of ID op een nieuwe regel.",

--- a/public/locales/pt-pt.json
+++ b/public/locales/pt-pt.json
@@ -1376,7 +1376,6 @@
     "char_import_6": "Link PNG direto (consulte",
     "char_import_7": "para hosts permitidos)",
     "char_import_8": "Personagem RisuRealm (link direto)",
-    "char_import_9": "Personagem Soulkyn (link direto)",
     "char_import_10": "Personagem Perchance (Link Direto ou UUID + .gz)",
     "Supports importing multiple characters.": "Suporta importação de vários caracteres.",
     "Write each URL or ID into a new line.": "Escreva cada URL ou ID em uma nova linha.",

--- a/public/locales/ru-ru.json
+++ b/public/locales/ru-ru.json
@@ -963,7 +963,6 @@
     "char_import_5": "Персонаж с AICharacterCards.com (прямая ссылка или ID)",
     "char_import_6": "Прямая ссылка на PNG-файл (список разрешённых хостов находится в",
     "char_import_7": ")",
-    "char_import_9": "Персонаж с Soulkyn (прямая ссылка)",
     "char_import_10": "Персонаж с Perchance (прямая ссылка или UUID + .gz)",
     "Grammar String": "Грамматика",
     "GBNF or EBNF, depends on the backend in use. If you're using this you should know which.": "GBNF или EBNF, зависит от бэкенда. Если вы это используете, то, скорее всего, сами знаете, какой именно.",

--- a/public/locales/uk-ua.json
+++ b/public/locales/uk-ua.json
@@ -1376,7 +1376,6 @@
     "char_import_6": "Пряме посилання на PNG (див",
     "char_import_7": "для дозволених хостів)",
     "char_import_8": "Персонаж RisuRealm (пряме посилання)",
-    "char_import_9": "Персонаж Soulkyn (пряме посилання)",
     "char_import_10": "Персонаж Perchance (пряме посилання або UUID + .gz)",
     "Supports importing multiple characters.": "Підтримується імпорт кількох символів.",
     "Write each URL or ID into a new line.": "Напишіть кожну URL-адресу або ідентифікатор у новому рядку.",

--- a/public/locales/vi-vn.json
+++ b/public/locales/vi-vn.json
@@ -1376,7 +1376,6 @@
     "char_import_6": "Nhập PNG trực tiếp (tham khảo",
     "char_import_7": "đối với các máy chủ được phép)",
     "char_import_8": "RisuRealm (URL trực tiếp)",
-    "char_import_9": "Soulkyn (URL trực tiếp)",
     "char_import_10": "Perchance (Nhập URL trực tiếp hoặc UUID + .gz)",
     "Supports importing multiple characters.": "Hỗ trợ nhập nhiều ký tự.",
     "Write each URL or ID into a new line.": "Viết mỗi URL hoặc ID vào một dòng mới.",

--- a/public/locales/zh-cn.json
+++ b/public/locales/zh-cn.json
@@ -1888,7 +1888,6 @@
     "char_import_6": "被允许的PNG直链（请参阅",
     "char_import_7": "）",
     "char_import_8": "RisuRealm 角色（直链）",
-    "char_import_9": "Soulkyn 角色（直链）",
     "char_import_10": "Perchance 角色（直链或UUID + .gz）",
     "Supports importing multiple characters.": "支持导入多个角色。",
     "Write each URL or ID into a new line.": "将每个 URL 或 ID 写入新行。",

--- a/public/locales/zh-tw.json
+++ b/public/locales/zh-tw.json
@@ -1381,7 +1381,6 @@
     "char_import_6": "直接 PNG 連結（請參閱",
     "char_import_7": "對於允許的主機）",
     "char_import_8": "RisuRealm 角色（直接連結）",
-    "char_import_9": "Soulkyn 角色（直接連結）",
     "char_import_10": "Perchance 角色（直接連結或 ID + .gz）",
     "Supports importing multiple characters.": "支援匯入多個字元。",
     "Write each URL or ID into a new line.": "將每個 URL 或 ID 寫入新行。",

--- a/public/scripts/templates/importCharacters.html
+++ b/public/scripts/templates/importCharacters.html
@@ -10,7 +10,6 @@
         <li><span data-i18n="char_import_5">AICharacterCards.com Character (Direct Link or ID)</span><br><span data-i18n="char_import_example">Example:</span> <tt>AICC/aicharcards/the-game-master</tt></li>
         <li><span data-i18n="char_import_6">Direct PNG Link (refer to</span> <code>config.yaml</code><span data-i18n="char_import_7"> for allowed hosts)</span><br><span data-i18n="char_import_example">Example:</span> <tt>https://files.catbox.moe/notarealfile.png</tt></li>
         <li><span data-i18n="char_import_8">RisuRealm Character (Direct Link)</span><br><span data-i18n="char_import_example">Example:</span> <tt>https://realm.risuai.net/character/3ca54c71-6efe-46a2-b9d0-4f62df23d712</tt></li>
-        <li><span data-i18n="char_import_9">Soulkyn Character (Direct Link)</span><br><span data-i18n="char_import_example">Example:</span> <tt>https://soulkyn.com/l/en-US/@haruka-509al</tt></li>
         <li><span data-i18n="char_import_10">Perchance Character (Direct Link or UUID + .gz)</span><br><span data-i18n="char_import_example">Example:</span> <tt>https://perchance.org/ai-character-chat?data=Loreena~cb3a1b531477378db7cad0148ba62d71.gz</tt><br><span data-i18n="char_import_example">Example:</span> <tt>Loreena~cb3a1b531477378db7cad0148ba62d71.gz</tt></li>
     </ul>
 </div>

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import zlib from 'node:zlib';
@@ -640,243 +639,6 @@ async function downloadRisuCharacter(uuid) {
     return { buffer, fileName, fileType };
 }
 
-/**
- * Parse Soulkyn URL to extract the character slug.
- * @param {string} url Soulkyn character URL
- * @returns {string | null} Slug of the character
- */
-function parseSoulkynUrl(url) {
-    // Example: https://soulkyn.com/l/en-US/@kayla-marie
-    const pattern = /^https:\/\/soulkyn\.com\/l\/[a-z]{2}-[A-Z]{2}\/@([\w\d-]+)/i;
-    const match = url.match(pattern);
-    return match ? match[1] : null;
-}
-
-/**
- * Generate Soulkyn API headers.
- * @param {string} slug Slug of the character
- * @returns {Promise<object>} API headers
- */
-async function generateSoulkynApiHeaders(slug) {
-    // Extract JS bundle URL from HTML
-    const personaUrl = `https://soulkyn.com/l/en-US/@${slug}`;
-    const personaResult = await fetch(personaUrl, {
-        headers: { 'User-Agent': USER_AGENT },
-    });
-    const html = await personaResult.text();
-    const bundleMatch = html.match(/<script[^>]+src="(\/assets\/index-[^"]+\.js)"/);
-    if (!bundleMatch) {
-        const msg = `Failed to extract website JS bundle: ${personaUrl}`;
-        console.error('Soulkyn returned error', msg);
-        throw new Error(`Failed to download character: ${msg}`);
-    }
-    const bundleUrl = `https://soulkyn.com${bundleMatch[1]}`;
-
-    // Extract key from bundle code
-    const bundleResult = await fetch(bundleUrl, { headers: { 'User-Agent': USER_AGENT } });
-    const jsCode = await bundleResult.text();
-    // The key length is currently 28 characters, but we allow a range to accommodate future changes
-    const keyMatch = jsCode.match(/const\s+\w+\s*=\s*['"]([a-f0-9]{20,60})['"]/i);
-    if (!keyMatch) {
-        const msg = 'Failed to extract key from JS bundle';
-        console.error('Soulkyn returned error', msg);
-        throw new Error(`Failed to download character: ${msg}`);
-    }
-    const keyHex = keyMatch[1];
-
-    // Create API headers
-    const timestamp = Date.now().toString();
-    const apiPath = `Sk/public/Persona/${slug}`;
-    const message = `GET${apiPath}${timestamp}`;
-    const keyBytes = Buffer.from(keyHex, 'utf8');
-    const msgBytes = Buffer.from(message, 'utf8');
-    const hmac = crypto.createHmac('sha256', keyBytes);
-    hmac.update(msgBytes);
-    const signature = hmac.digest('base64');
-
-    return {
-        'X-Timestamp': timestamp,
-        'X-Signature': signature,
-    };
-}
-
-/**
- * Download Soulkyn character card
- * @param {string} slug Slug of the character
- * @returns {Promise<{buffer: Buffer, fileName: string, fileType: string} | null>}
- */
-async function downloadSoulkynCharacter(slug) {
-    const soulkynReplacements = [
-        // https://soulkyn.com/l/en-US/help/character-backgrounds-advanced#variables-you-can-use-in-character-background-text
-        { pattern: /__USER_?NAME__/gi, replacement: '{{user}}' },
-        { pattern: /__PERSONA_?NAME__/gi, replacement: '{{char}}' },
-        // ST doesn't support gender-specific pronoun macros
-        { pattern: /__U_PRONOUN_1__/gi, replacement: 'they' },
-        { pattern: /__U_PRONOUN_2__/gi, replacement: 'them' },
-        { pattern: /__U_PRONOUN_3__/gi, replacement: 'their' },
-        { pattern: /__U_PRONOUN_4__/gi, replacement: 'themselves' },
-        { pattern: /__(USER_)?PRONOUN__/gi, replacement: 'they' },
-        { pattern: /__(USER_)?CPRONOUN__/gi, replacement: 'them' },
-        { pattern: /__(USER_)?UPRONOUN__/gi, replacement: 'their' },
-        // HTML tags -> Markdown syntax
-        { pattern: /<(strong|b)>/gi, replacement: '**' },
-        { pattern: /<\/(strong|b)>/gi, replacement: '**' },
-        { pattern: /<(em|i)>/gi, replacement: '*' },
-        { pattern: /<\/(em|i)>/gi, replacement: '*' },
-    ];
-
-    const normalizeContent = (str) => soulkynReplacements.reduce((acc, { pattern, replacement }) => acc.replace(pattern, replacement), str);
-
-    try {
-        // Extract API data
-        const url = `https://soulkyn.com/_special/rest/Sk/public/Persona/${slug}`;
-        const result = await fetch(url, {
-            headers: {
-                'Content-Type': 'application/json',
-                'User-Agent': USER_AGENT,
-                ...(await generateSoulkynApiHeaders(slug)),
-            },
-        });
-        if (result.ok) {
-            /** @type {any} */
-            const soulkynCharData = await result.json();
-
-            if (soulkynCharData.result !== 'success') {
-                console.error('Soulkyn returned error', soulkynCharData.message);
-                throw new Error(`Failed to download character: ${soulkynCharData.message}`);
-            }
-
-            // Fetch avatar
-            let avatarBuffer = null;
-            if (soulkynCharData.data?.Avatar?.FWSUUID) {
-                const avatarUrl = `https://rub.soulkyn.com/${soulkynCharData.data.Avatar.FWSUUID}/`;
-                const avatarResult = await fetch(avatarUrl, { headers: { 'User-Agent': USER_AGENT } });
-
-                if (avatarResult.ok) {
-                    const avatarContentType = avatarResult.headers.get('content-type');
-                    if (avatarContentType === 'image/png') {
-                        avatarBuffer = Buffer.from(await avatarResult.arrayBuffer());
-                    } else {
-                        console.warn(`Soulkyn character (${slug}) avatar is not PNG: ${avatarContentType}`);
-                    }
-                } else {
-                    console.warn(`Soulkyn character (${slug}) avatar download failed: ${avatarResult.status}`);
-                }
-            } else {
-                console.warn(`Soulkyn character (${slug}) does not have an avatar`);
-            }
-
-            // Fallback to default avatar
-            if (!avatarBuffer) {
-                const defaultAvatarPath = path.join(serverDirectory, DEFAULT_AVATAR_PATH);
-                avatarBuffer = fs.readFileSync(defaultAvatarPath);
-            }
-
-            const d = soulkynCharData.data;
-            soulkynReplacements.push({ pattern: d.Username, replacement: '{{char}}' });
-
-            // Parse Soulkyn data into character chard
-            const charData = {
-                name: d.Username,
-                first_mes: '',
-                tags: [],
-                description: '',
-                creator: d.User.Username,
-                creator_notes: '',
-                alternate_greetings: [],
-                character_version: '',
-                mes_example: '',
-                post_history_instructions: '',
-                system_prompt: '',
-                scenario: '',
-                personality: '',
-                extensions: {
-                    soulkyn_slug: slug,
-                    soulkyn_id: d.UUID,
-                },
-            };
-
-            if (d?.PersonaIntroText) {
-                const match = d.PersonaIntroText.match(/^(?:\[Scenario:\s*([\s\S]*?)\]\s*)?([\s\S]*)$/);
-                if (match) {
-                    if (match[1]) {
-                        charData.scenario = normalizeContent(match[1].trim());
-                    }
-                    charData.first_mes = normalizeContent(match[2].trim());
-                }
-            }
-
-            const descriptionArr = ['Name: {{char}}'];
-            if (d?.Version?.Age) {
-                descriptionArr.push(`Age: ${d.Version.Age}`);
-            }
-            if (d?.Version?.Gender) {
-                descriptionArr.push(`Gender: ${d.Version.Gender}`);
-            }
-            if (d?.Version?.Race?.Name && !d.Version.Race.Name.match(/no preset/i)) {
-                let race = d.Version.Race.Name;
-                if (d.Version.Race?.Description) {
-                    race += ` (${d.Version.Race.Description})`;
-                }
-                descriptionArr.push(`Race: ${race}`);
-            }
-            if (d?.PersonalityType) {
-                descriptionArr.push(`Personality type: ${d.PersonalityType}`);
-            }
-            if (Array.isArray(d?.Version?.PropertyPersonality)) {
-                const traits = d.Version.PropertyPersonality.map((t) => t.Value).join(', ');
-                descriptionArr.push(`Personality Traits: ${traits}`);
-            }
-            if (Array.isArray(d?.Version?.PropertyPhysical)) {
-                const traits = d.Version.PropertyPhysical.map((t) => t.Value).join(', ');
-                descriptionArr.push(`Physical Traits: ${traits}`);
-            }
-            if (Array.isArray(d?.Clothes?.Preset)) {
-                descriptionArr.push(`Clothes: ${d.Clothes.Preset.join(', ')}`);
-            }
-            if (d?.Avatar?.Caption) {
-                descriptionArr.push(`Image description featuring {{char}}: ${d.Avatar.Caption.replace(/\n+/g, ' ')}`);
-            }
-            if (d?.Version?.WelcomeMessage) {
-                if (charData.first_mes) {
-                    descriptionArr.push(`{{char}}'s self-description: "${d.Version.WelcomeMessage}"`);
-                } else {
-                    // Some characters lack `PersonaIntroText`. In that case we use `Version.WelcomeMessage` for `first_mes`
-                    charData.first_mes = normalizeContent(d.Version.WelcomeMessage);
-                }
-            }
-            charData.description = normalizeContent(descriptionArr.join('\n'));
-
-            if (Array.isArray(d?.Version?.ChatExamplesValue)) {
-                charData.mes_example = d.Version.ChatExamplesValue.map((example) => `<START>\n${normalizeContent(example)}`).join('\n');
-            }
-
-            if (Array.isArray(d?.PersonaTags)) {
-                charData.tags = d.PersonaTags.map((t) => t.Slug);
-            }
-
-            // Character card
-            const buffer = write(avatarBuffer, JSON.stringify({
-                'spec': 'chara_card_v2',
-                'spec_version': '2.0',
-                'data': charData,
-            }));
-
-            const fileName = `${sanitize(d.UUID)}.png`;
-            const fileType = 'image/png';
-
-            return { buffer, fileName, fileType };
-        } else {
-            const msg = `Failed to retrieve API data: ${result.status} ${await result.text()}`;
-            console.error('Soulkyn returned error', msg);
-            throw new Error(`Failed to download character: ${msg}`);
-        }
-    } catch (error) {
-        console.error('Error downloading character:', error);
-        throw error;
-    }
-}
-
 /** * Check if the given string is a valid Perchance UUID.
  * @param {string} uuid UUID string to check
  * @returns {boolean} True if the UUID is valid, false otherwise
@@ -978,13 +740,14 @@ async function downloadPerchanceCharacter(slug) {
     return null;
 }
 
-/** * Extracts Perchance character data from a gzipped response.
+/**
+ * Extracts Perchance character data from a gzipped response.
  * @param {import('node-fetch').Response} result Fetch response containing gzipped character data
  * @returns {Promise<Object>} Parsed Perchance character data
  * @throws {Error} If the character data is invalid or missing required fields
  */
 async function extractPerchanceCharacterFromGz(result) {
-    const compressedBuffer = Buffer.from(await result.arrayBuffer());
+    const compressedBuffer = await result.arrayBuffer();
     const decompressedBuffer = zlib.gunzipSync(compressedBuffer);
 
     // inside the gz file, there is a file of the same name without extensions, but it is a json file
@@ -1119,7 +882,6 @@ router.post('/importURL', async (request, response) => {
         const isPygmalionContent = host.includes('pygmalion.chat');
         const isAICharacterCardsContent = host.includes('aicharactercards.com');
         const isRisu = host.includes('realm.risuai.net');
-        const isSoulkyn = host.includes('soulkyn.com');
         const isPerchance = host.includes('perchance.org');
         const isGeneric = isHostWhitelisted(host);
 
@@ -1169,13 +931,6 @@ router.post('/importURL', async (request, response) => {
 
             type = 'character';
             result = await downloadRisuCharacter(uuid);
-        } else if (isSoulkyn) {
-            const soulkynSlug = parseSoulkynUrl(url);
-            if (!soulkynSlug) {
-                return response.sendStatus(404);
-            }
-            type = 'character';
-            result = await downloadSoulkynCharacter(soulkynSlug);
         } else if (isPerchance) {
             const perchanceSlug = parsePerchanceSlug(url);
             if (!perchanceSlug) {

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import zlib from 'node:zlib';
@@ -652,6 +653,54 @@ function parseSoulkynUrl(url) {
 }
 
 /**
+ * Generate Soulkyn API headers.
+ * @param {string} slug Slug of the character
+ * @returns {Promise<object>} API headers
+ */
+async function generateSoulkynApiHeaders(slug) {
+    // Extract JS bundle URL from HTML
+    const personaUrl = `https://soulkyn.com/l/en-US/@${slug}`;
+    const personaResult = await fetch(personaUrl, {
+        headers: { 'User-Agent': USER_AGENT },
+    });
+    const html = await personaResult.text();
+    const bundleMatch = html.match(/<script[^>]+src="(\/assets\/index-[^"]+\.js)"/);
+    if (!bundleMatch) {
+        const msg = `Failed to extract website JS bundle: ${personaUrl}`;
+        console.error('Soulkyn returned error', msg);
+        throw new Error(`Failed to download character: ${msg}`);
+    }
+    const bundleUrl = `https://soulkyn.com${bundleMatch[1]}`;
+
+    // Extract key from bundle code
+    const bundleResult = await fetch(bundleUrl, { headers: { 'User-Agent': USER_AGENT } });
+    const jsCode = await bundleResult.text();
+    // The key length is currently 28 characters, but we allow a range to accommodate future changes
+    const keyMatch = jsCode.match(/const\s+\w+\s*=\s*['"]([a-f0-9]{20,60})['"]/i);
+    if (!keyMatch) {
+        const msg = 'Failed to extract key from JS bundle';
+        console.error('Soulkyn returned error', msg);
+        throw new Error(`Failed to download character: ${msg}`);
+    }
+    const keyHex = keyMatch[1];
+
+    // Create API headers
+    const timestamp = Date.now().toString();
+    const apiPath = `Sk/public/Persona/${slug}`;
+    const message = `GET${apiPath}${timestamp}`;
+    const keyBytes = Buffer.from(keyHex, 'utf8');
+    const msgBytes = Buffer.from(message, 'utf8');
+    const hmac = crypto.createHmac('sha256', keyBytes);
+    hmac.update(msgBytes);
+    const signature = hmac.digest('base64');
+
+    return {
+        'X-Timestamp': timestamp,
+        'X-Signature': signature,
+    };
+}
+
+/**
  * Download Soulkyn character card
  * @param {string} slug Slug of the character
  * @returns {Promise<{buffer: Buffer, fileName: string, fileType: string} | null>}
@@ -679,9 +728,14 @@ async function downloadSoulkynCharacter(slug) {
     const normalizeContent = (str) => soulkynReplacements.reduce((acc, { pattern, replacement }) => acc.replace(pattern, replacement), str);
 
     try {
+        // Extract API data
         const url = `https://soulkyn.com/_special/rest/Sk/public/Persona/${slug}`;
         const result = await fetch(url, {
-            headers: { 'Content-Type': 'application/json', 'User-Agent': USER_AGENT },
+            headers: {
+                'Content-Type': 'application/json',
+                'User-Agent': USER_AGENT,
+                ...(await generateSoulkynApiHeaders(slug)),
+            },
         });
         if (result.ok) {
             /** @type {any} */
@@ -812,12 +866,15 @@ async function downloadSoulkynCharacter(slug) {
             const fileType = 'image/png';
 
             return { buffer, fileName, fileType };
+        } else {
+            const msg = `Failed to retrieve API data: ${result.status} ${await result.text()}`;
+            console.error('Soulkyn returned error', msg);
+            throw new Error(`Failed to download character: ${msg}`);
         }
     } catch (error) {
         console.error('Error downloading character:', error);
         throw error;
     }
-    return null;
 }
 
 /** * Check if the given string is a valid Perchance UUID.


### PR DESCRIPTION
Generate and supply necessary headers to Soulkyn API request. Fixes #4323

Soulkyn API recently added `X-Timestamp` and `X-Signature` headers, likely as anti-scraping measures.

This PR implements a workaround to generate these headers correctly. However, such scraping is inherently fragile and may break if Soulkyn updates their logic. Maintaining this import could lead to ongoing cat-and-mouse efforts with their developers.

I’m happy to provide this fix, but I understand if you prefer to remove the Soulkyn import altogether to avoid this maintenance burden.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
