### PR TITLE
bug-fix: adhere to chat template hash bound settings when a new model appears using the same hash as a bound one

### DIFF
--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -743,8 +743,9 @@ async function getStatusTextgen() {
                         }
                     }
                     console.log(`We have chat template ${chat_template.split('\n')[0]}...`);
-                    const { context, instruct } = power_user.model_templates_mappings[chat_template_hash]
-                        ?? await deriveTemplatesFromChatTemplate(chat_template, chat_template_hash);
+                    const savedTemplate = power_user.model_templates_mappings[chat_template_hash];
+                    const derivedTemplate = await deriveTemplatesFromChatTemplate(chat_template, chat_template_hash);
+                    const { context, instruct } = savedTemplate ?? derivedTemplate;
 
                     if (wantsContextDerivation && context) {
                         selectContextPreset(context, { isAuto: true });

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -743,7 +743,9 @@ async function getStatusTextgen() {
                         }
                     }
                     console.log(`We have chat template ${chat_template.split('\n')[0]}...`);
-                    const { context, instruct } = await deriveTemplatesFromChatTemplate(chat_template, chat_template_hash);
+                    const { context, instruct } = power_user.model_templates_mappings[chat_template_hash]
+                        ?? await deriveTemplatesFromChatTemplate(chat_template, chat_template_hash);
+
                     if (wantsContextDerivation && context) {
                         selectContextPreset(context, { isAuto: true });
                     }


### PR DESCRIPTION
When you bind a model A with chat template T to some preset X, and then load a different model B which has the same chat template T, you want it to default to preset X as well. This fixes.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
