### PR TITLE
Fix listing tags already assigned to a char on tag import popup

### DIFF
--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -765,8 +765,13 @@ async function importTags(character, { importSetting = null } = {}) {
  */
 async function handleTagImport(character, { importSetting = null } = {}) {
     /** @type {string[]} */
+    const alreadyAssignedTags = tag_map[character.avatar] ?? [];
     const importTags = character.tags.map(t => t.trim()).filter(t => t)
         .filter(t => !IMPORT_EXLCUDED_TAGS.includes(t))
+        .filter(t => {
+            const existingTag = getTag(t);
+            return !existingTag || !alreadyAssignedTags.includes(existingTag.id);
+        })
         .slice(0, ANTI_TROLL_MAX_TAGS);
     const existingTags = getExistingTags(importTags);
     const newTags = importTags.filter(t => !existingTags.some(existingTag => existingTag.name.toLowerCase() === t.toLowerCase()))


### PR DESCRIPTION
Noticed this when working on #4581, as it was more obvious there. Thought I make it a separate PR though, to not mix that bugfix with the new feature there too.

It's also easily reproducible by using the "Import Tags" functionality on a char and then just clicking "Import Existing". It'll work, but show an error toast saying tags could not be imported. Because from the listed tags none could be imported.

Error is right, code was wrong.
We should not show tags in the "Import Tags" popup that are already assigned to the char. Doesn't matter for any new char, but it does matter when re-importing tags on existing characters, or like in the PR, replacing character and importing their tags.

## Copilot Summary
This pull request improves the tag import functionality for characters by ensuring that tags already assigned to a character are not duplicated during the import process.

**Tag import improvements:**

* Updated the `handleTagImport` function in `tags.js` to filter out tags that are already assigned to the character, preventing duplicate tag assignments.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
