### PR TITLE
Preset Regex: event change

### DIFF
--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -87,6 +87,7 @@ export const event_types = {
     SECRET_EDITED: 'secret_edited',
     PRESET_CHANGED: 'preset_changed',
     PRESET_DELETED: 'preset_deleted',
+    PRESET_RENAMED: 'preset_renamed',
     MAIN_API_CHANGED: 'main_api_changed',
     WORLDINFO_ENTRIES_LOADED: 'worldinfo_entries_loaded',
 };

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -1035,8 +1035,7 @@ export async function initPresetManager() {
 
         await presetManager.renamePreset(newName);
 
-        await eventSource.emit(event_types.PRESET_DELETED, { apiId: apiId, name: oldName });
-        await eventSource.emit(event_types.PRESET_CHANGED, { apiId: apiId, name: newName });
+        await eventSource.emit(event_types.PRESET_RENAMED, { apiId: apiId, oldName: oldName, newName: newName });
 
         if (apiId === 'openai') {
             // This is a horrible mess, but prevents the renamed preset from being corrupted.

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -1115,13 +1115,13 @@ export async function initPresetManager() {
         if (result) {
             const successToast = !presetManager.isAdvancedFormatting() ? t`Preset deleted` : t`Template deleted`;
             toastr.success(successToast);
+            await eventSource.emit(event_types.PRESET_DELETED, { apiId, name });
         } else {
             const warningToast = !presetManager.isAdvancedFormatting() ? t`Preset was not deleted from server` : t`Template was not deleted from server`;
             toastr.warning(warningToast);
         }
 
         saveSettingsDebounced();
-        await eventSource.emit(event_types.PRESET_DELETED, { apiId: apiId, name: name });
     });
 
     $(document).on('click', '[data-preset-manager-restore]', async function () {


### PR DESCRIPTION
splitted from #4216 by me, while explicitly keeping the original pr author as the author of these commits

- new `PRESET_RENAMED` event
- emit `PRESET_DELETED` only when success

## Checklist:

- [x] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
