### PR TITLE
feat: set sortable handle for regex

### DIFF
--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -1921,6 +1921,7 @@ jQuery(async () => {
         // @ts-ignore
         $(selector).sortable({
             delay: getSortableDelay(),
+            handle: '.drag-handle',
             stop: async function () {
                 const oldScripts = getter();
                 const newScripts = [];


### PR DESCRIPTION
Currently in mobile, its hard to scroll down inside regex panel due to clicking on the regex item triggers regex sorting. So I propose to only allow regex sorting when clicking on the drag handle.

<img width="443" height="402" alt="image" src="https://github.com/user-attachments/assets/96d5edbd-12d8-4a3b-bb29-a77bd5572dd7" />

> The same problem applies to preset prompt entries too, but their drag handles are hidden so I'm hesitant on how to fix it.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
