### PR TITLE
Fix re-enable character source (open link) when group is selected

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7618,7 +7618,7 @@ export function select_selected_character(chid, { switchMenu = true } = {}) {
     $('#character_media_forbidden_icon').toggle(!externalMediaState);
 
     // Update some stuff about the char management dropdown
-    $('#character_source').attr('disabled', selected_group || !getCharacterSource(chid) ? '' : null);
+    $('#character_source').attr('disabled', !getCharacterSource(chid) ? '' : null);
 
     eventSource.emit(event_types.CHARACTER_EDITOR_OPENED, chid);
 


### PR DESCRIPTION
Cohee broke it, I fix it.
Groups on char peek still allow reading and showing the character source. As long as there is no gen, `this_chid` works. So we can just rely on that.

## Copilot Summary
This pull request makes a minor update to the logic controlling the disabled state of the `#character_source` dropdown in the character selection process. The condition now only disables the dropdown if there is no character source, regardless of the selected group.

- User interface logic:
  * Updated the condition for disabling the `#character_source` dropdown in the `select_selected_character` function to depend solely on the presence of a character source, removing the check for `selected_group`.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
