### PR TITLE
Workflows: Replace ISSUES_BOT_TOKEN with GitHub App for labeling + 'against release' auto comment

### DIFF
--- a/.github/pr-auto-comments.yml
+++ b/.github/pr-auto-comments.yml
@@ -49,6 +49,8 @@ labels:
 
           Please make sure this was intended, and you did not want to target the `staging` branch. Only hotfixes, readme changes and similar should be made against `release`.
 
+          You can change the target branch **without recreating the PR** by clicking "Edit" at the top of the page.
+
   - name: 🟥 ⬤⬤⬤⬤⬤
     labeled:
       pr:

--- a/.github/pr-auto-comments.yml
+++ b/.github/pr-auto-comments.yml
@@ -41,6 +41,14 @@ labels:
           🔬 This PR needs testing!
           Any contributor can test and leave reviews, so feel free to help us out!
 
+  - name: ❗ Against Release Branch
+    labeled:
+      pr:
+        body: >
+          ❗ This PR is against the `release` branch.
+
+          Please make sure this was intended, and you did not want to target the `staging` branch. Only hotfixes, readme changes and similar should be made against `release`.
+
   - name: 🟥 ⬤⬤⬤⬤⬤
     labeled:
       pr:

--- a/.github/workflows/pr-auto-manager.yml
+++ b/.github/workflows/pr-auto-manager.yml
@@ -12,6 +12,25 @@ permissions:
   pull-requests: write
 
 jobs:
+  app-auth:
+    name: 🔑 Mint App token
+    runs-on: ubuntu-latest
+    if: always()
+
+    outputs:
+      app_token: ${{ steps.app.outputs.token }}
+
+    steps:
+      - name: Create GitHub App Token
+        # Create a GitHub App token
+        # https://github.com/marketplace/actions/create-github-app-token
+        uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ vars.ST_BOT_APP_ID }}
+          private-key: ${{ secrets.ST_BOT_SECRET }}
+          owner: ${{ github.repository_owner }}
+
   run-eslint:
     name: ✅ Check ESLint on PR
     runs-on: ubuntu-latest
@@ -59,7 +78,7 @@ jobs:
   label-by-size:
     name: 🏷️ Label PR by Size
     # This job should run after all others, to prevent possible concurrency issues
-    needs: [label-by-branches, label-by-files, remove-stale-label, check-merge-blocking-labels, write-auto-comments]
+    needs: [app-auth, label-by-branches, label-by-files, remove-stale-label, check-merge-blocking-labels, write-auto-comments]
     runs-on: ubuntu-latest
     # Only needs to run when code is changed
     if: always() && (github.event.action == 'opened' || github.event.action == 'synchronize')
@@ -76,7 +95,7 @@ jobs:
         # https://github.com/marketplace/actions/pull-request-size-labeler
         uses: codelytv/pr-size-labeler@v1.10.2
         with:
-          GITHUB_TOKEN: ${{ secrets.ISSUES_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ needs.app-auth.outputs.app_token }}
           xs_label: '🟩 ⬤○○○○'
           xs_max_size: '20'
           s_label: '🟩 ⬤⬤○○○'
@@ -93,6 +112,7 @@ jobs:
 
   label-by-branches:
     name: 🏷️ Label PR by Branches
+    needs: [app-auth]
     runs-on: ubuntu-latest
     # Only label once when PR is created or when base branch is changed, to allow manual label removal
     if: github.event.action == 'opened' || (github.event.action == 'synchronize' && github.event.changes.base)
@@ -109,10 +129,11 @@ jobs:
         uses: actions/labeler@v5.0.0
         with:
           configuration-path: .github/pr-auto-labels-by-branch.yml
-          repo-token: ${{ secrets.ISSUES_BOT_TOKEN }}
+          repo-token: ${{ needs.app-auth.outputs.app_token }}
 
   label-by-files:
     name: 🏷️ Label PR by Files
+    needs: [app-auth]
     runs-on: ubuntu-latest
     # Only needs to run when code is changed
     if: github.event.action == 'opened' || github.event.action == 'synchronize'
@@ -129,7 +150,7 @@ jobs:
         uses: actions/labeler@v5.0.0
         with:
           configuration-path: .github/pr-auto-labels-by-files.yml
-          repo-token: ${{ secrets.ISSUES_BOT_TOKEN }}
+          repo-token: ${{ needs.app-auth.outputs.app_token }}
 
   remove-stale-label:
     name: 🗑️ Remove Stale Label on Comment


### PR DESCRIPTION
Let's test this with the first PR labeling actions first.

## Copilot Summary
This pull request updates the pull request automation workflows to use a GitHub App token for improved security and reliability. It introduces a new job to mint the token and updates all relevant jobs to use this token instead of a personal access token. Additionally, it adds an automated comment for PRs targeting the `release` branch to help prevent mistakes.

**Workflow authentication and security improvements:**

* Added a new `app-auth` job in `.github/workflows/pr-auto-manager.yml` to mint a GitHub App token using the `actions/create-github-app-token` action. This token is now used for subsequent jobs instead of a personal access token.
* Updated the `label-by-branches`, `label-by-files`, and `label-by-size` jobs to depend on `app-auth` and use the minted App token for authentication, replacing `ISSUES_BOT_TOKEN`. [[1]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L62-R81) [[2]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510R115) [[3]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L112-R136) [[4]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L132-R153) [[5]](diffhunk://#diff-17097d006e96f26da3d4c0c50e7085f1de33e3951212245bc4c3e92fb25d9510L79-R98)

**Automated PR guidance:**

* Added a new auto-comment in `.github/pr-auto-comments.yml` to notify contributors when a PR is opened against the `release` branch, reminding them to ensure this was intentional.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
