### PR TITLE
feat: Apply preset regexes before scoped regexes

### DIFF
--- a/public/scripts/extensions/regex/dropdown.html
+++ b/public/scripts/extensions/regex/dropdown.html
@@ -12,13 +12,13 @@
                     <i class="fa-solid fa-pen-to-square"></i>
                     <small data-i18n="ext_regex_new_global_script">+ Global</small>
                 </div>
-                <div id="open_scoped_editor" class="menu_button menu_button_icon" data-i18n="[title]ext_regex_new_scoped_script_desc" title="New scoped regex script">
-                    <i class="fa-solid fa-address-card"></i>
-                    <small data-i18n="ext_regex_new_scoped_script">+ Scoped</small>
-                </div>
                 <div id="open_preset_editor" class="menu_button menu_button_icon" data-i18n="[title]ext_regex_new_preset_script_desc" title="New preset regex script">
                     <i class="fa-solid fa-sliders"></i>
                     <small data-i18n="ext_regex_new_preset_script">+ Preset</small>
+                </div>
+                <div id="open_scoped_editor" class="menu_button menu_button_icon" data-i18n="[title]ext_regex_new_scoped_script_desc" title="New scoped regex script">
+                    <i class="fa-solid fa-address-card"></i>
+                    <small data-i18n="ext_regex_new_scoped_script">+ Scoped</small>
                 </div>
                 <div id="import_regex" class="menu_button menu_button_icon">
                     <i class="fa-solid fa-file-import"></i>
@@ -52,13 +52,13 @@
                     <i class="fa-solid fa-globe"></i>
                     <small data-i18n="ext_regex_move_to_global">Move to global scripts</small>
                 </div>
-                <div id="bulk_regex_move_to_scoped" class="menu_button menu_button_icon" hidden>
-                    <i class="fa-solid fa-address-card"></i>
-                    <small data-i18n="ext_regex_move_to_scoped">Move to scoped scripts</small>
-                </div>
                 <div id="bulk_regex_move_to_preset" class="menu_button menu_button_icon" hidden>
                     <i class="fa-solid fa-sliders"></i>
                     <small data-i18n="ext_regex_move_to_preset">Move to preset scripts</small>
+                </div>
+                <div id="bulk_regex_move_to_scoped" class="menu_button menu_button_icon" hidden>
+                    <i class="fa-solid fa-address-card"></i>
+                    <small data-i18n="ext_regex_move_to_scoped">Move to scoped scripts</small>
                 </div>
                 <div id="bulk_export_regex" class="menu_button menu_button_icon">
                     <i class="fa-solid fa-file-export"></i>
@@ -96,6 +96,21 @@
                 <div id="saved_regex_scripts" no-scripts-text="No scripts found" data-i18n="[no-scripts-text]No scripts found" class="flex-container regex-script-container flexFlowColumn"></div>
             </div>
             <hr />
+            <div id="preset_scripts_block">
+                <div class="flex-container alignItemsBaseline">
+                    <strong class="flex1" data-i18n="ext_regex_preset_scripts">Preset Scripts</strong>
+                    <label id="toggle_preset_regex" class="checkbox flex-container" for="regex_preset_toggle">
+                        <input type="checkbox" id="regex_preset_toggle" class="enable_scoped" />
+                        <span class="regex-toggle-on fa-solid fa-toggle-on fa-lg" data-i18n="[title]ext_regex_disallow_preset" title="Disallow using preset regex"></span>
+                        <span class="regex-toggle-off fa-solid fa-toggle-off fa-lg" data-i18n="[title]ext_regex_allow_preset" title="Allow using preset regex"></span>
+                    </label>
+                </div>
+                <small data-i18n="ext_regex_preset_scripts_desc">
+                    Only available for this preset. Saved to the preset data.
+                </small>
+                <div id="saved_preset_scripts" no-scripts-text="No scripts found" data-i18n="[no-scripts-text]No scripts found" class="flex-container regex-script-container flexFlowColumn"></div>
+            </div>
+            <hr />
             <div id="scoped_scripts_block">
                 <div class="flex-container alignItemsBaseline">
                     <strong class="flex1" data-i18n="ext_regex_scoped_scripts">Scoped Scripts</strong>
@@ -109,21 +124,6 @@
                     Only available for this character. Saved to the card data.
                 </small>
                 <div id="saved_scoped_scripts" no-scripts-text="No scripts found" data-i18n="[no-scripts-text]No scripts found" class="flex-container regex-script-container flexFlowColumn"></div>
-            </div>
-            <hr />
-            <div id="preset_scripts_block">
-                <div class="flex-container alignItemsBaseline">
-                    <strong class="flex1" data-i18n="ext_regex_preset_scripts">Preset Scripts</strong>
-                    <label id="toggle_preset_regex" class="checkbox flex-container" for="regex_preset_toggle">
-                        <input type="checkbox" id="regex_preset_toggle" class="enable_scoped" />
-                        <span class="regex-toggle-on fa-solid fa-toggle-on fa-lg" data-i18n="[title]ext_regex_disallow_preset" title="Disallow using preset regex"></span>
-                        <span class="regex-toggle-off fa-solid fa-toggle-off fa-lg" data-i18n="[title]ext_regex_allow_preset" title="Allow using preset regex"></span>
-                    </label>
-                </div>
-                <small data-i18n="ext_regex_preset_scripts_desc">
-                    Only available for this preset. Saved to the preset data.
-                </small>
-                <div id="saved_preset_scripts" class="flex-container regex-script-container flexFlowColumn"></div>
             </div>
         </div>
     </div>

--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -10,8 +10,8 @@ import { lodash } from '../../../lib.js';
  */
 export const SCRIPT_TYPES = {
     GLOBAL: 0,
-    SCOPED: 1,
     PRESET: 2,
+    SCOPED: 1,
 };
 
 /**

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -1088,7 +1088,7 @@ function populateDebuggerRuleList(container) {
         }
     });
 
-    container.data('allScripts', [...globalScripts, ...scopedScripts, ...presetScripts]);
+    container.data('allScripts', [...globalScripts, ...presetScripts, ...scopedScripts]);
 
     const renderRule = (script) => {
         if (!script.id) script.id = uuidv4();
@@ -1147,18 +1147,18 @@ function populateDebuggerRuleList(container) {
         rulesContainer.append(globalList);
     }
 
-    if (scopedScripts.length > 0) {
-        rulesContainer.append('<div class="list-header regex-debugger-list-header">' + t`Scoped Rules` + '</div>');
-        const scopedList = $('<ul id="regex_debugger_rules_scoped" class="sortable-list"></ul>');
-        scopedScripts.forEach(script => scopedList.append(renderRule(script)));
-        rulesContainer.append(scopedList);
-    }
-
     if (presetScripts.length > 0) {
         rulesContainer.append('<div class="list-header regex-debugger-list-header">' + t`Preset Rules` + '</div>');
         const presetList = $('<ul id="regex_debugger_rules_preset" class="sortable-list"></ul>');
         presetScripts.forEach(script => presetList.append(renderRule(script)));
         rulesContainer.append(presetList);
+    }
+
+    if (scopedScripts.length > 0) {
+        rulesContainer.append('<div class="list-header regex-debugger-list-header">' + t`Scoped Rules` + '</div>');
+        const scopedList = $('<ul id="regex_debugger_rules_scoped" class="sortable-list"></ul>');
+        scopedScripts.forEach(script => scopedList.append(renderRule(script)));
+        rulesContainer.append(scopedList);
     }
 }
 

--- a/public/scripts/extensions/regex/scriptTemplate.html
+++ b/public/scripts/extensions/regex/scriptTemplate.html
@@ -16,11 +16,11 @@
             <div class="move_to_global menu_button" data-i18n="[title]ext_regex_move_to_global" title="Move to global scripts">
                 <i class="fa-solid fa-globe"></i>
             </div>
-            <div class="move_to_scoped menu_button" data-i18n="[title]ext_regex_move_to_scoped" title="Move to scoped scripts">
-                <i class="fa-solid fa-address-card"></i>
-            </div>
             <div class="move_to_preset menu_button" data-i18n="[title]ext_regex_move_to_preset" title="Move to preset scripts">
                 <i class="fa-solid fa-sliders"></i>
+            </div>
+            <div class="move_to_scoped menu_button" data-i18n="[title]ext_regex_move_to_scoped" title="Move to scoped scripts">
+                <i class="fa-solid fa-address-card"></i>
             </div>
             <div class="export_regex menu_button" data-i18n="[title]ext_regex_export_script" title="Export script">
                 <i class="fa-solid fa-file-export"></i>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -6275,7 +6275,7 @@ export function initOpenAI() {
 
     $('#update_oai_preset').on('click', async function () {
         const name = oai_settings.preset_settings_openai;
-        await saveOpenAIPreset(name, oai_settings);
+        await saveOpenAIPreset(name, oai_settings, false);
         toastr.success(t`Preset updated`);
     });
 

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -19,12 +19,14 @@ import {
     this_chid,
 } from '../script.js';
 import { groups, selected_group } from './group-chats.js';
+import { t } from './i18n.js';
 import { instruct_presets } from './instruct-mode.js';
 import { kai_settings } from './kai-settings.js';
 import { convertNovelPreset } from './nai-settings.js';
-import { openai_settings, openai_setting_names, oai_settings } from './openai.js';
-import { Popup, POPUP_RESULT, POPUP_TYPE } from './popup.js';
+import { oai_settings, openai_setting_names, openai_settings } from './openai.js';
+import { POPUP_RESULT, POPUP_TYPE, Popup } from './popup.js';
 import { context_presets, getContextSettings, power_user } from './power-user.js';
+import { reasoning_templates } from './reasoning.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument } from './slash-commands/SlashCommandArgument.js';
 import { enumIcons } from './slash-commands/SlashCommandCommonEnumsProvider.js';
@@ -33,13 +35,11 @@ import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { checkForSystemPromptInInstructTemplate, system_prompts } from './sysprompt.js';
 import { renderTemplateAsync } from './templates.js';
 import {
+    textgenerationwebui_settings as textgen_settings,
     textgenerationwebui_preset_names,
     textgenerationwebui_presets,
-    textgenerationwebui_settings as textgen_settings,
 } from './textgen-settings.js';
 import { download, ensurePlainObject, equalsIgnoreCaseAndAccents, getSanitizedFilename, parseJsonFile, waitUntilCondition } from './utils.js';
-import { t } from './i18n.js';
-import { reasoning_templates } from './reasoning.js';
 
 const presetManagers = {};
 
@@ -397,8 +397,10 @@ class PresetManager {
 
     /**
      * Updates the preset select element with the current API presets.
+     * @param {object} [options] Options for saving the preset
+     * @param {boolean} [options.skipUpdate=false] If true, skips updating the preset list after saving.
      */
-    async updatePreset() {
+    async updatePreset(option = { skipUpdate: false }) {
         const selected = $(this.select).find('option:selected');
         console.log(selected);
 
@@ -408,7 +410,7 @@ class PresetManager {
         }
 
         const name = selected.text();
-        await this.savePreset(name);
+        await this.savePreset(name, option);
 
         const successToast = !this.isAdvancedFormatting() ? t`Preset updated` : t`Template updated`;
         toastr.success(successToast);
@@ -1000,7 +1002,7 @@ export async function initPresetManager() {
             return;
         }
 
-        await presetManager.updatePreset();
+        await presetManager.updatePreset({ skipUpdate: true });
     });
 
     $(document).on('click', '[data-preset-manager-new]', async function () {


### PR DESCRIPTION
Based on community feedback about Preset Regex, I believe a better order to apply regexes should be `global -> preset -> scoped`.
Another edit goes [here](https://github.com/SillyTavern/SillyTavern/pull/4665#discussion_r2440149842)

## Reason

### the community choice before officially supporting preset regexes

Before officially supporting preset regexes, the community
- either puts preset regexes inside global regexes (so the order is `global/preset -> scoped`),
- or uses some scripts to support preset regexes on its own (with the order `global -> preset -> scoped`).

### additional formats from presets are not character authors' concerns

While preset authors try hard to make presets applicable to all character cards, character authors don't know which preset players will use.

Presets may contain additional formats like `<summary>`, `<tidbits>` and so forth. In order to make scoped regexes work correctly, we should apply preset regexes to replace these formats before scoped regexes.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
