### PR TITLE
Add -webkit-tap-highlight-color for smoother touch experience

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -133,6 +133,7 @@
 * {
     box-sizing: border-box;
     -webkit-font-smoothing: antialiased;
+    -webkit-tap-highlight-color: transparent;
     -moz-osx-font-smoothing: grayscale;
     text-shadow: 0px 0px calc(var(--shadowWidth) * 1px) var(--SmartThemeShadowColor);
 }
@@ -162,8 +163,6 @@ body {
     color: var(--SmartThemeBodyColor);
     overflow: hidden;
     color-scheme: only light;
-    --interactable-outline-color: transparent;
-    --interactable-outline-color-faint: transparent;
 }
 
 ::-webkit-scrollbar {

--- a/public/style.css
+++ b/public/style.css
@@ -162,6 +162,8 @@ body {
     color: var(--SmartThemeBodyColor);
     overflow: hidden;
     color-scheme: only light;
+    --interactable-outline-color: transparent;
+    --interactable-outline-color-faint: transparent;
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
> Added `-webkit-tap-highlight-color: transparent` to the universal selector in `public/style.css` to remove the tap highlight on mobile browsers, resulting in a smoother user experience.

Currently, when tapping on the reasoning block button on iOS, an annoying shadow appears, and I want to remove it. Yesterday’s PR was my mistake (I was too sleepy).

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contributing guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).