### PR TITLE
Fix creator notes display field (in char panel) not updating when changed in Advanced Definitions

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7598,7 +7598,7 @@ function select_rm_create({ switchMenu = true } = {}) {
     $('#description_textarea').val(create_save.description);
     $('#character_world').val(create_save.world);
     $('#creator_notes_textarea').val(create_save.creator_notes);
-    $('#creator_notes_spoiler').html(formatCreatorNotes(create_save.creator_notes, characters[this_chid]?.avatar ?? ''));
+    $('#creator_notes_spoiler').html(formatCreatorNotes(create_save.creator_notes, ''));
     $('#post_history_instructions_textarea').val(create_save.post_history_instructions);
     $('#system_prompt_textarea').val(create_save.system_prompt);
     $('#tags_textarea').val(create_save.tags);
@@ -9796,7 +9796,8 @@ jQuery(async function () {
 
     $('#creator_notes_textarea').on('input', function () {
         const notes = String($('#creator_notes_textarea').val());
-        $('#creator_notes_spoiler').html(formatCreatorNotes(notes, characters[this_chid]?.avatar ?? ''));
+        const avatar = menu_type === 'create' ? '' : characters[this_chid]?.avatar;
+        $('#creator_notes_spoiler').html(formatCreatorNotes(notes, avatar));
     });
 
     $('#favorite_button').on('click', function () {

--- a/public/script.js
+++ b/public/script.js
@@ -7598,7 +7598,7 @@ function select_rm_create({ switchMenu = true } = {}) {
     $('#description_textarea').val(create_save.description);
     $('#character_world').val(create_save.world);
     $('#creator_notes_textarea').val(create_save.creator_notes);
-    $('#creator_notes_spoiler').html(formatCreatorNotes(create_save.creator_notes, ''));
+    $('#creator_notes_spoiler').html(formatCreatorNotes(create_save.creator_notes, characters[this_chid]?.avatar ?? ''));
     $('#post_history_instructions_textarea').val(create_save.post_history_instructions);
     $('#system_prompt_textarea').val(create_save.system_prompt);
     $('#tags_textarea').val(create_save.tags);
@@ -9792,6 +9792,11 @@ jQuery(async function () {
                 saveCharacterDebounced();
             }
         });
+    });
+
+    $('#creator_notes_textarea').on('input', function () {
+        const notes = String($('#creator_notes_textarea').val());
+        $('#creator_notes_spoiler').html(formatCreatorNotes(notes, characters[this_chid]?.avatar ?? ''));
     });
 
     $('#favorite_button').on('click', function () {


### PR DESCRIPTION
Small fix, because I was annoyed that when I changed the creators note field, it didn't update it right away in the char panel. You had to reload the whole char.
Now it updates on input, so you even get a WYSIWYG kinda experience, if you want.

## Copilot Summary
This pull request introduces a small update to the character creation and editing workflow, specifically improving how creator notes are displayed and updated in the UI. The main change ensures that the character's avatar is passed to the `formatCreatorNotes` function, both when loading saved data and when the creator notes are edited, resulting in a more context-aware rendering of the notes.

**Improvements to creator notes rendering:**

* Updated `select_rm_create` to pass the character's avatar to `formatCreatorNotes` when displaying saved creator notes, improving the accuracy of the notes preview. (`public/script.js`)
* Added an input event handler for `creator_notes_textarea` to dynamically update the `creator_notes_spoiler` preview with the latest notes and associated avatar as the user types. (`public/script.js`)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
