### PR TITLE
feat: Add close all reasonings button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6908,6 +6908,7 @@
                                     <span class="mes_reasoning_header_title" data-i18n="Thought for some time">Thought for some time</span>
                                     <div class="mes_reasoning_arrow fa-solid fa-chevron-up"></div>
                                 </div>
+                                <div class="mes_reasoning_close_all menu_button fa-solid fa-close" title="Close all reasonings" data-i18n="[title]Close all reasonings"></div>
                             </div>
                             <div class="mes_reasoning_actions flex-container">
                                 <div class="mes_reasoning_edit_done menu_button edit_button fa-solid fa-check" title="Confirm" data-i18n="[title]Confirm Edit"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -6908,12 +6908,12 @@
                                     <span class="mes_reasoning_header_title" data-i18n="Thought for some time">Thought for some time</span>
                                     <div class="mes_reasoning_arrow fa-solid fa-chevron-up"></div>
                                 </div>
-                                <div class="mes_reasoning_close_all menu_button fa-solid fa-close" title="Close all reasonings" data-i18n="[title]Close all reasonings"></div>
                             </div>
                             <div class="mes_reasoning_actions flex-container">
                                 <div class="mes_reasoning_edit_done menu_button edit_button fa-solid fa-check" title="Confirm" data-i18n="[title]Confirm Edit"></div>
                                 <div class="mes_reasoning_delete menu_button edit_button fa-solid fa-trash-can" title="Remove reasoning" data-i18n="[title]Remove reasoning"></div>
                                 <div class="mes_reasoning_edit_cancel menu_button edit_button fa-solid fa-xmark" title="Cancel edit" data-i18n="[title]Cancel edit"></div>
+                                <div class="mes_reasoning_close_all mes_button fa-solid fa-minimize" title="Collapse all reasoning blocks" data-i18n="[title]Collapse all reasoning blocks"></div>
                                 <div class="mes_reasoning_copy mes_button fa-solid fa-copy" title="Copy reasoning" data-i18n="[title]Copy reasoning"></div>
                                 <div class="mes_reasoning_edit mes_button fa-solid fa-pencil" title="Edit reasoning" data-i18n="[title]Edit reasoning"></div>
                             </div>

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1074,6 +1074,13 @@ function setReasoningEventHandlers() {
         }
     });
 
+    $(document).on('click', '.mes_reasoning_close_all', function (e) {
+        e.stopPropagation();
+        e.preventDefault();
+
+        $('.mes_reasoning_details[open] .mes_reasoning_header').trigger('click');
+    });
+
     $(document).on('click', '.mes_reasoning_edit_done', async function (e) {
         e.stopPropagation();
         e.preventDefault();

--- a/public/style.css
+++ b/public/style.css
@@ -477,6 +477,7 @@ input[type='checkbox']:focus-visible {
 .mes_reasoning_details:not([open]) .mes_reasoning_actions,
 .mes_reasoning_details:has(.reasoning_edit_textarea) .mes_reasoning,
 .mes_reasoning_details:has(.reasoning_edit_textarea) .mes_reasoning_header,
+.mes_reasoning_details:has(.reasoning_edit_textarea) .mes_reasoning_close_all,
 .mes_reasoning_details:has(.reasoning_edit_textarea) .mes_reasoning_actions .mes_button:not(.edit_button),
 .mes_reasoning_details:not(:has(.reasoning_edit_textarea)) .mes_reasoning_actions .edit_button,
 .mes_block:has(.edit_textarea):has(.reasoning_edit_textarea) .mes_reasoning_actions,
@@ -508,6 +509,14 @@ input[type='checkbox']:focus-visible {
 
 .mes_reasoning_details:not([open]) .mes_reasoning_arrow {
     transform: translateY(-50%) rotate(180deg);
+}
+
+.mes_reasoning_details[open]:not(:has(.reasoning_edit_textarea)) .mes_reasoning_close_all {
+    display: flex;
+}
+
+.mes_reasoning_details:not([open]) .mes_reasoning_close_all {
+    display: none;
 }
 
 .mes_reasoning_summary>span {

--- a/public/style.css
+++ b/public/style.css
@@ -477,7 +477,6 @@ input[type='checkbox']:focus-visible {
 .mes_reasoning_details:not([open]) .mes_reasoning_actions,
 .mes_reasoning_details:has(.reasoning_edit_textarea) .mes_reasoning,
 .mes_reasoning_details:has(.reasoning_edit_textarea) .mes_reasoning_header,
-.mes_reasoning_details:has(.reasoning_edit_textarea) .mes_reasoning_close_all,
 .mes_reasoning_details:has(.reasoning_edit_textarea) .mes_reasoning_actions .mes_button:not(.edit_button),
 .mes_reasoning_details:not(:has(.reasoning_edit_textarea)) .mes_reasoning_actions .edit_button,
 .mes_block:has(.edit_textarea):has(.reasoning_edit_textarea) .mes_reasoning_actions,

--- a/public/style.css
+++ b/public/style.css
@@ -511,14 +511,6 @@ input[type='checkbox']:focus-visible {
     transform: translateY(-50%) rotate(180deg);
 }
 
-.mes_reasoning_details[open]:not(:has(.reasoning_edit_textarea)) .mes_reasoning_close_all {
-    display: flex;
-}
-
-.mes_reasoning_details:not([open]) .mes_reasoning_close_all {
-    display: none;
-}
-
 .mes_reasoning_summary>span {
     margin-left: 0.5em;
 }


### PR DESCRIPTION
## Problem

When using CTRL+F, it automatically opens many reasoning toggles and it is a pain to scroll to close them again and again.

## Solution

Created a close all reasonings button that appears besides the current opened reasoning header.
Made sure to hide it the reasoning is being edited.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
