### PR TITLE
Backgrounds Border Conflicts

### DIFF
--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -116,8 +116,10 @@ body.reduced-motion #bg_custom {
 
     position: relative;
     overflow: hidden;
-    border-radius: 10px;
-    border: 1px solid var(--SmartThemeBorderColor);
+    border-radius: 8px;
+    border: 0px solid transparent;
+    outline: 2px solid var(--SmartThemeBorderColor);
+    outline-offset: -1px;
 }
 
 .bg_example_img {


### PR DESCRIPTION
- reduced border-radius from 10px to 8px. Whatever browser calculation goes into border-radius results in a narrower anti-aliased corner than edge (on firefox). 8px doesn't have that problem. Also looks more alike jg-buttons.
- CSS magic. Dunno what it does, but the image doesn't bleed through the transparent line if the user sets SmartThemeBorderColor to any transparency. This was variable and had different issues depending on hue and opacity. The border doesn't interact with the image to get rid of the conflict.

Before:
<img width="66" height="59" alt="image" src="https://github.com/user-attachments/assets/384d8c76-bcd5-47c4-a108-0f63404d235a" />
After:
<img width="45" height="45" alt="image" src="https://github.com/user-attachments/assets/4d99c659-2685-42a5-b2d5-012670563356" />


## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
