### PR TITLE
More modern backgrounds buttons and filename

### DIFF
--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -14,12 +14,14 @@
 #background_fitting {
     max-width: 6em;
 }
+
 /* Fill/Cover - scales to fill width while maintaining aspect ratio */
 #bg1.cover,
 #bg_custom.cover {
     background-size: cover;
     background-position: center;
 }
+
 /* Fit/Contain - shows entire image maintaining aspect ratio */
 #bg1.contain,
 #bg_custom.contain {
@@ -27,11 +29,13 @@
     background-position: center;
     background-repeat: no-repeat;
 }
+
 /* Stretch - stretches to fill entire space */
 #bg1.stretch,
 #bg_custom.stretch {
     background-size: 100% 100%;
 }
+
 /* Center - centers without scaling */
 #bg1.center,
 #bg_custom.center {
@@ -39,14 +43,17 @@
     background-position: center;
     background-repeat: no-repeat;
 }
+
 body.reduced-motion #bg1,
 body.reduced-motion #bg_custom {
     transition: none;
 }
+
 #bg1 {
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=');
     z-index: -3;
 }
+
 #bg_custom {
     background-image: none;
     z-index: -2;

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -150,7 +150,7 @@ body.reduced-motion #bg_custom {
     visibility: hidden;
     transform: scale(0.9);
     transform-origin: center;
-    transition: opacity 0.15s ease-out, visibility 0.15s ease-out, transform 0.15s ease-out;
+    transition: opacity var(--animation-duration) ease-out, visibility var(--animation-duration) ease-out, transform var(--animation-duration) ease-out;
 }
 
 .bg_example:hover .jg-menu {
@@ -167,7 +167,7 @@ body.reduced-motion #bg_custom {
     padding: 5px;
     font-size: 1.2em;
     border-radius: 6px;
-    transition: background-color 0.15s ease;
+    transition: background-color var(--animation-duration) ease;
 }
 
 .bg_example .jg-button:hover {
@@ -202,7 +202,7 @@ body.reduced-motion #bg_custom {
     overflow: hidden;
     text-overflow: ellipsis;
     opacity: 0;
-    transition: opacity 0.15s ease-in-out;
+    transition: opacity var(--animation-duration) ease-in-out;
     pointer-events: none;
     border-radius: 0 0 8px 8px;
 }

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -1,3 +1,61 @@
+/* Main Page Backgrounds */
+#bg1,
+#bg_custom {
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-size: cover;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    transition: background-image var(--animation-duration-3x) ease-in-out;
+}
+
+/* Fitting options */
+#background_fitting {
+    max-width: 6em;
+}
+/* Fill/Cover - scales to fill width while maintaining aspect ratio */
+#bg1.cover,
+#bg_custom.cover {
+    background-size: cover;
+    background-position: center;
+}
+/* Fit/Contain - shows entire image maintaining aspect ratio */
+#bg1.contain,
+#bg_custom.contain {
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+/* Stretch - stretches to fill entire space */
+#bg1.stretch,
+#bg_custom.stretch {
+    background-size: 100% 100%;
+}
+/* Center - centers without scaling */
+#bg1.center,
+#bg_custom.center {
+    background-size: auto;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+body.reduced-motion #bg1,
+body.reduced-motion #bg_custom {
+    transition: none;
+}
+#bg1 {
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=');
+    z-index: -3;
+}
+#bg_custom {
+    background-image: none;
+    z-index: -2;
+}
+
+.bg_example.locked {
+    outline: 2px solid var(--golden);
+}
+
 /* This is the main flex container for the entire drawer */
 #Backgrounds.drawer-content.openDrawer.bg-drawer-layout {
     display: flex;
@@ -37,7 +95,6 @@
 }
 
 /* Thumbnail Menu & Buttons */
-
 .mobile-only-menu-toggle {
     display: none;
 }
@@ -123,7 +180,6 @@
 }
 
 /* Thumbnail Title */
-
 .bg_example .BGSampleTitle {
     position: absolute;
     bottom: 0;

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -35,3 +35,90 @@
 #bg-filter {
     font-size: calc(var(--mainFontSize) * 0.95);
 }
+
+/* Thumbnail Menu & Buttons */
+
+.mobile-only-menu-toggle {
+    display: none;
+}
+
+.bg_example .jg-menu {
+    display: flex;
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 8px;
+    gap: 2px;
+    padding: 3px;
+    z-index: 3;
+    backdrop-filter: blur(4px);
+    border: 1px solid var(--SmartThemeBorderColor);
+
+    opacity: 0;
+    visibility: hidden;
+    transform: scale(0.9);
+    transform-origin: center;
+    transition: opacity 0.15s ease-out, visibility 0.15s ease-out, transform 0.15s ease-out;
+}
+
+.bg_example:hover .jg-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
+}
+
+.bg_example .jg-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    padding: 5px;
+    font-size: 1.2em;
+    border-radius: 6px;
+    transition: background-color 0.15s ease;
+}
+
+.bg_example .jg-button:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+}
+
+.bg_example .jg-unlock {
+    display: none;
+}
+
+.bg_example.locked .jg-lock {
+    display: none;
+}
+
+.bg_example.locked .jg-unlock {
+    display: flex;
+}
+
+/* Thumbnail Title */
+
+.bg_example .BGSampleTitle {
+    position: absolute;
+    bottom: 1px;
+    left: 0;
+    right: 0;
+    background: linear-gradient(transparent, rgba(0, 0, 0, 0.8));
+    color: var(--SmartThemeBodyColor);
+    font-size: 0.85em;
+    font-weight: 600;
+    padding: 8px 6px 0px;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+    pointer-events: none;
+    transform: translateY(1px);
+    border-radius: 0 0 6px 6px;
+}
+
+.bg_example:hover .BGSampleTitle {
+    opacity: 1;
+    transition-delay: 0.05s;
+}

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -42,6 +42,33 @@
     display: none;
 }
 
+.bg_example.flex-container {
+    width: 30%;
+    max-width: 200px;
+    margin: 5px;
+    aspect-ratio: 16/9;
+    cursor: pointer;
+    box-shadow: 0 0 7px var(--black50a);
+
+    position: relative;
+    overflow: hidden;
+    border-radius: 10px;
+    border: 1px solid var(--SmartThemeBorderColor);
+}
+
+.bg_example_img {
+    position: absolute;
+    top: -2px;
+    left: -2px;
+    right: -2px;
+    bottom: -2px;
+
+    background-image: inherit;
+
+    background-size: cover;
+    background-position: center;
+}
+
 .bg_example .jg-menu {
     display: flex;
     position: absolute;
@@ -99,14 +126,14 @@
 
 .bg_example .BGSampleTitle {
     position: absolute;
-    bottom: 1px;
+    bottom: 0;
     left: 0;
     right: 0;
-    background: linear-gradient(transparent, rgba(0, 0, 0, 0.8));
+    background: linear-gradient(transparent, rgba(0, 0, 0, 0.9));
     color: var(--SmartThemeBodyColor);
     font-size: 0.85em;
     font-weight: 600;
-    padding: 8px 6px 0px;
+    padding: 0px 6px 2px;
     text-align: center;
     white-space: nowrap;
     overflow: hidden;
@@ -114,8 +141,7 @@
     opacity: 0;
     transition: opacity 0.15s ease-in-out;
     pointer-events: none;
-    transform: translateY(1px);
-    border-radius: 0 0 6px 6px;
+    border-radius: 0 0 8px 8px;
 }
 
 .bg_example:hover .BGSampleTitle {

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -102,7 +102,7 @@ body.reduced-motion #bg_custom {
 }
 
 /* Thumbnail Menu & Buttons */
-.mobile-only-menu-toggle {
+.bg_example .mobile-only-menu-toggle {
     display: none;
 }
 
@@ -194,7 +194,7 @@ body.reduced-motion #bg_custom {
     right: 0;
     background: linear-gradient(transparent, rgba(0, 0, 0, 0.9));
     color: var(--SmartThemeBodyColor);
-    font-size: 0.85em;
+    font-size: 0.9em;
     font-weight: 600;
     padding: 0px 6px 2px;
     text-align: center;

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -209,5 +209,4 @@ body.reduced-motion #bg_custom {
 
 .bg_example:hover .BGSampleTitle {
     opacity: 1;
-    transition-delay: 0.05s;
 }

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -25,6 +25,37 @@
         font-size: 15px;
     }
 
+    #Backgrounds .bg_example .BGSampleTitle {
+        opacity: 1;
+        bottom: 0px;
+    }
+
+    .bg_example:hover .jg-menu {
+        display: none;
+    }
+
+    .bg_example.mobile-menu-open .jg-menu {
+        display: flex;
+        z-index: 4;
+    }
+
+    .mobile-only-menu-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        width: 32px;
+        height: 32px;
+        background-color: rgba(0, 0, 0, 0.4);
+        color: white;
+        border-radius: 6px;
+        z-index: 3;
+        cursor: pointer;
+        backdrop-filter: blur(2px);
+    }
+
     #bg-header-controls {
         flex-wrap: wrap;
         row-gap: 10px;
@@ -459,10 +490,6 @@
 
     .drawer33pWidth {
         flex-basis: max(calc(100% / 2 - 10px), 180px);
-    }
-
-    .BGSampleTitle {
-        display: none;
     }
 
     .tag.excluded:after {

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -39,15 +39,15 @@
         z-index: 4;
     }
 
-    .mobile-only-menu-toggle {
+    .bg_example .mobile-only-menu-toggle {
         display: flex;
         align-items: center;
         justify-content: center;
         position: absolute;
         top: 5px;
         right: 5px;
-        width: 32px;
-        height: 32px;
+        width: 28px;
+        height: 28px;
         background-color: rgba(0, 0, 0, 0.4);
         color: white;
         border-radius: 6px;

--- a/public/index.html
+++ b/public/index.html
@@ -6259,10 +6259,16 @@
         <div id="background_template" class="template_element">
             <div class="bg_example flex-container" bgfile="" class="bg_example_img" title="">
                 <div title="Copy to system backgrounds" data-i18n="[title]Copy to system backgrounds" class="bg_button bg_example_copy fa-solid fa-file-arrow-up"></div>
-                <div title="Rename background" data-i18n="[title]Rename background" class="bg_button bg_example_edit fa-solid fa-pencil"></div>
-                <div title="Lock" data-i18n="[title]Lock" class="bg_button bg_example_lock fa-solid fa-lock"></div>
-                <div title="Unlock" data-i18n="[title]Unlock" class="bg_button bg_example_unlock fa-solid fa-lock-open"></div>
-                <div title="Delete background" data-i18n="[title]Delete background" class="bg_button bg_example_cross fa-solid fa-circle-xmark"></div>
+                <div class="jg-menu">
+                    <!-- temporarily moved lock icon here (will be moved to header) -->
+                    <div data-action="lock" class="jg-button jg-lock fa-solid fa-lock fa-fw pointer" data-i18n="[title]Lock" title="Lock"></div>
+                    <div data-action="unlock" class="jg-button jg-unlock fa-solid fa-lock-open fa-fw pointer" data-i18n="[title]Unlock" title="Unlock"></div>
+                    <div data-action="edit" class="jg-button jg-edit fa-solid fa-pen-to-square fa-fw pointer" data-i18n="[title]Rename Background" title="Rename Background"></div>
+                    <div data-action="delete" class="jg-button jg-delete fa-solid fa-trash-can fa-fw pointer" data-i18n="[title]Delete Background" title="Delete Background"></div>
+                </div>
+                <div class="mobile-only-menu-toggle">
+                    <i class="fa-solid fa-ellipsis-vertical"></i>
+                </div>
                 <div class="BGSampleTitle">
                 </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -6257,7 +6257,8 @@
             </div>
         </div>
         <div id="background_template" class="template_element">
-            <div class="bg_example flex-container" bgfile="" class="bg_example_img" title="">
+            <div class="bg_example flex-container" bgfile="" title="">
+                <div class="bg_example_img"></div>
                 <div title="Copy to system backgrounds" data-i18n="[title]Copy to system backgrounds" class="bg_button bg_example_copy fa-solid fa-file-arrow-up"></div>
                 <div class="jg-menu">
                     <!-- temporarily moved lock icon here (will be moved to header) -->
@@ -6269,8 +6270,7 @@
                 <div class="mobile-only-menu-toggle">
                     <i class="fa-solid fa-ellipsis-vertical"></i>
                 </div>
-                <div class="BGSampleTitle">
-                </div>
+                <div class="BGSampleTitle"></div>
             </div>
         </div>
         <!-- templates for JS to reuse when needed -->

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -700,12 +700,40 @@ function onBackgroundFilterInput() {
 export function initBackgrounds() {
     eventSource.on(event_types.CHAT_CHANGED, onChatChanged);
     eventSource.on(event_types.FORCE_SET_BACKGROUND, forceSetBackground);
-    $(document).on('click', '.bg_example', onSelectBackgroundClick);
-    $(document).on('click', '.bg_example_lock', onLockBackgroundClick);
-    $(document).on('click', '.bg_example_unlock', onUnlockBackgroundClick);
-    $(document).on('click', '.bg_example_edit', onRenameBackgroundClick);
-    $(document).on('click', '.bg_example_cross', onDeleteBackgroundClick);
-    $(document).on('click', '.bg_example_copy', onCopyToSystemBackgroundClick);
+
+    $(document)
+        .off('click', '.bg_example').on('click', '.bg_example', onSelectBackgroundClick)
+        .off('click', '.bg_example_copy').on('click', '.bg_example_copy', onCopyToSystemBackgroundClick)
+        .off('click', '.mobile-only-menu-toggle').on('click', '.mobile-only-menu-toggle', function(e) {
+            e.stopPropagation();
+            const $context = $(this).closest('.bg_example');
+            const wasOpen = $context.hasClass('mobile-menu-open');
+            // Close all other open menus before opening a new one.
+            $('.bg_example.mobile-menu-open').removeClass('mobile-menu-open');
+            if (!wasOpen) {
+                $context.addClass('mobile-menu-open');
+            }
+        })
+        .off('click', '.jg-button').on('click', '.jg-button', function (e) {
+            e.stopPropagation();
+            const action = $(this).data('action');
+
+            switch (action) {
+                case 'lock':
+                    onLockBackgroundClick.call(this, e);
+                    break;
+                case 'unlock':
+                    onUnlockBackgroundClick.call(this, e);
+                    break;
+                case 'edit':
+                    onRenameBackgroundClick.call(this, e);
+                    break;
+                case 'delete':
+                    onDeleteBackgroundClick.call(this, e);
+                    break;
+            }
+        });
+
     $('#auto_background').on('click', autoBackgroundCommand);
     $('#add_bg_button').on('change', onBackgroundUploadSelected);
     $('#bg-filter').on('input', onBackgroundFilterInput);

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -265,9 +265,10 @@ async function onCopyToSystemBackgroundClick(e) {
  * It caches the thumbnail in local storage and returns a blob URL for the thumbnail.
  * If the thumbnail cannot be fetched, it returns a transparent PNG pixel as a fallback.
  * @param {string} bg Background URL
+ * @param {boolean} isCustom Is the background custom?
  * @returns {Promise<string>} Blob URL of the thumbnail
  */
-async function getThumbnailFromStorage(bg) {
+async function getThumbnailFromStorage(bg, isCustom) {
     const cachedBlobUrl = THUMBNAIL_BLOBS.get(bg);
     if (cachedBlobUrl) {
         return cachedBlobUrl;
@@ -281,7 +282,8 @@ async function getThumbnailFromStorage(bg) {
     }
 
     try {
-        const response = await fetch(getBackgroundPath(bg), { cache: 'force-cache' });
+        const url = isCustom ? bg : getBackgroundPath(bg);
+        const response = await fetch(url, { cache: 'force-cache' });
         if (!response.ok) {
             throw new Error('Fetch failed with status: ' + response.status);
         }
@@ -519,7 +521,7 @@ async function resolveImageUrl(bg, isCustom) {
     const fileExtension = bg.split('.').pop().toLowerCase();
     const isAnimated = ['mp4', 'webp'].includes(fileExtension);
     const thumbnailUrl = isAnimated && !background_settings.animation
-        ? await getThumbnailFromStorage(bg)
+        ? await getThumbnailFromStorage(bg, isCustom)
         : isCustom
             ? bg
             : getThumbnailUrl('bg', bg);

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -583,7 +583,7 @@ async function onBackgroundUploadSelected() {
     const formData = new FormData(form);
 
     const file = formData.get('avatar');
-    if (!file || file.size === 0) {
+    if (!(file instanceof File) || file.size === 0) {
         form.reset();
         return;
     }
@@ -621,7 +621,7 @@ async function convertFileIfVideo(formData) {
         const sourceBuffer = await file.arrayBuffer();
         const convertedBuffer = await globalThis.convertVideoToAnimatedWebp({ buffer: new Uint8Array(sourceBuffer), name: file.name });
         const convertedFileName = file.name.replace(/\.[^/.]+$/, '.webp');
-        const convertedFile = new File([convertedBuffer], convertedFileName, { type: 'image/webp' });
+        const convertedFile = new File([new Uint8Array(convertedBuffer)], convertedFileName, { type: 'image/webp' });
         formData.set('avatar', convertedFile);
         toastMessage.remove();
     } catch (error) {
@@ -704,7 +704,7 @@ export function initBackgrounds() {
     $(document)
         .off('click', '.bg_example').on('click', '.bg_example', onSelectBackgroundClick)
         .off('click', '.bg_example_copy').on('click', '.bg_example_copy', onCopyToSystemBackgroundClick)
-        .off('click', '.mobile-only-menu-toggle').on('click', '.mobile-only-menu-toggle', function(e) {
+        .off('click', '.bg_example .mobile-only-menu-toggle').on('click', '.bg_example .mobile-only-menu-toggle', function (e) {
             e.stopPropagation();
             const $context = $(this).closest('.bg_example');
             const wasOpen = $context.hasClass('mobile-menu-open');
@@ -720,16 +720,16 @@ export function initBackgrounds() {
 
             switch (action) {
                 case 'lock':
-                    onLockBackgroundClick.call(this, e);
+                    onLockBackgroundClick.call(this, e.originalEvent);
                     break;
                 case 'unlock':
-                    onUnlockBackgroundClick.call(this, e);
+                    onUnlockBackgroundClick.call(this, e.originalEvent);
                     break;
                 case 'edit':
-                    onRenameBackgroundClick.call(this, e);
+                    onRenameBackgroundClick.call(this, e.originalEvent);
                     break;
                 case 'delete':
-                    onDeleteBackgroundClick.call(this, e);
+                    onDeleteBackgroundClick.call(this, e.originalEvent);
                     break;
             }
         });

--- a/public/style.css
+++ b/public/style.css
@@ -3305,22 +3305,6 @@ input[type=search]:focus::-webkit-search-cancel-button {
     justify-content: space-evenly;
 }
 
-.bg_example {
-    width: 30%;
-    max-width: 200px;
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: center;
-    border-radius: 10px;
-    border: 1px solid var(--SmartThemeBorderColor);
-    box-shadow: 0 0 7px var(--black50a);
-    margin: 5px;
-    cursor: pointer;
-    aspect-ratio: 16/9;
-    justify-content: flex-end;
-    position: relative;
-}
-
 .bg_example.locked {
     outline: 2px solid var(--golden);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -3345,27 +3345,6 @@ input[type=search]:focus::-webkit-search-cancel-button {
     display: none;
 }
 
-.BGSampleTitle {
-    display: flex;
-    width: 100%;
-    height: min-content;
-    text-align: center;
-    justify-content: center;
-    align-self: flex-end;
-    bottom: 0;
-    position: relative;
-    word-break: break-word;
-    background-color: var(--SmartThemeBlurTintColor);
-    font-size: calc(var(--fontScale) * 0.9em);
-    max-height: 50%;
-    overflow-y: clip;
-    border-radius: 0 0 7px 7px;
-}
-
-.bg_example[custom="true"] .BGSampleTitle {
-    display: none;
-}
-
 .bg_button {
     padding: 4px;
     position: absolute;

--- a/public/style.css
+++ b/public/style.css
@@ -722,69 +722,9 @@ hr {
     opacity: 0.2;
 }
 
-#bg1,
-#bg_custom {
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-    background-size: cover;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    transition: background-image var(--animation-duration-3x) ease-in-out;
-}
-
-/* Background fitting options */
-#background_fitting {
-    max-width: 6em;
-}
-
-/* Fill/Cover - scales to fill width while maintaining aspect ratio */
-#bg1.cover,
-#bg_custom.cover {
-    background-size: cover;
-    background-position: center;
-}
-
-/* Fit/Contain - shows entire image maintaining aspect ratio */
-#bg1.contain,
-#bg_custom.contain {
-    background-size: contain;
-    background-position: center;
-    background-repeat: no-repeat;
-}
-
-/* Stretch - stretches to fill entire space */
-#bg1.stretch,
-#bg_custom.stretch {
-    background-size: 100% 100%;
-}
-
-/* Center - centers without scaling */
-#bg1.center,
-#bg_custom.center {
-    background-size: auto;
-    background-position: center;
-    background-repeat: no-repeat;
-}
-
-body.reduced-motion #bg1,
-body.reduced-motion #bg_custom {
-    transition: none;
-}
-
 #version_display {
     padding: 5px;
     opacity: 0.8;
-}
-
-#bg1 {
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=');
-    z-index: -3;
-}
-
-#bg_custom {
-    background-image: none;
-    z-index: -2;
 }
 
 /*TOPPER margin*/


### PR DESCRIPTION
- added CSS for BGSampleTitle and jg-buttons
- put back filename in mobile. The blur shows a more acceptable percentage of the image allowing both image and text in the limited space
- moved buttons to top right, only showing on mouseover
- mobile buttons have a dot menu
- one click handler for all
- removed template from style.css, removed text removal from custom backgrounds (backgrounds coming from the image gen extension are broken as far as I can tell)
- z-index is questionable
- moved backgrounds css from style.css to backgrounds.css
- enlarge and clip thumbnail to avoid anti-alising

<img width="290" height="164" alt="image" src="https://github.com/user-attachments/assets/36da0951-bef8-49ce-999a-81848f43edef" />

<img width="600" height="848" alt="image" src="https://github.com/user-attachments/assets/a8fe967f-7aaf-4512-b525-7f523769edda" />

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
