### PR TITLE
Fix group chat on new chat not respecting saved persona connections

### DIFF
--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1559,7 +1559,7 @@ async function loadPersonaForCurrentChat({ doRender = false } = {}) {
 export function getConnectedPersonas(characterKey = undefined) {
     characterKey ??= selected_group || characters[Number(this_chid)]?.avatar;
     const connectedPersonas = Object.entries(power_user.persona_descriptions)
-        .filter(([_, { connections }]) => connections?.some(conn => conn.type === (selected_group ? 'group' : 'character') && conn.id === characterKey))
+        .filter(([_, { connections }]) => connections?.some(conn => conn.id === characterKey))
         .map(([key, _]) => key);
     return connectedPersonas;
 }

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1559,10 +1559,7 @@ async function loadPersonaForCurrentChat({ doRender = false } = {}) {
 export function getConnectedPersonas(characterKey = undefined) {
     characterKey ??= selected_group || characters[Number(this_chid)]?.avatar;
     const connectedPersonas = Object.entries(power_user.persona_descriptions)
-        .filter(([_, desc]) => desc.connections?.some(conn => selected_group ?
-            conn.type === 'group' && conn.id === selected_group :
-            conn.type === 'character' && conn.id === characterKey,
-        ))
+        .filter(([_, { connections }]) => connections?.some(conn => conn.type === (selected_group ? 'group' : 'character') && conn.id === characterKey))
         .map(([key, _]) => key);
     return connectedPersonas;
 }

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1559,7 +1559,10 @@ async function loadPersonaForCurrentChat({ doRender = false } = {}) {
 export function getConnectedPersonas(characterKey = undefined) {
     characterKey ??= selected_group || characters[Number(this_chid)]?.avatar;
     const connectedPersonas = Object.entries(power_user.persona_descriptions)
-        .filter(([_, desc]) => desc.connections?.some(conn => conn.type === 'character' && conn.id === characterKey))
+        .filter(([_, desc]) => desc.connections?.some(conn => selected_group ?
+            conn.type === 'group' && conn.id === selected_group :
+            conn.type === 'character' && conn.id === characterKey,
+        ))
         .map(([key, _]) => key);
     return connectedPersonas;
 }


### PR DESCRIPTION
As title says.

Groups had correct persona connections support, but starting a new chat and calling `getConnectedPersonas` did not load the correct connected personas, defaulting to the default persona instead.

Fixes #3876

## Copilot
This pull request updates the logic for retrieving connected personas to better handle both character and group connections. The main change is an improvement to the filtering condition in the `getConnectedPersonas` function, ensuring that when a group is selected, the function checks for group connections, and otherwise checks for character connections.

**Persona connection logic improvements:**

* Updated `getConnectedPersonas` in `personas.js` to correctly filter for group connections when `selected_group` is set, and for character connections otherwise.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
