### PR TITLE
Small change, (visually) disable "Link to Source" on characters that weren't downloaded from a source

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7516,7 +7516,7 @@ export function select_rm_info(type, charId, previousCharId = null) {
 
 /**
  * Selects the right menu for displaying the character editor.
- * @param {number|string} chid Character array index
+ * @param {string} chid Character array index
  * @param {object} [param1] Options for the switch
  * @param {boolean} [param1.switchMenu=true] Whether to switch the menu
  */
@@ -7595,7 +7595,7 @@ export function select_selected_character(chid, { switchMenu = true } = {}) {
     $('#character_media_forbidden_icon').toggle(!externalMediaState);
 
     // Update some stuff about the char management dropdown
-    $('#character_source').attr('disabled', !getCharacterSource(this_chid) ? '' : null);
+    $('#character_source').attr('disabled', selected_group || !getCharacterSource(chid) ? '' : null);
 
     eventSource.emit(event_types.CHARACTER_EDITOR_OPENED, chid);
 

--- a/public/script.js
+++ b/public/script.js
@@ -7597,7 +7597,7 @@ export function select_selected_character(chid, { switchMenu = true } = {}) {
     // Update some stuff about the char management dropdown
     $('#character_source').attr('disabled', !getCharacterSource(this_chid) ? '' : null);
 
-    eventSource.emit(event_types.CHARACTER_SELECT_SELECTED, chid);
+    eventSource.emit(event_types.CHARACTER_EDITOR_OPENED, chid);
 
     saveSettingsDebounced();
 }

--- a/public/script.js
+++ b/public/script.js
@@ -7594,6 +7594,9 @@ export function select_selected_character(chid, { switchMenu = true } = {}) {
     $('#character_media_allowed_icon').toggle(externalMediaState);
     $('#character_media_forbidden_icon').toggle(!externalMediaState);
 
+    // Update some stuff about the char management dropdown
+    $('#character_source').attr('disabled', !getCharacterSource(this_chid) ? '' : null);
+
     saveSettingsDebounced();
 }
 

--- a/public/script.js
+++ b/public/script.js
@@ -7597,6 +7597,8 @@ export function select_selected_character(chid, { switchMenu = true } = {}) {
     // Update some stuff about the char management dropdown
     $('#character_source').attr('disabled', !getCharacterSource(this_chid) ? '' : null);
 
+    eventSource.emit(event_types.CHARACTER_SELECT_SELECTED, chid);
+
     saveSettingsDebounced();
 }
 

--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -36,6 +36,7 @@ export const event_types = {
     OAI_PRESET_IMPORT_READY: 'oai_preset_import_ready',
     WORLDINFO_SETTINGS_UPDATED: 'worldinfo_settings_updated',
     WORLDINFO_UPDATED: 'worldinfo_updated',
+    CHARACTER_SELECT_SELECTED: 'character_select_selected',
     CHARACTER_EDITED: 'character_edited',
     CHARACTER_PAGE_LOADED: 'character_page_loaded',
     CHARACTER_GROUP_OVERLAY_STATE_CHANGE_BEFORE: 'character_group_overlay_state_change_before',

--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -36,7 +36,7 @@ export const event_types = {
     OAI_PRESET_IMPORT_READY: 'oai_preset_import_ready',
     WORLDINFO_SETTINGS_UPDATED: 'worldinfo_settings_updated',
     WORLDINFO_UPDATED: 'worldinfo_updated',
-    CHARACTER_SELECT_SELECTED: 'character_select_selected',
+    CHARACTER_EDITOR_OPENED: 'character_editor_opened',
     CHARACTER_EDITED: 'character_edited',
     CHARACTER_PAGE_LOADED: 'character_page_loaded',
     CHARACTER_GROUP_OVERLAY_STATE_CHANGE_BEFORE: 'character_group_overlay_state_change_before',

--- a/public/style.css
+++ b/public/style.css
@@ -2931,6 +2931,10 @@ select option:not(:checked) {
     color: var(--white70a);
 }
 
+select option[disabled]:not(:checked) {
+    color: var(--white30a);
+}
+
 /*#######################################################################*/
 
 #rm_api_block {


### PR DESCRIPTION
Very small change, just a visual thingy.
I wasn't that happy that "Link to Source" always showed up and only showed there is no source when you clicked it.
It's nice to have a quicker indicator that a char was not downloaded from an URL source.

<img width="364" height="425" alt="image" src="https://github.com/user-attachments/assets/1d055b03-7c00-47fc-9ac9-0151b86a1f18" />

## Copilot Summary
This pull request introduces a minor UI improvement related to character management and dropdown appearance. The main changes ensure that the character source dropdown is properly enabled or disabled based on the character's source, and visually distinguishes disabled options in select dropdowns.

UI/UX improvements:

* [`public/script.js`](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R7597-R7599): The `select_selected_character` function now disables the `#character_source` dropdown when the selected character does not have a source, improving the clarity of the character management interface.
* [`public/style.css`](diffhunk://#diff-46467272678c3da621692b13b96d47ed25128fa8027d8dbedd84684c6336fb51R2934-R2937): Disabled options in select dropdowns are now styled with a lighter color, making it visually clear which options are unavailable.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
