### PR TITLE
Deepseek settings integration fix

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2262,16 +2262,6 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
     // https://api-docs.deepseek.com/api/create-chat-completion
     if (isDeepSeek) {
         generate_data.top_p = generate_data.top_p || Number.EPSILON;
-
-        if (generate_data.model.endsWith('-reasoner')) {
-            delete generate_data.top_p;
-            delete generate_data.temperature;
-            delete generate_data.frequency_penalty;
-            delete generate_data.presence_penalty;
-            delete generate_data.top_logprobs;
-            delete generate_data.logprobs;
-            delete generate_data.logit_bias;
-        }
     }
 
     if (isXAI) {

--- a/src/electron/package-lock.json
+++ b/src/electron/package-lock.json
@@ -265,9 +265,9 @@
       "optional": true
     },
     "node_modules/electron": {
-      "version": "35.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.0.0.tgz",
-      "integrity": "sha512-mwNQNktYLPnUWZVR8iNkfWCBjmM5e2/CmB1rhACwE9ASDbVU7CYPgp/jLUB3bj/LyQsfSuubD82OUite6SN8Uw==",
+      "version": "35.7.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
+      "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
I noticed that the model settings are not applied to the Deepseek thinking model. The current documentation states that the API now accepts all settings available in the Silly Tavern interface.
https://api-docs.deepseek.com/api/create-chat-completion

The PR removes outdated code that blocks model configuration.
Tested locally for both (reasoner and chat)

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
