### PR TITLE
Fix font size difference in API Connections dropdowns

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3001,6 +3001,11 @@ select option:not(:checked) {
     display: block;
 }
 
+/* Fix font size difference in API Connections dropdowns - Issue #4599 */
+#custom_model_id {
+    font-size: calc(var(--mainFontSize) * 0.95);
+}
+
 .menu_button.api_button:hover {
     background-color: var(--active);
 }


### PR DESCRIPTION
- Fixes visual inconsistency between 'Enter a Model ID' input and 'Available Models' dropdown
- Uses calc(var(--mainFontSize) * 0.95) to match the slightly smaller font size of the dropdown
- Resolves issue #4599

This is the most minimal fix I could think of that targets only the specific element causing the visual difference.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
