### PR TITLE
Fix trapped cursor on sampler input by removing focus call on event

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -10992,7 +10992,6 @@ jQuery(async function () {
         if (!(e.target instanceof HTMLElement)) {
             return;
         }
-        e.target.focus();
         e.target.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
     });
 


### PR DESCRIPTION
Dunno why this was even there?
When you changed a sampler value, you could not "leave" the manual input field right away, neither by using a mouse click nor by tab tabbing out of it.
This is really unintuitive and not a good design.

Fixed this by removing a redundant manual focus set in that event handler.

@RossAscends maybe check, dunno if this actually had a reason to be there.

## Copilot Summary
This pull request makes a minor adjustment to the event handling logic in `public/script.js` by removing a call to focus the event target before dispatching a keyboard event. This change streamlines the event flow and may prevent unwanted focus changes.

- Removed the call to `e.target.focus()` before dispatching a `KeyboardEvent` in the event handler, ensuring that the target element does not receive focus unnecessarily.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
