### PR TITLE
MobileUIEnhancer: add scoped mobile layout styling for enhanced mode

### DIFF
--- a/public/css/mobile-layouts.css
+++ b/public/css/mobile-layouts.css
@@ -1,0 +1,530 @@
+/*
+ * Mobile layout refinements for SillyTavern helper template.
+ * Inspired by color system defined in css/theme.css.
+ */
+
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.mobile-quick-layout-setting {
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.mobile-quick-layout-setting__hint {
+  color: var(--mobile-text-muted, rgba(200, 214, 242, 0.8));
+}
+
+.mobile-quick-customization {
+  position: relative;
+  margin-top: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(107, 205, 198, 0.22);
+  background: rgba(18, 26, 36, 0.55);
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mobile-quick-customization[open] {
+  box-shadow: 0 18px 36px rgba(9, 15, 24, 0.48);
+}
+
+.mobile-quick-customization__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  cursor: pointer;
+  list-style: none;
+  outline: none;
+}
+
+.mobile-quick-customization__summary::-webkit-details-marker {
+  display: none;
+}
+
+.mobile-quick-customization__summary:focus-visible {
+  outline: 2px solid rgba(107, 205, 198, 0.4);
+  outline-offset: 2px;
+}
+
+.mobile-quick-customization__title {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--mobile-icon-color, #cbeeff);
+}
+
+.mobile-quick-customization__chevron {
+  position: relative;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  color: rgba(203, 238, 255, 0.8);
+  transition: color 0.2s ease;
+}
+
+.mobile-quick-customization__summary:hover .mobile-quick-customization__chevron,
+.mobile-quick-customization[open] .mobile-quick-customization__chevron {
+  color: rgba(255, 186, 228, 0.85);
+}
+
+.mobile-quick-customization__chevron::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translate(-50%, -50%) rotate(45deg);
+  transition: transform 0.25s ease;
+}
+
+.mobile-quick-customization[open] .mobile-quick-customization__chevron::before {
+  transform: translate(-50%, -40%) rotate(-135deg);
+}
+
+.mobile-quick-customization__content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 14px 14px;
+  border-top: 1px solid rgba(107, 205, 198, 0.22);
+}
+
+.mobile-quick-customization__hint {
+  margin: 6px 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--mobile-text-muted, rgba(200, 214, 242, 0.75));
+}
+
+.mobile-quick-customization__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mobile-quick-customization__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 0;
+}
+
+.mobile-quick-customization__label {
+  flex: 1 1 auto;
+  font-size: 13px;
+  color: var(--mobile-text-muted, #d7e5ff);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-quick-customization__select {
+  flex: 0 0 150px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(107, 205, 198, 0.3);
+  background: rgba(22, 30, 40, 0.78);
+  color: var(--mobile-icon-color, #e3f9ff);
+}
+
+.mobile-quick-customization__select:focus {
+  outline: 2px solid rgba(107, 205, 198, 0.4);
+  outline-offset: 1px;
+}
+
+.mobile-quick-customization__reset {
+  align-self: flex-end;
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(107, 205, 198, 0.28);
+  background: rgba(30, 42, 56, 0.8);
+  color: var(--mobile-icon-color, #dff6ff);
+  cursor: pointer;
+  font-size: 12px;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.mobile-quick-customization__reset:hover,
+.mobile-quick-customization__reset:focus-visible {
+  border-color: rgba(107, 205, 198, 0.46);
+  background: rgba(42, 56, 72, 0.9);
+  color: var(--mobile-icon-color, #ffffff);
+  outline: none;
+}
+
+.mobile-quick-customization__reset:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mobile-quick-mode-message {
+  margin: 0 0 8px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(26, 31, 39, 0.75);
+  color: var(--mobile-text-muted, #c8d6f2);
+  font-size: 14px;
+  text-align: center;
+  line-height: 1.4;
+}
+
+.mobile-quick-mode-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.mobile-layout-toggle-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(107, 205, 198, 0.24);
+  background: rgba(32, 38, 48, 0.82);
+  color: var(--mobile-icon-color, #bff7ff);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease,
+    transform 0.2s ease;
+}
+
+.mobile-layout-toggle-button:hover,
+.mobile-layout-toggle-button:focus-visible {
+  color: var(--mobile-icon-color, #e6fdff);
+  border-color: var(--mobile-chrome-border, rgba(107, 205, 198, 0.46));
+  background: rgba(40, 48, 60, 0.9);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.mobile-layout-toggle-button:active {
+  transform: translateY(0);
+}
+
+.mobile-quick-toggle,
+.mobile-quick-panel,
+.mobile-quick-primary,
+.mobile-quick-primary-wrap {
+  display: none;
+}
+
+#mobile-quick-panel[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 1024px) {
+  :root[data-mobile-quick-layout="enhanced"] #top-bar {
+    display: none;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #top-settings-holder {
+    position: relative !important;
+    top: auto !important;
+    left: auto !important;
+    width: 100% !important;
+    height: auto !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    z-index: 95;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #sheld {
+    top: calc(var(--mobile-quick-primary-height, 0px)) !important;
+    padding-top: 0 !important;
+    height: calc(100vh - var(--mobile-quick-primary-height, 0px)) !important;
+    max-height: -webkit-fill-available !important;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-primary-wrap {
+    position: sticky;
+    top: 0;
+    z-index: 96;
+    display: flex;
+    justify-content: center;
+    padding: calc(env(safe-area-inset-top, 0px) + 10px) clamp(16px, 5vw, 26px) 12px;
+    background: rgba(10, 14, 20, 0.86);
+    backdrop-filter: blur(14px);
+    border-bottom: 1px solid var(--mobile-chrome-border-soft, rgba(107, 205, 198, 0.2));
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #send_form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #leftSendForm {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 10px;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0 12px;
+    border: 1px solid transparent;
+    border-radius: 14px;
+    background: rgba(26, 31, 39, 0.65);
+    color: var(--mobile-icon-muted);
+    font-size: 14px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease,
+      border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-toggle .fa-solid {
+    font-size: 20px;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-toggle:hover,
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-toggle:focus-visible,
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-toggle.is-active,
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-toggle[aria-expanded="true"] {
+    background: rgba(32, 38, 48, 0.86);
+    color: var(--mobile-icon-color);
+    border-color: var(--mobile-chrome-border);
+    transform: translateY(-1px);
+    outline: none;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-evenly;
+    gap: clamp(8px, 4vw, 18px);
+    flex-wrap: nowrap;
+    width: 100%;
+    padding: 8px clamp(16px, 5vw, 24px);
+    margin: 0;
+    background: rgba(17, 21, 27, 0.92);
+    border-radius: 18px;
+    border: 1px solid var(--mobile-chrome-border-soft, rgba(107, 205, 198, 0.24));
+    box-shadow: 0 10px 24px rgba(3, 5, 11, 0.28);
+    overflow: visible;
+    box-sizing: border-box;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-button {
+    flex: 0 0 26px;
+    width: 26px;
+    height: 26px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9px;
+    border: 1px solid transparent;
+    background: rgba(26, 31, 39, 0.72);
+    color: var(--mobile-icon-muted);
+    font-size: 15px;
+    cursor: pointer;
+    transition: color 0.2s ease, border-color 0.2s ease,
+      background 0.2s ease, transform 0.2s ease;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-button .fa-solid {
+    font-size: 16px;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-button .mobile-quick-label {
+    display: none;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-button:hover,
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-button:focus-visible {
+    color: var(--mobile-icon-color);
+    background: rgba(40, 48, 60, 0.92);
+    transform: translateY(-1px);
+    outline: none;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-layout-toggle-button:active {
+    transform: translateY(0);
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #send_form {
+    position: relative;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel {
+    order: 3;
+    display: block;
+    width: 100%;
+    border-radius: 18px;
+    background: rgba(17, 21, 27, 0.94);
+    border: 1px solid var(--mobile-chrome-border-soft);
+    box-shadow: 0 18px 30px rgba(3, 5, 11, 0.32);
+    max-height: 0;
+    opacity: 0;
+    pointer-events: none;
+    overflow: hidden;
+    padding: 0 clamp(16px, 5vw, 26px);
+    margin: 0;
+    transition: max-height 0.24s ease, opacity 0.22s ease, padding 0.18s ease,
+      margin 0.18s ease;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel.is-open {
+    max-height: 140px;
+    opacity: 1;
+    pointer-events: auto;
+    margin-top: 10px;
+    padding: 12px clamp(16px, 5vw, 26px);
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #mobile-quick-panel:focus {
+    outline: none;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel__buttons {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    gap: 10px;
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 4px;
+    margin: 0;
+    scroll-snap-type: x proximity;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(107, 205, 198, 0.35) transparent;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel__buttons::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel__buttons::-webkit-scrollbar-thumb {
+    background: rgba(107, 205, 198, 0.35);
+    border-radius: 999px;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel__buttons::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button {
+    flex: 0 0 auto;
+    width: 52px;
+    min-width: 52px;
+    height: 52px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    padding: 0;
+    border-radius: 16px;
+    border: 1px solid transparent;
+    background: rgba(26, 31, 39, 0.74);
+    color: var(--mobile-icon-muted);
+    font-size: 15px;
+    cursor: pointer;
+    transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease,
+      transform 0.2s ease;
+    white-space: nowrap;
+    scroll-snap-align: start;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button .fa-solid {
+    font-size: 20px;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button:hover,
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button:focus-visible {
+    color: var(--mobile-icon-color);
+    border-color: var(--mobile-chrome-border);
+    background: rgba(32, 38, 48, 0.82);
+    transform: translateY(-1px);
+    outline: none;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button.mobile-layout-toggle-button {
+    flex: 1 1 160px;
+    min-width: 160px;
+    height: auto;
+    padding: 10px 18px;
+    gap: 8px;
+    border: 1px solid rgba(107, 205, 198, 0.32);
+    background: rgba(32, 38, 48, 0.88);
+    font-weight: 500;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button.mobile-layout-toggle-button:hover,
+  :root[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button.mobile-layout-toggle-button:focus-visible {
+    color: var(--mobile-icon-color, #e6fdff);
+    border-color: var(--mobile-chrome-border, rgba(107, 205, 198, 0.46));
+    background: rgba(40, 48, 60, 0.94);
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #top-settings-holder::before,
+  :root[data-mobile-quick-layout="enhanced"] #top-settings-holder::after {
+    display: none !important;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #top-settings-holder .drawer-toggle,
+  :root[data-mobile-quick-layout="enhanced"] #top-settings-holder .drawer-header {
+    display: none !important;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #top-settings-holder .drawer {
+    width: min(100%, 520px) !important;
+    margin: 4px auto 0 !important;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] #top-settings-holder .drawer-content {
+    top: calc(var(--mobile-quick-primary-height, 0px)) !important;
+    max-height: calc(var(--mobile-drawer-max-height, 70vh));
+    height: calc(100vh - var(--mobile-quick-primary-height, 0px)) !important;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  :root[data-mobile-quick-layout="enhanced"] .chat {
+    padding-bottom: calc(88px + env(safe-area-inset-bottom, 12px));
+  }
+
+  :root[data-mobile-quick-layout="classic"] .mobile-quick-toggle {
+    display: none !important;
+  }
+
+  :root[data-mobile-quick-layout="classic"] #mobile-quick-panel {
+    display: none !important;
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-mobile-quick-layout="enhanced">
 
 <head>
     <title>SillyTavern</title>
@@ -11,6 +11,18 @@
     <meta name="darkreader-lock">
     <meta name="robots" content="noindex, nofollow" />
     <meta name="theme-color" content="#333">
+    <script>
+      (function () {
+        try {
+          const storedMode = window.localStorage?.getItem('mobileQuickLayoutMode');
+          if (storedMode === 'classic') {
+            document.documentElement.setAttribute('data-mobile-quick-layout', 'classic');
+          }
+        } catch (error) {
+          document.documentElement.setAttribute('data-mobile-quick-layout', 'enhanced');
+        }
+      })();
+    </script>
     <style>
         /* Put critical CSS here. The rest should go in stylesheets. */
         body {
@@ -42,6 +54,7 @@
     <link rel="stylesheet" type="text/css" href="css/extensions-panel.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css">
+    <link rel="stylesheet" type="text/css" href="css/mobile-layout.css">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
@@ -62,7 +75,11 @@
     <!-- top bar central settings buttons -->
     <div id="top-bar">
     </div>
+
     <div id="top-settings-holder">
+        <div class="mobile-quick-primary-wrap" role="presentation">
+          <div id="mobile-quick-primary" class="mobile-quick-primary" role="toolbar" aria-label="Quick actions" data-i18n="[aria-label]Quick actions"></div>
+        </div>
         <!-- background selection menu -->
         <div id="ai-config-button" class="drawer">
             <div class="drawer-toggle drawer-header">
@@ -4590,6 +4607,24 @@
                 </div>
                 <div id="user-settings-block-content" class="flex-container spaceEvenly">
                     <div name="UserSettingsFirstColumn" id="UI-Theme-Block" class="flex-container flexFlowColumn wide100p flex1">
+                      <div class="flex-container flexFlowColumn mobile-quick-layout-setting">
+                        <label class="checkbox_label" for="mobile-quick-layout-toggle">
+                          <input type="checkbox" id="mobile-quick-layout-toggle">
+                          <span data-i18n="Use classic top controls">Use classic top controls</span>
+                        </label>
+                        <small class="mobile-quick-layout-setting__hint" data-i18n="Restores the default toolbar and hides the mobile quick panel.">Restores the default toolbar and hides the mobile quick panel.</small>
+                        <details id="mobile-quick-customization" class="mobile-quick-customization" hidden>
+                          <summary class="mobile-quick-customization__summary">
+                            <span class="mobile-quick-customization__title" data-i18n="Quick toolbar layout">Quick toolbar layout</span>
+                            <span class="mobile-quick-customization__chevron" aria-hidden="true"></span>
+                          </summary>
+                          <div class="mobile-quick-customization__content">
+                            <p class="mobile-quick-customization__hint" data-i18n="Choose which drawers appear in the top toolbar. Others will show in the secondary panel.">Choose which drawers appear in the top toolbar. Others will show in the secondary panel.</p>
+                            <div id="mobile-quick-customization-list" class="mobile-quick-customization__list" role="list"></div>
+                            <button type="button" id="mobile-quick-customization-reset" class="mobile-quick-customization__reset" data-i18n="Restore defaults">Restore defaults</button>
+                          </div>
+                        </details>
+                      </div>
                         <div id="UI-presets-block" class="flex-container flexFlowColumn">
                             <h4 class="title_restorable">
                                 <span data-i18n="UI Theme">UI Theme</span>
@@ -7613,6 +7648,10 @@
                 <div id="nonQRFormItems">
                     <div id="leftSendForm" class="alignContentCenter">
                         <div id="options_button" class="fa-solid fa-bars interactable"></div>
+                          <button type="button" id="mobile-quick-toggle" class="mobile-quick-toggle interactable" aria-controls="mobile-quick-panel" aria-expanded="false">
+                            <span class="fa-solid fa-circle-plus" aria-hidden="true"></span>
+                            <span class="sr-only" data-i18n="Toggle quick panels">Toggle quick panels</span>
+                          </button>
                     </div>
                     <textarea id="send_textarea" name="text" class="mdHotkeys" data-i18n="[no_connection_text]Not connected to API!;[connected_text]Type a message, or /? for help" placeholder="Not connected to API!" no_connection_text="Not connected to API!" connected_text="Type a message, or /? for help" autocomplete="off"></textarea>
                     <div id="rightSendForm" class="alignContentCenter">
@@ -7633,6 +7672,7 @@
                         <div id="send_but" class="fa-solid fa-paper-plane interactable displayNone" title="Send a message" data-i18n="[title]Send a message"></div>
                     </div>
                 </div>
+                <div id="mobile-quick-panel" class="mobile-quick-panel" aria-live="polite" role="region" tabindex="-1" hidden></div>
             </div>
         </div>
     </div>
@@ -7727,6 +7767,776 @@
     <script type="module" src="lib/eventemitter.js"></script>
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="script.js"></script>
+    <script>
+      (function () {
+          const selector = '[data-drawer-target]';
+          let syncQuickPanelState = () => { };
+          let suppressPanelClose = false;
+          let activeDrawerTarget = null;
+          const primaryButtons = new Map();
+          let layoutModeToggleInput = null;
+          const LAYOUT_MODES = {
+            ENHANCED: 'enhanced',
+            CLASSIC: 'classic',
+          };
+          const LAYOUT_STORAGE_KEY = 'mobileQuickLayoutMode';
+          const DRAWER_PREFERENCE_KEY = 'mobileQuickDrawerPreferences';
+          const CUSTOMIZATION_PANEL_STATE_KEY = 'mobileQuickCustomizationExpanded';
+
+          const loadCustomizationPanelState = () => {
+            try {
+              const raw = window.localStorage?.getItem(CUSTOMIZATION_PANEL_STATE_KEY);
+              if (raw === 'true') {
+                return true;
+              }
+              if (raw === 'false') {
+                return false;
+              }
+            } catch (error) {
+              /* no-op */
+            }
+            return null;
+          };
+
+          const persistCustomizationPanelState = (isOpen) => {
+            try {
+              if (typeof isOpen === 'boolean') {
+                window.localStorage?.setItem(CUSTOMIZATION_PANEL_STATE_KEY, isOpen ? 'true' : 'false');
+              } else {
+                window.localStorage?.removeItem(CUSTOMIZATION_PANEL_STATE_KEY);
+              }
+            } catch (error) {
+              /* no-op */
+            }
+          };
+
+          const sanitizePriority = (value) => {
+            if (value === 'primary' || value === 'secondary' || value === 'hidden') {
+              return value;
+            }
+            return undefined;
+          };
+
+          const loadDrawerPreferences = () => {
+            try {
+              const raw = window.localStorage?.getItem(DRAWER_PREFERENCE_KEY);
+              if (!raw) {
+                return {};
+              }
+              const parsed = JSON.parse(raw);
+              return parsed && typeof parsed === 'object' ? parsed : {};
+            } catch (error) {
+              return {};
+            }
+          };
+
+          let drawerPreferences = loadDrawerPreferences();
+          let customizationPanelState = loadCustomizationPanelState();
+
+          const persistDrawerPreferences = () => {
+            try {
+              window.localStorage?.setItem(DRAWER_PREFERENCE_KEY, JSON.stringify(drawerPreferences));
+            } catch (error) {
+              /* no-op */
+            }
+          };
+
+          const getDrawerPreference = (targetId) => sanitizePriority(drawerPreferences?.[targetId]);
+
+          const setDrawerPreference = (targetId, priority) => {
+            const sanitized = sanitizePriority(priority);
+            if (!sanitized) {
+              delete drawerPreferences[targetId];
+            } else {
+              drawerPreferences[targetId] = sanitized;
+            }
+            persistDrawerPreferences();
+          };
+
+          const resetDrawerPreferences = () => {
+            drawerPreferences = {};
+            persistDrawerPreferences();
+          };
+
+          const getStoredLayoutMode = () => {
+            try {
+              const stored = window.localStorage?.getItem(LAYOUT_STORAGE_KEY);
+              return stored === LAYOUT_MODES.CLASSIC ? LAYOUT_MODES.CLASSIC : LAYOUT_MODES.ENHANCED;
+            } catch (error) {
+              return LAYOUT_MODES.ENHANCED;
+            }
+          };
+
+          const persistLayoutMode = (mode) => {
+            try {
+              window.localStorage?.setItem(LAYOUT_STORAGE_KEY, mode);
+            } catch (error) {
+              /* no-op */
+            }
+          };
+
+          let currentLayoutMode = getStoredLayoutMode();
+
+          const isClassicLayout = () => currentLayoutMode === LAYOUT_MODES.CLASSIC;
+
+          const clearPrimaryButtonStates = () => {
+            primaryButtons.forEach((button) => {
+              button.classList.remove('is-active');
+              button.setAttribute('aria-pressed', 'false');
+            });
+          };
+
+          const setPrimaryButtonActive = (targetId, isActive) => {
+            const button = primaryButtons.get(targetId);
+            if (!button) {
+              return;
+            }
+            button.classList.toggle('is-active', isActive);
+            button.setAttribute('aria-pressed', String(isActive));
+          };
+
+          const sanitizeIconClass = (iconClass = '') => {
+            if (!iconClass) {
+              return 'fa-solid fa-gear';
+            }
+            const blacklist = new Set(['drawer-icon', 'closedIcon', 'openIcon', 'drawer-toggle-icon']);
+            const filteredClasses = iconClass
+              .split(/\s+/)
+              .map((cls) => cls.trim())
+              .filter((cls) => cls && !blacklist.has(cls));
+            return filteredClasses.length ? filteredClasses.join(' ') : 'fa-solid fa-gear';
+          };
+
+          const extractLabelKey = (rawValue) => {
+            if (!rawValue) {
+              return null;
+            }
+            const segments = rawValue
+              .split(';')
+              .map((segment) => segment.trim())
+              .filter(Boolean);
+
+            for (const segment of segments) {
+              const match = segment.match(/\[[^\]]*](.+)/);
+              if (match) {
+                return match[1].trim();
+              }
+              if (!segment.startsWith('[')) {
+                return segment.trim();
+              }
+            }
+
+            return null;
+          };
+
+          function handleMobileShortcut(event) {
+            const targetElement = event.currentTarget;
+            const targetId = targetElement?.getAttribute('data-drawer-target');
+            if (!targetId) {
+              return;
+            }
+
+            const drawer = document.getElementById(targetId);
+            if (!drawer) {
+              return;
+            }
+
+            const toggle = drawer.querySelector('.drawer-toggle, .drawer-header');
+            const drawerContent = drawer.querySelector('.drawer-content');
+            if (!toggle || !drawerContent) {
+              return;
+            }
+
+            event.preventDefault();
+
+            const isCurrentlyClosed = drawerContent.classList.contains('closedDrawer');
+            const isActiveTarget = activeDrawerTarget === targetId && !isCurrentlyClosed;
+            const willOpen = !isActiveTarget;
+
+            suppressPanelClose = true;
+
+            if (willOpen) {
+              activeDrawerTarget = targetId;
+              clearPrimaryButtonStates();
+            }
+
+            if (typeof toggle.click === 'function') {
+              toggle.click();
+            } else {
+              toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+            }
+
+            if (willOpen) {
+              setPrimaryButtonActive(targetId, true);
+            } else {
+              setPrimaryButtonActive(targetId, false);
+              if (activeDrawerTarget === targetId) {
+                activeDrawerTarget = null;
+              }
+            }
+
+            toggle.classList.add('mobile-drawer-highlight');
+            toggle.focus?.({ preventScroll: true });
+            window.setTimeout(() => toggle.classList.remove('mobile-drawer-highlight'), 520);
+            window.setTimeout(() => {
+              suppressPanelClose = false;
+              const isClosedNow = drawerContent.classList.contains('closedDrawer');
+              if (isClosedNow) {
+                if (activeDrawerTarget === targetId) {
+                  activeDrawerTarget = null;
+                }
+                setPrimaryButtonActive(targetId, false);
+              } else {
+                activeDrawerTarget = targetId;
+                clearPrimaryButtonStates();
+                setPrimaryButtonActive(targetId, true);
+              }
+            }, 160);
+          }
+
+          document.addEventListener('DOMContentLoaded', () => {
+            const quickToggle = document.getElementById('mobile-quick-toggle');
+            const quickPanel = document.getElementById('mobile-quick-panel');
+            const primaryContainer = document.getElementById('mobile-quick-primary');
+            const chatArea = document.getElementById('chat');
+            const topSettingsHolder = document.getElementById('top-settings-holder');
+            const toggleIcon = quickToggle?.querySelector('.fa-solid');
+            layoutModeToggleInput = document.getElementById('mobile-quick-layout-toggle');
+            const customizationSection = document.getElementById('mobile-quick-customization');
+            const customizationList = document.getElementById('mobile-quick-customization-list');
+            const customizationResetButton = document.getElementById('mobile-quick-customization-reset');
+
+            if (customizationSection instanceof HTMLDetailsElement) {
+              customizationSection.addEventListener('toggle', () => {
+                customizationPanelState = customizationSection.open;
+                persistCustomizationPanelState(customizationPanelState);
+              });
+            }
+
+            const syncLayoutModeControls = () => {
+              if (!layoutModeToggleInput) {
+                return;
+              }
+              const shouldCheck = isClassicLayout();
+              if (layoutModeToggleInput.checked !== shouldCheck) {
+                layoutModeToggleInput.checked = shouldCheck;
+              }
+            };
+            const PRIMARY_ORDER = ['rightNavHolder', 'ai-config-button', 'WI-SP-button', 'extensions-settings-button'];
+            const PRIMARY_SHORTCUT_IDS = new Set(PRIMARY_ORDER);
+
+            const computeDefaultPriority = (drawer) => {
+              const explicit = drawer.dataset.mobilePriority?.toLowerCase();
+              if (explicit === 'primary' || explicit === 'secondary' || explicit === 'hidden') {
+                return explicit;
+              }
+              return PRIMARY_SHORTCUT_IDS.has(drawer.id) ? 'primary' : 'secondary';
+            };
+
+            const resolvePriorities = (drawer) => {
+              const defaultPriority = computeDefaultPriority(drawer);
+              const preference = getDrawerPreference(drawer.id);
+              return {
+                priority: preference ?? defaultPriority,
+                defaultPriority,
+              };
+            };
+
+            const buildDrawerConfig = () => {
+              if (!topSettingsHolder) {
+                return [];
+              }
+
+              const drawers = Array.from(topSettingsHolder.querySelectorAll(':scope > .drawer'));
+              return drawers
+                .map((drawer, index) => {
+                  const targetId = drawer.id;
+                  if (!targetId) {
+                    return null;
+                  }
+
+                  const toggleElement = drawer.querySelector('.drawer-toggle, .drawer-header');
+                  const iconElement = toggleElement?.querySelector('.drawer-icon, i')
+                    || drawer.querySelector('.drawer-icon, i');
+
+                  const iconClass = drawer.dataset.mobileIcon
+                    || iconElement?.className
+                    || '';
+                  const rawI18n = drawer.dataset.mobileI18n
+                    || iconElement?.getAttribute?.('data-i18n')
+                    || toggleElement?.getAttribute?.('data-i18n')
+                    || '';
+                  const labelKey = extractLabelKey(rawI18n);
+
+                  const fallbackLabel = drawer.dataset.mobileLabel
+                    || toggleElement?.getAttribute?.('title')
+                    || iconElement?.getAttribute?.('title')
+                    || toggleElement?.textContent?.trim()
+                    || iconElement?.textContent?.trim()
+                    || labelKey
+                    || targetId;
+
+                  const { priority, defaultPriority } = resolvePriorities(drawer);
+
+                  return {
+                    targetId,
+                    iconClass,
+                    labelKey,
+                    fallbackLabel,
+                    priority,
+                    defaultPriority,
+                    order: index,
+                  };
+                })
+                .filter(Boolean);
+            };
+
+            const bindShortcut = (element) => {
+              if (!element || element.dataset.drawerShortcutBound === 'true') {
+                return;
+              }
+              element.addEventListener('click', handleMobileShortcut);
+              element.dataset.drawerShortcutBound = 'true';
+            };
+
+            const createIconSpan = (iconClass) => {
+              const iconSpan = document.createElement('span');
+              iconSpan.classList.add('mobile-quick-icon');
+              const classes = sanitizeIconClass(iconClass)
+                .split(/\s+/)
+                .map((cls) => cls.trim())
+                .filter(Boolean);
+
+              classes.forEach((cls) => iconSpan.classList.add(cls));
+
+              const hasFaClass = classes.some((cls) => cls.startsWith('fa-'));
+              if (!hasFaClass) {
+                iconSpan.classList.add('fa-solid', 'fa-gear');
+              }
+
+              return iconSpan;
+            };
+
+            const createLabelSpan = (labelKey, fallbackLabel) => {
+              const labelSpan = document.createElement('span');
+              labelSpan.classList.add('mobile-quick-label');
+              labelSpan.textContent = fallbackLabel;
+              if (labelKey) {
+                labelSpan.setAttribute('data-i18n', labelKey);
+              }
+              return labelSpan;
+            };
+
+            const createShortcutButton = (config, options = {}) => {
+              const { targetId, iconClass, labelKey, fallbackLabel } = config;
+              const drawerExists = document.getElementById(targetId);
+              if (!drawerExists) {
+                return null;
+              }
+
+              const button = document.createElement('button');
+              button.type = 'button';
+              button.className = options.className ?? 'mobile-quick-panel-button';
+              button.setAttribute('data-drawer-target', targetId);
+              button.setAttribute('aria-controls', targetId);
+              button.setAttribute('aria-label', fallbackLabel);
+              button.setAttribute('aria-pressed', 'false');
+
+              button.appendChild(createIconSpan(iconClass));
+              const labelSpan = createLabelSpan(labelKey, fallbackLabel);
+              if (options.labelHidden) {
+                labelSpan.classList.add('sr-only');
+              }
+              button.appendChild(labelSpan);
+
+              bindShortcut(button);
+              options.container?.appendChild(button);
+              return button;
+            };
+
+            const createModeToggleButton = (nextMode, { variant = 'panel' } = {}) => {
+              const isNextClassic = nextMode === LAYOUT_MODES.CLASSIC;
+              const button = document.createElement('button');
+              button.type = 'button';
+              button.className = variant === 'panel'
+                ? 'mobile-quick-panel-button mobile-layout-toggle-button'
+                : 'mobile-layout-toggle-button';
+              const text = isNextClassic ? '切换为原生布局' : '切换为移动布局';
+              const i18nKey = isNextClassic ? 'Switch to classic layout' : 'Switch to enhanced mobile layout';
+              button.textContent = text;
+              button.setAttribute('data-i18n', i18nKey);
+              button.addEventListener('click', (event) => {
+                event.preventDefault();
+                setLayoutMode(nextMode);
+              });
+              return button;
+            };
+
+            const updateLayoutMetrics = () => {
+              if (!document?.documentElement) {
+                return;
+              }
+              const primaryWrap = document.querySelector('.mobile-quick-primary-wrap');
+              const primaryHeight = primaryWrap?.getBoundingClientRect?.().height ?? 0;
+              document.documentElement.style.setProperty('--mobile-quick-primary-height', `${Math.round(primaryHeight)}px`);
+
+              const sendForm = document.getElementById('send_form');
+              const sendFormHeight = sendForm?.getBoundingClientRect?.().height ?? 0;
+              document.documentElement.style.setProperty('--mobile-send-form-height', `${Math.round(sendFormHeight)}px`);
+            };
+
+            const renderClassicPanel = () => {
+              if (primaryContainer) {
+                primaryContainer.innerHTML = '';
+                primaryContainer.setAttribute('hidden', '');
+              }
+
+              primaryButtons.clear();
+
+              if (!quickPanel) {
+                return;
+              }
+
+              quickPanel.innerHTML = '';
+              panelButtonsContainer = null;
+
+              const message = document.createElement('p');
+              message.className = 'mobile-quick-mode-message';
+              message.textContent = '移动快捷布局已关闭';
+              message.setAttribute('data-i18n', 'Mobile quick layout disabled');
+              quickPanel.appendChild(message);
+
+              const controls = document.createElement('div');
+              controls.className = 'mobile-quick-mode-controls';
+              controls.appendChild(createModeToggleButton(LAYOUT_MODES.ENHANCED));
+              quickPanel.appendChild(controls);
+              updateLayoutMetrics();
+            };
+
+            let panelButtonsContainer = quickPanel;
+
+            const renderCustomizationControls = (drawerConfig) => {
+              if (!customizationSection || !customizationList) {
+                return;
+              }
+
+              if (!Array.isArray(drawerConfig) || drawerConfig.length === 0) {
+                customizationSection.setAttribute('hidden', '');
+                return;
+              }
+
+              customizationSection.removeAttribute('hidden');
+
+              const hasCustomPreferences = Object.keys(drawerPreferences || {}).length > 0;
+              if (customizationSection instanceof HTMLDetailsElement) {
+                if (typeof customizationPanelState === 'boolean') {
+                  customizationSection.open = customizationPanelState;
+                } else {
+                  customizationSection.open = hasCustomPreferences;
+                }
+              }
+
+              const locale = document.documentElement?.lang || navigator?.language || 'en';
+              const sortedConfig = [...drawerConfig].sort((a, b) => {
+                const labelA = a.fallbackLabel?.toString?.() || '';
+                const labelB = b.fallbackLabel?.toString?.() || '';
+                return labelA.localeCompare(labelB, locale, { sensitivity: 'base' });
+              });
+
+              const fragment = document.createDocumentFragment();
+
+              sortedConfig.forEach((configItem) => {
+                const item = document.createElement('div');
+                item.className = 'mobile-quick-customization__item';
+                item.setAttribute('role', 'listitem');
+
+                const label = document.createElement('span');
+                label.className = 'mobile-quick-customization__label';
+                label.textContent = configItem.fallbackLabel;
+                label.setAttribute('data-drawer-id', configItem.targetId);
+
+                const select = document.createElement('select');
+                select.className = 'mobile-quick-customization__select';
+                select.dataset.drawerId = configItem.targetId;
+                select.dataset.defaultPriority = configItem.defaultPriority ?? 'secondary';
+
+                const optionPrimary = document.createElement('option');
+                optionPrimary.value = 'primary';
+                optionPrimary.textContent = '顶部工具栏';
+                optionPrimary.setAttribute('data-i18n', 'Top toolbar');
+
+                const optionSecondary = document.createElement('option');
+                optionSecondary.value = 'secondary';
+                optionSecondary.textContent = '二级面板';
+                optionSecondary.setAttribute('data-i18n', 'Secondary panel');
+
+                select.append(optionPrimary, optionSecondary);
+
+                const effectivePriority = getDrawerPreference(configItem.targetId)
+                  ?? configItem.priority
+                  ?? 'secondary';
+                if (select.querySelector(`option[value="${effectivePriority}"]`)) {
+                  select.value = effectivePriority;
+                } else {
+                  select.value = 'secondary';
+                }
+
+                select.addEventListener('change', (event) => {
+                  const desiredPriority = event.target.value;
+                  const defaultPriority = event.target.dataset.defaultPriority ?? 'secondary';
+                  if (desiredPriority === defaultPriority) {
+                    setDrawerPreference(configItem.targetId, undefined);
+                  } else {
+                    setDrawerPreference(configItem.targetId, desiredPriority);
+                  }
+                  renderShortcuts();
+                });
+
+                item.append(label, select);
+                fragment.appendChild(item);
+              });
+
+              customizationList.innerHTML = '';
+              customizationList.appendChild(fragment);
+
+              if (customizationResetButton) {
+                customizationResetButton.disabled = !Object.keys(drawerPreferences || {}).length;
+              }
+            };
+
+            const sortPrimaryConfigs = (configs) => {
+              const orderIndex = (targetId) => {
+                const index = PRIMARY_ORDER.indexOf(targetId);
+                return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+              };
+              return configs.sort((a, b) => {
+                const orderDifference = orderIndex(a.targetId) - orderIndex(b.targetId);
+                if (orderDifference !== 0) {
+                  return orderDifference;
+                }
+                return a.order - b.order;
+              });
+            };
+
+            const sortSecondaryConfigs = (configs) => configs.sort((a, b) => a.order - b.order);
+
+            const renderShortcuts = () => {
+              const drawerConfig = buildDrawerConfig();
+              renderCustomizationControls(drawerConfig);
+
+              if (isClassicLayout()) {
+                renderClassicPanel();
+                document.querySelectorAll(selector).forEach((element) => {
+                  bindShortcut(element);
+                });
+                return;
+              }
+
+              if (quickPanel) {
+                quickPanel.innerHTML = '';
+                panelButtonsContainer = document.createElement('div');
+                panelButtonsContainer.className = 'mobile-quick-panel__buttons';
+                quickPanel.appendChild(panelButtonsContainer);
+              } else {
+                panelButtonsContainer = null;
+              }
+
+              if (primaryContainer) {
+                primaryContainer.innerHTML = '';
+                primaryContainer.removeAttribute('hidden');
+              }
+
+              primaryButtons.clear();
+
+              const visibleConfig = drawerConfig.filter((configItem) => configItem.priority !== 'hidden');
+              const primaryConfigs = sortPrimaryConfigs(visibleConfig.filter((configItem) => configItem.priority === 'primary'));
+              const secondaryConfigs = sortSecondaryConfigs(visibleConfig.filter((configItem) => configItem.priority !== 'primary'));
+
+              primaryConfigs.forEach((configItem) => {
+                if (!primaryContainer) {
+                  return;
+                }
+                const button = createShortcutButton(configItem, {
+                  container: primaryContainer,
+                  className: 'mobile-quick-button',
+                  labelHidden: true,
+                });
+                if (button) {
+                  primaryButtons.set(configItem.targetId, button);
+                }
+              });
+
+              secondaryConfigs.forEach((configItem) => {
+                if (!panelButtonsContainer) {
+                  return;
+                }
+                createShortcutButton(configItem, {
+                  container: panelButtonsContainer,
+                  className: 'mobile-quick-panel-button',
+                  labelHidden: true,
+                });
+              });
+
+              if (panelButtonsContainer) {
+                panelButtonsContainer.appendChild(createModeToggleButton(LAYOUT_MODES.CLASSIC, { variant: 'panel' }));
+              }
+
+              clearPrimaryButtonStates();
+              if (activeDrawerTarget) {
+                setPrimaryButtonActive(activeDrawerTarget, true);
+              }
+
+              document.querySelectorAll(selector).forEach((element) => {
+                bindShortcut(element);
+              });
+
+              updateLayoutMetrics();
+            };
+
+            const applyLayoutModeSideEffects = () => {
+              if (document?.documentElement) {
+                document.documentElement.setAttribute('data-mobile-quick-layout', currentLayoutMode);
+              }
+              if (quickToggle) {
+                if (isClassicLayout()) {
+                  quickToggle.setAttribute('hidden', '');
+                } else {
+                  quickToggle.removeAttribute('hidden');
+                }
+              }
+              syncLayoutModeControls();
+              updateLayoutMetrics();
+            };
+
+            const setLayoutMode = (mode, { persist = true, force = false } = {}) => {
+              const targetMode = mode === LAYOUT_MODES.CLASSIC ? LAYOUT_MODES.CLASSIC : LAYOUT_MODES.ENHANCED;
+              if (!force && targetMode === currentLayoutMode) {
+                applyLayoutModeSideEffects();
+                return;
+              }
+              currentLayoutMode = targetMode;
+              if (persist) {
+                persistLayoutMode(currentLayoutMode);
+              }
+              applyLayoutModeSideEffects();
+              syncQuickPanelState(false);
+              renderShortcuts();
+            };
+
+            applyLayoutModeSideEffects();
+
+            if (layoutModeToggleInput) {
+              layoutModeToggleInput.addEventListener('change', (event) => {
+                const nextMode = event.target.checked ? LAYOUT_MODES.CLASSIC : LAYOUT_MODES.ENHANCED;
+                setLayoutMode(nextMode);
+              });
+            }
+
+            if (customizationResetButton) {
+              customizationResetButton.addEventListener('click', () => {
+                resetDrawerPreferences();
+                renderShortcuts();
+              });
+            }
+
+            renderShortcuts();
+
+            if (topSettingsHolder && 'MutationObserver' in window) {
+              const observer = new MutationObserver((mutations) => {
+                const shouldRebuild = mutations.some((mutation) => {
+                  const nodes = [...mutation.addedNodes, ...mutation.removedNodes];
+                  return nodes.some((node) => node instanceof HTMLElement && node.classList?.contains('drawer'));
+                });
+                if (shouldRebuild) {
+                  renderShortcuts();
+                }
+              });
+              observer.observe(topSettingsHolder, { childList: true });
+            }
+
+            syncQuickPanelState = (isOpen) => {
+              if (!quickPanel) {
+                return;
+              }
+              quickPanel.classList.toggle('is-open', isOpen);
+              if (isOpen) {
+                quickPanel.removeAttribute('hidden');
+              } else {
+                quickPanel.setAttribute('hidden', '');
+              }
+              quickToggle?.setAttribute('aria-expanded', String(isOpen));
+              quickToggle?.classList.toggle('is-active', isOpen);
+              if (toggleIcon) {
+                toggleIcon.classList.toggle('fa-circle-plus', !isOpen);
+                toggleIcon.classList.toggle('fa-circle-minus', isOpen);
+              }
+              updateLayoutMetrics();
+            };
+
+            if (quickToggle) {
+              syncQuickPanelState(false);
+              quickToggle.addEventListener('click', (event) => {
+                event.preventDefault();
+                if (!quickPanel) {
+                  return;
+                }
+                const willOpen = !quickPanel.classList.contains('is-open');
+                syncQuickPanelState(willOpen);
+                if (willOpen) {
+                  const firstButton = panelButtonsContainer?.querySelector('button')
+                    ?? quickPanel?.querySelector('button');
+                  firstButton?.focus?.({ preventScroll: true });
+                }
+              });
+            }
+
+            if (quickPanel) {
+              document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && quickPanel.classList.contains('is-open')) {
+                  syncQuickPanelState(false);
+                  quickToggle?.focus?.({ preventScroll: true });
+                }
+              });
+            }
+
+            const updateDrawerMaxHeight = () => {
+              if (!chatArea) {
+                return;
+              }
+              const { height } = chatArea.getBoundingClientRect();
+              if (height > 0) {
+                document.documentElement.style.setProperty('--mobile-drawer-max-height', `${Math.round(height)}px`);
+              }
+            };
+
+            const handleWindowResize = () => {
+              updateDrawerMaxHeight();
+              updateLayoutMetrics();
+            };
+
+            handleWindowResize();
+            window.addEventListener('resize', handleWindowResize);
+            if (window.ResizeObserver && chatArea) {
+              const chatResizeObserver = new ResizeObserver(() => handleWindowResize());
+              chatResizeObserver.observe(chatArea);
+            }
+
+            if (quickPanel) {
+              document.addEventListener('click', (event) => {
+                if (suppressPanelClose) {
+                  return;
+                }
+                const isToggle = event.target.closest?.('.mobile-quick-toggle');
+                const insidePanel = event.target.closest?.('#mobile-quick-panel');
+                const insidePrimary = event.target.closest?.('#mobile-quick-primary');
+                if (!isToggle && !insidePanel && !insidePrimary && quickPanel.classList.contains('is-open')) {
+                  syncQuickPanelState(false);
+                }
+              });
+            }
+          });
+        })();
+    </script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/scripts/extensions/mobile-quick-layout/index.js
+++ b/public/scripts/extensions/mobile-quick-layout/index.js
@@ -1,0 +1,752 @@
+import { eventSource, event_types, saveSettingsDebounced } from '../../../script.js';
+import { extension_settings } from '../../extensions.js';
+import { accountStorage } from '../../util/AccountStorage.js';
+
+const extensionName = 'mobile-quick-layout';
+const extensionSettingsKey = 'mobileQuickLayout';
+const extensionFolderPath = `scripts/extensions/${extensionName}`;
+const defaultSettings = {
+    enabled: true,
+    isEnabled: true,
+};
+
+const LAYOUT_MODES = {
+    ENHANCED: 'enhanced',
+    CLASSIC: 'classic',
+};
+
+const LAYOUT_STORAGE_KEY = 'mobileQuickLayoutMode';
+const DRAWER_PREFERENCE_KEY = 'mobileQuickDrawerPreferences';
+const CUSTOMIZATION_PANEL_STATE_KEY = 'mobileQuickCustomizationExpanded';
+
+let hasAppReadyInitialized = false;
+let rebindSettingsControls = null;
+let requestRenderShortcuts = null;
+
+primeInitialLayoutMode();
+
+function ensureSettingsObject() {
+    extension_settings[extensionSettingsKey] = extension_settings[extensionSettingsKey] || {};
+    if (Object.keys(extension_settings[extensionSettingsKey]).length === 0) {
+        Object.assign(extension_settings[extensionSettingsKey], defaultSettings);
+        saveSettingsDebounced();
+    }
+    return extension_settings[extensionSettingsKey];
+}
+
+function primeInitialLayoutMode() {
+    const root = document.documentElement;
+    if (!root) return;
+
+    const fallbackMode = LAYOUT_MODES.CLASSIC;
+    try {
+        const stored = safeGetItem(LAYOUT_STORAGE_KEY);
+        const mode = stored === LAYOUT_MODES.ENHANCED ? LAYOUT_MODES.ENHANCED : fallbackMode;
+        root.setAttribute('data-mobile-quick-layout', mode);
+    } catch (error) {
+        root.setAttribute('data-mobile-quick-layout', fallbackMode);
+    }
+}
+
+function safeGetItem(key) {
+    try {
+        return accountStorage.getItem(key);
+    } catch (e) {
+        return null;
+    }
+}
+
+function safeSetItem(key, value) {
+    try {
+        accountStorage.setItem(key, value);
+    } catch (e) {
+        // no-op
+    }
+}
+
+function ensureSettingsScaffold() {
+    const settingsColumn = document.getElementById('UI-Theme-Block');
+    if (!settingsColumn) {
+        return {
+            layoutToggleInput: null,
+            customizationSection: null,
+            customizationList: null,
+            customizationResetButton: null,
+        };
+    }
+
+    let wrapper = document.getElementById('mobile-quick-settings');
+    if (!wrapper) {
+        wrapper = document.createElement('div');
+        wrapper.id = 'mobile-quick-settings';
+        wrapper.className = 'flex-container flexFlowColumn mobile-quick-layout-setting';
+
+        const label = document.createElement('label');
+        label.className = 'checkbox_label';
+        label.setAttribute('for', 'mobile-quick-layout-toggle');
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = 'mobile-quick-layout-toggle';
+
+        const labelText = document.createElement('span');
+        labelText.setAttribute('data-i18n', 'Use classic top controls');
+        labelText.textContent = 'Use classic top controls';
+
+        label.append(checkbox, labelText);
+
+        const hint = document.createElement('small');
+        hint.className = 'mobile-quick-layout-setting__hint';
+        hint.setAttribute('data-i18n', 'Restores the default toolbar and hides the mobile quick panel.');
+        hint.textContent = 'Restores the default toolbar and hides the mobile quick panel.';
+
+        const customization = document.createElement('details');
+        customization.id = 'mobile-quick-customization';
+        customization.className = 'mobile-quick-customization';
+        customization.hidden = true;
+
+        const summary = document.createElement('summary');
+        summary.className = 'mobile-quick-customization__summary';
+
+        const title = document.createElement('span');
+        title.className = 'mobile-quick-customization__title';
+        title.setAttribute('data-i18n', 'Quick toolbar layout');
+        title.textContent = 'Quick toolbar layout';
+
+        const chevron = document.createElement('span');
+        chevron.className = 'mobile-quick-customization__chevron';
+        chevron.setAttribute('aria-hidden', 'true');
+
+        summary.append(title, chevron);
+
+        const content = document.createElement('div');
+        content.className = 'mobile-quick-customization__content';
+
+        const explanation = document.createElement('p');
+        explanation.className = 'mobile-quick-customization__hint';
+        explanation.setAttribute('data-i18n', 'Choose which drawers appear in the top toolbar. Others will show in the secondary panel.');
+        explanation.textContent = 'Choose which drawers appear in the top toolbar. Others will show in the secondary panel.';
+
+        const list = document.createElement('div');
+        list.id = 'mobile-quick-customization-list';
+        list.className = 'mobile-quick-customization__list';
+        list.setAttribute('role', 'list');
+
+        const resetButton = document.createElement('button');
+        resetButton.type = 'button';
+        resetButton.id = 'mobile-quick-customization-reset';
+        resetButton.className = 'mobile-quick-customization__reset';
+        resetButton.setAttribute('data-i18n', 'Restore defaults');
+        resetButton.textContent = 'Restore defaults';
+
+        content.append(explanation, list, resetButton);
+        customization.append(summary, content);
+
+        wrapper.append(label, hint, customization);
+
+        settingsColumn.insertBefore(wrapper, settingsColumn.firstChild);
+    }
+
+    return {
+        layoutToggleInput: wrapper.querySelector('#mobile-quick-layout-toggle'),
+        customizationSection: wrapper.querySelector('#mobile-quick-customization'),
+        customizationList: wrapper.querySelector('#mobile-quick-customization-list'),
+        customizationResetButton: wrapper.querySelector('#mobile-quick-customization-reset'),
+    };
+}
+
+function initializeMobileQuickLayout() {
+    const settings = ensureSettingsObject();
+    const enabled = settings.enabled ?? settings.isEnabled ?? true;
+    if (!enabled) return;
+
+    if (hasAppReadyInitialized) {
+        if (typeof rebindSettingsControls === 'function') {
+            const sync = rebindSettingsControls();
+            if (typeof requestRenderShortcuts === 'function') {
+                requestRenderShortcuts();
+            }
+            return sync;
+        }
+        return null;
+    }
+
+    hasAppReadyInitialized = true;
+
+    let {
+        layoutToggleInput,
+        customizationSection,
+        customizationList,
+        customizationResetButton,
+    } = ensureSettingsScaffold();
+
+    const currentLayoutModeFromStorage = () => {
+        try {
+            const stored = safeGetItem(LAYOUT_STORAGE_KEY);
+            return stored === LAYOUT_MODES.ENHANCED ? LAYOUT_MODES.ENHANCED : LAYOUT_MODES.CLASSIC;
+        } catch (e) {
+            return LAYOUT_MODES.CLASSIC;
+        }
+    };
+
+    const persistLayoutMode = (mode) => {
+        safeSetItem(LAYOUT_STORAGE_KEY, mode);
+    };
+
+    const loadDrawerPreferences = () => {
+        try {
+            const raw = safeGetItem(DRAWER_PREFERENCE_KEY);
+            if (!raw) return {};
+            const parsed = JSON.parse(raw);
+            return parsed && typeof parsed === 'object' ? parsed : {};
+        } catch (e) {
+            return {};
+        }
+    };
+
+    const persistDrawerPreferences = (preferences) => {
+        try {
+            safeSetItem(DRAWER_PREFERENCE_KEY, JSON.stringify(preferences));
+        } catch (e) {
+            // ignore
+        }
+    };
+
+    const loadCustomizationPanelState = () => {
+        try {
+            const raw = safeGetItem(CUSTOMIZATION_PANEL_STATE_KEY);
+            if (raw === 'true') return true;
+            if (raw === 'false') return false;
+        } catch (e) {
+            // ignore
+        }
+        return null;
+    };
+
+    const persistCustomizationPanelState = (isOpen) => {
+        try {
+            if (typeof isOpen === 'boolean') {
+                safeSetItem(CUSTOMIZATION_PANEL_STATE_KEY, String(isOpen));
+            } else {
+                safeSetItem(CUSTOMIZATION_PANEL_STATE_KEY, 'false');
+            }
+        } catch (e) {
+            // ignore
+        }
+    };
+
+    let currentLayoutMode = currentLayoutModeFromStorage();
+    let drawerPreferences = loadDrawerPreferences();
+    let customizationPanelState = loadCustomizationPanelState();
+    const primaryButtons = new Map();
+    let activeDrawerTarget = null;
+    let suppressPanelClose = false;
+
+    const getDrawerPreference = (targetId) => {
+        const val = drawerPreferences?.[targetId];
+        if (val === 'primary' || val === 'secondary' || val === 'hidden') return val;
+        return undefined;
+    };
+
+    const setDrawerPreference = (targetId, priority) => {
+        const allowed = new Set(['primary', 'secondary', 'hidden']);
+        if (!allowed.has(priority)) {
+            delete drawerPreferences[targetId];
+        } else {
+            drawerPreferences[targetId] = priority;
+        }
+        persistDrawerPreferences(drawerPreferences);
+    };
+
+    const resetDrawerPreferences = () => {
+        drawerPreferences = {};
+        persistDrawerPreferences(drawerPreferences);
+    };
+
+    const sanitizeIconClass = (iconClass = '') => {
+        if (!iconClass) return 'fa-solid fa-gear';
+        const blacklist = new Set(['drawer-icon', 'closedIcon', 'openIcon', 'drawer-toggle-icon']);
+        const filtered = iconClass.split(/\s+/).map((c) => c.trim()).filter((c) => c && !blacklist.has(c));
+        return filtered.length ? filtered.join(' ') : 'fa-solid fa-gear';
+    };
+
+    const createIconSpan = (iconClass) => {
+        const iconSpan = document.createElement('span');
+        iconSpan.classList.add('mobile-quick-icon');
+        const classes = sanitizeIconClass(iconClass).split(/\s+/).map((c) => c.trim()).filter(Boolean);
+        classes.forEach((cls) => iconSpan.classList.add(cls));
+        if (!classes.some((cls) => cls.startsWith('fa-'))) iconSpan.classList.add('fa-solid', 'fa-gear');
+        return iconSpan;
+    };
+
+    const createLabelSpan = (labelKey, fallbackLabel) => {
+        const labelSpan = document.createElement('span');
+        labelSpan.classList.add('mobile-quick-label');
+        labelSpan.textContent = fallbackLabel || '';
+        if (labelKey) labelSpan.setAttribute('data-i18n', labelKey);
+        return labelSpan;
+    };
+
+    const updateLayoutMetrics = () => {
+        try {
+            const root = document.documentElement;
+            if (!root) return;
+
+            const isEnhanced = root.getAttribute('data-mobile-quick-layout') === LAYOUT_MODES.ENHANCED;
+            const primaryWrap = document.querySelector('.mobile-quick-primary-wrap');
+            const measuredHeight = isEnhanced ? Math.round(primaryWrap?.getBoundingClientRect?.().height ?? 0) : 0;
+            const topValue = measuredHeight > 0 ? `${measuredHeight}px` : '';
+            const heightValue = measuredHeight > 0 ? `calc(100vh - ${measuredHeight}px)` : '';
+
+            const sheld = document.getElementById('sheld');
+            if (sheld instanceof HTMLElement) {
+                sheld.style.top = topValue;
+                sheld.style.height = heightValue;
+            }
+
+            document.querySelectorAll('#top-settings-holder .drawer-content').forEach((drawerContent) => {
+                if (drawerContent instanceof HTMLElement) {
+                    drawerContent.style.top = topValue;
+                    drawerContent.style.height = heightValue;
+                }
+            });
+        } catch (e) {
+            // no-op
+        }
+    };
+
+    const clearPrimaryButtonStates = () => {
+        primaryButtons.forEach((btn) => {
+            btn.classList.remove('is-active');
+            btn.setAttribute('aria-pressed', 'false');
+        });
+    };
+
+    const setPrimaryButtonActive = (targetId, isActive) => {
+        const btn = primaryButtons.get(targetId);
+        if (!btn) return;
+        btn.classList.toggle('is-active', Boolean(isActive));
+        btn.setAttribute('aria-pressed', String(Boolean(isActive)));
+    };
+
+    const handleMobileShortcut = (event) => {
+        const el = event.currentTarget;
+        if (!el) return;
+        const targetId = el.getAttribute('data-drawer-target');
+        if (!targetId) return;
+
+        const drawer = document.getElementById(targetId);
+        if (!(drawer instanceof HTMLElement)) return;
+        const toggle = drawer.querySelector('.drawer-toggle, .drawer-header');
+        const drawerContent = drawer.querySelector('.drawer-content');
+        if (!(toggle instanceof HTMLElement) || !(drawerContent instanceof HTMLElement)) return;
+
+        event.preventDefault();
+
+        const isCurrentlyClosed = drawerContent.classList.contains('closedDrawer');
+        const isActiveTarget = activeDrawerTarget === targetId && !isCurrentlyClosed;
+        const willOpen = !isActiveTarget;
+
+        suppressPanelClose = true;
+
+        if (willOpen) {
+            activeDrawerTarget = targetId;
+            clearPrimaryButtonStates();
+        }
+
+        if (typeof toggle.click === 'function') toggle.click();
+        else toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        if (willOpen) setPrimaryButtonActive(targetId, true);
+        else {
+            setPrimaryButtonActive(targetId, false);
+            if (activeDrawerTarget === targetId) activeDrawerTarget = null;
+        }
+
+        toggle.classList.add('mobile-drawer-highlight');
+        if (typeof toggle.focus === 'function') {
+            toggle.focus({ preventScroll: true });
+        }
+        window.setTimeout(() => toggle.classList.remove('mobile-drawer-highlight'), 520);
+        window.setTimeout(() => {
+            suppressPanelClose = false;
+            const isClosedNow = drawerContent.classList.contains('closedDrawer');
+            if (isClosedNow) {
+                if (activeDrawerTarget === targetId) activeDrawerTarget = null;
+                setPrimaryButtonActive(targetId, false);
+            } else {
+                activeDrawerTarget = targetId;
+                clearPrimaryButtonStates();
+                setPrimaryButtonActive(targetId, true);
+            }
+        }, 160);
+    };
+
+    const createShortcutButton = (config, options = {}) => {
+        const { targetId, iconClass, fallbackLabel } = config;
+        if (!document.getElementById(targetId)) return null;
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = options.className ?? 'mobile-quick-panel-button';
+        button.setAttribute('data-drawer-target', targetId);
+        button.setAttribute('aria-controls', targetId);
+        button.setAttribute('aria-label', fallbackLabel || targetId);
+        button.setAttribute('aria-pressed', 'false');
+        button.appendChild(createIconSpan(iconClass));
+        const labelSpan = createLabelSpan(null, fallbackLabel);
+        if (options.labelHidden) labelSpan.classList.add('sr-only');
+        button.appendChild(labelSpan);
+        button.addEventListener('click', handleMobileShortcut);
+        options.container?.appendChild(button);
+        if ((button.className || '').includes('mobile-quick-button')) primaryButtons.set(targetId, button);
+        return button;
+    };
+
+    const applyLayoutModeSideEffects = () => {
+        try {
+            document.documentElement.setAttribute('data-mobile-quick-layout', currentLayoutMode);
+        } catch (e) {
+            /* no-op */
+        }
+        const quickToggle = document.getElementById('mobile-quick-toggle');
+        if (quickToggle) {
+            if (currentLayoutMode === LAYOUT_MODES.CLASSIC) quickToggle.setAttribute('hidden', ''); else quickToggle.removeAttribute('hidden');
+        }
+        syncLayoutModeControls();
+        updateLayoutMetrics();
+    };
+
+    const syncQuickPanelState = (isOpen) => {
+        const quickToggle = document.getElementById('mobile-quick-toggle');
+        const quickPanel = document.getElementById('mobile-quick-panel');
+        if (!quickPanel) return;
+        quickPanel.classList.toggle('is-open', Boolean(isOpen));
+        if (isOpen) quickPanel.removeAttribute('hidden'); else quickPanel.setAttribute('hidden', '');
+        if (quickToggle) {
+            quickToggle.setAttribute('aria-expanded', String(Boolean(isOpen)));
+            const icon = quickToggle.querySelector('.fa-solid');
+            if (icon) {
+                icon.classList.toggle('fa-circle-plus', !isOpen);
+                icon.classList.toggle('fa-circle-minus', Boolean(isOpen));
+            }
+        }
+        updateLayoutMetrics();
+    };
+
+    const renderShortcuts = () => {
+        const topSettingsHolder = document.getElementById('top-settings-holder');
+        const sendForm = document.getElementById('send_form');
+
+        const quickPanel = document.getElementById('mobile-quick-panel') || (() => {
+            const panel = document.createElement('div');
+            panel.id = 'mobile-quick-panel';
+            panel.className = 'mobile-quick-panel';
+            panel.setAttribute('aria-live', 'polite');
+            panel.setAttribute('role', 'region');
+            panel.tabIndex = -1;
+            const parent = sendForm ?? document.body;
+            const anchor = parent.querySelector('#mobile-quick-primary-wrap');
+            if (anchor && anchor.nextSibling) {
+                parent.insertBefore(panel, anchor.nextSibling);
+            } else {
+                parent.appendChild(panel);
+            }
+            return panel;
+        })();
+
+        if (sendForm && quickPanel.parentElement !== sendForm) {
+            const anchor = sendForm.querySelector('#mobile-quick-primary-wrap');
+            if (anchor && anchor.nextSibling) sendForm.insertBefore(quickPanel, anchor.nextSibling); else sendForm.appendChild(quickPanel);
+        }
+
+        const primaryContainer = document.getElementById('mobile-quick-primary') || (() => {
+            const wrap = document.createElement('div');
+            wrap.id = 'mobile-quick-primary-wrap';
+            wrap.className = 'mobile-quick-primary-wrap';
+            const inner = document.createElement('div');
+            inner.id = 'mobile-quick-primary';
+            inner.className = 'mobile-quick-primary';
+            wrap.appendChild(inner);
+            const parent = topSettingsHolder ?? document.body;
+            const reference = parent?.firstElementChild ?? null;
+            if (reference) parent.insertBefore(wrap, reference); else parent.appendChild(wrap);
+            return inner;
+        })();
+
+        if (topSettingsHolder) {
+            const wrap = document.getElementById('mobile-quick-primary-wrap');
+            if (wrap && wrap.parentElement !== topSettingsHolder) {
+                const reference = topSettingsHolder.firstElementChild;
+                if (reference) topSettingsHolder.insertBefore(wrap, reference); else topSettingsHolder.appendChild(wrap);
+            }
+        }
+        const leftSendForm = document.getElementById('leftSendForm');
+        if (leftSendForm && !document.getElementById('mobile-quick-toggle')) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.id = 'mobile-quick-toggle';
+            btn.className = 'mobile-quick-toggle interactable';
+            btn.setAttribute('aria-controls', 'mobile-quick-panel');
+            btn.setAttribute('aria-expanded', 'false');
+            const icon = document.createElement('span');
+            icon.className = 'fa-solid fa-circle-plus';
+            icon.setAttribute('aria-hidden', 'true');
+            const sr = document.createElement('span');
+            sr.className = 'sr-only';
+            sr.setAttribute('data-i18n', 'Toggle quick panels');
+            sr.textContent = 'Toggle quick panels';
+            btn.appendChild(icon);
+            btn.appendChild(sr);
+            leftSendForm.insertBefore(btn, leftSendForm.firstChild);
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                const isOpen = document.getElementById('mobile-quick-panel')?.classList.contains('is-open');
+                syncQuickPanelState(!isOpen);
+            });
+        }
+
+        const drawers = topSettingsHolder ? Array.from(topSettingsHolder.querySelectorAll(':scope > .drawer')) : [];
+        const configs = drawers.map((drawer, index) => {
+            if (!(drawer instanceof HTMLElement)) {
+                return null;
+            }
+            const targetId = drawer.id;
+            if (!targetId) return null;
+            const toggleElement = drawer.querySelector('.drawer-toggle, .drawer-header');
+            const iconElement = toggleElement instanceof HTMLElement ? toggleElement.querySelector('.drawer-icon, i') : drawer.querySelector('.drawer-icon, i');
+            const iconClass = drawer.dataset.mobileIcon || (iconElement instanceof HTMLElement ? iconElement.className : '') || '';
+            const fallbackLabel = drawer.dataset.mobileLabel
+                || (toggleElement instanceof HTMLElement ? toggleElement.getAttribute('title') : toggleElement?.getAttribute?.('title'))
+                || iconElement?.getAttribute?.('title')
+                || (toggleElement?.textContent ? toggleElement.textContent.trim() : '')
+                || (iconElement?.textContent ? iconElement.textContent.trim() : '')
+                || targetId;
+            const defaultPriority = ['rightNavHolder', 'ai-config-button', 'WI-SP-button', 'extensions-settings-button'].includes(targetId) ? 'primary' : 'secondary';
+            const priority = getDrawerPreference(targetId) ?? defaultPriority;
+            return { targetId, iconClass, fallbackLabel, priority, defaultPriority, order: index };
+        }).filter(Boolean);
+
+        primaryContainer.innerHTML = '';
+        quickPanel.innerHTML = '';
+
+        const primaryConfigs = configs.filter((c) => c.priority === 'primary').sort((a, b) => a.order - b.order);
+        const secondaryConfigs = configs.filter((c) => c.priority !== 'primary').sort((a, b) => a.order - b.order);
+
+        primaryConfigs.forEach((cfg) => {
+            createShortcutButton(cfg, { container: primaryContainer, className: 'mobile-quick-button', labelHidden: true });
+        });
+
+        const panelButtons = document.createElement('div');
+        panelButtons.className = 'mobile-quick-panel__buttons';
+        quickPanel.appendChild(panelButtons);
+        secondaryConfigs.forEach((cfg) => createShortcutButton(cfg, { container: panelButtons, className: 'mobile-quick-panel-button', labelHidden: true }));
+
+        const modeBtn = document.createElement('button');
+        modeBtn.type = 'button';
+        modeBtn.className = 'mobile-quick-panel-button mobile-layout-toggle-button';
+        const isClassic = currentLayoutMode === LAYOUT_MODES.CLASSIC;
+        modeBtn.textContent = isClassic ? 'Switch to enhanced mobile layout' : 'Switch to classic layout';
+        modeBtn.setAttribute('data-i18n', isClassic ? 'Switch to enhanced mobile layout' : 'Switch to classic layout');
+        modeBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            setLayoutMode(isClassic ? LAYOUT_MODES.ENHANCED : LAYOUT_MODES.CLASSIC);
+        });
+        panelButtons.appendChild(modeBtn);
+
+        if (customizationSection && customizationList) {
+            if (!Array.isArray(configs) || configs.length === 0) {
+                customizationSection.setAttribute('hidden', '');
+            } else {
+                customizationSection.removeAttribute('hidden');
+                if (customizationSection instanceof HTMLDetailsElement) {
+                    if (typeof customizationPanelState === 'boolean') customizationSection.open = customizationPanelState;
+                    else customizationSection.open = Object.keys(drawerPreferences || {}).length > 0;
+                }
+
+                customizationList.innerHTML = '';
+                const frag = document.createDocumentFragment();
+                const sorted = configs.slice().sort((a, b) => (a.fallbackLabel || '').localeCompare(b.fallbackLabel || ''));
+                sorted.forEach((cfg) => {
+                    const item = document.createElement('div');
+                    item.className = 'mobile-quick-customization__item';
+                    item.setAttribute('role', 'listitem');
+                    const label = document.createElement('span');
+                    label.className = 'mobile-quick-customization__label';
+                    label.textContent = cfg.fallbackLabel || cfg.targetId;
+                    label.setAttribute('data-drawer-id', cfg.targetId);
+                    const select = document.createElement('select');
+                    select.className = 'mobile-quick-customization__select';
+                    select.dataset.drawerId = cfg.targetId;
+                    select.dataset.defaultPriority = cfg.defaultPriority ?? 'secondary';
+                    const optPrimary = document.createElement('option');
+                    optPrimary.value = 'primary';
+                    optPrimary.textContent = 'Top toolbar';
+                    optPrimary.setAttribute('data-i18n', 'Top toolbar');
+                    const optSecondary = document.createElement('option');
+                    optSecondary.value = 'secondary';
+                    optSecondary.textContent = 'Secondary panel';
+                    optSecondary.setAttribute('data-i18n', 'Secondary panel');
+                    const optHidden = document.createElement('option');
+                    optHidden.value = 'hidden';
+                    optHidden.textContent = 'Hidden';
+                    select.append(optPrimary, optSecondary, optHidden);
+                    const effective = getDrawerPreference(cfg.targetId) ?? cfg.priority ?? 'secondary';
+                    if (select.querySelector(`option[value="${effective}"]`)) select.value = effective; else select.value = 'secondary';
+                    select.addEventListener('change', (ev) => {
+                        const target = ev.currentTarget;
+                        if (!(target instanceof HTMLSelectElement)) return;
+                        const val = target.value;
+                        const defaultPriority = target.dataset.defaultPriority ?? cfg.defaultPriority ?? 'secondary';
+                        if (val === defaultPriority) setDrawerPreference(cfg.targetId, undefined);
+                        else setDrawerPreference(cfg.targetId, val);
+                        renderShortcuts();
+                    });
+                    item.append(label, select);
+                    frag.appendChild(item);
+                });
+                customizationList.appendChild(frag);
+                if (customizationResetButton instanceof HTMLButtonElement) {
+                    customizationResetButton.disabled = !Object.keys(drawerPreferences || {}).length;
+                }
+            }
+        }
+
+        if (currentLayoutMode === LAYOUT_MODES.CLASSIC) {
+            primaryContainer.setAttribute('hidden', '');
+            const msg = document.createElement('p');
+            msg.className = 'mobile-quick-mode-message';
+            msg.textContent = 'Mobile quick layout disabled';
+            msg.setAttribute('data-i18n', 'Mobile quick layout disabled');
+            quickPanel.appendChild(msg);
+        }
+
+        updateLayoutMetrics();
+    };
+
+    const syncLayoutModeControls = () => {
+        if (!(layoutToggleInput instanceof HTMLInputElement)) {
+            return;
+        }
+        const shouldCheck = currentLayoutMode === LAYOUT_MODES.CLASSIC;
+        if (layoutToggleInput.checked !== shouldCheck) {
+            layoutToggleInput.checked = shouldCheck;
+        }
+    };
+
+    const setLayoutMode = (mode, { persist = true, force = false } = {}) => {
+        const targetMode = mode === LAYOUT_MODES.ENHANCED ? LAYOUT_MODES.ENHANCED : LAYOUT_MODES.CLASSIC;
+        if (!force && targetMode === currentLayoutMode) {
+            applyLayoutModeSideEffects();
+            return;
+        }
+        currentLayoutMode = targetMode;
+        if (persist) persistLayoutMode(currentLayoutMode);
+        applyLayoutModeSideEffects();
+        renderShortcuts();
+    };
+
+    rebindSettingsControls = () => {
+        const scaffold = ensureSettingsScaffold();
+        layoutToggleInput = scaffold.layoutToggleInput;
+        customizationSection = scaffold.customizationSection;
+        customizationList = scaffold.customizationList;
+        customizationResetButton = scaffold.customizationResetButton;
+
+        if (layoutToggleInput instanceof HTMLInputElement && layoutToggleInput.dataset.mobileQuickBound !== 'true') {
+            layoutToggleInput.addEventListener('change', (ev) => {
+                const target = ev.currentTarget;
+                const nextMode = target instanceof HTMLInputElement && target.checked ? LAYOUT_MODES.CLASSIC : LAYOUT_MODES.ENHANCED;
+                setLayoutMode(nextMode);
+            });
+            layoutToggleInput.dataset.mobileQuickBound = 'true';
+        }
+
+        const detailsSection = customizationSection instanceof HTMLDetailsElement ? customizationSection : null;
+        if (detailsSection && detailsSection.dataset.mobileQuickBound !== 'true') {
+            detailsSection.addEventListener('toggle', () => {
+                customizationPanelState = detailsSection.open;
+                persistCustomizationPanelState(customizationPanelState);
+            });
+            detailsSection.dataset.mobileQuickBound = 'true';
+        }
+
+        const resetBtn = customizationResetButton instanceof HTMLButtonElement ? customizationResetButton : null;
+        if (resetBtn && resetBtn.dataset.mobileQuickBound !== 'true') {
+            resetBtn.addEventListener('click', () => {
+                resetDrawerPreferences();
+                renderShortcuts();
+            });
+            resetBtn.dataset.mobileQuickBound = 'true';
+        }
+
+        return scaffold;
+    };
+
+    requestRenderShortcuts = () => renderShortcuts();
+
+    rebindSettingsControls();
+
+    document.addEventListener('click', (ev) => {
+        const quickPanel = document.getElementById('mobile-quick-panel');
+        if (!quickPanel || !quickPanel.classList.contains('is-open')) return;
+        if (suppressPanelClose) return;
+        const target = ev.target;
+        if (!(target instanceof Element)) {
+            return;
+        }
+        const isToggle = target.closest('.mobile-quick-toggle');
+        const insidePanel = target.closest('#mobile-quick-panel');
+        const insidePrimary = target.closest('#mobile-quick-primary');
+        if (!isToggle && !insidePanel && !insidePrimary) syncQuickPanelState(false);
+    });
+
+    document.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Escape') {
+            const quickPanel = document.getElementById('mobile-quick-panel');
+            if (quickPanel && quickPanel.classList.contains('is-open')) {
+                syncQuickPanelState(false);
+                const quickToggle = document.getElementById('mobile-quick-toggle');
+                quickToggle?.focus?.({ preventScroll: true });
+            }
+        }
+    });
+
+    applyLayoutModeSideEffects();
+    renderShortcuts();
+
+    const topSettingsHolder = document.getElementById('top-settings-holder');
+    if (topSettingsHolder && 'MutationObserver' in window) {
+        const observer = new MutationObserver((mutations) => {
+            const shouldRebuild = mutations.some((mutation) => {
+                const nodes = [...mutation.addedNodes, ...mutation.removedNodes];
+                return nodes.some((node) => node instanceof HTMLElement && node.classList?.contains('drawer'));
+            });
+            if (shouldRebuild) renderShortcuts();
+        });
+        observer.observe(topSettingsHolder, { childList: true });
+    }
+
+    return null;
+}
+
+eventSource.on(event_types.APP_READY, initializeMobileQuickLayout);
+
+eventSource.on(event_types.EXTENSION_SETTINGS_LOADED, () => {
+    ensureSettingsObject();
+    if (typeof rebindSettingsControls === 'function') {
+        rebindSettingsControls();
+        if (typeof requestRenderShortcuts === 'function') {
+            requestRenderShortcuts();
+        }
+    } else {
+        ensureSettingsScaffold();
+    }
+});
+
+jQuery(() => {
+    ensureSettingsObject();
+    ensureSettingsScaffold();
+    void extensionFolderPath;
+});
+
+export default {};

--- a/public/scripts/extensions/mobile-quick-layout/manifest.json
+++ b/public/scripts/extensions/mobile-quick-layout/manifest.json
@@ -1,0 +1,11 @@
+{
+    "display_name": "Mobile Quick Layout (experimental)",
+    "loading_order": 1000,
+    "requires": [],
+    "optional": [],
+    "js": "index.js",
+    "css": "style.css",
+    "author": "dascard",
+    "version": "0.1.0",
+    "homePage": "https://github.com/dascard/ST-MobileUIEnhanced"
+}

--- a/public/scripts/extensions/mobile-quick-layout/style.css
+++ b/public/scripts/extensions/mobile-quick-layout/style.css
@@ -1,0 +1,410 @@
+/* Mobile Quick Layout extension styles (migrated from public/css/mobile-layouts.css)
+  This file contains the full styling for the mobile quick toolbar and panel.
+  Keeping it inside the extension ensures styles load only when the extension
+  is enabled and avoids polluting global stylesheet space.
+*/
+
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+#mobile-quick-settings .mobile-quick-layout-setting {
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+#mobile-quick-customization {
+  position: relative;
+  margin-top: 10px;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+#mobile-quick-customization .mobile-quick-customization__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  cursor: pointer;
+  list-style: none;
+  outline: none;
+}
+
+#mobile-quick-customization .mobile-quick-customization__summary::-webkit-details-marker {
+  display: none;
+}
+
+#mobile-quick-customization .mobile-quick-customization__title {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+#mobile-quick-customization .mobile-quick-customization__chevron {
+  position: relative;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+}
+
+#mobile-quick-customization .mobile-quick-customization__chevron::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translate(-50%, -50%) rotate(45deg);
+  transition: transform 0.25s ease;
+}
+
+#mobile-quick-customization[open] .mobile-quick-customization__chevron::before {
+  transform: translate(-50%, -40%) rotate(-135deg);
+}
+
+#mobile-quick-customization .mobile-quick-customization__content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 14px 14px;
+}
+
+#mobile-quick-customization .mobile-quick-customization__hint {
+  margin: 6px 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+#mobile-quick-customization .mobile-quick-customization__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#mobile-quick-customization .mobile-quick-customization__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 0;
+}
+
+#mobile-quick-customization .mobile-quick-customization__label {
+  flex: 1 1 auto;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#mobile-quick-customization .mobile-quick-customization__select {
+  flex: 0 0 150px;
+  padding: 6px 10px;
+  border-radius: 10px;
+}
+
+#mobile-quick-customization .mobile-quick-customization__reset {
+  align-self: flex-end;
+  padding: 6px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+#mobile-quick-customization .mobile-quick-customization__reset:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+#mobile-quick-settings .mobile-quick-mode-message {
+  margin: 0 0 8px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  font-size: 14px;
+  text-align: center;
+  line-height: 1.4;
+}
+
+#mobile-quick-settings .mobile-quick-mode-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+#mobile-quick-settings .mobile-layout-toggle-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+#mobile-quick-settings .mobile-layout-toggle-button:active {
+  transform: translateY(0);
+}
+
+html[data-mobile-quick-layout] .mobile-quick-toggle,
+html[data-mobile-quick-layout] .mobile-quick-panel,
+html[data-mobile-quick-layout] .mobile-quick-primary,
+html[data-mobile-quick-layout] .mobile-quick-primary-wrap {
+  display: none;
+}
+
+#mobile-quick-panel[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 1024px) {
+  html[data-mobile-quick-layout="enhanced"] #top-bar {
+    display: none;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #top-settings-holder {
+    position: relative !important;
+    top: auto !important;
+    left: auto !important;
+    width: 100% !important;
+    height: auto !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    z-index: 95;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #sheld {
+    top: 0 !important;
+    padding-top: 0 !important;
+    height: 100vh !important;
+    max-height: -webkit-fill-available !important;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-primary-wrap {
+    position: sticky;
+    top: 0;
+    z-index: 96;
+    display: flex;
+    justify-content: center;
+    padding: calc(env(safe-area-inset-top, 0px) + 10px) clamp(16px, 5vw, 26px) 12px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #send_form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #leftSendForm {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 10px;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0 12px;
+    border-radius: 14px;
+    font-size: 14px;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-toggle .fa-solid {
+    font-size: 20px;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-evenly;
+    gap: clamp(8px, 4vw, 18px);
+    flex-wrap: nowrap;
+    width: 100%;
+    padding: 8px clamp(16px, 5vw, 24px);
+    margin: 0;
+    border-radius: 18px;
+    overflow: visible;
+    box-sizing: border-box;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-button {
+    flex: 0 0 26px;
+    width: 26px;
+    height: 26px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9px;
+    font-size: 15px;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-button .fa-solid {
+    font-size: 16px;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-button .mobile-quick-label {
+    display: none;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-layout-toggle-button:active {
+    transform: translateY(0);
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #send_form {
+    position: relative;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-panel {
+    order: 3;
+    display: block;
+    width: 100%;
+    border-radius: 18px;
+    max-height: 0;
+    opacity: 0;
+    pointer-events: none;
+    overflow: hidden;
+    padding: 0 clamp(16px, 5vw, 26px);
+    margin: 0;
+    transition: max-height 0.24s ease, opacity 0.22s ease, padding 0.18s ease,
+      margin 0.18s ease;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-panel.is-open {
+    max-height: 140px;
+    opacity: 1;
+    pointer-events: auto;
+    margin-top: 10px;
+    padding: 12px clamp(16px, 5vw, 26px);
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #mobile-quick-panel:focus {
+    outline: none;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-panel__buttons {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    gap: 10px;
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 4px;
+    margin: 0;
+    scroll-snap-type: x proximity;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px clamp(16px, 5vw, 22px) 6px;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-panel__actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button {
+    flex: 0 0 auto;
+    width: 52px;
+    min-width: 52px;
+    height: 52px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    padding: 0;
+    border-radius: 16px;
+    border: 1px solid transparent;
+    font-size: 15px;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+    white-space: nowrap;
+    scroll-snap-align: start;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button .fa-solid {
+    font-size: 20px;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .mobile-quick-panel-button.mobile-layout-toggle-button {
+    flex: 1 1 160px;
+    min-width: 160px;
+    height: auto;
+    padding: 10px 18px;
+    gap: 8px;
+    border: 1px solid transparent;
+    font-weight: 500;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #top-settings-holder::before,
+  html[data-mobile-quick-layout="enhanced"] #top-settings-holder::after {
+    display: none !important;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #top-settings-holder .drawer-toggle,
+  html[data-mobile-quick-layout="enhanced"] #top-settings-holder .drawer-header {
+    display: none !important;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #top-settings-holder .drawer {
+    width: min(100%, 520px) !important;
+    margin: 4px auto 0 !important;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] #top-settings-holder .drawer-content {
+    top: 0 !important;
+    max-height: 70vh;
+    height: 100vh !important;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  html[data-mobile-quick-layout="enhanced"] .chat {
+    padding-bottom: calc(88px + env(safe-area-inset-bottom, 12px));
+  }
+
+  html[data-mobile-quick-layout="classic"] .mobile-quick-toggle {
+    display: none !important;
+  }
+
+  html[data-mobile-quick-layout="classic"] #mobile-quick-panel {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
PR title Inject mobile-layout.css and link from index.html — fix compact mobile buttons, add top/bottom mobile nav

PR description This PR applies minimal, scoped mobile styling and links it from the HTML entry point. It targets mobile UX improvements by addressing overly compact buttons and adding lightweight mobile navigation controls.

**What changed**

Added public/css/mobile-layout.css 
Includes mobile-focused variables and rules.
Adds a custom top bar and a bottom secondary navigation area.
Provides a simple toggle / layout hint allowing switching between native and mobile-adapted UI.
Modified index.html to include:
<link rel="stylesheet" href="/css/mobile-layout.css">
**Why**

To solve the compact/tight button layout on mobile devices and improve touch target spacing.
To provide a lightweight mobile header and bottom secondary navigation
Keep changes limited to HTML/CSS to reduce runtime risk.
How to test

Checkout branch and run local SillyTavern dev server.
Confirm index.html includes the new stylesheet link.
Open the app on a mobile device or resize browser to ≤1024px and verify:
Buttons and controls have increased spacing and are more touch-friendly.
Custom top bar and bottom secondary nav appear and behave correctly.
Switching between native and mobile-adapted layouts works as expected (via the provided toggle/hint).
Ensure no console errors and no JS behavior changes.
**Notes**

Default provided CSS is intended for mobile use only; desktop appearance is not guaranteed.
Target branch: staging
Keep changes minimal and reviewable (CSS + HTML only).
## Checklist:

- [ ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
