### PR TITLE
Unblock textarea send during edit

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -276,6 +276,7 @@ import { event_types, eventSource } from './scripts/events.js';
 import { initAccessibility } from './scripts/a11y.js';
 import { applyStreamFadeIn } from './scripts/util/stream-fadein.js';
 import { initDomHandlers } from './scripts/dom-handlers.js';
+import { SimpleMutex } from './scripts/util/SimpleMutex.js';
 
 // API OBJECT FOR EXTERNAL WIRING
 globalThis.SillyTavern = {
@@ -1560,9 +1561,8 @@ export async function reloadCurrentChat() {
 export async function sendTextareaMessage() {
     if (is_send_press) return;
     if (isExecutingCommandsFromChatInput) return;
-    if (this_edit_mes_id >= 0) return; // don't proceed if editing a message
 
-    let generateType;
+    let generateType = 'normal';
     // "Continue on send" is activated when the user hits "send" (or presses enter) on an empty chat box, and the last
     // message was sent from a character (not the user or the system).
     const textareaText = String($('#send_textarea').val());
@@ -1581,7 +1581,7 @@ export async function sendTextareaMessage() {
         await newAssistantChat({ temporary: false });
     }
 
-    Generate(generateType);
+    return await Generate(generateType);
 }
 
 /**
@@ -2190,6 +2190,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
     }
 
     applyCharacterTagsToMessageDivs({ mesIds: newMessageId });
+    updateEditArrowClasses();
 }
 
 /**
@@ -9926,8 +9927,9 @@ jQuery(async function () {
         $('#option_continue').trigger('click');
     });
 
-    $('#send_but').on('click', function () {
-        sendTextareaMessage();
+    const userInputGenerateMutex = new SimpleMutex(sendTextareaMessage);
+    $('#send_but').on('click', async function () {
+        await userInputGenerateMutex.update();
     });
 
     //menu buttons setup

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -10,10 +10,12 @@ import { isAdmin } from './user.js';
 import { addLocaleData, getCurrentLocale, t } from './i18n.js';
 import { debounce_timeout } from './constants.js';
 import { accountStorage } from './util/AccountStorage.js';
+import { SimpleMutex } from './util/SimpleMutex.js';
 
 export {
     getContext,
     getApiUrl,
+    SimpleMutex as ModuleWorkerWrapper,
 };
 
 /** @type {string[]} */
@@ -122,31 +124,6 @@ export function renderExtensionTemplate(extensionName, templateId, templateData 
  */
 export function renderExtensionTemplateAsync(extensionName, templateId, templateData = {}, sanitize = true, localize = true) {
     return renderTemplateAsync(`scripts/extensions/${extensionName}/${templateId}.html`, templateData, sanitize, localize, true);
-}
-
-// Disables parallel updates
-export class ModuleWorkerWrapper {
-    constructor(callback) {
-        this.isBusy = false;
-        this.callback = callback;
-    }
-
-    // Called by the extension
-    async update(...args) {
-        // Don't touch me I'm busy...
-        if (this.isBusy) {
-            return;
-        }
-
-        // I'm free. Let's update!
-        try {
-            this.isBusy = true;
-            await this.callback(...args);
-        }
-        finally {
-            this.isBusy = false;
-        }
-    }
 }
 
 export const extension_settings = {

--- a/public/scripts/util/SimpleMutex.js
+++ b/public/scripts/util/SimpleMutex.js
@@ -1,0 +1,44 @@
+/**
+ * A simple mutex class to prevent concurrent updates.
+ */
+export class SimpleMutex {
+    /**
+     * @type {boolean}
+     */
+    isBusy = false;
+
+    /**
+     * @type {Function}
+     */
+    callback = () => {};
+
+    /**
+     * Constructs a SimpleMutex.
+     * @param {Function} callback Callback function.
+     */
+    constructor(callback) {
+        this.isBusy = false;
+        this.callback = callback;
+    }
+
+    /**
+     * Updates the mutex by calling the callback if not busy.
+     * @param  {...any} args Callback args
+     * @returns {Promise<void>}
+     */
+    async update(...args) {
+        // Don't touch me I'm busy...
+        if (this.isBusy) {
+            return;
+        }
+
+        // I'm free. Let's update!
+        try {
+            this.isBusy = true;
+            await this.callback(...args);
+        }
+        finally {
+            this.isBusy = false;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Bring back an ability to send from textarea while editing.
2. Update move message arrow classes when adding a chat message visually.
3. Use a mutex to prevent launching several Generate instances concurrently.
4. Explicitly set a 'normal' generation type when using regular textarea send.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
