### PR TITLE
feat: add move up/down functionality for alternate greetings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7216,10 +7216,17 @@
             <div class="alternate_greeting">
                 <details open>
                     <summary>
-                        <div class="title_restorable">
+                        <div class="title_restorable gap5px">
                             <div class="flex-container alignItemsCenter">
                                 <strong><span data-i18n="Alternate Greeting #">Alternate Greeting #</span><span class="greeting_index"></span></strong>
                                 <i class="editor_maximize fa-solid fa-maximize right_menu_button" title="Expand the editor" data-i18n="[title]Expand the editor"></i>
+                            </div>
+                            <span class="expander"></span>
+                            <div class="menu_button menu_button_icon move_up_alternate_greeting" title="Move up" data-i18n="[title]Move up">
+                                <i class="fa-solid fa-chevron-up"></i>
+                            </div>
+                            <div class="menu_button menu_button_icon move_down_alternate_greeting" title="Move down" data-i18n="[title]Move down">
+                                <i class="fa-solid fa-chevron-down"></i>
                             </div>
                             <div class="menu_button menu_button_icon delete_alternate_greeting">
                                 <i class="fa-solid fa-trash-alt"></i>

--- a/public/style.css
+++ b/public/style.css
@@ -3469,7 +3469,6 @@ grammarly-extension {
     filter: brightness(75%) grayscale(1);
     opacity: 0.5;
     pointer-events: none;
-    cursor: not-allowed;
 }
 
 .alternate_greeting summary {

--- a/public/style.css
+++ b/public/style.css
@@ -3464,10 +3464,18 @@ grammarly-extension {
     padding: 2px;
 }
 
+.alternate_greeting:first-of-type .move_up_alternate_greeting,
+.alternate_greeting:last-of-type .move_down_alternate_greeting {
+    filter: brightness(75%) grayscale(1);
+    opacity: 0.5;
+    pointer-events: none;
+    cursor: not-allowed;
+}
+
 .alternate_greeting summary {
     list-style-position: outside;
     margin-left: 1em;
-    padding-left: 1em;
+    padding-left: 5px;
 }
 
 .alternate_greeting textarea {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

This pull request enhances the user experience for managing alternate greetings by adding the ability to reorder greetings and improving the UI for this feature. The most important changes are grouped below:

**Feature Enhancements:**

* Added "Move up" and "Move down" buttons to each alternate greeting block in `public/index.html`, allowing users to reorder greetings in the list.
* Implemented logic in `public/script.js` to handle moving alternate greetings up or down, including bounds checking and updating both the data and UI accordingly. [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R8471) [[2]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6L8482-R8535)

**User Experience Improvements:**

* Disabled the "Move up" button for the first greeting and the "Move down" button for the last greeting, with corresponding visual cues (opacity, grayscale, and cursor changes) in `public/style.css`.
* Automatically scrolls the greetings list to the bottom when a new alternate greeting is added, ensuring the new entry is visible to the user.

**Technical/UI Adjustments:**

* Assigned a `data-index` attribute to each alternate greeting block for more reliable UI updates and event handling.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
