### PR TITLE
fix(perf): disable periodic expired item check in node-persist

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -108,6 +108,7 @@ class DiskCache {
             dir: this.cachePath,
             ttl: false,
             forgiveParseErrors: true,
+            expiredInterval: 0,
             // @ts-ignore
             maxFileDescriptors: 100,
         });

--- a/src/users.js
+++ b/src/users.js
@@ -511,6 +511,7 @@ export async function initUserStorage(dataRoot) {
     await storage.init({
         dir: path.join(dataRoot, '_storage'),
         ttl: false, // Never expire
+        expiredInterval: 0,
     });
 
     const keys = await getAllUserHandles();


### PR DESCRIPTION
### Summary

Sets the `expiredInterval` option to `0` for all `node-persist` storage instances to disable the periodic check for expired items.

The library's default interval of 2 minutes causes significant, periodic CPU and memory spikes for users with large data stores. Since SillyTavern sets `ttl: false` on these storage instances, this check is unnecessary.

Setting the interval to `0` correctly disables this behavior, significantly reducing idle resource usage without any functional impact.

### Background / Reproduction

On a server with a large amount of user data, the Node.js process would crash due to a heap out-of-memory error at a precise 120-second interval. This occurred even with no active clients connected, indicating a server-side background task.

The issue was traced to `node-persist`'s default `expiredInterval` of 2 minutes. The periodic task scanning all stored items caused a memory spike, leading to the following fatal error:

```
<--- Last few GCs --->
[4096422:0x3ce2c000] 132747 ms: Mark-Compact 1927.9 (1957.6) -> 1927.5 (1956.9) MB, pooled: 0 MB, 31.67 / 0.00 ms (average mu = 0.124, current mu = 0.097) allocation failure; scavenge might not succeed
[4096422:0x3ce2c000] 132795 ms: Mark-Compact 1928.4 (1957.8) -> 1928.1 (1961.6) MB, pooled: 0 MB, 41.52 / 0.00 ms (average mu = 0.130, current mu = 0.134) allocation failure; scavenge might not succeed

<--- JS stacktrace --->
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

This fix prevents the unnecessary periodic check and resolves the memory leak.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
