### PR TITLE
Scroll to top button

### DIFF
--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -10,6 +10,16 @@
     z-index: -1;
 }
 
+/* Theme variables for small UI controls in the backgrounds drawer */
+:root {
+    --bg-scroll-button-size: 42px;
+    --bg-scroll-button-font-size: 18px;
+    --bg-scroll-button-offset: 20px;
+    --bg-scroll-button-bg-alpha: 0.9;
+    --bg-scroll-button-bg-hover-alpha: 0.95;
+    --bg-scroll-button-z: 10;
+}
+
 /* Fitting options */
 #background_fitting {
     max-width: 8em;
@@ -222,38 +232,34 @@
 
 /* Scroll-to-Top Button */
 
-/* Scroll-to-Top Button */
-
 #bg-scroll-top {
     position: absolute;
-    bottom: 20px;
-    right: 20px;
-    width: 42px;
-    height: 42px;
-    background: rgba(40, 40, 40, 0.92);
+    bottom: var(--bg-scroll-button-offset);
+    right: var(--bg-scroll-button-offset);
+    width: var(--bg-scroll-button-size);
+    height: var(--bg-scroll-button-size);
+    background: rgba(40, 40, 40, var(--bg-scroll-button-bg-alpha));
     color: #fff;
     border: 1px solid var(--SmartThemeBorderColor, #888);
     border-radius: 50%;
     cursor: pointer;
-    z-index: 10;
-    font-size: 18px;
+    z-index: var(--bg-scroll-button-z);
+    font-size: var(--bg-scroll-button-font-size);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    visibility: hidden;
     opacity: 0;
-    transition: visibility 0s linear calc(var(--animation-duration) * -1), opacity var(--animation-duration) ease;
+    transition: opacity var(--animation-duration) ease;
     pointer-events: none;
 }
 
 #bg-scroll-top.visible {
-    visibility: visible;
     opacity: 1;
     pointer-events: auto;
 }
 
 #bg-scroll-top:hover {
-    background: rgba(60, 60, 60, 0.95);
+    background: rgba(60, 60, 60, var(--bg-scroll-button-bg-hover-alpha));
     border-color: var(--golden, #ffd700);
 }
 

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -221,7 +221,6 @@
 }
 
 /* Scroll-to-Top Button */
-
 #bg-scroll-top {
     position: absolute;
     bottom: 20px;
@@ -250,7 +249,7 @@
 
 #bg-scroll-top:hover {
     background: rgba(60, 60, 60, 0.95);
-    border-color: var(--golden, #ffd700);
+    border-color: var(--white100);
 }
 
 #bg-scroll-top .fa-solid {

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -10,16 +10,6 @@
     z-index: -1;
 }
 
-/* Theme variables for small UI controls in the backgrounds drawer */
-:root {
-    --bg-scroll-button-size: 42px;
-    --bg-scroll-button-font-size: 18px;
-    --bg-scroll-button-offset: 20px;
-    --bg-scroll-button-bg-alpha: 0.9;
-    --bg-scroll-button-bg-hover-alpha: 0.95;
-    --bg-scroll-button-z: 10;
-}
-
 /* Fitting options */
 #background_fitting {
     max-width: 8em;
@@ -234,17 +224,17 @@
 
 #bg-scroll-top {
     position: absolute;
-    bottom: var(--bg-scroll-button-offset);
-    right: var(--bg-scroll-button-offset);
-    width: var(--bg-scroll-button-size);
-    height: var(--bg-scroll-button-size);
-    background: rgba(40, 40, 40, var(--bg-scroll-button-bg-alpha));
+    bottom: 20px;
+    right: 20px;
+    width: 42px;
+    height: 42px;
+    background: rgba(40, 40, 40, 0.9);
     color: #fff;
     border: 1px solid var(--SmartThemeBorderColor, #888);
     border-radius: 50%;
     cursor: pointer;
-    z-index: var(--bg-scroll-button-z);
-    font-size: var(--bg-scroll-button-font-size);
+        z-index: 10;
+        font-size: 18px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -259,7 +249,7 @@
 }
 
 #bg-scroll-top:hover {
-    background: rgba(60, 60, 60, var(--bg-scroll-button-bg-hover-alpha));
+    background: rgba(60, 60, 60, 0.95);
     border-color: var(--golden, #ffd700);
 }
 

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -233,8 +233,8 @@
     border: 1px solid var(--SmartThemeBorderColor, #888);
     border-radius: 50%;
     cursor: pointer;
-        z-index: 10;
-        font-size: 18px;
+    z-index: 10;
+    font-size: 18px;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -88,6 +88,7 @@
     overflow-y: auto;
     overflow-x: hidden;
     padding: 0 5px 15px;
+    position: relative;
 }
 
 #bg_menu_content,
@@ -217,6 +218,49 @@
 
 .bg_example .jg-button:hover {
     background-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Scroll-to-Top Button */
+
+/* Scroll-to-Top Button */
+
+#bg-scroll-top {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    width: 42px;
+    height: 42px;
+    background: rgba(40, 40, 40, 0.92);
+    color: #fff;
+    border: 1px solid var(--SmartThemeBorderColor, #888);
+    border-radius: 50%;
+    cursor: pointer;
+    z-index: 10;
+    font-size: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s linear calc(var(--animation-duration) * -1), opacity var(--animation-duration) ease;
+    pointer-events: none;
+}
+
+#bg-scroll-top.visible {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+}
+
+#bg-scroll-top:hover {
+    background: rgba(60, 60, 60, 0.95);
+    border-color: var(--golden, #ffd700);
+}
+
+#bg-scroll-top .fa-solid {
+    margin: 0;
+    padding: 0;
+    line-height: 1;
 }
 
 .thumbnail-clipper {

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -227,9 +227,9 @@
     right: 20px;
     width: 42px;
     height: 42px;
-    background: rgba(40, 40, 40, 0.9);
-    color: #fff;
-    border: 1px solid var(--SmartThemeBorderColor, #888);
+    background: var(--SmartThemeBlurTintColor);
+    color: var(--SmartThemeBodyColor);
+    border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 50%;
     cursor: pointer;
     z-index: 10;
@@ -248,8 +248,8 @@
 }
 
 #bg-scroll-top:hover {
-    background: rgba(60, 60, 60, 0.95);
-    border-color: var(--white100);
+    filter: brightness(1.2);
+    outline: 1px solid var(--interactable-outline-color);
 }
 
 #bg-scroll-top .fa-solid {

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -248,7 +248,7 @@
 }
 
 #bg-scroll-top:hover {
-    filter: brightness(1.2);
+    filter: brightness(150%);
     outline: 1px solid var(--interactable-outline-color);
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -5346,6 +5346,9 @@
                 <form id="form_bg_upload" style="display: none;">
                     <input type="file" id="add_bg_button" name="avatar" accept="image/jpeg,image/png,image/gif,image/bmp,image/svg+xml,video/*">
                 </form>
+                <div id="bg-scroll-top" role="button" tabindex="0" aria-label="Scroll backgrounds to top">
+                    <i class="fa-solid fa-chevron-up" aria-hidden="true"></i>
+                </div>
             </div>
         </div>
         <div id="extensions-settings-button" class="drawer">

--- a/public/index.html
+++ b/public/index.html
@@ -5346,9 +5346,9 @@
                 <form id="form_bg_upload" style="display: none;">
                     <input type="file" id="add_bg_button" name="avatar" accept="image/jpeg,image/png,image/gif,image/bmp,image/svg+xml,video/*">
                 </form>
-                <div id="bg-scroll-top" role="button" tabindex="0" aria-label="Scroll backgrounds to top">
+                <button id="bg-scroll-top" type="button" class="menu_button menu_button_icon" aria-label="Scroll backgrounds to top">
                     <i class="fa-solid fa-chevron-up" aria-hidden="true"></i>
-                </div>
+                </button>
             </div>
         </div>
         <div id="extensions-settings-button" class="drawer">

--- a/public/index.html
+++ b/public/index.html
@@ -5351,7 +5351,7 @@
                 <form id="form_bg_upload" style="display: none;">
                     <input type="file" id="add_bg_button" name="avatar" accept="image/jpeg,image/png,image/gif,image/bmp,image/svg+xml,video/*">
                 </form>
-                <button id="bg-scroll-top" type="button" class="menu_button menu_button_icon" aria-label="Scroll backgrounds to top">
+                <button id="bg-scroll-top" type="button" class="menu_button menu_button_icon" title="Scroll backgrounds to top" data-i18n="[title]Scroll backgrounds to top">
                     <i class="fa-solid fa-chevron-up" aria-hidden="true"></i>
                 </button>
             </div>

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -21,7 +21,6 @@ const THUMBNAIL_COLUMNS_MAX = 8;
 const THUMBNAIL_COLUMNS_DEFAULT_DESKTOP = 5;
 const THUMBNAIL_COLUMNS_DEFAULT_MOBILE = 3;
 
-
 /**
  * Storage for frontend-generated background thumbnails.
  * This is used to store thumbnails for backgrounds that cannot be generated on the server.
@@ -746,7 +745,6 @@ function onBackgroundFilterInput() {
 }
 
 const debouncedOnBackgroundFilterInput = debounce(onBackgroundFilterInput, debounce_timeout.standard);
-
 
 export function initBackgrounds() {
     eventSource.on(event_types.CHAT_CHANGED, onChatChanged);

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -798,9 +798,7 @@ function setupScrollToTop() {
             e.stopPropagation();
         }
 
-        const userPrefersReduced = (typeof power_user !== 'undefined' && !!power_user.reduced_motion)
-            || document.body.classList.contains('reduced-motion')
-            || (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+        const userPrefersReduced = (typeof power_user !== 'undefined' && power_user.reduced_motion);
 
         scrollContainer.scrollTo({ top: 0, behavior: userPrefersReduced ? 'auto' : 'smooth' });
     };

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -766,19 +766,18 @@ function setupScrollToTop() {
         return () => { /* noop cleanup */ };
     }
 
-    // rAF-throttled scroll handler
+    // Throttled scroll handler
     let ticking = false;
+    const THROTTLE_DELAY = 300; // 300ms delay
+
     const onScroll = () => {
         if (!ticking) {
-            window.requestAnimationFrame(() => {
-                if (scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD) {
-                    btn.classList.add('visible');
-                } else {
-                    btn.classList.remove('visible');
-                }
-                ticking = false;
-            });
             ticking = true;
+
+            setTimeout(() => {
+                btn.classList.toggle('visible', scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD);
+                ticking = false;
+            }, THROTTLE_DELAY);
         }
     };
     scrollContainer.addEventListener('scroll', onScroll, { passive: true });

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -21,6 +21,9 @@ const THUMBNAIL_COLUMNS_MAX = 8;
 const THUMBNAIL_COLUMNS_DEFAULT_DESKTOP = 5;
 const THUMBNAIL_COLUMNS_DEFAULT_MOBILE = 3;
 
+// How far (px) the user must scroll before the scroll-to-top button appears
+const SCROLL_VISIBILITY_THRESHOLD = 300;
+
 /**
  * Storage for frontend-generated background thumbnails.
  * This is used to store thumbnails for backgrounds that cannot be generated on the server.
@@ -43,6 +46,8 @@ const THUMBNAIL_CONFIG = {
  * @type {IntersectionObserver|null}
  */
 let lazyLoadObserver = null;
+// cleanup function returned by setupScrollToTop
+let bgScrollCleanup = null;
 
 export let background_settings = {
     name: '__transparent.png',
@@ -747,72 +752,65 @@ function onBackgroundFilterInput() {
 const debouncedOnBackgroundFilterInput = debounce(onBackgroundFilterInput, debounce_timeout.standard);
 
 function setupScrollToTop() {
-    // Delay setup slightly to ensure DOM elements exist when called during init
-    setTimeout(() => {
-        const scrollContainer = document.getElementById('bg-scrollable-content');
-        const btn = document.getElementById('bg-scroll-top');
-        const drawer = document.getElementById('Backgrounds');
+    const scrollContainer = document.getElementById('bg-scrollable-content');
+    const btn = document.getElementById('bg-scroll-top');
+    const drawer = document.getElementById('Backgrounds');
 
-        if (!scrollContainer || !btn || !drawer) {
-            // Not fatal; backgrounds drawer may not be present in some contexts
-            console.error('Scroll-to-top dependencies not found.');
-            return;
+    if (!btn || !drawer) {
+        // Not fatal; the drawer or button may not exist in some builds. Use debug level.
+        console.debug('Scroll-to-top: button or drawer not found during setup.');
+        return () => { /* noop cleanup */ };
+    }
+
+    if (!scrollContainer) {
+        console.debug('Scroll-to-top: scroll container not found during setup.');
+        return () => { /* noop cleanup */ };
+    }
+
+    // rAF-throttled scroll handler
+    let ticking = false;
+    const onScroll = () => {
+        if (!ticking) {
+            window.requestAnimationFrame(() => {
+                if (scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD) {
+                    btn.classList.add('visible');
+                } else {
+                    btn.classList.remove('visible');
+                }
+                ticking = false;
+            });
+            ticking = true;
         }
+    };
+    scrollContainer.addEventListener('scroll', onScroll, { passive: true });
 
-        // rAF-throttled scroll handler
-        let ticking = false;
-        const onScroll = () => {
-            if (!ticking) {
-                window.requestAnimationFrame(() => {
-                    if (scrollContainer.scrollTop > 300) {
-                        btn.classList.add('visible');
-                    } else {
-                        btn.classList.remove('visible');
-                    }
-                    ticking = false;
-                });
-                ticking = true;
-            }
-        };
-        scrollContainer.addEventListener('scroll', onScroll, { passive: true });
+    // Hide the button when the drawer is closed. This is defensive—prefer emitting an event from the drawer open/close logic.
+    const drawerObserver = new MutationObserver(() => {
+        if (!drawer.classList.contains('openDrawer')) {
+            btn.classList.remove('visible');
+        }
+    });
+    drawerObserver.observe(drawer, { attributes: true, attributeFilter: ['class'] });
 
-        // Hide the button if the drawer is closed
-        const drawerObserver = new MutationObserver(() => {
-            if (!drawer.classList.contains('openDrawer')) {
-                btn.classList.remove('visible');
-            }
-        });
-        drawerObserver.observe(drawer, { attributes: true, attributeFilter: ['class'] });
+    // Scroll to top on click (button semantics provide keyboard activation natively)
+    const onActivate = (e) => {
+        if (e) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+        scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+    btn.addEventListener('click', onActivate);
 
-        // Scroll to top on click
-        const onActivate = (e) => {
-            if (e) {
-                e.preventDefault();
-                e.stopPropagation();
-            }
-            scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
-        };
-        btn.addEventListener('click', onActivate);
+    // Initial state check
+    if (scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD) btn.classList.add('visible');
 
-        // Keyboard activation (Enter / Space)
-        const onKey = (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                onActivate(e);
-            }
-        };
-        btn.addEventListener('keydown', onKey);
-
-        // Expose cleanup so disconnects can remove listeners if needed
-        /** @type {any} */ (btn)._bg_scroll_cleanup = () => {
-            scrollContainer.removeEventListener('scroll', onScroll);
-            btn.removeEventListener('click', onActivate);
-            btn.removeEventListener('keydown', onKey);
-            drawerObserver.disconnect();
-        };
-
-        // Initial state check
-        if (scrollContainer.scrollTop > 300) btn.classList.add('visible');
-    }, 100);
+    // Return cleanup function for caller to hold and invoke when appropriate
+    return () => {
+        scrollContainer.removeEventListener('scroll', onScroll);
+        btn.removeEventListener('click', onActivate);
+        drawerObserver.disconnect();
+    };
 }
 
 export function initBackgrounds() {
@@ -909,5 +907,13 @@ export function initBackgrounds() {
     });
 
     // Initialize scroll-to-top button behavior for the backgrounds drawer
-    setupScrollToTop();
+    try {
+        if (typeof bgScrollCleanup === 'function') {
+            bgScrollCleanup();
+        }
+        bgScrollCleanup = setupScrollToTop();
+    } catch (err) {
+        console.debug('Failed to initialize bg scroll-to-top:', err);
+        bgScrollCleanup = null;
+    }
 }

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -4,6 +4,7 @@ import { openThirdPartyExtensionMenu, saveMetadataDebounced } from './extensions
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { createThumbnail, flashHighlight, getBase64Async, stringFormat, debounce } from './utils.js';
+import { power_user } from './power-user.js';
 import { debounce_timeout } from './constants.js';
 import { t } from './i18n.js';
 import { Popup } from './popup.js';
@@ -798,7 +799,12 @@ function setupScrollToTop() {
             e.preventDefault();
             e.stopPropagation();
         }
-        scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
+
+        const userPrefersReduced = (typeof power_user !== 'undefined' && !!power_user.reduced_motion)
+            || document.body.classList.contains('reduced-motion')
+            || (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+
+        scrollContainer.scrollTo({ top: 0, behavior: userPrefersReduced ? 'auto' : 'smooth' });
     };
     btn.addEventListener('click', onActivate);
 

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -798,7 +798,7 @@ function setupScrollToTop() {
             e.stopPropagation();
         }
 
-        const userPrefersReduced = (typeof power_user !== 'undefined' && power_user.reduced_motion);
+        const userPrefersReduced = power_user.reduced_motion;
 
         scrollContainer.scrollTo({ top: 0, behavior: userPrefersReduced ? 'auto' : 'smooth' });
     };

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -746,6 +746,75 @@ function onBackgroundFilterInput() {
 
 const debouncedOnBackgroundFilterInput = debounce(onBackgroundFilterInput, debounce_timeout.standard);
 
+function setupScrollToTop() {
+    // Delay setup slightly to ensure DOM elements exist when called during init
+    setTimeout(() => {
+        const scrollContainer = document.getElementById('bg-scrollable-content');
+        const btn = document.getElementById('bg-scroll-top');
+        const drawer = document.getElementById('Backgrounds');
+
+        if (!scrollContainer || !btn || !drawer) {
+            // Not fatal; backgrounds drawer may not be present in some contexts
+            console.error('Scroll-to-top dependencies not found.');
+            return;
+        }
+
+        // rAF-throttled scroll handler
+        let ticking = false;
+        const onScroll = () => {
+            if (!ticking) {
+                window.requestAnimationFrame(() => {
+                    if (scrollContainer.scrollTop > 300) {
+                        btn.classList.add('visible');
+                    } else {
+                        btn.classList.remove('visible');
+                    }
+                    ticking = false;
+                });
+                ticking = true;
+            }
+        };
+        scrollContainer.addEventListener('scroll', onScroll, { passive: true });
+
+        // Hide the button if the drawer is closed
+        const drawerObserver = new MutationObserver(() => {
+            if (!drawer.classList.contains('openDrawer')) {
+                btn.classList.remove('visible');
+            }
+        });
+        drawerObserver.observe(drawer, { attributes: true, attributeFilter: ['class'] });
+
+        // Scroll to top on click
+        const onActivate = (e) => {
+            if (e) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+            scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
+        };
+        btn.addEventListener('click', onActivate);
+
+        // Keyboard activation (Enter / Space)
+        const onKey = (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                onActivate(e);
+            }
+        };
+        btn.addEventListener('keydown', onKey);
+
+        // Expose cleanup so disconnects can remove listeners if needed
+        /** @type {any} */ (btn)._bg_scroll_cleanup = () => {
+            scrollContainer.removeEventListener('scroll', onScroll);
+            btn.removeEventListener('click', onActivate);
+            btn.removeEventListener('keydown', onKey);
+            drawerObserver.disconnect();
+        };
+
+        // Initial state check
+        if (scrollContainer.scrollTop > 300) btn.classList.add('visible');
+    }, 100);
+}
+
 export function initBackgrounds() {
     eventSource.on(event_types.CHAT_CHANGED, onChatChanged);
     eventSource.on(event_types.FORCE_SET_BACKGROUND, forceSetBackground);
@@ -838,4 +907,7 @@ export function initBackgrounds() {
         await getBackgrounds();
         await onChatChanged();
     });
+
+    // Initialize scroll-to-top button behavior for the backgrounds drawer
+    setupScrollToTop();
 }

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -47,8 +47,6 @@ const THUMBNAIL_CONFIG = {
  * @type {IntersectionObserver|null}
  */
 let lazyLoadObserver = null;
-// cleanup function returned by setupScrollToTop
-let bgScrollCleanup = null;
 
 export let background_settings = {
     name: '__transparent.png',
@@ -912,14 +910,5 @@ export function initBackgrounds() {
         await onChatChanged();
     });
 
-    // Initialize scroll-to-top button behavior for the backgrounds drawer
-    try {
-        if (typeof bgScrollCleanup === 'function') {
-            bgScrollCleanup();
-        }
-        bgScrollCleanup = setupScrollToTop();
-    } catch (err) {
-        console.debug('Failed to initialize bg scroll-to-top:', err);
-        bgScrollCleanup = null;
-    }
+    setupScrollToTop();
 }

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -3,8 +3,7 @@ import { chat_metadata, eventSource, event_types, generateQuietPrompt, getCurren
 import { openThirdPartyExtensionMenu, saveMetadataDebounced } from './extensions.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
-import { createThumbnail, flashHighlight, getBase64Async, stringFormat, debounce } from './utils.js';
-import { power_user } from './power-user.js';
+import { createThumbnail, flashHighlight, getBase64Async, stringFormat, debounce, setupScrollToTop } from './utils.js';
 import { debounce_timeout } from './constants.js';
 import { t } from './i18n.js';
 import { Popup } from './popup.js';
@@ -22,8 +21,6 @@ const THUMBNAIL_COLUMNS_MAX = 8;
 const THUMBNAIL_COLUMNS_DEFAULT_DESKTOP = 5;
 const THUMBNAIL_COLUMNS_DEFAULT_MOBILE = 3;
 
-// How far (px) the user must scroll before the scroll-to-top button appears
-const SCROLL_VISIBILITY_THRESHOLD = 300;
 
 /**
  * Storage for frontend-generated background thumbnails.
@@ -750,60 +747,6 @@ function onBackgroundFilterInput() {
 
 const debouncedOnBackgroundFilterInput = debounce(onBackgroundFilterInput, debounce_timeout.standard);
 
-function setupScrollToTop() {
-    const scrollContainer = document.getElementById('bg-scrollable-content');
-    const btn = document.getElementById('bg-scroll-top');
-    const drawer = document.getElementById('Backgrounds');
-
-    if (!btn || !drawer) {
-        // Not fatal; the drawer or button may not exist in some builds. Use debug level.
-        console.debug('Scroll-to-top: button or drawer not found during setup.');
-        return () => { /* noop cleanup */ };
-    }
-
-    if (!scrollContainer) {
-        console.debug('Scroll-to-top: scroll container not found during setup.');
-        return () => { /* noop cleanup */ };
-    }
-
-    // Throttled scroll handler
-    let ticking = false;
-    const THROTTLE_DELAY = 300; // 300ms delay
-
-    const onScroll = () => {
-        if (!ticking) {
-            ticking = true;
-
-            setTimeout(() => {
-                btn.classList.toggle('visible', scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD);
-                ticking = false;
-            }, THROTTLE_DELAY);
-        }
-    };
-    scrollContainer.addEventListener('scroll', onScroll, { passive: true });
-
-    // Scroll to top on click (button semantics provide keyboard activation natively)
-    const onActivate = (e) => {
-        if (e) {
-            e.preventDefault();
-            e.stopPropagation();
-        }
-
-        const userPrefersReduced = power_user.reduced_motion;
-
-        scrollContainer.scrollTo({ top: 0, behavior: userPrefersReduced ? 'auto' : 'smooth' });
-    };
-    btn.addEventListener('click', onActivate);
-
-    // Initial state check
-    if (scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD) btn.classList.add('visible');
-
-    // Return cleanup function for caller to hold and invoke when appropriate
-    return () => {
-        scrollContainer.removeEventListener('scroll', onScroll);
-        btn.removeEventListener('click', onActivate);
-    };
-}
 
 export function initBackgrounds() {
     eventSource.on(event_types.CHAT_CHANGED, onChatChanged);
@@ -898,5 +841,9 @@ export function initBackgrounds() {
         await onChatChanged();
     });
 
-    setupScrollToTop();
+    setupScrollToTop({
+        scrollContainerId: 'bg-scrollable-content',
+        buttonId: 'bg-scroll-top',
+        drawerId: 'Backgrounds',
+    });
 }

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -783,14 +783,6 @@ function setupScrollToTop() {
     };
     scrollContainer.addEventListener('scroll', onScroll, { passive: true });
 
-    // Hide the button when the drawer is closed. This is defensive—prefer emitting an event from the drawer open/close logic.
-    const drawerObserver = new MutationObserver(() => {
-        if (!drawer.classList.contains('openDrawer')) {
-            btn.classList.remove('visible');
-        }
-    });
-    drawerObserver.observe(drawer, { attributes: true, attributeFilter: ['class'] });
-
     // Scroll to top on click (button semantics provide keyboard activation natively)
     const onActivate = (e) => {
         if (e) {
@@ -811,7 +803,6 @@ function setupScrollToTop() {
     return () => {
         scrollContainer.removeEventListener('scroll', onScroll);
         btn.removeEventListener('click', onActivate);
-        drawerObserver.disconnect();
     };
 }
 

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -3,6 +3,7 @@ import {
     DOMPurify,
     Readability,
     isProbablyReaderable,
+    lodash,
 } from '../lib.js';
 
 import { getContext } from './extensions.js';
@@ -2569,12 +2570,10 @@ export function versionCompare(srcVersion, minVersion) {
  * @param {string} params.scrollContainerId Scrollable container element ID
  * @param {string} params.buttonId Button element ID
  * @param {string} params.drawerId Drawer element ID
+ * @param {number} params.visibilityThreshold Scroll position (px) to show the button (default: 300)
  * @returns {() => void} Cleanup function to remove event listeners
  */
-export function setupScrollToTop({ scrollContainerId, buttonId, drawerId }) {
-    // How far (px) the user must scroll before the scroll-to-top button appears
-    const SCROLL_VISIBILITY_THRESHOLD = 300;
-
+export function setupScrollToTop({ scrollContainerId, buttonId, drawerId, visibilityThreshold = 300 }) {
     const scrollContainer = document.getElementById(scrollContainerId);
     const btn = document.getElementById(buttonId);
     const drawer = document.getElementById(drawerId);
@@ -2590,37 +2589,23 @@ export function setupScrollToTop({ scrollContainerId, buttonId, drawerId }) {
         return () => { /* noop cleanup */ };
     }
 
-    // Throttled scroll handler
-    let ticking = false;
-    const THROTTLE_DELAY = 300; // 300ms delay
-
-    const onScroll = () => {
-        if (!ticking) {
-            ticking = true;
-
-            setTimeout(() => {
-                btn.classList.toggle('visible', scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD);
-                ticking = false;
-            }, THROTTLE_DELAY);
-        }
-    };
+    const updateButtonVisibility = () => btn.classList.toggle('visible', scrollContainer.scrollTop > visibilityThreshold);
+    const updateButtonVisibilityThrottled = lodash.throttle(updateButtonVisibility, debounce_timeout.standard, { leading: true, trailing: true });
+    const onScroll = () => updateButtonVisibilityThrottled();
     scrollContainer.addEventListener('scroll', onScroll, { passive: true });
 
     // Scroll to top on click (button semantics provide keyboard activation natively)
-    const onActivate = (e) => {
-        if (e) {
-            e.preventDefault();
-            e.stopPropagation();
-        }
+    const onActivate = (/** @type {MouseEvent} */ e) => {
+        e.preventDefault();
+        e.stopPropagation();
 
         const userPrefersReduced = power_user.reduced_motion;
-
         scrollContainer.scrollTo({ top: 0, behavior: userPrefersReduced ? 'auto' : 'smooth' });
     };
     btn.addEventListener('click', onActivate);
 
     // Initial state check
-    if (scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD) btn.classList.add('visible');
+    updateButtonVisibility();
 
     // Return cleanup function for caller to hold and invoke when appropriate
     return () => {

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -58,7 +58,7 @@ export const renderPaginationDropdown = function(pageSize, sizeChangerOptions) {
     return sizeSelect.outerHTML;
 };
 
-export const paginationDropdownChangeHandler = function (event, size) {
+export const paginationDropdownChangeHandler = function(event, size) {
     let dropdown = $(event?.originalEvent?.currentTarget || event.delegateTarget).find('select');
     dropdown.find('[selected]').removeAttr('selected');
     dropdown.find(`[value=${size}]`).attr('selected', '');
@@ -2272,7 +2272,7 @@ export async function fetchFaFile(name) {
     return [...sheet.cssRules]
         .filter(rule => rule.style?.content)
         .map(rule => rule.selectorText.split(/,\s*/).map(selector => selector.split('::').shift().slice(1)))
-        ;
+    ;
 }
 export async function fetchFa() {
     return [...new Set((await Promise.all([

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -57,7 +57,7 @@ export const renderPaginationDropdown = function(pageSize, sizeChangerOptions) {
     return sizeSelect.outerHTML;
 };
 
-export const paginationDropdownChangeHandler = function(event, size) {
+export const paginationDropdownChangeHandler = function (event, size) {
     let dropdown = $(event?.originalEvent?.currentTarget || event.delegateTarget).find('select');
     dropdown.find('[selected]').removeAttr('selected');
     dropdown.find(`[value=${size}]`).attr('selected', '');
@@ -2271,7 +2271,7 @@ export async function fetchFaFile(name) {
     return [...sheet.cssRules]
         .filter(rule => rule.style?.content)
         .map(rule => rule.selectorText.split(/,\s*/).map(selector => selector.split('::').shift().slice(1)))
-    ;
+        ;
 }
 export async function fetchFa() {
     return [...new Set((await Promise.all([
@@ -2561,4 +2561,70 @@ export function textValueMatcher(params, data) {
  */
 export function versionCompare(srcVersion, minVersion) {
     return (srcVersion || '0.0.0').localeCompare(minVersion, undefined, { numeric: true, sensitivity: 'base' }) > -1;
+}
+
+/**
+ * Sets up the scroll-to-top button functionality.
+ * @param {object} params Parameters object
+ * @param {string} params.scrollContainerId Scrollable container element ID
+ * @param {string} params.buttonId Button element ID
+ * @param {string} params.drawerId Drawer element ID
+ * @returns {() => void} Cleanup function to remove event listeners
+ */
+export function setupScrollToTop({ scrollContainerId, buttonId, drawerId }) {
+    // How far (px) the user must scroll before the scroll-to-top button appears
+    const SCROLL_VISIBILITY_THRESHOLD = 300;
+
+    const scrollContainer = document.getElementById(scrollContainerId);
+    const btn = document.getElementById(buttonId);
+    const drawer = document.getElementById(drawerId);
+
+    if (!btn || !drawer) {
+        // Not fatal; the drawer or button may not exist in some builds. Use debug level.
+        console.debug('Scroll-to-top: button or drawer not found during setup.');
+        return () => { /* noop cleanup */ };
+    }
+
+    if (!scrollContainer) {
+        console.debug('Scroll-to-top: scroll container not found during setup.');
+        return () => { /* noop cleanup */ };
+    }
+
+    // Throttled scroll handler
+    let ticking = false;
+    const THROTTLE_DELAY = 300; // 300ms delay
+
+    const onScroll = () => {
+        if (!ticking) {
+            ticking = true;
+
+            setTimeout(() => {
+                btn.classList.toggle('visible', scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD);
+                ticking = false;
+            }, THROTTLE_DELAY);
+        }
+    };
+    scrollContainer.addEventListener('scroll', onScroll, { passive: true });
+
+    // Scroll to top on click (button semantics provide keyboard activation natively)
+    const onActivate = (e) => {
+        if (e) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+
+        const userPrefersReduced = power_user.reduced_motion;
+
+        scrollContainer.scrollTo({ top: 0, behavior: userPrefersReduced ? 'auto' : 'smooth' });
+    };
+    btn.addEventListener('click', onActivate);
+
+    // Initial state check
+    if (scrollContainer.scrollTop > SCROLL_VISIBILITY_THRESHOLD) btn.classList.add('visible');
+
+    // Return cleanup function for caller to hold and invoke when appropriate
+    return () => {
+        scrollContainer.removeEventListener('scroll', onScroll);
+        btn.removeEventListener('click', onActivate);
+    };
 }

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2570,7 +2570,7 @@ export function versionCompare(srcVersion, minVersion) {
  * @param {string} params.scrollContainerId Scrollable container element ID
  * @param {string} params.buttonId Button element ID
  * @param {string} params.drawerId Drawer element ID
- * @param {number} params.visibilityThreshold Scroll position (px) to show the button (default: 300)
+ * @param {number} [params.visibilityThreshold] Scroll position (px) to show the button (default: 300)
  * @returns {() => void} Cleanup function to remove event listeners
  */
 export function setupScrollToTop({ scrollContainerId, buttonId, drawerId, visibilityThreshold = 300 }) {


### PR DESCRIPTION
This PR adds a scroll to top button to the backgrounds drawer.

- adds position: relative to bg-scrollable-content to position the button
- css and html for button
- keyboard and mobile support
- respects reduced motion

<img width="68" height="70" alt="image" src="https://github.com/user-attachments/assets/8a6f20f3-4382-497d-8e81-1e12caeda22b" />

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
