### PR TITLE
Authentik automatic login support

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -82,26 +82,30 @@ requestProxy:
 enableUserAccounts: false
 # Enable discreet login mode: hides user list on the login screen
 enableDiscreetLogin: false
-# Enable's authlia based auto login. Only enable this if you
-# have setup and installed Authelia as a middle-ware on your
-# reverse proxy
-# https://www.authelia.com/
-# This will use auto login to an account with the same username
-# as that used for authlia. (Ensure the username in authlia
-# is an exact match in lowercase with that in sillytavern)
-autheliaAuth: false
-# Enable's authentik based auto login. Only enable this if you
-# have setup and installed Authentik as a middle-ware on your
-# reverse proxy.
-# https://goauthentik.io/
-# This will use auto login to an account with the same username
-# as that used for authentik. (Ensure the username in authentik
-# is an exact match in lowercase with that in sillytavern).
-authentikAuth: false
 # If `basicAuthMode` and this are enabled then
 # the username and passwords for basic auth are the same as those
 # for the individual accounts
 perUserBasicAuth: false
+
+# -- SSO LOGIN CONFIGURATION --
+sso:
+  # Enable's authlia based auto login. Only enable this if you
+  # have setup and installed Authelia as a middle-ware on your
+  # reverse proxy
+  # https://www.authelia.com/
+  # This will use auto login to an account with the same username
+  # as that used for authlia. (Ensure the username in authlia
+  # is an exact match in lowercase with that in sillytavern)
+  autheliaAuth: false
+  # Enable's authentik based auto login. Only enable this if you
+  # have setup and installed Authentik as a middle-ware on your
+  # reverse proxy.
+  # https://goauthentik.io/
+  # This will use auto login to an account with the same username
+  # as that used for authentik. (Ensure the username in authentik
+  # is an exact match in lowercase with that in sillytavern).
+  authentikAuth: false
+
 # Host whitelist configuration. Recommended if you're using a listen mode
 hostWhitelist:
   # Enable or disable host whitelisting

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -90,6 +90,14 @@ enableDiscreetLogin: false
 # as that used for authlia. (Ensure the username in authlia
 # is an exact match in lowercase with that in sillytavern)
 autheliaAuth: false
+# Enable's authentik based auto login. Only enable this if you
+# have setup and installed Authentik as a middle-ware on your
+# reverse proxy.
+# https://goauthentik.io/
+# This will use auto login to an account with the same username
+# as that used for authentik. (Ensure the username in authentik
+# is an exact match in lowercase with that in sillytavern).
+authentikAuth: false
 # If `basicAuthMode` and this are enabled then
 # the username and passwords for basic auth are the same as those
 # for the individual accounts

--- a/src/config-init.js
+++ b/src/config-init.js
@@ -124,6 +124,16 @@ const keyMigrationMap = [
         migrate: () => void 0,
         remove: true,
     },
+    {
+        oldKey: 'autheliaAuth',
+        newKey: 'sso.autheliaAuth',
+        migrate: (value) => value,
+    },
+    {
+        oldKey: 'authentikAuth',
+        newKey: 'sso.authentikAuth',
+        migrate: (value) => value,
+    },
 ];
 
 /**

--- a/src/users.js
+++ b/src/users.js
@@ -25,6 +25,7 @@ export const KEY_PREFIX = 'user:';
 const AVATAR_PREFIX = 'avatar:';
 const ENABLE_ACCOUNTS = getConfigValue('enableUserAccounts', false, 'boolean');
 const AUTHELIA_AUTH = getConfigValue('autheliaAuth', false, 'boolean');
+const AUTHENTIK_AUTH = getConfigValue('authentikAuth', false, 'boolean');
 const PER_USER_BASIC_AUTH = getConfigValue('perUserBasicAuth', false, 'boolean');
 const ANON_CSRF_SECRET = crypto.randomBytes(64).toString('base64');
 
@@ -716,6 +717,10 @@ export async function tryAutoLogin(request, basicAuthMode) {
             return true;
         }
 
+        if (AUTHENTIK_AUTH && await authentikUserLogin(request)) {
+            return true;
+        }
+
         if (basicAuthMode && PER_USER_BASIC_AUTH && await basicUserLogin(request)) {
             return true;
         }
@@ -746,20 +751,41 @@ async function singleUserLogin(request) {
 }
 
 /**
- * Tries auto-login with authlia trusted headers.
+ * Attempts auto-login using an Authelia header.
  * https://www.authelia.com/integration/trusted-header-sso/introduction/
  * @param {import('express').Request} request Request object
  * @returns {Promise<boolean>} Whether auto-login was performed
  */
 async function autheliaUserLogin(request) {
+    return headerUserLogin(request, 'Remote-User');
+}
+
+/**
+ * Attempts auto-login using an Authentik header.
+ * https://docs.goauthentik.io/add-secure-apps/providers/proxy/forward_auth/
+ * @param {import('express').Request} request Request object
+ * @returns {Promise<boolean>} Whether auto-login was performed
+ */
+async function authentikUserLogin(request) {
+    return headerUserLogin(request, 'X-Authentik-Username');
+}
+
+/**
+ * Tries auto-login with a given header.
+ * @param {import('express').Request} request Request object
+ * @param {string} [header='Remote-User'] The header to use for the trusted user
+ * @returns {Promise<boolean>} Whether auto-login was performed
+ */
+async function headerUserLogin(request, header = 'Remote-User') {
     if (!request.session) {
         return false;
     }
 
-    const remoteUser = request.get('Remote-User');
+    const remoteUser = request.get(header);
     if (!remoteUser) {
         return false;
     }
+    console.debug(`Attempting auto-login for user from header ${header}: ${remoteUser}`);
 
     const userHandles = await getAllUserHandles();
     for (const userHandle of userHandles) {

--- a/src/users.js
+++ b/src/users.js
@@ -24,8 +24,8 @@ import { serverDirectory } from './server-directory.js';
 export const KEY_PREFIX = 'user:';
 const AVATAR_PREFIX = 'avatar:';
 const ENABLE_ACCOUNTS = getConfigValue('enableUserAccounts', false, 'boolean');
-const AUTHELIA_AUTH = getConfigValue('autheliaAuth', false, 'boolean');
-const AUTHENTIK_AUTH = getConfigValue('authentikAuth', false, 'boolean');
+const AUTHELIA_AUTH = getConfigValue('sso.autheliaAuth', false, 'boolean');
+const AUTHENTIK_AUTH = getConfigValue('sso.authentikAuth', false, 'boolean');
 const PER_USER_BASIC_AUTH = getConfigValue('perUserBasicAuth', false, 'boolean');
 const ANON_CSRF_SECRET = crypto.randomBytes(64).toString('base64');
 


### PR DESCRIPTION
Current [SSO documentation](https://docs.sillytavern.app/administration/sso/#sign-in-with-sso) suggests using Authentik, but the app itself does not actually support it. This PR addresses this issue, including the config for Authentik, and slightly more abstracted header login function for re-use with other such proxies going forward, as well as a line in the logs for easier debugging.

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
