### PR TITLE
Add: id="PersonaManagement" to Persona Management div

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5428,7 +5428,7 @@
             <div class="drawer-toggle">
                 <div class="drawer-icon fa-solid fa-face-smile fa-fw closedIcon" title="Persona Management" data-i18n="[title]Persona Management"></div>
             </div>
-            <div class="drawer-content closedDrawer">
+            <div id="PersonaManagement" class="drawer-content closedDrawer">
                 <div class="flex-container wide100p alignitemscenter spaceBetween flexNoGap">
                     <div class="flex-container alignItemsBaseline wide100p">
                         <div class="flex1 flex-container alignItemsBaseline">


### PR DESCRIPTION
## Checklist:
- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

---

Adds a missing id for the Persona Management div to align with other panels. If another naming convention is preferred, feel free to update.

While editing and customizing all top menu sections, I noticed that **Persona Management** is the only section without a div id. This inconsistency makes it harder to target or modify via CSS/JS compared to other panels (e.g., `#WorldInfo`, `#Backgrounds`, `#user-settings-block`).
