### PR TITLE
Add interactable outline color CSS variables

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -162,6 +162,8 @@ body {
     color: var(--SmartThemeBodyColor);
     overflow: hidden;
     color-scheme: only light;
+    --interactable-outline-color: transparent;
+    --interactable-outline-color-faint: transparent;
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
> Introduces `--interactable-outline-color` and `--interactable-outline-color-faint` variables to the body style, both set to transparent for future use in styling interactive elements.

In short, the current reasoning block shows this annoying highlight when clicked, and I’d like to make it transparent.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
