### PR TITLE
Hide self-responses option in group chat unless "natural" strategy chosen

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3299,6 +3299,10 @@ input[type=search]:focus::-webkit-search-cancel-button {
     position: relative;
 }
 
+#rm_group_top_bar:not(:has(#rm_group_activation_strategy option[value="0"]:checked)) label:has(#rm_group_allow_self_responses) {
+    display: none;
+}
+
 .group_member .queue_position:not(:empty)::before {
     content: "#";
 }


### PR DESCRIPTION
Supersedes #3752 as the *correct* choice.
Based on Cohee's reply, the "allow self responses" toggle was only ever intended for natural activation strategy. So we should only show it there.

(No need to reset the option in the background, as it doesn't do anything for any other strategy as is.)

## Copilot Summary
This pull request introduces a small CSS change to conditionally hide a label in the group top bar UI. The update ensures that the label associated with `#rm_group_allow_self_responses` is only visible when a specific activation strategy is selected.

- UI Conditional Visibility:
  * In `public/style.css`, the label for `#rm_group_allow_self_responses` inside `#rm_group_top_bar` is hidden unless the activation strategy select box has the value "0" selected.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
