### PR TITLE
feat: Add {{notChar}} macro for participant list

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2253,6 +2253,38 @@ export function substituteParams(content, _name1, _name2, _original, _group, _re
         }
     };
 
+    const getNotCharValue = () => {
+        const currentUser = _name1 ?? name1;
+        const currentSpeaker = _name2 ?? name2;
+
+        // Impersonate mode: {{char}} is {{user}}, so {{notChar}} should be the full group.
+        if (currentSpeaker === currentUser) {
+            return getGroupValue(true);
+        }
+
+        // Single character chat
+        if (!selected_group) {
+            return currentUser;
+        }
+
+        // Group chat
+        const members = groups.find(x => x.id === selected_group)?.members;
+
+        if (!Array.isArray(members)) {
+            return currentUser;
+        }
+
+        const memberNames = members
+            .map(m => characters.find(c => c.avatar === m)?.name)
+            .filter(Boolean); // Filter out any null/undefined names
+
+        // Filter out the current speaker and add the user
+        const otherMembers = memberNames.filter(name => name !== currentSpeaker);
+        otherMembers.push(currentUser);
+
+        return otherMembers.join(', ');
+    };
+
     if (_replaceCharacterCard) {
         const fields = getCharacterCardFields();
         environment.charPrompt = fields.system || '';
@@ -2282,6 +2314,7 @@ export function substituteParams(content, _name1, _name2, _original, _group, _re
     environment.char = _name2 ?? name2;
     environment.group = environment.charIfNotGroup = getGroupValue(true);
     environment.groupNotMuted = getGroupValue(false);
+    environment.notChar = getNotCharValue();
     environment.model = getGeneratingModel();
 
     if (additionalMacro && typeof additionalMacro === 'object') {

--- a/public/script.js
+++ b/public/script.js
@@ -2257,11 +2257,6 @@ export function substituteParams(content, _name1, _name2, _original, _group, _re
         const currentUser = _name1 ?? name1;
         const currentSpeaker = _name2 ?? name2;
 
-        // Impersonate mode: {{char}} is {{user}}, so {{notChar}} should be the full group.
-        if (currentSpeaker === currentUser) {
-            return getGroupValue(true);
-        }
-
         // Single character chat
         if (!selected_group) {
             return currentUser;

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -25,7 +25,7 @@
     <li><tt>&lcub;&lcub;outlet::(name)&rcub;&rcub;</tt> – <span data-i18n="help_macros_outletName">the WI entry content for the outlet with the specified name</span></li>
     <li><tt>&lcub;&lcub;group&rcub;&rcub;</tt> – <span data-i18n="help_macros_18">a comma-separated list of group member names (including muted) or the character name in solo chats. Alias: &lcub;&lcub;charIfNotGroup&rcub;&rcub;</span></li>
     <li><tt>&lcub;&lcub;groupNotMuted&rcub;&rcub;</tt> – <span data-i18n="help_groupNotMuted">the same as &lcub;&lcub;group&rcub;&rcub;, but excludes muted members</span></li>
-    <li><tt>&lcub;&lcub;notChar&rcub;&rcub;</tt> – <span data-i18n="help_notChar">"A comma-separated list of all participants in the conversation except for the current speaker (&lcub;&lcub;char&rcub;&rcub;). In group chats, this includes muted characters.<br></li>
+    <li><tt>&lcub;&lcub;notChar&rcub;&rcub;</tt> – <span data-i18n="help_notChar">A comma-separated list of all participants in the conversation except for the current speaker (&lcub;&lcub;char&rcub;&rcub;). In group chats, this includes muted characters.<br></li>
     <li><tt>&lcub;&lcub;model&rcub;&rcub;</tt> – <span data-i18n="help_macros_19">a text generation model name for the currently selected API. </span><b data-i18n="Can be inaccurate!">Can be inaccurate!</b></li>
     <li><tt>&lcub;&lcub;lastMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_20">the text of the latest chat message.</span></li>
     <li><tt>&lcub;&lcub;lastUserMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_lastUser">the text of the latest user chat message.</span></li>

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -25,6 +25,7 @@
     <li><tt>&lcub;&lcub;outlet::(name)&rcub;&rcub;</tt> – <span data-i18n="help_macros_outletName">the WI entry content for the outlet with the specified name</span></li>
     <li><tt>&lcub;&lcub;group&rcub;&rcub;</tt> – <span data-i18n="help_macros_18">a comma-separated list of group member names (including muted) or the character name in solo chats. Alias: &lcub;&lcub;charIfNotGroup&rcub;&rcub;</span></li>
     <li><tt>&lcub;&lcub;groupNotMuted&rcub;&rcub;</tt> – <span data-i18n="help_groupNotMuted">the same as &lcub;&lcub;group&rcub;&rcub;, but excludes muted members</span></li>
+    <li><tt>&lcub;&lcub;notChar&rcub;&rcub;</tt> – A comma-separated list of all participants in the conversation except for the current speaker (<code>{{char}}</code>). In group chats, this includes muted characters.<br><em>Example: In a group with Char1, Char2, and Char3, if Char2 is speaking, this becomes "Char1, Char3, {{user}}". In a single chat, it becomes "{{user}}".</em></li>
     <li><tt>&lcub;&lcub;model&rcub;&rcub;</tt> – <span data-i18n="help_macros_19">a text generation model name for the currently selected API. </span><b data-i18n="Can be inaccurate!">Can be inaccurate!</b></li>
     <li><tt>&lcub;&lcub;lastMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_20">the text of the latest chat message.</span></li>
     <li><tt>&lcub;&lcub;lastUserMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_lastUser">the text of the latest user chat message.</span></li>

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -25,7 +25,7 @@
     <li><tt>&lcub;&lcub;outlet::(name)&rcub;&rcub;</tt> – <span data-i18n="help_macros_outletName">the WI entry content for the outlet with the specified name</span></li>
     <li><tt>&lcub;&lcub;group&rcub;&rcub;</tt> – <span data-i18n="help_macros_18">a comma-separated list of group member names (including muted) or the character name in solo chats. Alias: &lcub;&lcub;charIfNotGroup&rcub;&rcub;</span></li>
     <li><tt>&lcub;&lcub;groupNotMuted&rcub;&rcub;</tt> – <span data-i18n="help_groupNotMuted">the same as &lcub;&lcub;group&rcub;&rcub;, but excludes muted members</span></li>
-    <li><tt>&lcub;&lcub;notChar&rcub;&rcub;</tt> – <span data-i18n="help_notChar">A comma-separated list of all participants in the conversation except for the current speaker (&lcub;&lcub;char&rcub;&rcub;). In group chats, this includes muted characters.<br></li>
+    <li><tt>&lcub;&lcub;notChar&rcub;&rcub;</tt> – <span data-i18n="help_notChar">a comma-separated list of all participants in the conversation except for the current speaker (&lcub;&lcub;char&rcub;&rcub;). In group chats, this includes muted characters. When not in a generation, the list include all characters.</span></li>
     <li><tt>&lcub;&lcub;model&rcub;&rcub;</tt> – <span data-i18n="help_macros_19">a text generation model name for the currently selected API. </span><b data-i18n="Can be inaccurate!">Can be inaccurate!</b></li>
     <li><tt>&lcub;&lcub;lastMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_20">the text of the latest chat message.</span></li>
     <li><tt>&lcub;&lcub;lastUserMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_lastUser">the text of the latest user chat message.</span></li>

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -25,7 +25,7 @@
     <li><tt>&lcub;&lcub;outlet::(name)&rcub;&rcub;</tt> – <span data-i18n="help_macros_outletName">the WI entry content for the outlet with the specified name</span></li>
     <li><tt>&lcub;&lcub;group&rcub;&rcub;</tt> – <span data-i18n="help_macros_18">a comma-separated list of group member names (including muted) or the character name in solo chats. Alias: &lcub;&lcub;charIfNotGroup&rcub;&rcub;</span></li>
     <li><tt>&lcub;&lcub;groupNotMuted&rcub;&rcub;</tt> – <span data-i18n="help_groupNotMuted">the same as &lcub;&lcub;group&rcub;&rcub;, but excludes muted members</span></li>
-    <li><tt>&lcub;&lcub;notChar&rcub;&rcub;</tt> – A comma-separated list of all participants in the conversation except for the current speaker (&lcub;&lcub;char&rcub;&rcub;). In group chats, this includes muted characters.<br></li>
+    <li><tt>&lcub;&lcub;notChar&rcub;&rcub;</tt> – <span data-i18n="help_notChar">"A comma-separated list of all participants in the conversation except for the current speaker (&lcub;&lcub;char&rcub;&rcub;). In group chats, this includes muted characters.<br></li>
     <li><tt>&lcub;&lcub;model&rcub;&rcub;</tt> – <span data-i18n="help_macros_19">a text generation model name for the currently selected API. </span><b data-i18n="Can be inaccurate!">Can be inaccurate!</b></li>
     <li><tt>&lcub;&lcub;lastMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_20">the text of the latest chat message.</span></li>
     <li><tt>&lcub;&lcub;lastUserMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_lastUser">the text of the latest user chat message.</span></li>

--- a/public/scripts/templates/macros.html
+++ b/public/scripts/templates/macros.html
@@ -25,7 +25,7 @@
     <li><tt>&lcub;&lcub;outlet::(name)&rcub;&rcub;</tt> – <span data-i18n="help_macros_outletName">the WI entry content for the outlet with the specified name</span></li>
     <li><tt>&lcub;&lcub;group&rcub;&rcub;</tt> – <span data-i18n="help_macros_18">a comma-separated list of group member names (including muted) or the character name in solo chats. Alias: &lcub;&lcub;charIfNotGroup&rcub;&rcub;</span></li>
     <li><tt>&lcub;&lcub;groupNotMuted&rcub;&rcub;</tt> – <span data-i18n="help_groupNotMuted">the same as &lcub;&lcub;group&rcub;&rcub;, but excludes muted members</span></li>
-    <li><tt>&lcub;&lcub;notChar&rcub;&rcub;</tt> – A comma-separated list of all participants in the conversation except for the current speaker (<code>{{char}}</code>). In group chats, this includes muted characters.<br><em>Example: In a group with Char1, Char2, and Char3, if Char2 is speaking, this becomes "Char1, Char3, {{user}}". In a single chat, it becomes "{{user}}".</em></li>
+    <li><tt>&lcub;&lcub;notChar&rcub;&rcub;</tt> – A comma-separated list of all participants in the conversation except for the current speaker (&lcub;&lcub;char&rcub;&rcub;). In group chats, this includes muted characters.<br></li>
     <li><tt>&lcub;&lcub;model&rcub;&rcub;</tt> – <span data-i18n="help_macros_19">a text generation model name for the currently selected API. </span><b data-i18n="Can be inaccurate!">Can be inaccurate!</b></li>
     <li><tt>&lcub;&lcub;lastMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_20">the text of the latest chat message.</span></li>
     <li><tt>&lcub;&lcub;lastUserMessage&rcub;&rcub;</tt> – <span data-i18n="help_macros_lastUser">the text of the latest user chat message.</span></li>


### PR DESCRIPTION
Closes #4536

This pull request introduces a new dynamic macro, `{{notChar}}`, which resolves to a comma-separated list of all participants in a conversation *except* for the current speaker (`{{char}}`).

This provides more granular control for prompts, particularly in group chat scenarios where context about "everyone else" listening or present is needed.

### Macro Behavior

The `{{notChar}}` macro behaves according to the following rules:

*   **In a group chat:** It resolves to a list of all other characters in the group (including muted ones), plus `{{user}}`.
    *   **Example:** For a group with `Char1`, `Char2`, and `Char3`, if the current speaker is `Char2`, `{{notChar}}` will become `"Char1, Char3, {{user}}"`.

*   **In a single-character chat:** It resolves to `{{user}}`, as the user is the only other participant.