### PR TITLE
deleteSwipe now emits the deleted message Id.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6132,7 +6132,7 @@ export function setOnlineStatus(value) {
 }
 
 export function setEditedMessageId(value) {
-    this_edit_mes_id = Number(value);
+    this_edit_mes_id = value;
 }
 
 export function setSendButtonState(value) {
@@ -10227,7 +10227,7 @@ jQuery(async function () {
             $(this).closest('.mes_block').find('.mes_buttons').css('display', 'none');
             $(this).closest('.mes_block').find('.mes_edit_buttons').css('display', 'inline-flex');
             var edit_mes_id = $(this).closest('.mes').attr('mesid');
-            this_edit_mes_id = Number(edit_mes_id);
+            this_edit_mes_id = edit_mes_id;
 
             // Also edit reasoning, if it exists
             const reasoningEdit = $(this).closest('.mes_block').find('.mes_reasoning_edit:visible');

--- a/public/script.js
+++ b/public/script.js
@@ -6132,7 +6132,7 @@ export function setOnlineStatus(value) {
 }
 
 export function setEditedMessageId(value) {
-    this_edit_mes_id = value;
+    this_edit_mes_id = Number(value);
 }
 
 export function setSendButtonState(value) {
@@ -7943,16 +7943,16 @@ export function hideSwipeButtons() {
  * Deletes a swipe from the chat.
  *
  * @param {number?} [swipeId = null] - The ID of the swipe to delete. If not provided, the current swipe will be deleted.
- * @param {number?} [mesId = chat.length - 1] - The ID of the message to delete from. If not provided, the last message will be targeted.
+ * @param {number?} [messageId = chat.length - 1] - The ID of the message to delete from. If not provided, the last message will be targeted.
  * @returns {Promise<number>|undefined} - The ID of the new swipe after deletion.
  */
-export async function deleteSwipe(swipeId = null, mesId = chat.length - 1) {
+export async function deleteSwipe(swipeId = null, messageId = chat.length - 1) {
     if (swipeId && (isNaN(swipeId) || swipeId < 0)) {
         toastr.warning(t`Invalid swipe ID: ${swipeId + 1}`);
         return;
     }
 
-    const message = chat[mesId];
+    const message = chat[messageId];
     if (!message || !Array.isArray(message.swipes) || !message.swipes.length) {
         toastr.warning(t`No messages to delete swipes from.`);
         return;
@@ -7978,9 +7978,9 @@ export async function deleteSwipe(swipeId = null, mesId = chat.length - 1) {
 
     // Select the next swipe, or the one before if it was the last one
     const newSwipeId = Math.min(swipeId, message.swipes.length - 1);
-    syncSwipeToMes(mesId, newSwipeId);
+    syncSwipeToMes(messageId, newSwipeId);
 
-    await eventSource.emit(event_types.MESSAGE_SWIPE_DELETED, { mesId, swipeId, newSwipeId });
+    await eventSource.emit(event_types.MESSAGE_SWIPE_DELETED, { messageId, swipeId, newSwipeId });
 
     await saveChatConditional();
     await reloadCurrentChat();
@@ -10227,7 +10227,7 @@ jQuery(async function () {
             $(this).closest('.mes_block').find('.mes_buttons').css('display', 'none');
             $(this).closest('.mes_block').find('.mes_edit_buttons').css('display', 'inline-flex');
             var edit_mes_id = $(this).closest('.mes').attr('mesid');
-            this_edit_mes_id = edit_mes_id;
+            this_edit_mes_id = Number(edit_mes_id);
 
             // Also edit reasoning, if it exists
             const reasoningEdit = $(this).closest('.mes_block').find('.mes_reasoning_edit:visible');
@@ -10487,7 +10487,7 @@ jQuery(async function () {
         if (deleteOnlySwipe) {
             const message = chat[this_edit_mes_id];
             const swipe_id = message.swipe_id;
-            await deleteSwipe(swipe_id, this_edit_mes_id);
+            await deleteSwipe(swipe_id, Number(this_edit_mes_id));
             return;
         }
 

--- a/public/script.js
+++ b/public/script.js
@@ -7942,44 +7942,45 @@ export function hideSwipeButtons() {
 /**
  * Deletes a swipe from the chat.
  *
- * @param {number?} swipeId - The ID of the swipe to delete. If not provided, the current swipe will be deleted.
+ * @param {number?} [swipeId = null] - The ID of the swipe to delete. If not provided, the current swipe will be deleted.
+ * @param {number?} [mesId = chat.length - 1] - The ID of the message to delete from. If not provided, the last message will be targeted.
  * @returns {Promise<number>|undefined} - The ID of the new swipe after deletion.
  */
-export async function deleteSwipe(swipeId = null) {
+export async function deleteSwipe(swipeId = null, mesId = chat.length - 1) {
     if (swipeId && (isNaN(swipeId) || swipeId < 0)) {
         toastr.warning(t`Invalid swipe ID: ${swipeId + 1}`);
         return;
     }
 
-    const lastMessage = chat[chat.length - 1];
-    if (!lastMessage || !Array.isArray(lastMessage.swipes) || !lastMessage.swipes.length) {
+    const message = chat[mesId];
+    if (!message || !Array.isArray(message.swipes) || !message.swipes.length) {
         toastr.warning(t`No messages to delete swipes from.`);
         return;
     }
 
-    if (lastMessage.swipes.length <= 1) {
+    if (message.swipes.length <= 1) {
         toastr.warning(t`Can't delete the last swipe.`);
         return;
     }
 
-    swipeId = swipeId ?? lastMessage.swipe_id;
+    swipeId = swipeId ?? message.swipe_id;
 
-    if (swipeId < 0 || swipeId >= lastMessage.swipes.length) {
+    if (swipeId < 0 || swipeId >= message.swipes.length) {
         toastr.warning(t`Invalid swipe ID: ${swipeId + 1}`);
         return;
     }
 
-    lastMessage.swipes.splice(swipeId, 1);
+    message.swipes.splice(swipeId, 1);
 
-    if (Array.isArray(lastMessage.swipe_info) && lastMessage.swipe_info.length) {
-        lastMessage.swipe_info.splice(swipeId, 1);
+    if (Array.isArray(message.swipe_info) && message.swipe_info.length) {
+        message.swipe_info.splice(swipeId, 1);
     }
 
     // Select the next swipe, or the one before if it was the last one
-    const newSwipeId = Math.min(swipeId, lastMessage.swipes.length - 1);
-    syncSwipeToMes(null, newSwipeId);
+    const newSwipeId = Math.min(swipeId, message.swipes.length - 1);
+    syncSwipeToMes(mesId, newSwipeId);
 
-    await eventSource.emit(event_types.MESSAGE_SWIPE_DELETED, { swipeId, newSwipeId });
+    await eventSource.emit(event_types.MESSAGE_SWIPE_DELETED, { mesId, swipeId, newSwipeId });
 
     await saveChatConditional();
     await reloadCurrentChat();
@@ -10486,7 +10487,7 @@ jQuery(async function () {
         if (deleteOnlySwipe) {
             const message = chat[this_edit_mes_id];
             const swipe_id = message.swipe_id;
-            await deleteSwipe(swipe_id);
+            await deleteSwipe(swipe_id, this_edit_mes_id);
             return;
         }
 


### PR DESCRIPTION
Please change this to emit the mesId.
```javascript
export async function deleteSwipe(swipeId = null, mesId = chat.length - 1) {
//...
await eventSource.emit(event_types.MESSAGE_SWIPE_DELETED, { mesId, swipeId, newSwipeId });
```

https://github.com/SillyTavern/SillyTavern/pull/4573#issuecomment-3368843222

