### PR TITLE
Fix not jumping twice to group chat when creating a new group chat with deleting the old one

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9054,7 +9054,7 @@ export async function doNewChat({ deleteCurrentChat = false } = {}) {
 
     if (selected_group) {
         await createNewGroupChat(selected_group);
-        if (deleteCurrentChat) await deleteGroupChat(selected_group, chat_file_for_del);
+        if (deleteCurrentChat) await deleteGroupChat(selected_group, chat_file_for_del, { jumpToNewChat: false }); // don't jump, new chat was already created and jumped to above
     }
     else {
         //RossAscends: added character name to new chat filenames and replaced Date.now() with humanizedDateTime;

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -2018,7 +2018,14 @@ export async function deleteGroupChatByName(groupId, chatName) {
     await eventSource.emit(event_types.GROUP_CHAT_DELETED, chatName);
 }
 
-export async function deleteGroupChat(groupId, chatId) {
+/**
+ * Deletes a group chat by name.
+ * @param {string} groupId The ID of the group containing the chat to delete.
+ * @param {string} chatId The id/name of the chat to delete.
+ * @param {object} [options={}] Options for the deletion.
+ * @param {boolean} [options.jumpToNewChat=true] Whether to jump to a new chat after deletion (existing one, or create a new one if none exists)
+ */
+export async function deleteGroupChat(groupId, chatId, { jumpToNewChat = true } = {}) {
     const group = groups.find(x => x.id === groupId);
 
     if (!group || !group.chats.includes(chatId)) {
@@ -2038,10 +2045,12 @@ export async function deleteGroupChat(groupId, chatId) {
     });
 
     if (response.ok) {
-        if (group.chats.length) {
-            await openGroupChat(groupId, group.chats[group.chats.length - 1]);
-        } else {
-            await createNewGroupChat(groupId);
+        if (jumpToNewChat) {
+            if (group.chats.length) {
+                await openGroupChat(groupId, group.chats[group.chats.length - 1]);
+            } else {
+                await createNewGroupChat(groupId);
+            }
         }
 
         await eventSource.emit(event_types.GROUP_CHAT_DELETED, chatId);

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -2039,6 +2039,8 @@ export async function deleteGroupChat(groupId, chatId, { jumpToNewChat = true } 
         updateChatMetadata(group.chat_metadata, true);
     }
 
+    group.chats.splice(group.chats.indexOf(chatId), 1);
+
     const response = await fetch('/api/chats/group/delete', {
         method: 'POST',
         headers: getRequestHeaders(),

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -2032,14 +2032,14 @@ export async function deleteGroupChat(groupId, chatId, { jumpToNewChat = true } 
         return;
     }
 
+    group.chats.splice(group.chats.indexOf(chatId), 1);
+    delete group.past_metadata[chatId];
+
     if (group.chat_id === chatId) {
-        group.chat_metadata = {};
         group.chat_id = '';
-        delete group.past_metadata[chatId];
+        group.chat_metadata = {};
         updateChatMetadata(group.chat_metadata, true);
     }
-
-    group.chats.splice(group.chats.indexOf(chatId), 1);
 
     const response = await fetch('/api/chats/group/delete', {
         method: 'POST',

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -2032,11 +2032,12 @@ export async function deleteGroupChat(groupId, chatId, { jumpToNewChat = true } 
         return;
     }
 
-    group.chats.splice(group.chats.indexOf(chatId), 1);
-    group.chat_metadata = {};
-    group.chat_id = '';
-    delete group.past_metadata[chatId];
-    updateChatMetadata(group.chat_metadata, true);
+    if (group.chat_id === chatId) {
+        group.chat_metadata = {};
+        group.chat_id = '';
+        delete group.past_metadata[chatId];
+        updateChatMetadata(group.chat_metadata, true);
+    }
 
     const response = await fetch('/api/chats/group/delete', {
         method: 'POST',


### PR DESCRIPTION
I am finding more and more bugs in group chats...
~~(who uses those anyway?)~~

btw, **jumo** is a vibe. That was on purpose.

Steps to reproduce:
- Open group chat.
- Select "New Chat", select the checkbox "delete current chat"
- there it is

## Copilot Summary
This pull request enhances the group chat deletion workflow by introducing an option to control whether the UI jumps to a new chat after deleting a group chat. This adds flexibility for different scenarios where automatic navigation may or may not be desired.

**Group chat deletion improvements:**

* Added an optional `jumpToNewChat` parameter (defaulting to `true`) to the `deleteGroupChat` function in `public/scripts/group-chats.js`, allowing callers to specify whether to automatically jump to a new chat after deletion.
* Updated the logic in `deleteGroupChat` to only navigate to a new chat if `jumpToNewChat` is `true`.
* Modified the call to `deleteGroupChat` in `doNewChat` (in `public/script.js`) to pass `{ jumpToNewChat: false }` when creating and jumping to a new chat, preventing redundant navigation.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
