### PR TITLE
Add pronoun macros feature for persona management

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5571,6 +5571,52 @@
                                 <h4 data-i18n="Persona Description">Persona Description</h4>
                                 <textarea id="persona_description" name="persona_description" data-i18n="[placeholder]Example: [{{user}} is a 28-year-old Romanian cat girl.]" placeholder="Example:&#10;[{{user}} is a 28-year-old Romanian cat girl.]" class="text_pole textarea_compact" value="" autocomplete="off" rows="8"></textarea>
 
+                                <h4 data-i18n="Pronoun Settings">Pronoun Settings</h4>
+                                <div class="persona_pronoun_settings_container">
+                                    <div class="flex-container">
+                                        <div class="flex1">
+                                            <label for="persona_pronoun_subjective" data-i18n="Subjective ({{pronoun.subjective}}):">Subjective ({{pronoun.subjective}}):</label>
+                                            <input id="persona_pronoun_subjective" class="text_pole" type="text" placeholder="e.g. she, he, they, it">
+                                        </div>
+                                        <div class="flex1">
+                                            <label for="persona_pronoun_objective" data-i18n="Objective ({{pronoun.objective}}):">Objective ({{pronoun.objective}}):</label>
+                                            <input id="persona_pronoun_objective" class="text_pole" type="text" placeholder="e.g. her, him, them, it">
+                                        </div>
+                                    </div>
+                                    <div class="flex-container">
+                                        <div class="flex1">
+                                            <label for="persona_pronoun_pos_det" data-i18n="Possessive Determiner ({{pronoun.pos_det}}):">Possessive Determiner ({{pronoun.pos_det}}):</label>
+                                            <input id="persona_pronoun_pos_det" class="text_pole" type="text" placeholder="e.g. her, his, their, its">
+                                        </div>
+                                        <div class="flex1">
+                                            <label for="persona_pronoun_pos_pro" data-i18n="Possessive Pronoun ({{pronoun.pos_pro}}):">Possessive Pronoun ({{pronoun.pos_pro}}):</label>
+                                            <input id="persona_pronoun_pos_pro" class="text_pole" type="text" placeholder="e.g. hers, his, theirs, its">
+                                        </div>
+                                    </div>
+                                    <div class="flex-container">
+                                        <div class="flex1">
+                                            <label for="persona_pronoun_reflexive" data-i18n="Reflexive ({{pronoun.reflexive}}):">Reflexive ({{pronoun.reflexive}}):</label>
+                                            <input id="persona_pronoun_reflexive" class="text_pole" type="text" placeholder="e.g. herself, himself, themselves, itself">
+                                        </div>
+                                        <div class="flex1"></div>
+                                    </div>
+                                </div>
+
+                                <div class="pronoun_preset_buttons flex-container">
+                                    <div id="pronoun_preset_she" class="menu_button menu_button_icon" data-preset="she" title="Set pronouns to She/Her" data-i18n="[title]Set pronouns to She/Her">
+                                        <div data-i18n="She/Her">She/Her</div>
+                                    </div>
+                                    <div id="pronoun_preset_he" class="menu_button menu_button_icon" data-preset="he" title="Set pronouns to He/Him" data-i18n="[title]Set pronouns to He/Him">
+                                        <div data-i18n="He/Him">He/Him</div>
+                                    </div>
+                                    <div id="pronoun_preset_they" class="menu_button menu_button_icon" data-preset="they" title="Set pronouns to They/Them" data-i18n="[title]Set pronouns to They/Them">
+                                        <div data-i18n="They/Them">They/Them</div>
+                                    </div>
+                                    <div id="pronoun_preset_it" class="menu_button menu_button_icon" data-preset="it" title="Set pronouns to It/Its" data-i18n="[title]Set pronouns to It/Its">
+                                        <div data-i18n="It/Its">It/Its</div>
+                                    </div>
+                                </div>
+
                                 <div class="flex-container justifySpaceBetween">
                                     <h4 data-i18n="Position">Position</h4>
                                     <div class="extension_token_counter widthFitContent">

--- a/public/script.js
+++ b/public/script.js
@@ -2284,21 +2284,12 @@ export function substituteParams(content, _name1, _name2, _original, _group, _re
     environment.model = getGeneratingModel();
 
     // Add pronoun macros from current persona
-    if (power_user.persona_descriptions && power_user.persona_descriptions[user_avatar]) {
-        const personaData = power_user.persona_descriptions[user_avatar];
-        environment['pronoun.subjective'] = personaData.pronoun?.subjective || '';
-        environment['pronoun.objective'] = personaData.pronoun?.objective || '';
-        environment['pronoun.pos_det'] = personaData.pronoun?.posDet || '';
-        environment['pronoun.pos_pro'] = personaData.pronoun?.posPro || '';
-        environment['pronoun.reflexive'] = personaData.pronoun?.reflexive || '';
-    } else {
-        // Default empty values if no persona data
-        environment['pronoun.subjective'] = '';
-        environment['pronoun.objective'] = '';
-        environment['pronoun.pos_det'] = '';
-        environment['pronoun.pos_pro'] = '';
-        environment['pronoun.reflexive'] = '';
-    }
+    const personaData = power_user.persona_descriptions?.[user_avatar] ?? {};
+    environment['pronoun.subjective'] = personaData.pronoun?.subjective || '';
+    environment['pronoun.objective'] = personaData.pronoun?.objective || '';
+    environment['pronoun.pos_det'] = personaData.pronoun?.posDet || '';
+    environment['pronoun.pos_pro'] = personaData.pronoun?.posPro || '';
+    environment['pronoun.reflexive'] = personaData.pronoun?.reflexive || '';
 
     if (additionalMacro && typeof additionalMacro === 'object') {
         Object.assign(environment, additionalMacro);

--- a/public/script.js
+++ b/public/script.js
@@ -2286,11 +2286,11 @@ export function substituteParams(content, _name1, _name2, _original, _group, _re
     // Add pronoun macros from current persona
     if (power_user.persona_descriptions && power_user.persona_descriptions[user_avatar]) {
         const personaData = power_user.persona_descriptions[user_avatar];
-        environment['pronoun.subjective'] = personaData.pronounSubjective || '';
-        environment['pronoun.objective'] = personaData.pronounObjective || '';
-        environment['pronoun.pos_det'] = personaData.pronounPosDet || '';
-        environment['pronoun.pos_pro'] = personaData.pronounPosPro || '';
-        environment['pronoun.reflexive'] = personaData.pronounReflexive || '';
+        environment['pronoun.subjective'] = personaData.pronoun?.subjective || '';
+        environment['pronoun.objective'] = personaData.pronoun?.objective || '';
+        environment['pronoun.pos_det'] = personaData.pronoun?.posDet || '';
+        environment['pronoun.pos_pro'] = personaData.pronoun?.posPro || '';
+        environment['pronoun.reflexive'] = personaData.pronoun?.reflexive || '';
     } else {
         // Default empty values if no persona data
         environment['pronoun.subjective'] = '';
@@ -6823,11 +6823,13 @@ async function doOnboarding(avatarId) {
         power_user.persona_descriptions[avatarId] = {
             description: '',
             position: persona_description_positions.IN_PROMPT,
-            pronounSubjective: '',
-            pronounObjective: '',
-            pronounPosDet: '',
-            pronounPosPro: '',
-            pronounReflexive: '',
+            pronoun: {
+                subjective: '',
+                objective: '',
+                posDet: '',
+                posPro: '',
+                reflexive: '',
+            },
         };
     }
 }

--- a/public/script.js
+++ b/public/script.js
@@ -2283,6 +2283,23 @@ export function substituteParams(content, _name1, _name2, _original, _group, _re
     environment.groupNotMuted = getGroupValue(false);
     environment.model = getGeneratingModel();
 
+    // Add pronoun macros from current persona
+    if (power_user.persona_descriptions && power_user.persona_descriptions[user_avatar]) {
+        const personaData = power_user.persona_descriptions[user_avatar];
+        environment['pronoun.subjective'] = personaData.pronounSubjective || '';
+        environment['pronoun.objective'] = personaData.pronounObjective || '';
+        environment['pronoun.pos_det'] = personaData.pronounPosDet || '';
+        environment['pronoun.pos_pro'] = personaData.pronounPosPro || '';
+        environment['pronoun.reflexive'] = personaData.pronounReflexive || '';
+    } else {
+        // Default empty values if no persona data
+        environment['pronoun.subjective'] = '';
+        environment['pronoun.objective'] = '';
+        environment['pronoun.pos_det'] = '';
+        environment['pronoun.pos_pro'] = '';
+        environment['pronoun.reflexive'] = '';
+    }
+
     if (additionalMacro && typeof additionalMacro === 'object') {
         Object.assign(environment, additionalMacro);
     }
@@ -6806,6 +6823,11 @@ async function doOnboarding(avatarId) {
         power_user.persona_descriptions[avatarId] = {
             description: '',
             position: persona_description_positions.IN_PROMPT,
+            pronounSubjective: '',
+            pronounObjective: '',
+            pronounPosDet: '',
+            pronounPosPro: '',
+            pronounReflexive: '',
         };
     }
 }

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -588,20 +588,12 @@ export function setPersonaDescription() {
     $('#persona_lore_button').toggleClass('world_set', !!power_user.persona_description_lorebook);
 
     // Load pronoun values from current persona
-    const personaData = power_user.persona_descriptions?.[user_avatar];
-    if (personaData) {
-        $('#persona_pronoun_subjective').val(personaData.pronoun?.subjective || '');
-        $('#persona_pronoun_objective').val(personaData.pronoun?.objective || '');
-        $('#persona_pronoun_pos_det').val(personaData.pronoun?.posDet || '');
-        $('#persona_pronoun_pos_pro').val(personaData.pronoun?.posPro || '');
-        $('#persona_pronoun_reflexive').val(personaData.pronoun?.reflexive || '');
-    } else {
-        $('#persona_pronoun_subjective').val('');
-        $('#persona_pronoun_objective').val('');
-        $('#persona_pronoun_pos_det').val('');
-        $('#persona_pronoun_pos_pro').val('');
-        $('#persona_pronoun_reflexive').val('');
-    }
+    const personaData = power_user.persona_descriptions?.[user_avatar] ?? {};
+    $('#persona_pronoun_subjective').val(personaData.pronoun?.subjective || '');
+    $('#persona_pronoun_objective').val(personaData.pronoun?.objective || '');
+    $('#persona_pronoun_pos_det').val(personaData.pronoun?.posDet || '');
+    $('#persona_pronoun_pos_pro').val(personaData.pronoun?.posPro || '');
+    $('#persona_pronoun_reflexive').val(personaData.pronoun?.reflexive || '');
 
     countPersonaDescriptionTokens();
 

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -2059,14 +2059,14 @@ function onPronounFieldInput() {
  */
 function onPronounPresetClick(event) {
     const preset = $(event.currentTarget).data('preset');
-    
+
     const presets = {
         she: { subjective: 'she', objective: 'her', posDet: 'her', posPro: 'hers', reflexive: 'herself' },
         he: { subjective: 'he', objective: 'him', posDet: 'his', posPro: 'his', reflexive: 'himself' },
         they: { subjective: 'they', objective: 'them', posDet: 'their', posPro: 'theirs', reflexive: 'themselves' },
         it: { subjective: 'it', objective: 'it', posDet: 'its', posPro: 'its', reflexive: 'itself' },
     };
-    
+
     const pronouns = presets[preset];
     if (!pronouns) {
         return;

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -465,11 +465,13 @@ export function initPersona(avatarId, personaName, personaDescription, personaTi
         role: DEFAULT_ROLE,
         lorebook: '',
         title: personaTitle || '',
-        pronounSubjective: '',
-        pronounObjective: '',
-        pronounPosDet: '',
-        pronounPosPro: '',
-        pronounReflexive: '',
+        pronoun: {
+            subjective: '',
+            objective: '',
+            posDet: '',
+            posPro: '',
+            reflexive: '',
+        },
     };
 
     saveSettingsDebounced();
@@ -527,11 +529,13 @@ export async function convertCharacterToPersona(characterId = null) {
         role: DEFAULT_ROLE,
         lorebook: '',
         title: '',
-        pronounSubjective: '',
-        pronounObjective: '',
-        pronounPosDet: '',
-        pronounPosPro: '',
-        pronounReflexive: '',
+        pronoun: {
+            subjective: '',
+            objective: '',
+            posDet: '',
+            posPro: '',
+            reflexive: '',
+        },
     };
 
     // If the user is currently using this persona, update the description
@@ -586,11 +590,11 @@ export function setPersonaDescription() {
     // Load pronoun values from current persona
     const personaData = power_user.persona_descriptions?.[user_avatar];
     if (personaData) {
-        $('#persona_pronoun_subjective').val(personaData.pronounSubjective || '');
-        $('#persona_pronoun_objective').val(personaData.pronounObjective || '');
-        $('#persona_pronoun_pos_det').val(personaData.pronounPosDet || '');
-        $('#persona_pronoun_pos_pro').val(personaData.pronounPosPro || '');
-        $('#persona_pronoun_reflexive').val(personaData.pronounReflexive || '');
+        $('#persona_pronoun_subjective').val(personaData.pronoun?.subjective || '');
+        $('#persona_pronoun_objective').val(personaData.pronoun?.objective || '');
+        $('#persona_pronoun_pos_det').val(personaData.pronoun?.posDet || '');
+        $('#persona_pronoun_pos_pro').val(personaData.pronoun?.posPro || '');
+        $('#persona_pronoun_reflexive').val(personaData.pronoun?.reflexive || '');
     } else {
         $('#persona_pronoun_subjective').val('');
         $('#persona_pronoun_objective').val('');
@@ -882,11 +886,13 @@ async function selectCurrentPersona({ toastPersonaNameChange = true } = {}) {
                 lorebook: '',
                 connections: [],
                 title: '',
-                pronounSubjective: '',
-                pronounObjective: '',
-                pronounPosDet: '',
-                pronounPosPro: '',
-                pronounReflexive: '',
+                pronoun: {
+                    subjective: '',
+                    objective: '',
+                    posDet: '',
+                    posPro: '',
+                    reflexive: '',
+                },
             };
         }
 
@@ -1034,11 +1040,13 @@ async function lockPersona(type = 'chat') {
             lorebook: '',
             connections: [],
             title: '',
-            pronounSubjective: '',
-            pronounObjective: '',
-            pronounPosDet: '',
-            pronounPosPro: '',
-            pronounReflexive: '',
+            pronoun: {
+                subjective: '',
+                objective: '',
+                posDet: '',
+                posPro: '',
+                reflexive: '',
+            },
         };
     }
 
@@ -1161,11 +1169,13 @@ function onPersonaDescriptionInput() {
                 role: Number($('#persona_depth_role').find(':selected').val()),
                 lorebook: '',
                 title: '',
-                pronounSubjective: '',
-                pronounObjective: '',
-                pronounPosDet: '',
-                pronounPosPro: '',
-                pronounReflexive: '',
+                pronoun: {
+                    subjective: '',
+                    objective: '',
+                    posDet: '',
+                    posPro: '',
+                    reflexive: '',
+                },
             };
             power_user.persona_descriptions[user_avatar] = object;
         }
@@ -1273,11 +1283,13 @@ function getOrCreatePersonaDescriptor() {
             lorebook: power_user.persona_description_lorebook,
             connections: [],
             title: '',
-            pronounSubjective: '',
-            pronounObjective: '',
-            pronounPosDet: '',
-            pronounPosPro: '',
-            pronounReflexive: '',
+            pronoun: {
+                subjective: '',
+                objective: '',
+                posDet: '',
+                posPro: '',
+                reflexive: '',
+            },
         };
         power_user.persona_descriptions[user_avatar] = object;
     }
@@ -1823,11 +1835,13 @@ async function duplicatePersona(avatarId) {
         role: descriptor?.role ?? DEFAULT_ROLE,
         lorebook: descriptor?.lorebook ?? '',
         title: descriptor?.title ?? '',
-        pronounSubjective: descriptor?.pronounSubjective ?? '',
-        pronounObjective: descriptor?.pronounObjective ?? '',
-        pronounPosDet: descriptor?.pronounPosDet ?? '',
-        pronounPosPro: descriptor?.pronounPosPro ?? '',
-        pronounReflexive: descriptor?.pronounReflexive ?? '',
+        pronoun: {
+            subjective: descriptor?.pronoun?.subjective ?? '',
+            objective: descriptor?.pronoun?.objective ?? '',
+            posDet: descriptor?.pronoun?.posDet ?? '',
+            posPro: descriptor?.pronoun?.posPro ?? '',
+            reflexive: descriptor?.pronoun?.reflexive ?? '',
+        },
     };
 
     await uploadUserAvatar(getUserAvatar(avatarId), newAvatarId);
@@ -2036,11 +2050,14 @@ function onPronounFieldInput() {
         return;
     }
 
-    personaData.pronounSubjective = $('#persona_pronoun_subjective').val();
-    personaData.pronounObjective = $('#persona_pronoun_objective').val();
-    personaData.pronounPosDet = $('#persona_pronoun_pos_det').val();
-    personaData.pronounPosPro = $('#persona_pronoun_pos_pro').val();
-    personaData.pronounReflexive = $('#persona_pronoun_reflexive').val();
+    if (!personaData.pronoun) {
+        personaData.pronoun = {};
+    }
+    personaData.pronoun.subjective = $('#persona_pronoun_subjective').val();
+    personaData.pronoun.objective = $('#persona_pronoun_objective').val();
+    personaData.pronoun.posDet = $('#persona_pronoun_pos_det').val();
+    personaData.pronoun.posPro = $('#persona_pronoun_pos_pro').val();
+    personaData.pronoun.reflexive = $('#persona_pronoun_reflexive').val();
 
     saveSettingsDebounced();
 }

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -2049,7 +2049,7 @@ function onPronounFieldInput() {
  * Handles pronoun preset button clicks and fills the pronoun fields with preset values.
  */
 function onPronounPresetClick(event) {
-    const preset = $(event.target).data('preset');
+    const preset = $(event.currentTarget).data('preset');
     let pronouns = {};
     
     switch (preset) {

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -465,6 +465,11 @@ export function initPersona(avatarId, personaName, personaDescription, personaTi
         role: DEFAULT_ROLE,
         lorebook: '',
         title: personaTitle || '',
+        pronounSubjective: '',
+        pronounObjective: '',
+        pronounPosDet: '',
+        pronounPosPro: '',
+        pronounReflexive: '',
     };
 
     saveSettingsDebounced();
@@ -522,6 +527,11 @@ export async function convertCharacterToPersona(characterId = null) {
         role: DEFAULT_ROLE,
         lorebook: '',
         title: '',
+        pronounSubjective: '',
+        pronounObjective: '',
+        pronounPosDet: '',
+        pronounPosPro: '',
+        pronounReflexive: '',
     };
 
     // If the user is currently using this persona, update the description
@@ -572,6 +582,23 @@ export function setPersonaDescription() {
         .find(`option[value="${power_user.persona_description_role}"]`)
         .prop('selected', String(true));
     $('#persona_lore_button').toggleClass('world_set', !!power_user.persona_description_lorebook);
+    
+    // Load pronoun values from current persona
+    const personaData = power_user.persona_descriptions?.[user_avatar];
+    if (personaData) {
+        $('#persona_pronoun_subjective').val(personaData.pronounSubjective || '');
+        $('#persona_pronoun_objective').val(personaData.pronounObjective || '');
+        $('#persona_pronoun_pos_det').val(personaData.pronounPosDet || '');
+        $('#persona_pronoun_pos_pro').val(personaData.pronounPosPro || '');
+        $('#persona_pronoun_reflexive').val(personaData.pronounReflexive || '');
+    } else {
+        $('#persona_pronoun_subjective').val('');
+        $('#persona_pronoun_objective').val('');
+        $('#persona_pronoun_pos_det').val('');
+        $('#persona_pronoun_pos_pro').val('');
+        $('#persona_pronoun_reflexive').val('');
+    }
+    
     countPersonaDescriptionTokens();
 
     updatePersonaUIStates();
@@ -855,6 +882,11 @@ async function selectCurrentPersona({ toastPersonaNameChange = true } = {}) {
                 lorebook: '',
                 connections: [],
                 title: '',
+                pronounSubjective: '',
+                pronounObjective: '',
+                pronounPosDet: '',
+                pronounPosPro: '',
+                pronounReflexive: '',
             };
         }
 
@@ -1002,6 +1034,11 @@ async function lockPersona(type = 'chat') {
             lorebook: '',
             connections: [],
             title: '',
+            pronounSubjective: '',
+            pronounObjective: '',
+            pronounPosDet: '',
+            pronounPosPro: '',
+            pronounReflexive: '',
         };
     }
 
@@ -1124,6 +1161,11 @@ function onPersonaDescriptionInput() {
                 role: Number($('#persona_depth_role').find(':selected').val()),
                 lorebook: '',
                 title: '',
+                pronounSubjective: '',
+                pronounObjective: '',
+                pronounPosDet: '',
+                pronounPosPro: '',
+                pronounReflexive: '',
             };
             power_user.persona_descriptions[user_avatar] = object;
         }
@@ -1231,6 +1273,11 @@ function getOrCreatePersonaDescriptor() {
             lorebook: power_user.persona_description_lorebook,
             connections: [],
             title: '',
+            pronounSubjective: '',
+            pronounObjective: '',
+            pronounPosDet: '',
+            pronounPosPro: '',
+            pronounReflexive: '',
         };
         power_user.persona_descriptions[user_avatar] = object;
     }
@@ -1776,6 +1823,11 @@ async function duplicatePersona(avatarId) {
         role: descriptor?.role ?? DEFAULT_ROLE,
         lorebook: descriptor?.lorebook ?? '',
         title: descriptor?.title ?? '',
+        pronounSubjective: descriptor?.pronounSubjective ?? '',
+        pronounObjective: descriptor?.pronounObjective ?? '',
+        pronounPosDet: descriptor?.pronounPosDet ?? '',
+        pronounPosPro: descriptor?.pronounPosPro ?? '',
+        pronounReflexive: descriptor?.pronounReflexive ?? '',
     };
 
     await uploadUserAvatar(getUserAvatar(avatarId), newAvatarId);
@@ -1972,6 +2024,86 @@ function registerPersonaSlashCommands() {
 }
 
 /**
+ * Handles input changes for pronoun fields and saves them to the current persona.
+ */
+function onPronounFieldInput() {
+    if (!user_avatar || !power_user.persona_descriptions) {
+        return;
+    }
+    
+    const personaData = power_user.persona_descriptions[user_avatar];
+    if (!personaData) {
+        return;
+    }
+    
+    personaData.pronounSubjective = $('#persona_pronoun_subjective').val();
+    personaData.pronounObjective = $('#persona_pronoun_objective').val();
+    personaData.pronounPosDet = $('#persona_pronoun_pos_det').val();
+    personaData.pronounPosPro = $('#persona_pronoun_pos_pro').val();
+    personaData.pronounReflexive = $('#persona_pronoun_reflexive').val();
+    
+    saveSettingsDebounced();
+}
+
+/**
+ * Handles pronoun preset button clicks and fills the pronoun fields with preset values.
+ */
+function onPronounPresetClick(event) {
+    const preset = $(event.target).data('preset');
+    let pronouns = {};
+    
+    switch (preset) {
+        case 'she':
+            pronouns = {
+                subjective: 'she',
+                objective: 'her',
+                posDet: 'her',
+                posPro: 'hers',
+                reflexive: 'herself'
+            };
+            break;
+        case 'he':
+            pronouns = {
+                subjective: 'he',
+                objective: 'him',
+                posDet: 'his',
+                posPro: 'his',
+                reflexive: 'himself'
+            };
+            break;
+        case 'they':
+            pronouns = {
+                subjective: 'they',
+                objective: 'them',
+                posDet: 'their',
+                posPro: 'theirs',
+                reflexive: 'themselves'
+            };
+            break;
+        case 'it':
+            pronouns = {
+                subjective: 'it',
+                objective: 'it',
+                posDet: 'its',
+                posPro: 'its',
+                reflexive: 'itself'
+            };
+            break;
+        default:
+            return;
+    }
+    
+    $('#persona_pronoun_subjective').val(pronouns.subjective);
+    $('#persona_pronoun_objective').val(pronouns.objective);
+    $('#persona_pronoun_pos_det').val(pronouns.posDet);
+    $('#persona_pronoun_pos_pro').val(pronouns.posPro);
+    $('#persona_pronoun_reflexive').val(pronouns.reflexive);
+    
+    // Trigger the input event to save the values
+    onPronounFieldInput();
+}
+
+/**
  * Initializes the persona management and all its functionality.
  * This is called during the initialization of the page.
  */
@@ -1988,6 +2120,17 @@ export async function initPersonas() {
     $('#persona_depth_value').on('input', onPersonaDescriptionDepthValueInput);
     $('#persona_depth_role').on('input', onPersonaDescriptionDepthRoleInput);
     $('#persona_lore_button').on('click', onPersonaLoreButtonClick);
+    
+    // Pronoun field event handlers
+    $('#persona_pronoun_subjective').on('input', onPronounFieldInput);
+    $('#persona_pronoun_objective').on('input', onPronounFieldInput);
+    $('#persona_pronoun_pos_det').on('input', onPronounFieldInput);
+    $('#persona_pronoun_pos_pro').on('input', onPronounFieldInput);
+    $('#persona_pronoun_reflexive').on('input', onPronounFieldInput);
+    
+    // Pronoun preset button event handlers
+    $('[data-preset]').on('click', onPronounPresetClick);
+    
     $('#personas_backup').on('click', onBackupPersonas);
     $('#personas_restore').on('click', () => $('#personas_restore_input').trigger('click'));
     $('#personas_restore_input').on('change', onPersonasRestoreInput);

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -582,7 +582,7 @@ export function setPersonaDescription() {
         .find(`option[value="${power_user.persona_description_role}"]`)
         .prop('selected', String(true));
     $('#persona_lore_button').toggleClass('world_set', !!power_user.persona_description_lorebook);
-    
+
     // Load pronoun values from current persona
     const personaData = power_user.persona_descriptions?.[user_avatar];
     if (personaData) {
@@ -598,7 +598,7 @@ export function setPersonaDescription() {
         $('#persona_pronoun_pos_pro').val('');
         $('#persona_pronoun_reflexive').val('');
     }
-    
+
     countPersonaDescriptionTokens();
 
     updatePersonaUIStates();
@@ -2030,18 +2030,18 @@ function onPronounFieldInput() {
     if (!user_avatar || !power_user.persona_descriptions) {
         return;
     }
-    
+
     const personaData = power_user.persona_descriptions[user_avatar];
     if (!personaData) {
         return;
     }
-    
+
     personaData.pronounSubjective = $('#persona_pronoun_subjective').val();
     personaData.pronounObjective = $('#persona_pronoun_objective').val();
     personaData.pronounPosDet = $('#persona_pronoun_pos_det').val();
     personaData.pronounPosPro = $('#persona_pronoun_pos_pro').val();
     personaData.pronounReflexive = $('#persona_pronoun_reflexive').val();
-    
+
     saveSettingsDebounced();
 }
 
@@ -2051,7 +2051,7 @@ function onPronounFieldInput() {
 function onPronounPresetClick(event) {
     const preset = $(event.currentTarget).data('preset');
     let pronouns = {};
-    
+
     switch (preset) {
         case 'she':
             pronouns = {
@@ -2059,7 +2059,7 @@ function onPronounPresetClick(event) {
                 objective: 'her',
                 posDet: 'her',
                 posPro: 'hers',
-                reflexive: 'herself'
+                reflexive: 'herself',
             };
             break;
         case 'he':
@@ -2068,7 +2068,7 @@ function onPronounPresetClick(event) {
                 objective: 'him',
                 posDet: 'his',
                 posPro: 'his',
-                reflexive: 'himself'
+                reflexive: 'himself',
             };
             break;
         case 'they':
@@ -2077,7 +2077,7 @@ function onPronounPresetClick(event) {
                 objective: 'them',
                 posDet: 'their',
                 posPro: 'theirs',
-                reflexive: 'themselves'
+                reflexive: 'themselves',
             };
             break;
         case 'it':
@@ -2086,19 +2086,19 @@ function onPronounPresetClick(event) {
                 objective: 'it',
                 posDet: 'its',
                 posPro: 'its',
-                reflexive: 'itself'
+                reflexive: 'itself',
             };
             break;
         default:
             return;
     }
-    
+
     $('#persona_pronoun_subjective').val(pronouns.subjective);
     $('#persona_pronoun_objective').val(pronouns.objective);
     $('#persona_pronoun_pos_det').val(pronouns.posDet);
     $('#persona_pronoun_pos_pro').val(pronouns.posPro);
     $('#persona_pronoun_reflexive').val(pronouns.reflexive);
-    
+
     // Trigger the input event to save the values
     onPronounFieldInput();
 }
@@ -2120,17 +2120,16 @@ export async function initPersonas() {
     $('#persona_depth_value').on('input', onPersonaDescriptionDepthValueInput);
     $('#persona_depth_role').on('input', onPersonaDescriptionDepthRoleInput);
     $('#persona_lore_button').on('click', onPersonaLoreButtonClick);
-    
+
     // Pronoun field event handlers
     $('#persona_pronoun_subjective').on('input', onPronounFieldInput);
     $('#persona_pronoun_objective').on('input', onPronounFieldInput);
     $('#persona_pronoun_pos_det').on('input', onPronounFieldInput);
     $('#persona_pronoun_pos_pro').on('input', onPronounFieldInput);
     $('#persona_pronoun_reflexive').on('input', onPronounFieldInput);
-    
+
     // Pronoun preset button event handlers
     $('[data-preset]').on('click', onPronounPresetClick);
-    
     $('#personas_backup').on('click', onBackupPersonas);
     $('#personas_restore').on('click', () => $('#personas_restore_input').trigger('click'));
     $('#personas_restore_input').on('change', onPersonasRestoreInput);

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -2059,47 +2059,17 @@ function onPronounFieldInput() {
  */
 function onPronounPresetClick(event) {
     const preset = $(event.currentTarget).data('preset');
-    let pronouns = {};
-
-    switch (preset) {
-        case 'she':
-            pronouns = {
-                subjective: 'she',
-                objective: 'her',
-                posDet: 'her',
-                posPro: 'hers',
-                reflexive: 'herself',
-            };
-            break;
-        case 'he':
-            pronouns = {
-                subjective: 'he',
-                objective: 'him',
-                posDet: 'his',
-                posPro: 'his',
-                reflexive: 'himself',
-            };
-            break;
-        case 'they':
-            pronouns = {
-                subjective: 'they',
-                objective: 'them',
-                posDet: 'their',
-                posPro: 'theirs',
-                reflexive: 'themselves',
-            };
-            break;
-        case 'it':
-            pronouns = {
-                subjective: 'it',
-                objective: 'it',
-                posDet: 'its',
-                posPro: 'its',
-                reflexive: 'itself',
-            };
-            break;
-        default:
-            return;
+    
+    const presets = {
+        she: { subjective: 'she', objective: 'her', posDet: 'her', posPro: 'hers', reflexive: 'herself' },
+        he: { subjective: 'he', objective: 'him', posDet: 'his', posPro: 'his', reflexive: 'himself' },
+        they: { subjective: 'they', objective: 'them', posDet: 'their', posPro: 'theirs', reflexive: 'themselves' },
+        it: { subjective: 'it', objective: 'it', posDet: 'its', posPro: 'its', reflexive: 'itself' },
+    };
+    
+    const pronouns = presets[preset];
+    if (!pronouns) {
+        return;
     }
 
     $('#persona_pronoun_subjective').val(pronouns.subjective);

--- a/public/style.css
+++ b/public/style.css
@@ -6127,3 +6127,12 @@ body:not(.movingUI) .drawer-content.maximized {
     border-color: var(--error-color, #e87f7f);
     background-color: rgba(241, 163, 163, 0.2);
 }
+
+/* Pronoun Settings Styles */
+.persona_pronoun_settings_container {
+    margin: 10px 0;
+}
+
+.pronoun_preset_buttons {
+    margin: 15px 0;
+}


### PR DESCRIPTION
Adds the Makros 
{{pronoun.subjective}}
{{pronoun.objective}}
{{pronoun.pos_det}}
{{pronoun.pos_pro}}
{{pronoun.reflexive}}
And add Pronoun Settings to the persona management.
Macros are identical to the once used on Wyvern.chat

<!-- Put X in the box below to confirm -->

## Checklist:

- [x ] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
