### PR TITLE
Header change

### DIFF
--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -1,5 +1,4 @@
-/* This is the main flex container for the entire drawer.
-   It establishes the column layout and fixed height needed for internal scrolling. */
+/* This is the main flex container for the entire drawer */
 #Backgrounds.drawer-content.openDrawer.bg-drawer-layout {
     display: flex;
     flex-direction: column;
@@ -14,7 +13,7 @@
 }
 
 #bg-header-fixed {
-    flex-shrink: 0; /* Prevent header from shrinking */
+    flex-shrink: 0;
     padding: 5px;
     background-color: var(--SmartThemeBlurTintColor);
     border-bottom: 1px solid var(--SmartThemeBorderColor);
@@ -26,7 +25,6 @@
     gap: 5px;
 }
 
-/* This container will grow to fill available space and handle its own scrolling. */
 #bg-scrollable-content {
     flex-grow: 1;
     overflow-y: auto;

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -1,0 +1,35 @@
+/* This is the main flex container for the entire drawer.
+   It establishes the column layout and fixed height needed for internal scrolling. */
+#Backgrounds.drawer-content.openDrawer.bg-drawer-layout {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - var(--topBarBlockSize));
+    max-height: calc(100vh - var(--topBarBlockSize));
+    height: calc(100dvh - var(--topBarBlockSize));
+    max-height: calc(100dvh - var(--topBarBlockSize));
+    overflow: hidden;
+    width: var(--sheldWidth);
+    max-width: var(--sheldWidth);
+    padding: 0;
+}
+
+#bg-header-fixed {
+    flex-shrink: 0; /* Prevent header from shrinking */
+    padding: 5px;
+    background-color: var(--SmartThemeBlurTintColor);
+    border-bottom: 1px solid var(--SmartThemeBorderColor);
+}
+
+#bg-header-fixed > .flex-container {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+/* This container will grow to fill available space and handle its own scrolling. */
+#bg-scrollable-content {
+    flex-grow: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 0 5px 5px;
+}

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -19,7 +19,7 @@
     border-bottom: 1px solid var(--SmartThemeBorderColor);
 }
 
-#bg-header-fixed > .flex-container {
+#bg-header-fixed>.flex-container {
     display: flex;
     align-items: center;
     gap: 5px;
@@ -30,4 +30,8 @@
     overflow-y: auto;
     overflow-x: hidden;
     padding: 0 5px 5px;
+}
+
+#bg-filter {
+    font-size: calc(var(--mainFontSize) * 0.95);
 }

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -30,12 +30,12 @@
         row-gap: 10px;
     }
 
-    #bg-header-fixed > .flex-container {
+    #bg-header-fixed>.flex-container {
         flex-wrap: wrap;
         row-gap: 0px;
     }
 
-    #Backgrounds:not(.selection-mode-active) #bg-header-fixed > .flex-container::after {
+    #Backgrounds:not(.selection-mode-active) #bg-header-fixed>.flex-container::after {
         content: '';
         order: 1;
         flex-basis: 100%;
@@ -43,30 +43,30 @@
     }
 
     /* --- Row 1 Item --- */
-    .standard-mode-item[data-i18n="Backgrounds"] {
+    #bg-header-fixed #bg-header-title {
         order: 1;
         flex-grow: 1;
     }
-    .standard-mode-item#background_fitting,
-    .standard-mode-item#auto_background {
+
+    #bg-header-fixed #background_fitting,
+    #bg-header-fixed #auto_background {
         order: 1;
     }
 
     /* --- Row 2 Item --- */
-    .standard-mode-item#bg-filter {
+    #bg-header-fixed #bg-filter {
         order: 2;
         flex-grow: 1;
         min-width: 0;
     }
 
     /* --- Row 3 Item --- */
-    .standard-mode-item#add_background_button_top {
+    #bg-header-fixed #add_background_button_top {
         order: 3;
         width: 100%;
         text-align: center;
-        padding-top: 0.8rem;
-        padding-bottom: 0.8rem;
-        font-size: 1.1em;
+        padding-top: 0.5em;
+        padding-bottom: 0.5em;
     }
 
     #Backgrounds.drawer-content.openDrawer.bg-drawer-layout {

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -25,6 +25,55 @@
         font-size: 15px;
     }
 
+    #bg-header-controls {
+        flex-wrap: wrap;
+        row-gap: 10px;
+    }
+
+    #bg-header-fixed > .flex-container {
+        flex-wrap: wrap;
+        row-gap: 0px;
+    }
+
+    #Backgrounds:not(.selection-mode-active) #bg-header-fixed > .flex-container::after {
+        content: '';
+        order: 1;
+        flex-basis: 100%;
+        height: 0;
+    }
+
+    /* --- Row 1 Item --- */
+    .standard-mode-item[data-i18n="Backgrounds"] {
+        order: 1;
+        flex-grow: 1;
+    }
+    .standard-mode-item#background_fitting,
+    .standard-mode-item#auto_background {
+        order: 1;
+    }
+
+    /* --- Row 2 Item --- */
+    .standard-mode-item#bg-filter {
+        order: 2;
+        flex-grow: 1;
+        min-width: 0;
+    }
+
+    /* --- Row 3 Item --- */
+    .standard-mode-item#add_background_button_top {
+        order: 3;
+        width: 100%;
+        text-align: center;
+        padding-top: 0.8rem;
+        padding-bottom: 0.8rem;
+        font-size: 1.1em;
+    }
+
+    #Backgrounds.drawer-content.openDrawer.bg-drawer-layout {
+        width: 100dvw;
+        max-width: 100dvw;
+    }
+
     #extensions_settings,
     #extensions_settings2 {
         width: 100% !important;

--- a/public/index.html
+++ b/public/index.html
@@ -5284,35 +5284,33 @@
             <div id="site_logo" class="drawer-toggle drawer-header" title="Change Background Image" data-i18n="[title]Change Background Image">
                 <div class="drawer-icon fa-solid fa-panorama fa-fw closedIcon"></div>
             </div>
-            <div id="Backgrounds" class="drawer-content closedDrawer">
-                <div class="flex-container">
+            <div id="Backgrounds" class="drawer-content closedDrawer bg-drawer-layout">
+                <div id="bg-header-fixed">
                     <div class="flex-container alignItemsBaseline wide100p">
-                        <h3 class="margin0 flex2" data-i18n="Background Image">
-                            Background Image
-                        </h3>
-                        <input id="bg-filter" data-i18n="[placeholder]Filter" placeholder="Filter" class="text_pole flex1" type="search" />
-                        <select id="background_fitting" class="text_pole" data-i18n="[title]Background Fitting" title="Background Fitting">
+                        <h3 class="margin0 standard-mode-item" data-i18n="Backgrounds">Backgrounds</h3>
+                        <input id="bg-filter" class="text_pole flex1 standard-mode-item" type="search" data-i18n="[placeholder]Search" placeholder="Search" />
+                        <select id="background_fitting" class="text_pole standard-mode-item" data-i18n="[title]Background Fitting" title="Background Fitting">
                             <option value="classic" data-i18n="Classic">Classic</option>
                             <option value="cover" data-i18n="Cover">Cover</option>
                             <option value="contain" data-i18n="Contain">Contain</option>
                             <option value="stretch" data-i18n="Stretch">Stretch</option>
                             <option value="center" data-i18n="Center">Center</option>
                         </select>
-                        <div id="auto_background" class="menu_button menu_button_icon" data-i18n="[title]Automatically select a background based on the chat context" title="Automatically select a background based on the chat context.">
+                        <div id="auto_background" class="menu_button menu_button_icon standard-mode-item" data-i18n="[title]Automatically select a background based on the chat context" title="Automatically select a background based on the chat context.">
                             <i class="fa-solid fa-wand-magic"></i>
                             <span data-i18n="Auto-select">Auto-select</span>
                         </div>
+                        <label for="add_bg_button" id="add_background_button_top" class="menu_button menu_button_icon interactable standard-mode-item" title="Add a new background">
+                            <i class="fa-solid fa-plus"></i>
+                            <span data-i18n="Add Background">Add Background</span>
+                        </label>
                     </div>
+                </div>
+                <div id="bg-scrollable-content">
                     <h3 data-i18n="System Backgrounds" class="wide100p textAlignCenter">
                         System Backgrounds
                     </h3>
                     <div id="bg_menu_content" class="bg_list">
-                        <form id="form_bg_download" class="bg_example no-border no-shadow" action="javascript:void(null);" method="post" enctype="multipart/form-data">
-                            <label class="input-file">
-                                <input type="file" id="add_bg_button" name="avatar" accept="image/*, video/*">
-                                <div class="bg_example no-border no-shadow add_bg_but" style="background-image: url('/img/addbg3.png');"></div>
-                            </label>
-                        </form>
                     </div>
                     <h3 data-i18n="Chat Backgrounds" class="wide100p textAlignCenter">
                         Chat Backgrounds
@@ -5323,6 +5321,9 @@
                     <div id="bg_custom_content" class="bg_list">
                     </div>
                 </div>
+                <form id="form_bg_upload" style="display: none;">
+                   <input type="file" id="add_bg_button" name="avatar" accept="image/jpeg,image/png,image/gif,image/bmp,image/svg+xml,video/*">
+                </form>
             </div>
         </div>
         <div id="extensions-settings-button" class="drawer">

--- a/public/index.html
+++ b/public/index.html
@@ -5287,20 +5287,20 @@
             <div id="Backgrounds" class="drawer-content closedDrawer bg-drawer-layout">
                 <div id="bg-header-fixed">
                     <div class="flex-container alignItemsBaseline wide100p">
-                        <h3 class="margin0 standard-mode-item" data-i18n="Backgrounds">Backgrounds</h3>
-                        <input id="bg-filter" class="text_pole flex1 standard-mode-item" type="search" data-i18n="[placeholder]Search" placeholder="Search" />
-                        <select id="background_fitting" class="text_pole standard-mode-item" data-i18n="[title]Background Fitting" title="Background Fitting">
+                        <h3 id="bg-header-title" class="margin0" data-i18n="Backgrounds">Backgrounds</h3>
+                        <input id="bg-filter" class="text_pole flex1" type="search" data-i18n="[placeholder]Search" placeholder="Search" />
+                        <select id="background_fitting" class="text_pole" data-i18n="[title]Background Fitting" title="Background Fitting">
                             <option value="classic" data-i18n="Classic">Classic</option>
                             <option value="cover" data-i18n="Cover">Cover</option>
                             <option value="contain" data-i18n="Contain">Contain</option>
                             <option value="stretch" data-i18n="Stretch">Stretch</option>
                             <option value="center" data-i18n="Center">Center</option>
                         </select>
-                        <div id="auto_background" class="menu_button menu_button_icon standard-mode-item" data-i18n="[title]Automatically select a background based on the chat context" title="Automatically select a background based on the chat context.">
+                        <div id="auto_background" class="menu_button menu_button_icon" data-i18n="[title]Automatically select a background based on the chat context" title="Automatically select a background based on the chat context.">
                             <i class="fa-solid fa-wand-magic"></i>
                             <span data-i18n="Auto-select">Auto-select</span>
                         </div>
-                        <label for="add_bg_button" id="add_background_button_top" class="menu_button menu_button_icon interactable standard-mode-item" title="Add a new background">
+                        <label for="add_bg_button" id="add_background_button_top" class="menu_button menu_button_icon interactable" title="Add a new background">
                             <i class="fa-solid fa-plus"></i>
                             <span data-i18n="Add Background">Add Background</span>
                         </label>

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -573,14 +573,21 @@ async function delBackground(bg) {
 }
 
 async function onBackgroundUploadSelected() {
-    const form = $('#form_bg_download').get(0);
+    const form = $('#form_bg_upload').get(0);
 
     if (!(form instanceof HTMLFormElement)) {
-        console.error('form_bg_download is not a form');
+        console.error('form_bg_upload is not a form');
         return;
     }
 
     const formData = new FormData(form);
+
+    const file = formData.get('avatar');
+    if (!file || file.size === 0) {
+        form.reset();
+        return;
+    }
+
     await convertFileIfVideo(formData);
     await uploadBackground(formData);
     form.reset();

--- a/public/style.css
+++ b/public/style.css
@@ -13,6 +13,7 @@
 @import url(css/welcome.css);
 @import url(css/data-maid.css);
 @import url(css/secrets.css);
+@import url(css/backgrounds.css);
 
 :root {
     interpolate-size: allow-keywords;


### PR DESCRIPTION
- Removed the big "add background" button
- Added a nicer looking button in the header
- Altered the styling to form three rows and "add background" button larger on mobile widths only
- "Background Image" -> "Backgrounds" and "Filter" -> "Search"
- Made the search bar expand to fill on desktop
- Made the top bar sticky

<img width="639" height="694" alt="image" src="https://github.com/user-attachments/assets/315a9d34-95d0-4fc3-8d19-13f277d74e3a" />

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
