### PR TITLE
Fix make `/profile` await the for an actual successful API connection

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -723,13 +723,11 @@ async function renderDetailsContent(detailsContent) {
             if (shouldAwait) {
                 await awaitPromise;
 
-                try {
-                    // We should also await the connection to be established
-                    const parsedTimeout = parseInt(args?.timeout?.toString());
-                    const timeout = !isNaN(parsedTimeout) ? Math.max(0, parsedTimeout) : 2000;
-                    await waitUntilCondition(() => online_status !== 'no_connection', timeout, 100);
-                } catch (e) {
-                    console.log(e);
+                // We should also await the connection to be established
+                const parsedTimeout = parseInt(args?.timeout?.toString());
+                const timeout = !isNaN(parsedTimeout) ? Math.max(0, parsedTimeout) : 2000;
+                if (timeout > 0) {
+                    await waitUntilCondition(() => online_status !== 'no_connection', timeout, 100, { rejectOnTimeout: false });
                 }
             }
 

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -1,6 +1,6 @@
 import { DOMPurify, Fuse } from '../../../lib.js';
 
-import { event_types, eventSource, main_api, saveSettingsDebounced } from '../../../script.js';
+import { event_types, eventSource, main_api, online_status, saveSettingsDebounced } from '../../../script.js';
 import { extension_settings, renderExtensionTemplateAsync } from '../../extensions.js';
 import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from '../../popup.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
@@ -11,7 +11,7 @@ import { SlashCommandDebugController } from '../../slash-commands/SlashCommandDe
 import { enumTypes, SlashCommandEnumValue } from '../../slash-commands/SlashCommandEnumValue.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
 import { SlashCommandScope } from '../../slash-commands/SlashCommandScope.js';
-import { collapseSpaces, getUniqueName, isFalseBoolean, uuidv4 } from '../../utils.js';
+import { collapseSpaces, getUniqueName, isFalseBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
 import { t } from '../../i18n.js';
 import { getSecretLabelById } from '../../secrets.js';
 
@@ -715,6 +715,9 @@ async function renderDetailsContent(detailsContent) {
 
             if (shouldAwait) {
                 await awaitPromise;
+
+                // We should also await the connection to be established
+                await waitUntilCondition(() => online_status !== 'no_connection', 5000, 100);
             }
 
             return profile.name;

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -684,6 +684,13 @@ async function renderDetailsContent(detailsContent) {
                 defaultValue: 'true',
                 enumList: commonEnumProviders.boolean('trueFalse')(),
             }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'timeout',
+                description: 'Maximum time to wait for the API connection to be established, in milliseconds. Set to 0 to disable. Only applies when await=true.',
+                isRequired: false,
+                typeList: [ARGUMENT_TYPE.NUMBER],
+                defaultValue: '2000',
+            }),
         ],
         callback: async (args, value) => {
             if (!value || typeof value !== 'string') {
@@ -716,8 +723,14 @@ async function renderDetailsContent(detailsContent) {
             if (shouldAwait) {
                 await awaitPromise;
 
-                // We should also await the connection to be established
-                await waitUntilCondition(() => online_status !== 'no_connection', 5000, 100);
+                try {
+                    // We should also await the connection to be established
+                    const parsedTimeout = parseInt(args?.timeout?.toString());
+                    const timeout = !isNaN(parsedTimeout) ? Math.max(0, parsedTimeout) : 2000;
+                    await waitUntilCondition(() => online_status !== 'no_connection', timeout, 100);
+                } catch (e) {
+                    console.log(e);
+                }
             }
 
             return profile.name;

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1637,13 +1637,18 @@ export function createThumbnail(dataUrl, maxWidth = null, maxHeight = null, type
  * @param {{ (): boolean; }} condition The condition to wait for.
  * @param {number} [timeout=1000] The timeout in milliseconds.
  * @param {number} [interval=100] The interval in milliseconds.
+ * @param {object} [options] Options object
+ * @param {boolean} [options.rejectOnTimeout=true] Whether to reject the promise on timeout or resolve it.
  * @returns {Promise<void>} A promise that resolves when the condition is true.
  */
-export async function waitUntilCondition(condition, timeout = 1000, interval = 100) {
+export async function waitUntilCondition(condition, timeout = 1000, interval = 100, options = {}) {
+    const { rejectOnTimeout = true } = options;
+
     return new Promise((resolve, reject) => {
         const timeoutId = setTimeout(() => {
             clearInterval(intervalId);
-            reject(new Error('Timed out waiting for condition to be true'));
+            const timeoutFn = rejectOnTimeout ? reject : resolve;
+            timeoutFn(new Error('Timed out waiting for condition to be true'));
         }, timeout);
 
         const intervalId = setInterval(() => {


### PR DESCRIPTION
Any `/profile` command should await if `/api` was called and the connection has changed, so the actual connection is established before continuing.
Otherwise any following continue command can't utilize the new profile correctly.

This is only applied if `await=true` is set on the `/profile` command, which defaults to `true`, as a sensible default.
Worst case, if you want to connect to an API that does not have a successful connection via slash commands, either manually set `await=false` or wait the five seconds...

This is a much more reasonable default state.

Fixes #4262

## Copilot Summary
This pull request makes a small update to the `connection-manager` extension script by ensuring that, when awaiting a connection-related promise, the code now also waits until the application is no longer in a "no connection" state. This is achieved by adding a utility function to wait for the `online_status` to change, improving reliability when establishing connections. Additionally, necessary imports have been updated to support this change.

Key changes:

**Connection status handling:**
* Added a call to `waitUntilCondition` after awaiting the main promise in `renderDetailsContent`, ensuring the code waits until `online_status` is no longer `'no_connection'` before proceeding.

**Imports and dependencies:**
* Imported `online_status` from `script.js` to access the current connection status.
* Imported `waitUntilCondition` from `utils.js` to support the new waiting logic.


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
