### PR TITLE
Improve tag visibility toggle logic

### DIFF
--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1822,12 +1822,18 @@ const debouncedTagColoring = debounce((tagId, cssProperty, newColor) => {
 
 function onTagListHintClick() {
     $(this).toggleClass('selected');
-    $(this).siblings('.tag:not(.actionable)').toggle(100);
+    
+    const $tagSiblings = $(this).siblings('.tag:not(.actionable)');
+    
+    if ($(this).hasClass('selected')) {
+        $tagSiblings.show();
+    } else {
+        $tagSiblings.hide();
+    }
+    
     $(this).siblings('.innerActionable').toggleClass('hidden');
-
     power_user.show_tag_filters = $(this).hasClass('selected');
     saveSettingsDebounced();
-
     console.debug('show_tag_filters', power_user.show_tag_filters);
 }
 

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1822,15 +1822,15 @@ const debouncedTagColoring = debounce((tagId, cssProperty, newColor) => {
 
 function onTagListHintClick() {
     $(this).toggleClass('selected');
-    
+
     const $tagSiblings = $(this).siblings('.tag:not(.actionable)');
-    
+
     if ($(this).hasClass('selected')) {
         $tagSiblings.show();
     } else {
         $tagSiblings.hide();
     }
-    
+
     $(this).siblings('.innerActionable').toggleClass('hidden');
     power_user.show_tag_filters = $(this).hasClass('selected');
     saveSettingsDebounced();


### PR DESCRIPTION
Cache selector once, and remove hardcoded animation duration in favour of faster show hide. Takes toggles when 300 tags are present from 3 seconds down to 2ms.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
