### PR TITLE
Refactor: add has() and get() to MacrosParser

### DIFF
--- a/public/scripts/macros.js
+++ b/public/scripts/macros.js
@@ -57,6 +57,24 @@ export class MacrosParser {
     };
 
     /**
+     * Access a macro by its name.
+     * @param {string} key Macro name (key)
+     * @returns {string|MacroFunction|undefined} The macro value
+     */
+    static get(key) {
+        return MacrosParser.#macros.get(key);
+    }
+
+    /**
+     * Checks if a macro is registered.
+     * @param {string} key Macro name (key)
+     * @returns {boolean} True if the macro is registered, false otherwise
+     */
+    static has(key) {
+        return MacrosParser.#macros.has(key);
+    }
+
+    /**
      * Registers a global macro that can be used anywhere where substitution is allowed.
      * @param {string} key Macro name (key)
      * @param {string|MacroFunction} value A string or a function that returns a string


### PR DESCRIPTION
Very small. We already expose the full macros via an iterator.
But I found it tedious to test if a macro is there in an extension by iterating and seeing if I can find it.
And just doing an add throws a warning.

## Copilot Summary
This pull request adds two new static utility methods to the `MacrosParser` class to improve macro management and lookup functionality.

**Enhancements to macro management:**

* Added a static `get` method to `MacrosParser` for accessing a macro by its name.
* Added a static `has` method to `MacrosParser` to check if a macro is registered.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contributing guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
