### PR TITLE
fix: Enhances model display for Fal.ai image gen source

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -1739,7 +1739,11 @@ async function loadModels() {
 
     for (const model of models) {
         const option = document.createElement('option');
-        option.innerText = model.text;
+        if (extension_settings.sd.source === sources.falai && model.value) {
+            option.innerText = model.text + ' (' + model.value + ')';
+        } else {
+            option.innerText = model.text;
+        }
         option.value = model.value;
         option.selected = model.value === extension_settings.sd.model;
         $(option).data('model', model);

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -1739,11 +1739,7 @@ async function loadModels() {
 
     for (const model of models) {
         const option = document.createElement('option');
-        if (extension_settings.sd.source === sources.falai && model.value) {
-            option.innerText = model.text + ' (' + model.value + ')';
-        } else {
-            option.innerText = model.text;
-        }
+        option.innerText = model.text;
         option.value = model.value;
         option.selected = model.value === extension_settings.sd.model;
         $(option).data('model', model);

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -1322,7 +1322,8 @@ falai.post('/models', async (_request, response) => {
 
         const modelOptions = models
             .sort((a, b) => a.title.localeCompare(b.title))
-            .map(x => ({ value: x.modelUrl.split('fal-ai/')[1], text: x.title }));
+            .map(x => ({ value: x.modelUrl.split('fal-ai/')[1], text: x.title }))
+            .map(x => ({ ...x, text: `${x.text} (${x.value})` }));
         return response.send(modelOptions);
     } catch (error) {
         console.error(error);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Appends model value in parentheses to the dropdown text when using Fal.ai image gen source, improving selection clarity for users by providing additional model identifiers.

Makes cases like the ByteDance models distinguishable:
<img width="750" height="320" alt="image" src="https://github.com/user-attachments/assets/6e7e6b0c-2b22-4ede-86f5-26921df40a68" />