### PR TITLE
Server: Support passphrase for SSL private key

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -40,9 +40,14 @@ browserLaunch:
 port: 8000
 # -- SSL options --
 ssl:
+  # Enable SSL/TLS encryption
   enabled: false
+  # Path to certificate (relative to server root)
   certPath: "./certs/cert.pem"
+  # Path to private key (relative to server root)
   keyPath: "./certs/privkey.pem"
+  # Private key passphrase (leave empty if not needed)
+  keyPassphrase: ""
 # -- SECURITY CONFIGURATION --
 # Toggle whitelist mode
 whitelistMode: true

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -47,6 +47,7 @@ ssl:
   # Path to private key (relative to server root)
   keyPath: "./certs/privkey.pem"
   # Private key passphrase (leave empty if not needed)
+  # For better security, use a CLI argument or an environment variable (SILLYTAVERN_SSL_KEYPASSPHRASE)
   keyPassphrase: ""
 # -- SECURITY CONFIGURATION --
 # Toggle whitelist mode

--- a/src/command-line.js
+++ b/src/command-line.js
@@ -27,6 +27,7 @@ import { initConfig } from './config-init.js';
  * @property {boolean} ssl If enable SSL
  * @property {string} certPath Path to certificate
  * @property {string} keyPath Path to private key
+ * @property {string} keyPassphrase SSL private key passphrase
  * @property {boolean} whitelistMode If enable whitelist mode
  * @property {boolean} basicAuthMode If enable basic authentication
  * @property {boolean} requestProxyEnabled If enable outgoing request proxy
@@ -70,6 +71,7 @@ export class CommandLineParser {
             ssl: false,
             certPath: 'certs/cert.pem',
             keyPath: 'certs/privkey.pem',
+            keyPassphrase: '',
             whitelistMode: true,
             basicAuthMode: false,
             requestProxyEnabled: false,
@@ -193,6 +195,11 @@ export class CommandLineParser {
                 default: null,
                 describe: 'Path to SSL private key file',
             })
+            .option('keyPassphrase', {
+                type: 'string',
+                default: null,
+                describe: 'Passphrase for the SSL private key',
+            })
             .option('whitelist', {
                 type: 'boolean',
                 default: null,
@@ -291,6 +298,7 @@ export class CommandLineParser {
             ssl: cliArguments.ssl ?? getConfigValue('ssl.enabled', defaultConfig.ssl, 'boolean'),
             certPath: cliArguments.certPath ?? getConfigValue('ssl.certPath', defaultConfig.certPath),
             keyPath: cliArguments.keyPath ?? getConfigValue('ssl.keyPath', defaultConfig.keyPath),
+            keyPassphrase: cliArguments.keyPassphrase ?? getConfigValue('ssl.keyPassphrase', defaultConfig.keyPassphrase),
             whitelistMode: cliArguments.whitelist ?? getConfigValue('whitelistMode', defaultConfig.whitelistMode, 'boolean'),
             basicAuthMode: cliArguments.basicAuthMode ?? getConfigValue('basicAuthMode', defaultConfig.basicAuthMode, 'boolean'),
             requestProxyEnabled: cliArguments.requestProxyEnabled ?? getConfigValue('requestProxy.enabled', defaultConfig.requestProxyEnabled, 'boolean'),

--- a/src/server-startup.js
+++ b/src/server-startup.js
@@ -237,7 +237,7 @@ export class ServerStartup {
             const sslOptions = {
                 cert: fs.readFileSync(this.cliArgs.certPath),
                 key: fs.readFileSync(this.cliArgs.keyPath),
-                passphrase: this.cliArgs.keyPassphrase || undefined,
+                passphrase: String(this.cliArgs.keyPassphrase ?? ''),
             };
             const server = https.createServer(sslOptions, this.app);
             server.on('error', reject);

--- a/src/server-startup.js
+++ b/src/server-startup.js
@@ -233,9 +233,11 @@ export class ServerStartup {
     #createHttpsServer(url, ipVersion) {
         this.#verifySslOptions();
         return new Promise((resolve, reject) => {
+            /** @type {import('https').ServerOptions} */
             const sslOptions = {
                 cert: fs.readFileSync(this.cliArgs.certPath),
                 key: fs.readFileSync(this.cliArgs.keyPath),
+                passphrase: this.cliArgs.keyPassphrase || undefined,
             };
             const server = https.createServer(sslOptions, this.app);
             server.on('error', reject);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->
This pull request adds support for specifying an SSL private key passphrase in the server configuration. This enhancement allows users to provide a passphrase for encrypted private keys, improving SSL/TLS flexibility and security. The changes update configuration files, command-line options, and server startup logic to handle the new `keyPassphrase` setting.

**SSL/TLS Configuration Enhancements:**

* Added `keyPassphrase` option to the `ssl` section in `config.yaml`, allowing users to specify a passphrase for the SSL private key.
* Updated the `CommandLineParser` class and related documentation to support the new `keyPassphrase` property, including command-line argument parsing and default values. [[1]](diffhunk://#diff-803228b691474bfabc6dae9d0124cbd2f8a013e75aa60314bc3c2f7f7de415fcR30) [[2]](diffhunk://#diff-803228b691474bfabc6dae9d0124cbd2f8a013e75aa60314bc3c2f7f7de415fcR74) [[3]](diffhunk://#diff-803228b691474bfabc6dae9d0124cbd2f8a013e75aa60314bc3c2f7f7de415fcR198-R202) [[4]](diffhunk://#diff-803228b691474bfabc6dae9d0124cbd2f8a013e75aa60314bc3c2f7f7de415fcR301)

**Server Startup Logic:**

* Modified the HTTPS server creation logic to use the `keyPassphrase` from the configuration when initializing SSL options, ensuring the server can start with encrypted private keys.
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
