### PR TITLE
Small fix to not show a (wrong) error on quickly switching to group chat

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6680,7 +6680,7 @@ async function getChatResult() {
 }
 
 function getFirstMessage() {
-    const firstMes = characters[this_chid].first_mes || '';
+    const firstMes = characters[this_chid]?.first_mes || '';
     const alternateGreetings = characters[this_chid]?.data?.alternate_greetings;
 
     const message = {


### PR DESCRIPTION
This happened when I switch from a char to a group via my favorites menu. Dunno if it only happens if I click on it multiple times, but it sure is a bug.
Easy fix.

<img width="360" height="175" alt="image" src="https://github.com/user-attachments/assets/e60326a3-8619-4f58-9b61-8a0a2d5bcf76" />


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).

