### PR TITLE
feat: emit dryRun for GENERATE_AFTER_DATA

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4457,7 +4457,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         }
     }
 
-    await eventSource.emit(event_types.GENERATE_AFTER_DATA, generate_data);
+    await eventSource.emit(event_types.GENERATE_AFTER_DATA, generate_data, dryRun);
 
     if (dryRun) {
         return Promise.resolve();


### PR DESCRIPTION
Emit `dryRun` for `GENERATION_AFTER_DATA` to allow extensions to only modify non-dry-run prompts at this point

```diff
- await eventSource.emit(event_types.GENERATE_AFTER_DATA, generate_data)
+ await eventSource.emit(event_types.GENERATE_AFTER_DATA, generate_data, dryRun);
```

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
