### PR TITLE
Reasoning: Support auto-parse for impersonation results

### DIFF
--- a/public/scripts/extensions/translate/index.js
+++ b/public/scripts/extensions/translate/index.js
@@ -182,9 +182,11 @@ function isGeneratingSwipe(messageId) {
     return $(`#chat .mes[mesid="${messageId}"] .mes_text`).text() === '...';
 }
 
-async function translateImpersonate(text) {
+async function translateImpersonate() {
+    const sendTextArea = $('#send_textarea');
+    const text = sendTextArea.val().toString();
     const translatedText = await translate(text, extension_settings.translate.target_language);
-    $('#send_textarea').val(translatedText);
+    sendTextArea.val(translatedText);
 }
 
 /**

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1348,6 +1348,29 @@ function registerReasoningAppEvents() {
     for (const event of [event_types.GENERATION_STOPPED, event_types.GENERATION_ENDED, event_types.CHAT_CHANGED]) {
         eventSource.on(event, () => PromptReasoning.clearLatest());
     }
+
+    eventSource.makeFirst(event_types.IMPERSONATE_READY, async () => {
+        if (!power_user.reasoning.auto_parse) {
+            return;
+        }
+
+        const sendTextArea = /** @type {HTMLTextAreaElement} */ (document.getElementById('send_textarea'));
+
+        if (!sendTextArea) {
+            console.warn('[Reasoning] Send textarea not found');
+            return;
+        }
+
+        console.debug('[Reasoning] Auto-parsing reasoning block for impersonation');
+
+        if (!sendTextArea.value) {
+            console.debug('[Reasoning] Reasoning is empty, skipping');
+            return;
+        }
+
+        sendTextArea.value = removeReasoningFromString(sendTextArea.value);
+        sendTextArea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
 }
 
 /**


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->
This pull request introduces improvements to the impersonation and reasoning workflows in the chat interface, focusing on automating the handling of reasoning blocks and streamlining the translation process. The most important changes are grouped below:

**Impersonation and Reasoning Automation:**

* Added an event handler for `IMPERSONATE_READY` in `registerReasoningAppEvents` that automatically removes reasoning blocks from the text area when auto-parse is enabled, improving the impersonation workflow for power users.

**Translation Functionality:**

* Updated the `translateImpersonate` function to directly read the current value of the send text area, translate it, and update the text area, simplifying the translation process and ensuring the latest user input is used.
## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
