### PR TITLE
Update GitHub workflows to use `ISSUES_BOT_TOKEN`, so that they may chain-trigger other workflows. maybe. hopefully.

### DIFF
--- a/.github/workflows/issues-auto-manager.yml
+++ b/.github/workflows/issues-auto-manager.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           configuration-path: .github/issues-auto-labels.yml
           enable-versioned-regex: 0
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ISSUES_BOT_TOKEN }}
 
   label-on-labels:
     name: 🏷️ Label Issues by Labels
@@ -46,7 +46,7 @@ jobs:
         uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: 'add-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ISSUES_BOT_TOKEN }}
           labels: '👍 Approved'
 
       - name: ❌ Remove progress labels when issue is marked done or stale
@@ -56,7 +56,7 @@ jobs:
         uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ISSUES_BOT_TOKEN }}
           labels: '🧑‍💻 In Progress,🤔 Unsure,🤔 Under Consideration'
 
       - name: ❌ Remove temporary labels when confirmed labels are added
@@ -66,7 +66,7 @@ jobs:
         uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ISSUES_BOT_TOKEN }}
           labels: '🤔 Unsure,🤔 Under Consideration'
 
       - name: ❌ Remove no bug labels when "🪲 Confirmed" is added
@@ -76,7 +76,7 @@ jobs:
         uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ISSUES_BOT_TOKEN }}
           labels: '✖️ Not Reproducible,✖️ Not A Bug'
 
   remove-stale-label:
@@ -92,7 +92,7 @@ jobs:
         uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ISSUES_BOT_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           labels: '⚰️ Stale,🕸️ Inactive,🚏 Awaiting User Response,🛑 No Response'
 
@@ -113,4 +113,4 @@ jobs:
         uses: peaceiris/actions-label-commenter@v1.10.0
         with:
           config_file: .github/issues-auto-comments.yml
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ISSUES_BOT_TOKEN }}

--- a/.github/workflows/issues-updates-on-merge.yml
+++ b/.github/workflows/issues-updates-on-merge.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Label Linked Issues
         id: label_linked_issues
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ISSUES_BOT_TOKEN }}
         run: |
             for ISSUE in $(echo $issues | jq -r '.[]'); do
             if [ "${{ github.ref }}" == "refs/heads/staging" ]; then

--- a/.github/workflows/job-close-stale.yml
+++ b/.github/workflows/job-close-stale.yml
@@ -22,7 +22,7 @@ jobs:
         # https://github.com/marketplace/actions/close-stale-issues
         uses: actions/stale@v9.1.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ISSUES_BOT_TOKEN }}
           days-before-stale: 183
           days-before-close: 7
           operations-per-run: 30
@@ -56,7 +56,7 @@ jobs:
         # https://github.com/marketplace/actions/close-stale-issues
         uses: actions/stale@v9.1.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ISSUES_BOT_TOKEN }}
           days-before-stale: 7
           days-before-close: 7
           operations-per-run: 30
@@ -83,7 +83,7 @@ jobs:
         # https://github.com/marketplace/actions/close-stale-issues
         uses: actions/stale@v9.1.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ISSUES_BOT_TOKEN }}
           days-before-stale: 7
           days-before-close: 7
           operations-per-run: 30

--- a/.github/workflows/on-close-handler.yml
+++ b/.github/workflows/on-close-handler.yml
@@ -23,6 +23,6 @@ jobs:
         uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: remove-labels
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ISSUES_BOT_TOKEN }}
           issue-number: ${{ github.event.issue.number || github.event.pull_request.number }}
           labels: '🚏 Awaiting User Response,🧑‍💻 In Progress,📌 Keep Open,🚫 Merge Conflicts,🔬 Needs Testing,🔨 Needs Work,⚰️ Stale,⛔ Waiting For External/Upstream'

--- a/.github/workflows/on-open-handler.yml
+++ b/.github/workflows/on-open-handler.yml
@@ -24,6 +24,6 @@ jobs:
         uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: 'add-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ISSUES_BOT_TOKEN }}
           issue-number: ${{ github.event.issue.number || github.event.pull_request.number }}
           labels: '👷 Maintainer'

--- a/.github/workflows/pr-auto-manager.yml
+++ b/.github/workflows/pr-auto-manager.yml
@@ -76,7 +76,7 @@ jobs:
         # https://github.com/marketplace/actions/pull-request-size-labeler
         uses: codelytv/pr-size-labeler@v1.10.2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ISSUES_BOT_TOKEN }}
           xs_label: '🟩 ⬤○○○○'
           xs_max_size: '20'
           s_label: '🟩 ⬤⬤○○○'
@@ -109,7 +109,7 @@ jobs:
         uses: actions/labeler@v5.0.0
         with:
           configuration-path: .github/pr-auto-labels-by-branch.yml
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ISSUES_BOT_TOKEN }}
 
   label-by-files:
     name: 🏷️ Label PR by Files
@@ -129,7 +129,7 @@ jobs:
         uses: actions/labeler@v5.0.0
         with:
           configuration-path: .github/pr-auto-labels-by-files.yml
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ISSUES_BOT_TOKEN }}
 
   remove-stale-label:
     name: 🗑️ Remove Stale Label on Comment
@@ -150,7 +150,7 @@ jobs:
         uses: actions-cool/issues-helper@v3.6.0
         with:
           actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ISSUES_BOT_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           labels: '⚰️ Stale'
 
@@ -250,7 +250,7 @@ jobs:
           PR_NUMBER=${{ github.event.pull_request.number }}
           REPO=${{ github.repository }}
           API_URL="https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/issues"
-          ISSUES=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$API_URL" | jq -r '.[].number' | jq -R -s -c 'split("\n")[:-1]')
+          ISSUES=$(curl -s -H "Authorization: token ${{ secrets.ISSUES_BOT_TOKEN }}" "$API_URL" | jq -r '.[].number' | jq -R -s -c 'split("\n")[:-1]')
           echo "linked_issues=$ISSUES" >> $GITHUB_ENV
 
       - name: Merge Issue Lists
@@ -262,7 +262,7 @@ jobs:
       - name: Label Linked Issues
         id: label_linked_issues
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ISSUES_BOT_TOKEN }}
         run: |
           for ISSUE in $(echo $final_issues | jq -r '.[]'); do
             gh issue edit $ISSUE -R ${{ github.repository }} --add-label "✅ Done (staging)" --remove-label "🧑‍💻 In Progress"

--- a/.github/workflows/pr-check-merge-conflicts.yaml
+++ b/.github/workflows/pr-check-merge-conflicts.yaml
@@ -23,6 +23,6 @@ jobs:
         uses: eps1lon/actions-label-merge-conflict@v3.0.3
         with:
           dirtyLabel: '🚫 Merge Conflicts'
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          repoToken: ${{ secrets.ISSUES_BOT_TOKEN }}
           commentOnDirty: >
             ⚠️ This PR has conflicts that need to be resolved before it can be merged.


### PR DESCRIPTION
Well, Copilot doesn't understand. Not sure I do, but let's try this.
With the separate token, the workflows labeling stuff *should* be triggering other workflows, if needed.
Let's see if it works.

## Copilot Summary
This pull request updates several GitHub Actions workflow files to use a dedicated `ISSUES_BOT_TOKEN` secret in place of the default `GITHUB_TOKEN` for all issue and pull request management automation. This change improves security and separation of permissions for the bot that manages issues and PRs. The updates affect workflows related to auto-labeling, label management, stale issue handling, and merge conflict labeling.

The most important changes are:

**Switch to `ISSUES_BOT_TOKEN` in issue automation workflows:**
- Updated `.github/workflows/issues-auto-manager.yml` to use `ISSUES_BOT_TOKEN` instead of `GITHUB_TOKEN` for all steps involving issue labeling, label removal, and automated commenting. [[1]](diffhunk://#diff-36a474fa4807b6d0bf15cd404cdc0cd87e254ed630b57002ac6ceb555b75189cL35-R35) [[2]](diffhunk://#diff-36a474fa4807b6d0bf15cd404cdc0cd87e254ed630b57002ac6ceb555b75189cL49-R49) [[3]](diffhunk://#diff-36a474fa4807b6d0bf15cd404cdc0cd87e254ed630b57002ac6ceb555b75189cL59-R59) [[4]](diffhunk://#diff-36a474fa4807b6d0bf15cd404cdc0cd87e254ed630b57002ac6ceb555b75189cL69-R69) [[5]](diffhunk://#diff-36a474fa4807b6d0bf15cd404cdc0cd87e254ed630b57002ac6ceb555b75189cL79-R79) [[6]](diffhunk://#diff-36a474fa4807b6d0bf15cd404cdc0cd87e254ed630b57002ac6ceb555b75189cL95-R95) [[7]](diffhunk://#diff-36a474fa4807b6d0bf15cd404cdc0cd87e254ed630b57002ac6ceb555b75189cL116-R116)

**Switch to `ISSUES_BOT_TOKEN` in stale issue/PR management:**
- Updated `.github/workflows/job-close-stale.yml` to use `ISSUES_BOT_TOKEN` for the `actions/stale` steps that close or mark issues as stale. [[1]](diffhunk://#diff-340c84f34f7ba634b523825ecbd772192c725a0026cb82b864ad1a0f6001cfe5L25-R25) [[2]](diffhunk://#diff-340c84f34f7ba634b523825ecbd772192c725a0026cb82b864ad1a0f6001cfe5L59-R59) [[3]](diffhunk://#diff-340c84f34f7ba634b523825ecbd772192c725a0026cb82b864ad1a0f6001cfe5L86-R86)

**Switch to `ISSUES_BOT_TOKEN` in PR automation workflows:**
- Updated `.github/workflows/pr-auto-manager.yml` to use `ISSUES_BOT_TOKEN` for PR size labeling, PR auto-labeling, label removal, and API calls to fetch and label linked issues. [[1]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L79-R79) [[2]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L112-R112) [[3]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L132-R132) [[4]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L153-R153) [[5]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L253-R253) [[6]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L265-R265)

**Switch to `ISSUES_BOT_TOKEN` in open/close handlers:**
- Updated `.github/workflows/on-close-handler.yml` and `.github/workflows/on-open-handler.yml` to use `ISSUES_BOT_TOKEN` for adding or removing labels when issues or PRs are opened or closed. [[1]](diffhunk://#diff-d0cd706ac648bd3375ba465d4a9b5d1dae39a4c611f87b9e2c60a63121283503L26-R26) [[2]](diffhunk://#diff-ec45ac24bcf27c2bbbd656492ad74bf95ac5c16c891fe5526febbf9f3cf0dc16L27-R27)

**Switch to `ISSUES_BOT_TOKEN` for merge conflict labeling:**
- Updated `.github/workflows/pr-check-merge-conflicts.yaml` to use `ISSUES_BOT_TOKEN` for labeling PRs with merge conflicts.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).