### PR TITLE
Remove unnecessary check for swipe info to fix #4717

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6059,7 +6059,7 @@ export function syncSwipeToMes(messageId = null, swipeId = null) {
         return false;
     }
     // If swipes structure is invalid, exit out
-    if (!Array.isArray(targetMessage.swipe_info) || !Array.isArray(targetMessage.swipes)) {
+    if (!Array.isArray(targetMessage.swipes)) {
         return false;
     }
 
@@ -6069,7 +6069,7 @@ export function syncSwipeToMes(messageId = null, swipeId = null) {
         return false;
     }
 
-    const targetSwipeInfo = targetMessage?.swipe_info[targetSwipeId];
+    const targetSwipeInfo = targetMessage?.swipe_info?.[targetSwipeId];
     if (typeof targetSwipeInfo !== 'object') {
         console.warn(`[syncSwipeToMes] Invalid swipe info: ${targetSwipeId}`);
     }

--- a/public/script.js
+++ b/public/script.js
@@ -6063,6 +6063,15 @@ export function syncSwipeToMes(messageId = null, swipeId = null) {
         return false;
     }
 
+    // Backfill swipe_info if missing.
+    if(!Array.isArray(targetMessage.swipe_info)) {
+        targetMessage.swipe_info = targetMessage.swipes.map(_ => ({
+        send_date: targetMessage.send_date,
+        gen_started: void 0,
+        gen_finished: void 0,
+        extra: {},
+    }));
+
     const targetSwipeId = targetMessage.swipe_id;
     if (typeof targetMessage.swipes[targetSwipeId] !== 'string') {
         console.warn(`[syncSwipeToMes] Invalid swipe ID: ${targetSwipeId}`);

--- a/public/script.js
+++ b/public/script.js
@@ -6064,13 +6064,14 @@ export function syncSwipeToMes(messageId = null, swipeId = null) {
     }
 
     // Backfill swipe_info if missing.
-    if(!Array.isArray(targetMessage.swipe_info)) {
+    if (!Array.isArray(targetMessage.swipe_info)) {
         targetMessage.swipe_info = targetMessage.swipes.map(_ => ({
-        send_date: targetMessage.send_date,
-        gen_started: void 0,
-        gen_finished: void 0,
-        extra: {},
-    }));
+            send_date: targetMessage.send_date,
+            gen_started: void 0,
+            gen_finished: void 0,
+            extra: {},
+        }));
+    }
 
     const targetSwipeId = targetMessage.swipe_id;
     if (typeof targetMessage.swipes[targetSwipeId] !== 'string') {


### PR DESCRIPTION
Fix for #4717

## Details on the issue itself
When a chat jsonl has swipes, but no swipe_info associated with a message, the UI incorrectly displays the correct *number* of swipes, but does not correctly display the swipes when swiping, instead it will indicate that you have swiped, but it will display the same message, never updating it, which makes it appear as though all swipes have the same text, despite that not being what is in the chat file.

The swipe_info is _not actually needed_ to display the swipes, so there is no need to strictly check for it and cause incorrect frontend behaviour if it is not present. It's better to only check for the swipes themselves, which **are** actually needed.

## To test
Use a chat file with swipes, but no swipe_info object included on the message. Verify that the messages display correctly when swiping in the UI. If the behaviour appears normal, the fix is working.


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
