### PR TITLE
Add Variety Boost option for NovelAI image generation.

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -306,6 +306,7 @@ const defaultSettings = {
     novel_sm: false,
     novel_sm_dyn: false,
     novel_decrisper: false,
+    novel_variety_boost: false,
 
     // OpenAI settings
     openai_style: 'vivid',
@@ -482,6 +483,7 @@ async function loadSettings() {
     $('#sd_novel_sm_dyn').prop('checked', extension_settings.sd.novel_sm_dyn);
     $('#sd_novel_sm_dyn').prop('disabled', !extension_settings.sd.novel_sm);
     $('#sd_novel_decrisper').prop('checked', extension_settings.sd.novel_decrisper);
+    $('#sd_novel_variety_boost').prop('checked', extension_settings.sd.novel_variety_boost);
     $('#sd_pollinations_enhance').prop('checked', extension_settings.sd.pollinations_enhance);
     $('#sd_horde').prop('checked', extension_settings.sd.horde);
     $('#sd_horde_nsfw').prop('checked', extension_settings.sd.horde_nsfw);
@@ -1052,6 +1054,11 @@ function onNovelSmDynInput() {
 
 function onNovelDecrisperInput() {
     extension_settings.sd.novel_decrisper = !!$('#sd_novel_decrisper').prop('checked');
+    saveSettingsDebounced();
+}
+
+function onNovelVarietyBoostInput() {
+    extension_settings.sd.novel_variety_boost = !!$('#sd_novel_variety_boost').prop('checked');
     saveSettingsDebounced();
 }
 
@@ -3234,6 +3241,7 @@ async function generateNovelImage(prompt, negativePrompt, signal) {
             negative_prompt: negativePrompt,
             upscale_ratio: extension_settings.sd.hr_scale,
             decrisper: extension_settings.sd.novel_decrisper,
+            variety_boost: extension_settings.sd.novel_variety_boost,
             sm: sm,
             sm_dyn: sm_dyn,
             seed: extension_settings.sd.seed >= 0 ? extension_settings.sd.seed : undefined,
@@ -4654,6 +4662,7 @@ jQuery(async () => {
     $('#sd_novel_sm').on('input', onNovelSmInput);
     $('#sd_novel_sm_dyn').on('input', onNovelSmDynInput);
     $('#sd_novel_decrisper').on('input', onNovelDecrisperInput);
+    $('#sd_novel_variety_boost').on('input', onNovelVarietyBoostInput);
     $('#sd_pollinations_enhance').on('input', onPollinationsEnhanceInput);
     $('#sd_comfy_validate').on('click', validateComfyUrl);
     $('#sd_comfy_url').on('input', onComfyUrlInput);

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -451,6 +451,10 @@
                     <input id="sd_novel_decrisper" type="checkbox" />
                     <small data-i18n="Decrisper">Decrisper</small>
                 </label>
+                <label class="flex1 checkbox_label" data-i18n="[title]Enable guidance only after body has been formed, to improve diversity and saturation of samples. May reduce relevance" title="Enable guidance only after body has been formed, to improve diversity and saturation of samples. May reduce relevance">
+                    <input id="sd_novel_variety_boost" type="checkbox" />
+                    <small data-i18n="Variety+">Variety+</small>
+                </label>
             </div>
 
             <div data-sd-source="novel,togetherai,pollinations,comfy,drawthings,vlad,auto,horde,extras,stability,bfl" class="marginTop5">


### PR DESCRIPTION
## Description
This PR adds the Variety Boost option to the Image Generation plugin, which was introduced by Novel AI in their August sampler update.

Variety Boost is available for all current models (V3, V4, and V4.5, including their variants) since Auguest 2024. For more details about this feature, please refer to the [Novel AI Summer Sampler Update blog post](https://blog.novelai.net/summer-sampler-update-en-3a34eb32b613).

## Implementation Details
- When Variety Boost is **disabled**: `skip_cfg_above_sigma` is set to `null` in the NovelAI API request
- When Variety Boost is **enabled**: `skip_cfg_above_sigma` value is determined based on the target image pixels and a baseline sigma value:
  - V4.5 base sigma: **58**
  - All other models (V3, V4): **19**

The implementation follows the reference from [bedovyy/ComfyUI_NAIDGenerator](https://github.com/bedovyy/ComfyUI_NAIDGenerator).

## Related Links
- [Novel AI Summer Sampler Update Announcement](https://blog.novelai.net/summer-sampler-update-en-3a34eb32b613)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
