### PR TITLE
Add new Grok models

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3684,17 +3684,12 @@
                             <div data-for="api_key_xai" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'.">
                                 For privacy reasons, your API key will be hidden after you click 'Connect'.
                             </div>
-                            <h4 data-i18n="xAI Model">xAI Model</h4>
-                            <select id="model_xai_select">
-                                <option value="grok-4-0709">grok-4-0709</option>
-                                <option value="grok-code-fast-1">grok-code-fast-1</option>
-                                <option value="grok-4-fast-non-reasoning">grok-4-fast-non-reasoning</option>
-                                <option value="grok-4-fast-reasoning">grok-4-fast-reasoning</option>
-                                <option value="grok-3">grok-3</option>
-                                <option value="grok-3-mini">grok-3-mini</option>
-                                <option value="grok-2-vision-1212">grok-2-vision-1212</option>
-                                <option value="grok-2-1212">grok-2-1212</option>
-                            </select>
+                            <div>
+                                <h4 data-i18n="xAI Model">xAI Model</h4>
+                                <select id="model_xai_select">
+                                    <option value="" data-i18n="-- Connect to the API --">-- Connect to the API --</option>
+                                </select>
+                            </div>
                         </div>
                         <div id="aimlapi_form" data-source="aimlapi">
                             <h4>

--- a/public/index.html
+++ b/public/index.html
@@ -3687,14 +3687,13 @@
                             <h4 data-i18n="xAI Model">xAI Model</h4>
                             <select id="model_xai_select">
                                 <option value="grok-4-0709">grok-4-0709</option>
-                                <option value="grok-3-beta">grok-3-beta</option>
-                                <option value="grok-3-fast-beta">grok-3-fast-beta</option>
-                                <option value="grok-3-mini-beta">grok-3-mini-beta</option>
-                                <option value="grok-3-mini-fast-beta">grok-3-mini-fast-beta</option>
+                                <option value="grok-code-fast-1">grok-code-fast-1</option>
+                                <option value="grok-4-fast-non-reasoning">grok-4-fast-non-reasoning</option>
+                                <option value="grok-4-fast-reasoning">grok-4-fast-reasoning</option>
+                                <option value="grok-3">grok-3</option>
+                                <option value="grok-3-mini">grok-3-mini</option>
                                 <option value="grok-2-vision-1212">grok-2-vision-1212</option>
                                 <option value="grok-2-1212">grok-2-1212</option>
-                                <option value="grok-vision-beta">grok-vision-beta</option>
-                                <option value="grok-beta">grok-beta</option>
                             </select>
                         </div>
                         <div id="aimlapi_form" data-source="aimlapi">

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -550,6 +550,7 @@ jQuery(async function () {
         await processEndpoint('nanogpt', '/api/backends/chat-completions/multimodal-models/nanogpt');
         await processEndpoint('electronhub', '/api/backends/chat-completions/multimodal-models/electronhub');
         await processEndpoint('mistral', '/api/backends/chat-completions/multimodal-models/mistral');
+        await processEndpoint('xai', '/api/backends/chat-completions/multimodal-models/xai');
     }
 
     await addSettings();

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -164,8 +164,9 @@
                         <option data-type="vllm" value="vllm_current" data-i18n="currently_selected">[Currently selected]</option>
                         <option data-type="custom" value="custom_current" data-i18n="currently_selected">[Currently selected]</option>
                         <option data-type="xai" value="grok-4-0709">grok-4-0709</option>
+                        <option data-type="xai" value="grok-4-fast-non-reasoning">grok-4-fast-non-reasoning</option>
+                        <option data-type="xai" value="grok-4-fast-reasoning">grok-4-fast-reasoning</option>
                         <option data-type="xai" value="grok-2-vision-1212">grok-2-vision-1212</option>
-                        <option data-type="xai" value="grok-vision-beta">grok-vision-beta</option>
                     </select>
                 </div>
                 <div data-type="ollama">

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -42,7 +42,7 @@
                 <div class="flex1 flex-container flexFlowColumn flexNoGap">
                     <label for="caption_multimodal_model" data-i18n="Model">Model</label>
                     <select id="caption_multimodal_model" class="flex1 text_pole">
-                        <!-- AI/ML API, OpenRouter, Pollinations, NanoGPT, Mistral are added externally by JavaScript -->
+                        <!-- AI/ML API, OpenRouter, Pollinations, NanoGPT, Mistral, xAI are added externally by JavaScript -->
                         <option data-type="cohere" value="c4ai-aya-vision-8b">c4ai-aya-vision-8b</option>
                         <option data-type="cohere" value="c4ai-aya-vision-32b">c4ai-aya-vision-32b</option>
                         <option data-type="cohere" value="command-a-vision-07-2025">command-a-vision-07-2025</option>
@@ -163,10 +163,6 @@
                         <option data-type="koboldcpp" value="koboldcpp_current" data-i18n="currently_loaded">[Currently loaded]</option>
                         <option data-type="vllm" value="vllm_current" data-i18n="currently_selected">[Currently selected]</option>
                         <option data-type="custom" value="custom_current" data-i18n="currently_selected">[Currently selected]</option>
-                        <option data-type="xai" value="grok-4-0709">grok-4-0709</option>
-                        <option data-type="xai" value="grok-4-fast-non-reasoning">grok-4-fast-non-reasoning</option>
-                        <option data-type="xai" value="grok-4-fast-reasoning">grok-4-fast-reasoning</option>
-                        <option data-type="xai" value="grok-2-vision-1212">grok-2-vision-1212</option>
                     </select>
                 </div>
                 <div data-type="ollama">

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2465,15 +2465,24 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
     }
 
     if (isXAI) {
-        if (generate_data.model.includes('grok-4')) {
+        const model = generate_data.model;
+        if (model.includes('grok-3-mini')) {
             delete generate_data.presence_penalty;
             delete generate_data.frequency_penalty;
             delete generate_data.stop;
+        } else {
+            // As of 2025/09/21, only grok-3-mini accepts reasoning_effort
             delete generate_data.reasoning_effort;
         }
-        if (generate_data.model.includes('grok-3-mini')) {
+
+        if (model.includes('grok-4') || model.includes('grok-code')) {
             delete generate_data.presence_penalty;
             delete generate_data.frequency_penalty;
+
+            // grok-4-fast-non-reasoning accepts stop
+            if (!model.includes('grok-4-fast-non-reasoning')) {
+                delete generate_data.stop;
+            }
         }
     }
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2475,10 +2475,6 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
             delete generate_data.presence_penalty;
             delete generate_data.frequency_penalty;
         }
-        if (generate_data.model.includes('grok-vision')) {
-            delete generate_data.tools;
-            delete generate_data.tool_choice;
-        }
     }
 
     if (isPollinations) {
@@ -5264,11 +5260,14 @@ async function onModelChange() {
             $('#openai_max_context').attr('max', unlocked_max);
         } else if (oai_settings.xai_model.includes('grok-2-vision')) {
             $('#openai_max_context').attr('max', max_32k);
-        } else if (oai_settings.xai_model.includes('grok-vision')) {
-            $('#openai_max_context').attr('max', max_8k);
+        } else if (oai_settings.xai_model.includes('grok-4-fast')) {
+            $('#openai_max_context').attr('max', max_2mil);
         } else if (oai_settings.xai_model.includes('grok-4')) {
             $('#openai_max_context').attr('max', max_256k);
+        } else if (oai_settings.xai_model.includes('grok-code')) {
+            $('#openai_max_context').attr('max', max_256k);
         } else {
+            // grok 2 and grok 3
             $('#openai_max_context').attr('max', max_128k);
         }
 
@@ -5817,7 +5816,6 @@ export function isImageInliningSupported() {
         // xAI (Grok)
         'grok-4',
         'grok-2-vision',
-        'grok-vision',
         // Moonshot
         'moonshot-v1-8k-vision-preview',
         'moonshot-v1-32k-vision-preview',

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2041,6 +2041,24 @@ function saveModelList(data) {
             .append(new Option(modelId || 'None', modelId || '', true, true))
             .trigger('change');
     }
+
+    if (oai_settings.chat_completion_source == chat_completion_sources.XAI) {
+        $('#model_xai_select').empty();
+        model_list.forEach((model) => {
+            $('#model_xai_select').append(
+                $('<option>', {
+                    value: model.id,
+                    text: model.id,
+                }));
+        });
+
+        const selectedModel = model_list.find(model => model.id === oai_settings.xai_model);
+        if (model_list.length > 0 && (!selectedModel || !oai_settings.xai_model)) {
+            oai_settings.xai_model = model_list[0].id;
+        }
+
+        $('#model_xai_select').val(oai_settings.xai_model).trigger('change');
+    }
 }
 
 function appendOpenRouterOptions(model_list, groupModels = false, sort = false) {
@@ -5001,6 +5019,10 @@ async function onModelChange() {
     }
 
     if ($(this).is('#model_xai_select')) {
+        if (!value) {
+            console.debug('Null XAI model selected. Ignoring.');
+            return;
+        }
         console.log('XAI model changed to', value);
         oai_settings.xai_model = value;
     }
@@ -5857,6 +5879,7 @@ export function isImageInliningSupported() {
         case chat_completion_sources.COHERE:
             return visionSupportedModels.some(model => oai_settings.cohere_model.includes(model));
         case chat_completion_sources.XAI:
+            // TODO: xAI's /models endpoint doesn't return modality info
             return visionSupportedModels.some(model => oai_settings.xai_model.includes(model));
         case chat_completion_sources.AIMLAPI:
             return (Array.isArray(model_list) && model_list.find(m => m.id === oai_settings.aimlapi_model)?.features?.includes('openai/chat-completion.vision'));

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2238,4 +2238,37 @@ multimodalModels.post('/mistral', async (req, res) => {
     }
 });
 
+multimodalModels.post('/xai', async (req, res) => {
+    try {
+        const key = readSecret(req.user.directories, SECRET_KEYS.XAI);
+
+        if (!key) {
+            return res.json([]);
+        }
+
+        // xAI's /models endpoint doesn't return modality info, so we must use /language-models instead
+        const response = await fetch('https://api.x.ai/v1/language-models', {
+            headers: {
+                'Authorization': `Bearer ${key}`,
+            },
+        });
+
+        if (!response.ok) {
+            return res.json([]);
+        }
+
+        /** @type {any} */
+        const data = await response.json();
+        const multimodalModels = data.models.filter(m => m.input_modalities?.includes('image')).map(m => m.id);
+        if (!multimodalModels.includes('grok-4-0709')) {
+            // The endpoint says it doesn't support images, but it does
+            multimodalModels.push('grok-4-0709');
+        }
+        return res.json(multimodalModels);
+    } catch (error) {
+        console.error(error);
+        return res.sendStatus(500);
+    }
+});
+
 router.use('/multimodal-models', multimodalModels);

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1012,7 +1012,7 @@ async function sendXaiRequest(request, response) {
             bodyParams['stop'] = request.body.stop;
         }
 
-        if (request.body.reasoning_effort && ['grok-3-mini-beta', 'grok-3-mini-fast-beta'].includes(request.body.model)) {
+        if (request.body.reasoning_effort) {
             bodyParams['reasoning_effort'] = request.body.reasoning_effort === 'high' ? 'high' : 'low';
         }
 


### PR DESCRIPTION
New models:
- Add Grok 4 Fast models. (with vision capability)
    - Note that all Grok 4 models are vision capable, despite [the current document saying grok-4-0709 doesn't accept images](https://docs.x.ai/docs/models/grok-4-0709).
- Add Grok Code Fast. (I don't use the model personally, but more is better!)

Cleaning up:
- Remove grok-beta and grok-vision-beta, which are now 404.
- Remove grok-3 fast variants, which are now aliases to non-fast ones.
- Rename models with canonical names in [the models page](https://docs.x.ai/docs/models).

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
