### PR TITLE
Reprint non-tainted group chat on switching personas

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5040,6 +5040,8 @@ export async function sendMessageAsUser(messageText, messageBias, insertAt = nul
     await populateFileAttachment(message);
     statMesProcess(message, 'user', characters, this_chid, '');
 
+    chat_metadata['tainted'] = true;
+
     if (typeof insertAt === 'number' && insertAt >= 0 && insertAt <= chat.length) {
         chat.splice(insertAt, 0, message);
         await saveChatConditional();

--- a/public/script.js
+++ b/public/script.js
@@ -391,7 +391,7 @@ let isExportPopupOpen = false;
 
 // Saved here for performance reasons
 const messageTemplate = $('#message_template .mes');
-const chatElement = $('#chat');
+export const chatElement = $('#chat');
 
 let dialogueResolve = null;
 let dialogueCloseStop = false;

--- a/public/script.js
+++ b/public/script.js
@@ -8330,7 +8330,7 @@ function addAlternateGreeting(template, greeting, index, getArray, popup) {
  * Creates or edits a character based on the form data.
  * @param {Event} [e] Event that triggered the function call.
  */
-async function createOrEditCharacter(e) {
+export async function createOrEditCharacter(e) {
     $('#rm_info_avatar').html('');
     const formData = new FormData(/** @type {HTMLFormElement} */($('#form_create').get(0)));
     formData.set('fav', String(fav_ch_checked));

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -1,6 +1,6 @@
 import { ensureImageFormatSupported, getBase64Async, getFileExtension, isTrueBoolean, saveBase64AsFile } from '../../utils.js';
 import { getContext, getApiUrl, doExtrasFetch, extension_settings, modules, renderExtensionTemplateAsync } from '../../extensions.js';
-import { appendMediaToMessage, eventSource, event_types, getRequestHeaders, saveChatConditional, saveSettingsDebounced, substituteParamsExtended } from '../../../script.js';
+import { appendMediaToMessage, chat_metadata, eventSource, event_types, getRequestHeaders, saveChatConditional, saveSettingsDebounced, substituteParamsExtended } from '../../../script.js';
 import { getMessageTimeStamp } from '../../RossAscends-mods.js';
 import { SECRET_KEYS, secret_state } from '../../secrets.js';
 import { getMultimodalCaption } from '../shared.js';
@@ -174,6 +174,7 @@ async function sendCaptionedMessage(caption, image) {
             inline_image: !!extension_settings.caption.show_in_chat,
         },
     };
+    chat_metadata['tainted'] = true;
     context.chat.push(message);
     const messageId = context.chat.length - 1;
     await eventSource.emit(event_types.MESSAGE_SENT, messageId);

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -7,6 +7,7 @@ import {
     default_user_avatar,
     eventSource,
     event_types,
+    getCurrentChatId,
     getRequestHeaders,
     getThumbnailUrl,
     groupToEntity,
@@ -69,6 +70,9 @@ export let user_avatar = '';
 /** @type {FilterHelper} Filter helper for the persona list */
 export const personasFilter = new FilterHelper(debounce(getUserAvatars, debounce_timeout.quick));
 
+/** @type {string} The last loaded chat id to remember for persona loading */
+let personaLastLoadedChatId = null;
+
 /** @type {function(string): void} */
 let navigateToAvatar = () => { };
 
@@ -107,12 +111,16 @@ export function initUserAvatar(avatar) {
  * @param {boolean} [options.toastPersonaNameChange=true] Whether to show a toast when the persona name is changed
  * @param {boolean} [options.navigateToCurrent=false] Whether to navigate to the current persona after setting the avatar
  */
-export function setUserAvatar(imgfile, { toastPersonaNameChange = true, navigateToCurrent = false } = {}) {
+export async function setUserAvatar(imgfile, { toastPersonaNameChange = true, navigateToCurrent = false } = {}) {
+    const currentUserAvatar = user_avatar;
     user_avatar = imgfile && typeof imgfile === 'string' ? imgfile : $(this).attr('data-avatar-id');
+    if (currentUserAvatar === user_avatar) {
+        return;
+    }
     reloadUserAvatar();
     updatePersonaUIStates({ navigateToCurrent: navigateToCurrent });
     selectCurrentPersona({ toastPersonaNameChange: toastPersonaNameChange });
-    retriggerFirstMessageOnEmptyChat();
+    await retriggerFirstMessageOnEmptyChat();
     saveSettingsDebounced();
     $('.zoomed_avatar[forchar]').remove();
 }
@@ -732,13 +740,13 @@ export async function askForPersonaSelection(title, text, personas, { okButton =
 /**
  * Automatically selects a persona based on the given name if a matching persona exists.
  * @param {string} name - The name to search for
- * @returns {boolean} True if a matching persona was found and selected, false otherwise
+ * @returns {Promise<boolean>} True if a matching persona was found and selected, false otherwise
  */
-export function autoSelectPersona(name) {
+export async function autoSelectPersona(name) {
     for (const [key, value] of Object.entries(power_user.personas)) {
         if (value === name) {
             console.log(`Auto-selecting persona ${key} for name ${name}`);
-            setUserAvatar(key);
+            await setUserAvatar(key);
             return true;
         }
     }
@@ -1429,13 +1437,16 @@ function getPersonaTemporaryLockInfo() {
  * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating whether a persona was selected
  */
 async function loadPersonaForCurrentChat({ doRender = false } = {}) {
+    if (getCurrentChatId() === personaLastLoadedChatId) return;
+    personaLastLoadedChatId = getCurrentChatId();
+
     // Cache persona list to check if they exist
     const userAvatars = await getUserAvatars(doRender);
 
     // Check if the user avatar is set and exists in the list of user avatars
     if (userAvatars.length && !userAvatars.includes(user_avatar)) {
         console.log(`User avatar ${user_avatar} not found in user avatars list, pick the first available one`);
-        setUserAvatar(userAvatars[0], { toastPersonaNameChange: false, navigateToCurrent: true });
+        await setUserAvatar(userAvatars[0], { toastPersonaNameChange: false, navigateToCurrent: true });
     }
 
     // Define a persona for this chat
@@ -1530,7 +1541,7 @@ async function loadPersonaForCurrentChat({ doRender = false } = {}) {
     // Persona avatar found, select it
     if (chatPersona && user_avatar !== chatPersona) {
         const willAutoLock = power_user.persona_auto_lock && user_avatar !== chat_metadata['persona'];
-        setUserAvatar(chatPersona, { toastPersonaNameChange: false, navigateToCurrent: true });
+        await setUserAvatar(chatPersona, { toastPersonaNameChange: false, navigateToCurrent: true });
 
         if (power_user.persona_show_notifications) {
             let message = t`Auto-selected persona based on ${connectType} connection.<br />Your messages will now be sent as ${power_user.personas[chatPersona]}.`;
@@ -1542,7 +1553,7 @@ async function loadPersonaForCurrentChat({ doRender = false } = {}) {
     }
     // Even if it's the same persona, we still might need to auto-lock to chat if that's enabled
     else if (chatPersona && power_user.persona_auto_lock && !chat_metadata['persona']) {
-        lockPersona('chat');
+        await lockPersona('chat');
     }
 
     updatePersonaUIStates();
@@ -1606,7 +1617,7 @@ export async function showCharConnections() {
 
     // One of the persona was selected. So load it.
     if (!isRemoving && selectedPersona) {
-        setUserAvatar(selectedPersona, { toastPersonaNameChange: false });
+        await setUserAvatar(selectedPersona, { toastPersonaNameChange: false });
         if (power_user.persona_show_notifications) {
             toastr.success(t`Selected persona ${power_user.personas[selectedPersona]} for current chat.`, t`Connected Persona Selected`);
         }
@@ -1739,8 +1750,11 @@ async function syncUserNameToPersona() {
  *
  * Only works if only the first message is present, and not in group mode.
  */
-export function retriggerFirstMessageOnEmptyChat() {
-    if (Number(this_chid) >= 0 && !selected_group && chat.length === 1) {
+export async function retriggerFirstMessageOnEmptyChat() {
+    if (selected_group) {
+        await reloadCurrentChat();
+    }
+    if (Number(this_chid) >= 0 && chat.length === 1) {
         $('#firstmessage_textarea').trigger('input');
     }
 }
@@ -1838,9 +1852,9 @@ async function lockPersonaCallback(_args, value) {
  * Sets a persona name and optionally an avatar.
  * @param {{mode: 'lookup' | 'temp' | 'all'}} namedArgs Named arguments
  * @param {string} name Name to set
- * @returns {string}
+ * @returns {Promise<string>}
  */
-function setNameCallback({ mode = 'all' }, name) {
+async function setNameCallback({ mode = 'all' }, name) {
     if (!name) {
         toastr.warning('You must specify a name to change to');
         return '';
@@ -1858,7 +1872,7 @@ function setNameCallback({ mode = 'all' }, name) {
         let persona = Object.entries(power_user.personas).find(([avatar, _]) => avatar === name)?.[1];
         if (!persona) persona = Object.entries(power_user.personas).find(([_, personaName]) => personaName.toLowerCase() === name.toLowerCase())?.[1];
         if (persona) {
-            autoSelectPersona(persona);
+            await autoSelectPersona(persona);
             return '';
         } else if (mode === 'lookup') {
             toastr.warning(`Persona ${name} not found`);
@@ -2016,9 +2030,9 @@ export async function initPersonas() {
     $('#sync_name_button').on('click', syncUserNameToPersona);
     $('#avatar_upload_file').on('change', changeUserAvatar);
 
-    $(document).on('click', '#user_avatar_block .avatar-container', function () {
+    $(document).on('click', '#user_avatar_block .avatar-container', async function () {
         const imgfile = $(this).attr('data-avatar-id');
-        setUserAvatar(imgfile);
+        await setUserAvatar(imgfile);
     });
 
     $('#persona_rename_button').on('click', () => renamePersona(user_avatar));

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1438,8 +1438,9 @@ function getPersonaTemporaryLockInfo() {
  * @returns {Promise<boolean>} - A promise that resolves to a boolean indicating whether a persona was selected
  */
 async function loadPersonaForCurrentChat({ doRender = false } = {}) {
-    if (getCurrentChatId() === personaLastLoadedChatId) return;
-    personaLastLoadedChatId = getCurrentChatId();
+    const currentChatId = getCurrentChatId();
+    if (currentChatId === personaLastLoadedChatId) return;
+    personaLastLoadedChatId = currentChatId;
 
     // Cache persona list to check if they exist
     const userAvatars = await getUserAvatars(doRender);

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1749,14 +1749,15 @@ async function syncUserNameToPersona() {
 
 /**
  * Retriggers the first message to reload it from the char definition.
- *
- * Only works if only the first message is present, and not in group mode.
  */
 export async function retriggerFirstMessageOnEmptyChat() {
+    if (chat_metadata.tainted) {
+        return;
+    }
     if (selected_group) {
         await reloadCurrentChat();
     }
-    if (Number(this_chid) >= 0 && chat.length === 1) {
+    if (!selected_group && Number(this_chid) >= 0 && chat.length === 1) {
         await createOrEditCharacter();
     }
 }

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -4,6 +4,7 @@ import {
     characters,
     chat,
     chat_metadata,
+    createOrEditCharacter,
     default_user_avatar,
     eventSource,
     event_types,
@@ -1755,7 +1756,7 @@ export async function retriggerFirstMessageOnEmptyChat() {
         await reloadCurrentChat();
     }
     if (Number(this_chid) >= 0 && chat.length === 1) {
-        $('#firstmessage_textarea').trigger('input');
+        await createOrEditCharacter();
     }
 }
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -4585,6 +4585,8 @@ export async function sendMessageAs(args, text) {
         insertAt = chat.length + insertAt;
     }
 
+    chat_metadata['tainted'] = true;
+
     if (!isNaN(insertAt) && insertAt >= 0 && insertAt <= chat.length) {
         chat.splice(insertAt, 0, message);
         await saveChatConditional();
@@ -4634,6 +4636,8 @@ export async function sendNarratorMessage(args, text) {
         // Negative value means going back from current chat length. (E.g.: 8 messages, Depth 1 means insert at index 7)
         insertAt = chat.length + insertAt;
     }
+
+    chat_metadata['tainted'] = true;
 
     if (!isNaN(insertAt) && insertAt >= 0 && insertAt <= chat.length) {
         chat.splice(insertAt, 0, message);
@@ -4685,6 +4689,8 @@ export async function promptQuietForLoudResponse(who, text) {
         },
     };
 
+    chat_metadata['tainted'] = true;
+
     chat.push(message);
     await eventSource.emit(event_types.MESSAGE_SENT, (chat.length - 1));
     addOneMessage(message);
@@ -4718,6 +4724,8 @@ async function sendCommentMessage(args, text) {
         // Negative value means going back from current chat length. (E.g.: 8 messages, Depth 1 means insert at index 7)
         insertAt = chat.length + insertAt;
     }
+
+    chat_metadata['tainted'] = true;
 
     if (!isNaN(insertAt) && insertAt >= 0 && insertAt <= chat.length) {
         chat.splice(insertAt, 0, message);


### PR DESCRIPTION
I hope I didn't break more.

No one cares about group chat. I tried.
There was no functionality to reprint a group chat on context changes (like switched persona) to load the actual accurate macros.
The `retriggerFirstMessageOnEmptyChat` should now correctly load the group chat again, print the "new" first messages of every char.

Closes #4596

## Copilot Summary
This pull request introduces several improvements and fixes to the persona and group chat handling logic, focusing on making persona selection and avatar changes more robust and asynchronous. The main changes include converting key persona-related functions to async/await, improving chat and UI updates when switching personas, and ensuring state consistency when loading group chats or switching personas.

**Persona selection and avatar update improvements:**

- Converted `setUserAvatar`, `autoSelectPersona`, and related persona functions to async to ensure avatar changes and persona selections are handled reliably, especially when chained or dependent on async operations. [[1]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fL110-R123) [[2]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fL735-R749) [[3]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fL1841-R1857) [[4]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fL1861-R1875)
- Updated all internal calls and UI event handlers to await these async persona functions, preventing race conditions and ensuring UI consistency. [[1]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fR1440-R1449) [[2]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fL1533-R1544) [[3]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fL1545-R1556) [[4]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fL1609-R1620) [[5]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fL2019-R2035)

**Group chat and chat element handling:**

- Improved group chat loading logic to clear the chat UI and state more reliably when switching between group chats, using the exported `chatElement` and ensuring message elements are properly removed and re-rendered. [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L394-R394) [[2]](diffhunk://#diff-87068eb81cbdcdeccc61b128947e5a25793616860a506c3c89338585c774f92dR79) [[3]](diffhunk://#diff-87068eb81cbdcdeccc61b128947e5a25793616860a506c3c89338585c774f92dL239-R246) [[4]](diffhunk://#diff-87068eb81cbdcdeccc61b128947e5a25793616860a506c3c89338585c774f92dL269-R270)

**State management and performance:**

- Added a check to prevent redundant persona loading for the same chat by tracking the last loaded chat ID, reducing unnecessary operations. [[1]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fR73-R75) [[2]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fR1440-R1449)
- Made `retriggerFirstMessageOnEmptyChat` async and improved its logic to reload the current chat if in group mode, ensuring the first message is properly re-triggered in all scenarios.

These changes collectively make persona and group chat interactions smoother, more predictable, and less prone to UI or state inconsistencies.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
