### PR TITLE
fix: timeout git process after 5 minutes of inactivity

### DIFF
--- a/src/endpoints/extensions.js
+++ b/src/endpoints/extensions.js
@@ -10,7 +10,7 @@ import { PUBLIC_DIRECTORIES } from '../constants.js';
 /**
  * @type {Partial<import('simple-git').SimpleGitOptions>}
  */
-const OPTIONS = Object.freeze({ timeout: { block: 10 * 60 * 1000 } });
+const OPTIONS = Object.freeze({ timeout: { block: 5 * 60 * 1000 } });
 
 /**
  * This function extracts the extension information from the manifest file.
@@ -76,7 +76,8 @@ router.post('/install', async (request, response) => {
     }
 
     try {
-        const git = simpleGit(OPTIONS);
+        // No timeout for cloning, as it may take a while depending on the repo size
+        const git = simpleGit();
 
         // make sure the third-party directory exists
         if (!fs.existsSync(path.join(request.user.directories.extensions))) {

--- a/src/endpoints/extensions.js
+++ b/src/endpoints/extensions.js
@@ -8,6 +8,11 @@ import { CheckRepoActions, default as simpleGit } from 'simple-git';
 import { PUBLIC_DIRECTORIES } from '../constants.js';
 
 /**
+ * @type {Partial<import('simple-git').SimpleGitOptions>}
+ */
+const OPTIONS = Object.freeze({ timeout: { block: 10000 } });
+
+/**
  * This function extracts the extension information from the manifest file.
  * @param {string} extensionPath - The path of the extension folder
  * @returns {Promise<Object>} - Returns the manifest data as an object
@@ -30,7 +35,7 @@ async function getManifest(extensionPath) {
  * @returns {Promise<Object>} - Returns the extension information as an object
  */
 async function checkIfRepoIsUpToDate(extensionPath) {
-    const git = simpleGit({ baseDir: extensionPath });
+    const git = simpleGit({ baseDir: extensionPath, ...OPTIONS });
     await git.fetch('origin');
     const currentBranch = await git.branch();
     const currentCommitHash = await git.revparse(['HEAD']);
@@ -71,7 +76,7 @@ router.post('/install', async (request, response) => {
     }
 
     try {
-        const git = simpleGit();
+        const git = simpleGit(OPTIONS);
 
         // make sure the third-party directory exists
         if (!fs.existsSync(path.join(request.user.directories.extensions))) {
@@ -144,7 +149,7 @@ router.post('/update', async (request, response) => {
         }
 
         const { isUpToDate, remoteUrl } = await checkIfRepoIsUpToDate(extensionPath);
-        const git = simpleGit({ baseDir: extensionPath });
+        const git = simpleGit({ baseDir: extensionPath, ...OPTIONS });
         const isRepo = await git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
         if (!isRepo) {
             throw new Error(`Directory is not a Git repository at ${extensionPath}`);
@@ -187,7 +192,7 @@ router.post('/branches', async (request, response) => {
             return response.status(404).send(`Directory does not exist at ${extensionPath}`);
         }
 
-        const git = simpleGit({ baseDir: extensionPath });
+        const git = simpleGit({ baseDir: extensionPath, ...OPTIONS });
         // Unshallow the repository if it is shallow
         const isShallow = await git.revparse(['--is-shallow-repository']) === 'true';
         if (isShallow) {
@@ -232,7 +237,7 @@ router.post('/switch', async (request, response) => {
             return response.status(404).send(`Directory does not exist at ${extensionPath}`);
         }
 
-        const git = simpleGit({ baseDir: extensionPath });
+        const git = simpleGit({ baseDir: extensionPath, ...OPTIONS });
         const branches = await git.branchLocal();
 
         if (String(branch).startsWith('origin/')) {
@@ -339,7 +344,7 @@ router.post('/version', async (request, response) => {
             return response.status(404).send(`Directory does not exist at ${extensionPath}`);
         }
 
-        const git = simpleGit({ baseDir: extensionPath });
+        const git = simpleGit({ baseDir: extensionPath, ...OPTIONS });
         let currentCommitHash;
         try {
             const isRepo = await git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);

--- a/src/endpoints/extensions.js
+++ b/src/endpoints/extensions.js
@@ -10,7 +10,7 @@ import { PUBLIC_DIRECTORIES } from '../constants.js';
 /**
  * @type {Partial<import('simple-git').SimpleGitOptions>}
  */
-const OPTIONS = Object.freeze({ timeout: { block: 10000 } });
+const OPTIONS = Object.freeze({ timeout: { block: 10 * 60 * 1000 } });
 
 /**
  * This function extracts the extension information from the manifest file.


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

https://github.com/steveukx/git-js/blob/main/docs/PLUGIN-TIMEOUT.md

> I think I might have identified a critical bug
I had like, several dozen git.exe processes running that were from extension update checks for two extensions that had been taken off Github
Despite SillyTavern itself being closed and those checks never resolving, the git.exe, git-credential exe, etc stayed open for literal weeks 
I think the updater code literally doesn't know what to do if an installed extension no longer has a public repo/the repo call fails 
This was on staging from maybe two days ago at the maximum
It was checking for, notably, CharacterStyleCustomizer by Rivelle and BunnyMoTags, neither of which I know to have anything wrong with them themselves 
Checking the command line argument showed it was specifically from the extension update checker
there were multiple gigabytes of RAM tied up from zombie processes spawned by the extension updater that didn't close when I closed the SIllyTavern server


## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
