### PR TITLE
Change Ctrl+Enter handling for non-empty text input to send, instead of regenerate

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -1061,6 +1061,19 @@ export function initRossMods() {
                     $('#option_regenerate').trigger('click');
                     $('#options').hide();
                 }
+
+                // If there is input text, we do not trigger a regenerate - we just send it
+                if ($('#send_textarea').val() !== '') {
+                    if (shouldSendOnEnter()) {
+                        console.debug('Sending with Ctrl+Enter');
+                        event.preventDefault();
+                        sendTextareaMessage();
+                    } else {
+                        console.debug('Text area is not empty, but send on enter is disabled');
+                    }
+                    return;
+                }
+
                 if (skipConfirm) {
                     doRegenerate();
                 } else {


### PR DESCRIPTION
Input handling improvement (for <kbd>Ctrl</kbd>+<kbd>Enter</kbd> hotkey):

* Updated `initRossMods` in `public/scripts/RossAscends-mods.js` to check if the input textarea is non-empty and, if so, send the message using `sendTextareaMessage()` when appropriate, instead of triggering a regenerate. This respects the "send on enter" setting and prevents accidental regeneration when the user intends to send a message.


Closes #4497

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
