### PR TITLE
Assets: Display extension author in the list

### DIFF
--- a/public/scripts/extensions/assets/index.js
+++ b/public/scripts/extensions/assets/index.js
@@ -82,8 +82,6 @@ function getAuthorFromUrl(url) {
             result.name = pathSegments[0];
             result.url = `${parsedUrl.protocol}//${parsedUrl.hostname}/${result.name}`;
         }
-
-        return result;
     }
     catch (error) {
         console.debug(DEBUG_PREFIX, 'Error parsing URL:', error);
@@ -221,7 +219,7 @@ async function downloadAssetsList(url) {
 
                         const assetBlock = $('<i></i>')
                             .append(element)
-                            .append(`<div class="flex-container flexFlowColumn flexNoGap wide100p">
+                            .append(`<div class="flex-container flexFlowColumn flexNoGap wide100p overflowHidden">
                                         <span class="asset-name flex-container alignitemscenter">
                                             <b>${displayName}</b>
                                             <a class="asset_preview" href="${url}" target="_blank" title="${title}">
@@ -230,7 +228,7 @@ async function downloadAssetsList(url) {
                                             (toolTag ? '<span class="tag" title="' + t`Adds a function tool` + '"><i class="fa-solid fa-sm fa-wrench"></i> ' +
                                             t`Tool` + '</span>' : '') +
                                             '<span class="expander"></span>' +
-                                            (author.name ? `<a href="${author.url}" target="_blank" class="asset-author-info"><i class="fa-solid fa-at fa-xs"></i>${author.name}</a>` : '') +
+                                            (author.name ? `<a href="${author.url}" target="_blank" class="asset-author-info"><i class="fa-solid fa-at fa-xs"></i><span>${author.name}</span></a>` : '') +
                                         `</span>
                                         <small class="asset-description">
                                             ${description}

--- a/public/scripts/extensions/assets/index.js
+++ b/public/scripts/extensions/assets/index.js
@@ -10,7 +10,7 @@ import { POPUP_TYPE, Popup, callGenericPopup } from '../../popup.js';
 import { executeSlashCommandsWithOptions } from '../../slash-commands.js';
 import { accountStorage } from '../../util/AccountStorage.js';
 import { flashHighlight, getStringHash, isValidUrl } from '../../utils.js';
-import { t } from '../../i18n.js';
+import { t, translate } from '../../i18n.js';
 export { MODULE_NAME };
 
 const MODULE_NAME = 'assets';
@@ -60,6 +60,38 @@ const KNOWN_TYPES = {
     'blip': t`Blip sounds`,
 };
 
+const EMPTY_AUTHOR = {
+    name: '',
+    url: '',
+};
+
+/**
+ * Extracts the repository author from a given URL.
+ * @param {string} url - The URL of the repository.
+ * @returns {{name: string, url: string}} Object containing the author's name and URL, or empty strings if not found.
+ */
+function getAuthorFromUrl(url) {
+    const result = structuredClone(EMPTY_AUTHOR);
+
+    try {
+        const parsedUrl = new URL(url);
+        const pathSegments = parsedUrl.pathname.split('/').filter(s => s.length > 0);
+
+        // TODO: Handle non-GitHub URLs if needed
+        if (parsedUrl.host === 'github.com' && pathSegments.length >= 2) {
+            result.name = pathSegments[0];
+            result.url = `${parsedUrl.protocol}//${parsedUrl.hostname}/${result.name}`;
+        }
+
+        return result;
+    }
+    catch (error) {
+        console.debug(DEBUG_PREFIX, 'Error parsing URL:', error);
+    }
+
+    return result;
+}
+
 async function downloadAssetsList(url) {
     updateCurrentAssets().then(async function () {
         fetch(url, { cache: 'no-cache' })
@@ -88,7 +120,8 @@ async function downloadAssetsList(url) {
                 $('#assets_type_select').append($('<option />', { value: '', text: t`All` }));
 
                 for (const type of assetTypes) {
-                    const option = $('<option />', { value: type, text: t([KNOWN_TYPES[type] || type]) });
+                    const text = translate(KNOWN_TYPES[type] || type);
+                    const option = $('<option />', { value: type, text: text });
                     $('#assets_type_select').append(option);
                 }
 
@@ -184,10 +217,11 @@ async function downloadAssetsList(url) {
                         const title = assetType === 'extension' ? t`Extension repo/guide:` + ` ${url}` : t`Preview in browser`;
                         const previewIcon = (assetType === 'extension' || assetType === 'character') ? 'fa-arrow-up-right-from-square' : 'fa-headphones-simple';
                         const toolTag = assetType === 'extension' && asset['tool'];
+                        const author = url && assetType === 'extension' ? getAuthorFromUrl(url) : EMPTY_AUTHOR;
 
                         const assetBlock = $('<i></i>')
                             .append(element)
-                            .append(`<div class="flex-container flexFlowColumn flexNoGap">
+                            .append(`<div class="flex-container flexFlowColumn flexNoGap wide100p">
                                         <span class="asset-name flex-container alignitemscenter">
                                             <b>${displayName}</b>
                                             <a class="asset_preview" href="${url}" target="_blank" title="${title}">
@@ -195,6 +229,8 @@ async function downloadAssetsList(url) {
                                             </a>` +
                                             (toolTag ? '<span class="tag" title="' + t`Adds a function tool` + '"><i class="fa-solid fa-sm fa-wrench"></i> ' +
                                             t`Tool` + '</span>' : '') +
+                                            '<span class="expander"></span>' +
+                                            (author.name ? `<a href="${author.url}" target="_blank" class="asset-author-info"><i class="fa-solid fa-at fa-xs"></i>${author.name}</a>` : '') +
                                         `</span>
                                         <small class="asset-description">
                                             ${description}

--- a/public/scripts/extensions/assets/style.css
+++ b/public/scripts/extensions/assets/style.css
@@ -35,14 +35,15 @@
     color: inherit;
 }
 
-.assets-list-div > i {
+.assets-list-div>i {
     display: flex;
     flex-direction: row;
     align-items: center;
     justify-content: left;
-    padding: 5px;
+    padding: 10px 5px;
     font-style: normal;
     gap: 5px;
+    border-bottom: 1px solid var(--SmartThemeBorderColor);
 }
 
 .assets-list-div i span:first-of-type {
@@ -172,4 +173,21 @@
     cursor: pointer;
     opacity: 0.9;
     margin-left: 2px;
+}
+
+.asset-name .asset-author-info {
+    display: flex;
+    align-items: baseline;
+    gap: 2px;
+    opacity: 0.7;
+    font-size: 0.85em;
+}
+
+.asset-name .asset-author-info:hover {
+    opacity: 1;
+    transition: opacity var(--animation-duration) ease-in-out;
+}
+
+.asset-name>b {
+    font-weight: 600;
 }

--- a/public/scripts/extensions/assets/style.css
+++ b/public/scripts/extensions/assets/style.css
@@ -181,6 +181,13 @@
     gap: 2px;
     opacity: 0.7;
     font-size: 0.85em;
+    overflow: hidden;
+}
+
+.asset-name .asset-author-info>span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .asset-name .asset-author-info:hover {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

This pull request enhances the asset listing UI by displaying the repository author for extension assets and refines the visual presentation of asset items. It introduces a utility to extract author information from GitHub URLs and updates both the code and styles to support these improvements.

**Asset Author Display Improvements**
* Added a new utility function `getAuthorFromUrl` to extract repository author information from GitHub URLs, providing both the author's name and profile URL.
* Updated the asset rendering logic in `downloadAssetsList` to display the author name and link for extension assets, improving attribution and discoverability.

**Internationalization Enhancements**
* Switched asset type option rendering to use the `translate` function for improved localization support.
* Imported the new `translate` function from `i18n.js` to support the above change.

**UI and Styling Updates**
* Increased padding and added a border to asset item rows for clearer separation in the asset list.
* Added styles for the new `.asset-author-info` element, including hover effects and font adjustments for better readability and emphasis.

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
