### PR TITLE
Multiple attachments

### DIFF
--- a/public/css/file-form.css
+++ b/public/css/file-form.css
@@ -25,6 +25,10 @@
     border-radius: 15px;
 }
 
+.mes_file_container:not(:last-child) {
+    margin-bottom: 5px;
+}
+
 .mes_file_container .right_menu_button {
     padding-right: 0;
 }

--- a/public/css/file-form.css
+++ b/public/css/file-form.css
@@ -32,7 +32,7 @@
 .mes .mes_file_wrapper {
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: 0.5em;
 }
 
 .mes_file_container .right_menu_button {

--- a/public/css/file-form.css
+++ b/public/css/file-form.css
@@ -25,8 +25,14 @@
     border-radius: 15px;
 }
 
-.mes_file_container:not(:last-child) {
-    margin-bottom: 5px;
+.mes .mes_file_wrapper:empty {
+    display: none;
+}
+
+.mes .mes_file_wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
 }
 
 .mes_file_container .right_menu_button {

--- a/public/global.d.ts
+++ b/public/global.d.ts
@@ -6,7 +6,6 @@ import { oai_settings } from './scripts/openai';
 import { textgenerationwebui_settings } from './scripts/textgen-settings';
 import { FileAttachment } from './scripts/chats';
 import { ReasoningMessageExtra } from './scripts/reasoning';
-import { MEDIA_TYPE, MEDIA_DISPLAY } from './scripts/constants';
 
 declare global {
     // Custom types
@@ -35,6 +34,8 @@ declare global {
     };
 
     interface ChatMessageExtra {
+        bias?: string;
+        uses_system_ui?: boolean;
         memory?: string;
         display_text?: string;
         reasoning_display_text?: string;
@@ -47,16 +48,20 @@ declare global {
         media_display?: string;
         media_index?: number;
         media?: MediaAttachment[],
-        /** @deprecated Use 'files' instead */
+        /** @deprecated Use `files` instead */
         file?: FileAttachment;
-        /** @deprecated Use 'media' instead */
+        /** @deprecated Use `media` instead */
         image?: string;
-        /** @deprecated Use 'media' instead */
+        /** @deprecated Use `media` instead */
         video?: string;
-        /** @deprecated Use 'media' with media_display = 'gallery' */
+        /** @deprecated Use `media` with `media_display = 'gallery'` instead */
         image_swipes?: string[];
-        /** @deprecated Use 'append_title' of the 'media' element */
+        /** @deprecated Use `MediaAttachment.append_title` instead */
         append_title?: boolean;
+        /** @deprecated Use `MediaAttachment.generation_type` instead */
+        generationType?: number;
+        /** @deprecated Use `MediaAttachment.negative` instead */
+        negative?: string;
     }
 
     type MediaAttachment = MediaAttachmentProps & ImageGenerationAttachmentProps & ImageCaptionAttachmentProps;

--- a/public/global.d.ts
+++ b/public/global.d.ts
@@ -4,6 +4,9 @@ import { power_user } from './scripts/power-user';
 import { QuickReplyApi } from './scripts/extensions/quick-reply/api/QuickReplyApi';
 import { oai_settings } from './scripts/openai';
 import { textgenerationwebui_settings } from './scripts/textgen-settings';
+import { FileAttachment } from './scripts/chats';
+import { ReasoningMessageExtra } from './scripts/reasoning';
+import { MEDIA_TYPE, MEDIA_DISPLAY } from './scripts/constants';
 
 declare global {
     // Custom types
@@ -12,6 +15,66 @@ declare global {
     type ReasoningSettings = typeof power_user.reasoning;
     type ChatCompletionSettings = typeof oai_settings;
     type TextCompletionSettings = typeof textgenerationwebui_settings;
+    type MessageTimestamp = string | number | Date;
+
+    interface ChatMessage {
+        name?: string;
+        mes?: string;
+        title?: string;
+        gen_started?: MessageTimestamp;
+        gen_finished?: MessageTimestamp;
+        send_date?: MessageTimestamp;
+        is_user?: boolean;
+        is_system?: boolean;
+        force_avatar?: string;
+        original_avatar?: string;
+        swipes?: string[];
+        swipe_info?: Record<string, any>;
+        swipe_id?: number;
+        extra?: ChatMessageExtra & Partial<ReasoningMessageExtra> & Record<string, any>;
+    };
+
+    interface ChatMessageExtra {
+        memory?: string;
+        display_text?: string;
+        reasoning_display_text?: string;
+        tool_invocations?: any[];
+        title?: string;
+        isSmallSys?: boolean;
+        token_count?: number;
+        files?: FileAttachment[];
+        inline_image?: boolean;
+        media_display?: string;
+        media_index?: number;
+        media?: MediaAttachment[],
+        /** @deprecated Use 'files' instead */
+        file?: FileAttachment;
+        /** @deprecated Use 'media' instead */
+        image?: string;
+        /** @deprecated Use 'media' instead */
+        video?: string;
+        /** @deprecated Use 'media' with media_display = 'gallery' */
+        image_swipes?: string[];
+        /** @deprecated Use 'append_title' of the 'media' element */
+        append_title?: boolean;
+    }
+
+    type MediaAttachment = MediaAttachmentProps & ImageGenerationAttachmentProps & ImageCaptionAttachmentProps;
+
+    interface MediaAttachmentProps {
+        url: string;
+        title?: string;
+        type: string;
+    }
+
+    interface ImageGenerationAttachmentProps {
+        generation_type?: number;
+        negative?: string;
+    }
+
+    interface ImageCaptionAttachmentProps {
+        append_title?: boolean;
+    }
 
     // Global namespace modules
     interface Window {

--- a/public/index.html
+++ b/public/index.html
@@ -7641,8 +7641,8 @@
             <div id="send_form" class="no-connection">
                 <form id="file_form" class="wide100p displayNone">
                     <div class="file_attached">
-                        <input id="file_form_input" type="file" hidden>
-                        <input id="embed_file_input" type="file" hidden>
+                        <input id="file_form_input" type="file" multiple hidden>
+                        <input id="embed_file_input" type="file" multiple hidden>
                         <i class="fa-solid fa-file-alt"></i>
                         <span class="file_name">File Name</span>
                         <span class="file_size">File Size</span>

--- a/public/index.html
+++ b/public/index.html
@@ -7043,19 +7043,8 @@
                         <div class="mes_reasoning"></div>
                     </details>
                     <div class="mes_text"></div>
-                    <div class="mes_img_container">
-                        <div class="mes_img_controls">
-                            <div title="Expand and zoom" class="right_menu_button fa-lg fa-solid fa-magnifying-glass mes_img_enlarge" data-i18n="[title]Expand and zoom"></div>
-                            <div title="Caption" class="right_menu_button fa-lg fa-solid fa-envelope-open-text mes_img_caption" data-i18n="[title]Caption"></div>
-                            <div title="Delete" class="right_menu_button fa-lg fa-solid fa-trash-can mes_img_delete" data-i18n="[title]Delete"></div>
-                        </div>
-                        <div class="mes_img_swipes">
-                            <div title="Swipe left" class="right_menu_button fa-lg fa-solid fa-chevron-left mes_img_swipe_left" data-i18n="[title]Swipe left"></div>
-                            <div class="mes_img_swipe_counter">1/1</div>
-                            <div title="Swipe right" class="right_menu_button fa-lg fa-solid fa-chevron-right mes_img_swipe_right" data-i18n="[title]Swipe right"></div>
-                        </div>
-                        <img class="mes_img" src="" />
-                    </div>
+                    <div class="mes_img_wrapper"></div>
+                    <div class="mes_file_wrapper"></div>
                     <div class="mes_bias"></div>
                 </div>
                 <div class="flex-container swipeRightBlock flexFlowColumn flexNoGap">
@@ -7273,6 +7262,22 @@
                 <div class="mes_file_size"></div>
                 <div class="right_menu_button mes_file_open fa-solid fa-magnifying-glass" title="View contents" data-i18n="[title]View contents"></div>
                 <div class="right_menu_button mes_file_delete fa-solid fa-trash-can" title="Remove the file" data-i18n="[title]Remove the file"></div>
+            </div>
+        </div>
+
+        <div id="message_image_template" class="template_element">
+            <div class="mes_img_container">
+                <div class="mes_img_controls">
+                    <div title="Expand and zoom" class="right_menu_button fa-lg fa-solid fa-magnifying-glass mes_img_enlarge" data-i18n="[title]Expand and zoom"></div>
+                    <div title="Caption" class="right_menu_button fa-lg fa-solid fa-envelope-open-text mes_img_caption" data-i18n="[title]Caption"></div>
+                    <div title="Delete" class="right_menu_button fa-lg fa-solid fa-trash-can mes_img_delete" data-i18n="[title]Delete"></div>
+                </div>
+                <div class="mes_img_swipes">
+                    <div title="Swipe left" class="right_menu_button fa-lg fa-solid fa-chevron-left mes_img_swipe_left" data-i18n="[title]Swipe left"></div>
+                    <div class="mes_img_swipe_counter">1/1</div>
+                    <div title="Swipe right" class="right_menu_button fa-lg fa-solid fa-chevron-right mes_img_swipe_right" data-i18n="[title]Swipe right"></div>
+                </div>
+                <img class="mes_img" src="" />
             </div>
         </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -4671,6 +4671,13 @@
                                         <option value="2" data-i18n="Document">Document</option>
                                     </select>
                                 </div>
+                                <div class="flex-container alignitemscenter" title="Default display style for media attachments in chat messages. Extensions can override this setting." data-i18n="[title]Default display style for media attachments in chat messages. Extensions can override this setting.">
+                                    <span data-i18n="Media Style:">Media Style:</span>
+                                    <select id="media_display" class="widthNatural flex1 margin0 text_pole">
+                                        <option value="list" data-i18n="List">List</option>
+                                        <option value="gallery" data-i18n="Gallery">Gallery</option>
+                                    </select>
+                                </div>
                                 <div class="flex-container alignItemsBaseline">
                                     <span data-i18n="Notifications:">Notifications:</span>
                                     <select id="toastr_position" class="widthNatural flex1 margin0 text_pole">

--- a/public/index.html
+++ b/public/index.html
@@ -7005,6 +7005,8 @@
                                 <div title="Prompt" class="mes_button mes_prompt fa-solid fa-square-poll-horizontal " data-i18n="[title]Prompt" style="display: none;"></div>
                                 <div title="Exclude message from prompts" class="mes_button mes_hide fa-solid fa-eye" data-i18n="[title]Exclude message from prompts"></div>
                                 <div title="Include message in prompts" class="mes_button mes_unhide fa-solid fa-eye-slash" data-i18n="[title]Include message in prompts"></div>
+                                <div title="Toggle media display style" class="mes_button mes_media_gallery fa-solid fa-photo-film" data-i18n="[title]Toggle media display style"></div>
+                                <div title="Toggle media display style" class="mes_button mes_media_list fa-solid fa-table-cells-large" data-i18n="[title]Toggle media display style"></div>
                                 <div title="Embed file or image" class="mes_button mes_embed fa-solid fa-paperclip" data-i18n="[title]Embed file or image"></div>
                                 <div title="Create checkpoint" class="mes_button mes_create_bookmark fa-regular fa-solid fa-flag-checkered" data-i18n="[title]Create checkpoint"></div>
                                 <div title="Create branch" class="mes_button mes_create_branch fa-regular fa-code-branch" data-i18n="[title]Create Branch"></div>
@@ -7255,9 +7257,9 @@
             </div>
         </div>
 
-        <!-- chat and input bar -->
+        <!-- Media Templates -->
         <div id="message_file_template" class="template_element">
-            <div class="mes_file_container">
+            <div class="mes_media_container mes_file_container">
                 <div class="fa-lg fa-solid fa-file-alt mes_file_icon"></div>
                 <div class="mes_file_name"></div>
                 <div class="mes_file_size"></div>
@@ -7267,28 +7269,31 @@
         </div>
 
         <div id="message_image_template" class="template_element">
-            <div class="mes_img_container">
+            <div class="mes_media_container mes_img_container">
                 <div class="mes_img_controls">
-                    <div title="Expand and zoom" class="right_menu_button fa-lg fa-solid fa-magnifying-glass mes_img_enlarge" data-i18n="[title]Expand and zoom"></div>
+                    <div title="Expand and zoom" class="right_menu_button fa-lg fa-solid fa-magnifying-glass mes_media_enlarge" data-i18n="[title]Expand and zoom"></div>
                     <div title="Caption" class="right_menu_button fa-lg fa-solid fa-envelope-open-text mes_img_caption" data-i18n="[title]Caption"></div>
-                    <div title="Delete" class="right_menu_button fa-lg fa-solid fa-trash-can mes_img_delete" data-i18n="[title]Delete"></div>
-                </div>
-                <div class="mes_img_swipes">
-                    <div title="Swipe left" class="right_menu_button fa-lg fa-solid fa-chevron-left mes_img_swipe_left" data-i18n="[title]Swipe left"></div>
-                    <div class="mes_img_swipe_counter">1/1</div>
-                    <div title="Swipe right" class="right_menu_button fa-lg fa-solid fa-chevron-right mes_img_swipe_right" data-i18n="[title]Swipe right"></div>
+                    <div title="Delete" class="right_menu_button fa-lg fa-solid fa-trash-can mes_media_delete" data-i18n="[title]Delete"></div>
                 </div>
                 <img class="mes_img" src="" />
             </div>
         </div>
 
         <div id="message_video_template" class="template_element">
-            <div class="mes_video_container">
+            <div class="mes_media_container mes_video_container">
                 <div class="mes_video_controls">
-                    <div><!-- Placeholder --></div>
-                    <div title="Delete" class="right_menu_button fa-lg fa-solid fa-trash-can mes_video_delete" data-i18n="[title]Delete"></div>
+                    <div title="Expand and zoom" class="right_menu_button fa-lg fa-solid fa-magnifying-glass mes_media_enlarge" data-i18n="[title]Expand and zoom"></div>
+                    <div title="Delete" class="right_menu_button fa-lg fa-solid fa-trash-can mes_media_delete" data-i18n="[title]Delete"></div>
                 </div>
                 <video class="mes_video" controls preload="metadata"></video>
+            </div>
+        </div>
+
+        <div id="message_gallery_controls" class="template_element">
+            <div class="mes_img_swipes">
+                <div title="Swipe left" class="right_menu_button fa-lg fa-solid fa-chevron-left mes_img_swipe_left" data-i18n="[title]Swipe left"></div>
+                <div class="mes_img_swipe_counter">1/1</div>
+                <div title="Swipe right" class="right_menu_button fa-lg fa-solid fa-chevron-right mes_img_swipe_right" data-i18n="[title]Swipe right"></div>
             </div>
         </div>
     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -7052,8 +7052,7 @@
                         <div class="mes_reasoning"></div>
                     </details>
                     <div class="mes_text"></div>
-                    <div class="mes_img_wrapper"></div>
-                    <div class="mes_video_wrapper"></div>
+                    <div class="mes_media_wrapper"></div>
                     <div class="mes_file_wrapper"></div>
                     <div class="mes_bias"></div>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -7044,6 +7044,7 @@
                     </details>
                     <div class="mes_text"></div>
                     <div class="mes_img_wrapper"></div>
+                    <div class="mes_video_wrapper"></div>
                     <div class="mes_file_wrapper"></div>
                     <div class="mes_bias"></div>
                 </div>

--- a/public/script.js
+++ b/public/script.js
@@ -2161,7 +2161,7 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         return appendImageAttachment(attachment, index);
     }
 
-    // Only display swipe buttons if there is a single image and multiple swipes
+    // Add media gallery to message
     if (hasMedia && mediaDisplay === MEDIA_DISPLAY.GALLERY) {
         const mediaIndex = getMediaIndex(mes);
         const selectedMedia = mes.extra.media[mediaIndex];

--- a/public/script.js
+++ b/public/script.js
@@ -1968,6 +1968,7 @@ export function ensureMessageMediaIsArray(mes) {
     }
 
     addArrayAutoWrapper(mes.extra, 'file', 'files');
+    addArrayAutoWrapper(mes.extra, 'image', 'images');
 }
 
 /**
@@ -1979,13 +1980,9 @@ export function ensureMessageMediaIsArray(mes) {
 export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     ensureMessageMediaIsArray(mes);
 
-    // Add image to message
-    if (mes.extra?.image) {
-        const container = messageElement.find('.mes_img_container');
-        const chatHeight = chatElement.prop('scrollHeight');
-        const image = messageElement.find('.mes_img');
-        const text = messageElement.find('.mes_text');
-        const isInline = !!mes.extra?.inline_image;
+    // Add images to message
+    if (mes.extra && Array.isArray(mes.extra.images) && mes.extra.images.length > 0) {
+        let chatHeight = chatElement.prop('scrollHeight');
         const doAdjustScroll = () => {
             if (!adjustScroll) {
                 return;
@@ -1994,45 +1991,54 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
             const newChatHeight = chatElement.prop('scrollHeight');
             const diff = newChatHeight - chatHeight;
             chatElement.scrollTop(scrollPosition + diff);
+            chatHeight = newChatHeight;
         };
-        image.off('load').on('load', function () {
-            image.removeAttr('alt');
-            image.removeClass('error');
-            doAdjustScroll();
-        });
-        image.off('error').on('error', function () {
-            image.attr('alt', '');
-            image.addClass('error');
-            doAdjustScroll();
-        });
-        image.attr('src', mes.extra?.image);
-        image.attr('title', mes.extra?.title || mes.title || '');
-        container.addClass('img_extra');
-        image.toggleClass('img_inline', isInline);
-        text.toggleClass('displayNone', !isInline);
 
-        const imageSwipes = mes.extra.image_swipes;
-        if (Array.isArray(imageSwipes) && imageSwipes.length > 0) {
-            container.addClass('img_swipes');
-            const counter = container.find('.mes_img_swipe_counter');
-            const currentImage = imageSwipes.indexOf(mes.extra.image) + 1;
-            counter.text(`${currentImage}/${imageSwipes.length}`);
+        messageElement.find('.mes_text').toggleClass('displayNone', !mes.extra.inline_image);
+        messageElement.find('.mes_img_container').remove();
 
-            const swipeLeft = container.find('.mes_img_swipe_left');
-            swipeLeft.off('click').on('click', function () {
-                eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: 'left' });
+        for (let index = 0; index < mes.extra.images.length; index++) {
+            const template = $('#message_image_template .mes_img_container').clone();
+            template.attr('data-index', index);
+
+            const image = template.find('.mes_img');
+            image.off('load').on('load', function () {
+                image.removeAttr('alt');
+                image.removeClass('error');
+                doAdjustScroll();
             });
-
-            const swipeRight = container.find('.mes_img_swipe_right');
-            swipeRight.off('click').on('click', function () {
-                eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: 'right' });
+            image.off('error').on('error', function () {
+                image.attr('alt', '');
+                image.addClass('error');
+                doAdjustScroll();
             });
+            image.attr('src', mes.extra.images[index]);
+            image.attr('title', mes.extra?.title || mes.title || '');
+
+            // Only display swipe buttons if there is a single image and multiple swipes
+            const imageSwipes = mes.extra.image_swipes;
+            if (mes.extra.images.length === 1 && Array.isArray(imageSwipes) && imageSwipes.length > 0) {
+                template.addClass('img_swipes');
+                const counter = template.find('.mes_img_swipe_counter');
+                const currentImage = imageSwipes.indexOf(mes.extra.image) + 1;
+                counter.text(`${currentImage}/${imageSwipes.length}`);
+
+                const swipeLeft = template.find('.mes_img_swipe_left');
+                swipeLeft.off('click').on('click', function () {
+                    eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: 'left' });
+                });
+
+                const swipeRight = template.find('.mes_img_swipe_right');
+                swipeRight.off('click').on('click', function () {
+                    eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: 'right' });
+                });
+            }
+
+            messageElement.find('.mes_img_wrapper').append(template);
         }
     } else {
-        const container = messageElement.find('.mes_img_container');
-        container.removeClass('img_extra img_swipes');
-        const text = messageElement.find('.mes_text');
-        text.removeClass('displayNone');
+        messageElement.find('.mes_img_container').remove();
+        messageElement.find('.mes_text').removeClass('displayNone');
     }
 
     // Add video to message
@@ -2066,7 +2072,7 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
             template.attr('data-index', index);
             template.find('.mes_file_name').text(file.name).attr('title', file.name);
             template.find('.mes_file_size').text(humanFileSize(file.size)).attr('title', file.size);
-            messageElement.find('.mes_block').append(template);
+            messageElement.find('.mes_file_wrapper').append(template);
         }
     } else {
         messageElement.find('.mes_file_container').remove();
@@ -6183,7 +6189,10 @@ function saveImageToMessage(img, mes) {
         if (!mes.extra || typeof mes.extra !== 'object') {
             mes.extra = {};
         }
-        mes.extra.image = img.image;
+        if (!Array.isArray(mes.extra.images)) {
+            mes.extra.images = [];
+        }
+        mes.extra.images.push(img.image);
         mes.extra.title = img.title;
         mes.extra.inline_image = img.inline;
     }
@@ -9047,7 +9056,7 @@ export async function swipe(_event, direction, { source, repeated, message = cha
             // ditto for display text
             delete chat[mesId].extra.display_text;
 
-            delete chat[mesId].extra.image;
+            delete chat[mesId].extra.images;
             delete chat[mesId].extra.image_swipes;
             delete chat[mesId].extra.video;
             delete chat[mesId].extra.inline_image;

--- a/public/script.js
+++ b/public/script.js
@@ -1969,6 +1969,7 @@ export function ensureMessageMediaIsArray(mes) {
 
     addArrayAutoWrapper(mes.extra, 'file', 'files');
     addArrayAutoWrapper(mes.extra, 'image', 'images');
+    addArrayAutoWrapper(mes.extra, 'video', 'videos');
 }
 
 /**
@@ -1980,20 +1981,24 @@ export function ensureMessageMediaIsArray(mes) {
 export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     ensureMessageMediaIsArray(mes);
 
-    // Add images to message
-    if (mes.extra && Array.isArray(mes.extra.images) && mes.extra.images.length > 0) {
-        let chatHeight = chatElement.prop('scrollHeight');
-        const doAdjustScroll = () => {
-            if (!adjustScroll) {
-                return;
-            }
-            const scrollPosition = chatElement.scrollTop();
-            const newChatHeight = chatElement.prop('scrollHeight');
-            const diff = newChatHeight - chatHeight;
-            chatElement.scrollTop(scrollPosition + diff);
-            chatHeight = newChatHeight;
-        };
+    const hasImages = mes.extra && Array.isArray(mes.extra.images) && mes.extra.images.length > 0;
+    const hasVideos = mes.extra && Array.isArray(mes.extra.videos) && mes.extra.videos.length > 0;
+    const hasFiles = mes.extra && Array.isArray(mes.extra.files) && mes.extra.files.length > 0;
 
+    let chatHeight = adjustScroll && (hasImages || hasVideos || hasFiles) ? chatElement.prop('scrollHeight') : 0;
+    const doAdjustScroll = () => {
+        if (!adjustScroll) {
+            return;
+        }
+        const scrollPosition = chatElement.scrollTop();
+        const newChatHeight = chatElement.prop('scrollHeight');
+        const diff = newChatHeight - chatHeight;
+        chatElement.scrollTop(scrollPosition + diff);
+        chatHeight = newChatHeight;
+    };
+
+    // Add images to message
+    if (hasImages) {
         messageElement.find('.mes_text').toggleClass('displayNone', !mes.extra.inline_image);
         messageElement.find('.mes_img_container').remove();
 
@@ -2025,12 +2030,12 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
 
                 const swipeLeft = template.find('.mes_img_swipe_left');
                 swipeLeft.off('click').on('click', function () {
-                    eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: 'left' });
+                    eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: SWIPE_DIRECTION.LEFT });
                 });
 
                 const swipeRight = template.find('.mes_img_swipe_right');
                 swipeRight.off('click').on('click', function () {
-                    eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: 'right' });
+                    eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: SWIPE_DIRECTION.RIGHT });
                 });
             }
 
@@ -2041,30 +2046,30 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         messageElement.find('.mes_text').removeClass('displayNone');
     }
 
-    // Add video to message
-    if (mes.extra?.video) {
-        const container = $('#message_video_template .mes_video_container').clone();
+    // Add videos to message
+    if (hasVideos) {
         messageElement.find('.mes_video_container').remove();
-        messageElement.find('.mes_block').append(container);
-        const chatHeight = chatElement.prop('scrollHeight');
-        const video = container.find('.mes_video');
-        video.off('loadedmetadata').on('loadedmetadata', function () {
-            if (!adjustScroll) {
-                return;
-            }
-            const scrollPosition = chatElement.scrollTop();
-            const newChatHeight = chatElement.prop('scrollHeight');
-            const diff = newChatHeight - chatHeight;
-            chatElement.scrollTop(scrollPosition + diff);
-        });
+        for (let index = 0; index < mes.extra.videos.length; index++) {
+            const videoUrl = mes.extra.videos[index];
+            const template = $('#message_video_template .mes_video_container').clone();
+            template.attr('data-index', index);
+            const video = template.find('.mes_video');
+            video.off('loadedmetadata').on('loadedmetadata', function () {
+                if (!adjustScroll) {
+                    return;
+                }
+                doAdjustScroll();
+            });
 
-        video.attr('src', mes.extra?.video);
+            video.attr('src', videoUrl);
+            messageElement.find('.mes_video_wrapper').append(template);
+        }
     } else {
         messageElement.find('.mes_video_container').remove();
     }
 
     // Add files to message
-    if (mes.extra && Array.isArray(mes.extra.files) && mes.extra.files.length > 0) {
+    if (hasFiles) {
         messageElement.find('.mes_file_container').remove();
         for (let index = 0; index < mes.extra.files.length; index++) {
             const file = mes.extra.files[index];
@@ -9058,7 +9063,7 @@ export async function swipe(_event, direction, { source, repeated, message = cha
 
             delete chat[mesId].extra.images;
             delete chat[mesId].extra.image_swipes;
-            delete chat[mesId].extra.video;
+            delete chat[mesId].extra.videos;
             delete chat[mesId].extra.inline_image;
         }
         delete chat[mesId].gen_started;

--- a/public/script.js
+++ b/public/script.js
@@ -1411,17 +1411,26 @@ export async function printMessages() {
         addOneMessage(item, { scroll: false, forceId: i, showSwipes: false });
     }
 
-    // Scroll to bottom when all images are loaded
-    const images = document.querySelectorAll('#chat .mes img');
-    let imagesLoaded = 0;
+    // Scroll to bottom when all media are loaded
+    const media = document.querySelectorAll('#chat .mes img, #chat .mes video');
+    let mediaLoaded = 0;
 
-    for (let i = 0; i < images.length; i++) {
-        const image = images[i];
-        if (image instanceof HTMLImageElement) {
-            if (image.complete) {
+    for (let i = 0; i < media.length; i++) {
+        const currentElement = media[i];
+        if (currentElement instanceof HTMLImageElement) {
+            if (currentElement.complete) {
                 incrementAndCheck();
             } else {
-                image.addEventListener('load', incrementAndCheck);
+                currentElement.addEventListener('load', incrementAndCheck);
+                currentElement.addEventListener('error', incrementAndCheck);
+            }
+        }
+        if (currentElement instanceof HTMLVideoElement) {
+            if (currentElement.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+                incrementAndCheck();
+            } else {
+                currentElement.addEventListener('loadeddata', incrementAndCheck);
+                currentElement.addEventListener('error', incrementAndCheck);
             }
         }
     }
@@ -1433,8 +1442,8 @@ export async function printMessages() {
     applyStylePins();
 
     function incrementAndCheck() {
-        imagesLoaded++;
-        if (imagesLoaded === images.length) {
+        mediaLoaded++;
+        if (mediaLoaded === media.length) {
             scrollChatToBottom();
         }
     }
@@ -2066,8 +2075,11 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     const mediaDisplay = getMediaDisplay(mes);
     const hideMessageText = hasMedia && mes?.extra?.inline_image === false;
 
-    let chatHeight = adjustScroll && (hasMedia || hasFiles) ? chatElement.prop('scrollHeight') : 0;
-    const previousScrollTop = chatElement.scrollTop();
+    const mediaBlocks = [];
+    const mediaPromises = [];
+
+    const chatHeight = adjustScroll && (hasMedia || hasFiles) ? chatElement.prop('scrollHeight') : 0;
+    const previousScrollTop = !adjustScroll ? chatElement.scrollTop() : 0;
     const doAdjustScroll = () => {
         if (!adjustScroll) {
             chatElement.scrollTop(previousScrollTop);
@@ -2077,11 +2089,8 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         const newChatHeight = chatElement.prop('scrollHeight');
         const diff = newChatHeight - chatHeight;
         chatElement.scrollTop(scrollPosition + diff);
-        chatHeight = newChatHeight;
     };
 
-    // Remove existing media containers
-    messageElement.find('.mes_media_container').remove();
     // Set media display attribute
     messageElement.attr('data-media-display', mediaDisplay);
     // Toggle text visibility
@@ -2098,20 +2107,28 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         template.attr('data-index', index);
 
         const image = template.find('.mes_img');
-        image.off('load').on('load', function () {
-            image.removeAttr('alt');
-            image.removeClass('error');
-            doAdjustScroll();
-        });
-        image.off('error').on('error', function () {
-            image.attr('alt', '');
-            image.addClass('error');
-            doAdjustScroll();
-        });
         image.attr('src', attachment.url);
         image.attr('title', attachment.title || mes.extra.title || '');
+        mediaPromises.push(new Promise((resolve) => {
+            function onLoad() {
+                image.removeAttr('alt');
+                image.removeClass('error');
+                resolve();
+            }
+            function onError() {
+                image.attr('alt', '');
+                image.addClass('error');
+                resolve();
+            }
+            if (image.prop('complete')) {
+                onLoad();
+            } else {
+                image.off('load').on('load', onLoad);
+                image.off('error').on('error', onError);
+            }
+        }));
 
-        messageElement.find('.mes_media_wrapper').append(template);
+        mediaBlocks.push(template);
         return template;
     }
 
@@ -2126,20 +2143,25 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         template.attr('data-index', index);
 
         const video = template.find('.mes_video');
-        video.off('loadedmetadata').on('loadedmetadata', function () {
-            if (!adjustScroll) {
-                return;
-            }
-            doAdjustScroll();
-        });
-        video.off('error').on('error', function () {
-            video.addClass('error');
-            doAdjustScroll();
-        });
         video.attr('src', attachment.url);
         video.attr('title', attachment.title || mes.extra.title || '');
+        mediaPromises.push(new Promise((resolve) => {
+            function onLoad() {
+                resolve();
+            }
+            function onError() {
+                video.addClass('error');
+                resolve();
+            }
+            if (video.prop('readyState') >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+                onLoad();
+            } else {
+                video.off('loadeddata').on('loadeddata', onLoad);
+                video.off('error').on('error', onError);
+            }
+        }));
 
-        messageElement.find('.mes_media_wrapper').append(template);
+        mediaBlocks.push(template);
         return template;
     }
 
@@ -2186,6 +2208,9 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         }
     }
 
+    // Remove existing file containers
+    messageElement.find('.mes_file_wrapper').empty();
+
     // Add files to message
     if (hasFiles) {
         for (let index = 0; index < mes.extra.files.length; index++) {
@@ -2197,6 +2222,12 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
             messageElement.find('.mes_file_wrapper').append(template);
         }
     }
+
+    // TODO: Consider making this awaitable
+    Promise.race([Promise.all(mediaPromises), delay(debounce_timeout.standard)]).then(() => {
+        messageElement.find('.mes_media_wrapper').empty().append(mediaBlocks);
+        doAdjustScroll();
+    });
 }
 
 export function addCopyToCodeBlocks(messageElement) {

--- a/public/script.js
+++ b/public/script.js
@@ -1890,7 +1890,7 @@ export function updateMessageBlock(messageId, message, { rerenderMessage = true 
 
 /**
  * Ensures that the message media properties are arrays, adding getters/setters for single media items.
- * @param {object} mes Message object
+ * @param {ChatMessage} mes Message object
  */
 export function ensureMessageMediaIsArray(mes) {
     /**

--- a/public/script.js
+++ b/public/script.js
@@ -2080,13 +2080,12 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     const mediaPromises = [];
 
     const chatHeight = adjustScroll && (hasMedia || hasFiles) ? chatElement.prop('scrollHeight') : 0;
-    const previousScrollTop = !adjustScroll ? chatElement.scrollTop() : 0;
+    const scrollPosition = chatElement.scrollTop();
     const doAdjustScroll = () => {
         if (!adjustScroll) {
-            chatElement.scrollTop(previousScrollTop);
+            chatElement.scrollTop(scrollPosition);
             return;
         }
-        const scrollPosition = chatElement.scrollTop();
         const newChatHeight = chatElement.prop('scrollHeight');
         const diff = newChatHeight - chatHeight;
         chatElement.scrollTop(scrollPosition + diff);

--- a/public/script.js
+++ b/public/script.js
@@ -2109,7 +2109,7 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         image.attr('src', attachment.url);
         image.attr('title', attachment.title || mes.extra.title || '');
 
-        messageElement.find('.mes_img_wrapper').append(template);
+        messageElement.find('.mes_media_wrapper').append(template);
         return template;
     }
 
@@ -2137,7 +2137,7 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         video.attr('src', attachment.url);
         video.attr('title', attachment.title || mes.extra.title || '');
 
-        messageElement.find('.mes_video_wrapper').append(template);
+        messageElement.find('.mes_media_wrapper').append(template);
         return template;
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -1411,12 +1411,19 @@ export async function printMessages() {
         addOneMessage(item, { scroll: false, forceId: i, showSwipes: false });
     }
 
-    // Scroll to bottom when all media are loaded
-    const media = document.querySelectorAll('#chat .mes img, #chat .mes video');
+    chatElement.find('.mes').removeClass('last_mes');
+    chatElement.find('.mes').last().addClass('last_mes');
+    refreshSwipeButtons();
+    scrollChatToBottom();
+    scrollOnMediaLoad();
+    applyStylePins();
+}
+
+function scrollOnMediaLoad() {
+    const media = chatElement.find('.mes_block img, .mes_block video').toArray();
     let mediaLoaded = 0;
 
-    for (let i = 0; i < media.length; i++) {
-        const currentElement = media[i];
+    for (const currentElement of media) {
         if (currentElement instanceof HTMLImageElement) {
             if (currentElement.complete) {
                 incrementAndCheck();
@@ -1434,12 +1441,6 @@ export async function printMessages() {
             }
         }
     }
-
-    chatElement.find('.mes').removeClass('last_mes');
-    chatElement.find('.mes').last().addClass('last_mes');
-    refreshSwipeButtons();
-    scrollChatToBottom();
-    applyStylePins();
 
     function incrementAndCheck() {
         mediaLoaded++;

--- a/public/script.js
+++ b/public/script.js
@@ -9061,17 +9061,19 @@ export async function swipe(_event, direction, { source, repeated, message = cha
         //Update the swipe_id.
         chat[mesId]['swipe_id'] = newSwipeId;
 
-        if (chat[mesId].extra) {
-            // if message has memory attached - remove it to allow regen
+        if (chat[mesId].extra && typeof chat[mesId].extra === 'object') {
             delete chat[mesId].extra.memory;
-
-            // ditto for display text
             delete chat[mesId].extra.display_text;
-
             delete chat[mesId].extra.images;
             delete chat[mesId].extra.image_swipes;
             delete chat[mesId].extra.videos;
             delete chat[mesId].extra.inline_image;
+            delete chat[mesId].extra.files;
+            delete chat[mesId].extra.fileLength;
+            delete chat[mesId].extra.generationType;
+            delete chat[mesId].extra.negative;
+            delete chat[mesId].extra.title;
+            delete chat[mesId].extra.append_title;
         }
         delete chat[mesId].gen_started;
         delete chat[mesId].gen_finished;
@@ -9079,7 +9081,6 @@ export async function swipe(_event, direction, { source, repeated, message = cha
         syncSwipeToMes(mesId, chat[mesId]['swipe_id']);
     }
 
-    //Deepseek-V3.1
     // Helper function to convert transition to promise
     const transitionPromise = (element, properties) => {
         return new Promise((resolve) => {

--- a/public/script.js
+++ b/public/script.js
@@ -313,7 +313,10 @@ export {
     getSystemMessageByType,
     event_types,
     eventSource,
+    /** @deprecated Use setCharacterSettingsOverrides instead. */
     setCharacterSettingsOverrides as setScenarioOverride,
+    /** @deprecated Use appendMediaToMessage instead. */
+    appendMediaToMessage as appendImageToMessage,
 };
 
 /**
@@ -2082,13 +2085,6 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     } else {
         messageElement.find('.mes_file_container').remove();
     }
-}
-
-/**
- * @deprecated Use appendMediaToMessage instead.
- */
-export function appendImageToMessage(mes, messageElement) {
-    appendMediaToMessage(mes, messageElement);
 }
 
 export function addCopyToCodeBlocks(messageElement) {

--- a/public/script.js
+++ b/public/script.js
@@ -6335,8 +6335,7 @@ function saveImageToMessage(img, mes) {
         if (!Array.isArray(mes.extra.media)) {
             mes.extra.media = [];
         }
-        mes.extra.media.push({ url: img.image, type: 'image' });
-        mes.extra.title = img.title;
+        mes.extra.media.push({ url: img.image, type: MEDIA_TYPE.IMAGE, title: img.title });
         mes.extra.inline_image = img.inline;
     }
 }

--- a/public/script.js
+++ b/public/script.js
@@ -1414,12 +1414,13 @@ export async function printMessages() {
     chatElement.find('.mes').removeClass('last_mes');
     chatElement.find('.mes').last().addClass('last_mes');
     refreshSwipeButtons();
-    scrollChatToBottom();
-    scrollOnMediaLoad();
     applyStylePins();
+    scrollChatToBottom();
+    delay(debounce_timeout.quick).then(() => scrollOnMediaLoad());
 }
 
 function scrollOnMediaLoad() {
+    const started = Date.now();
     const media = chatElement.find('.mes_block img, .mes_block video').toArray();
     let mediaLoaded = 0;
 
@@ -1443,6 +1444,10 @@ function scrollOnMediaLoad() {
     }
 
     function incrementAndCheck() {
+        const MAX_DELAY = 1000; // 1 second
+        if ((Date.now() - started) > MAX_DELAY) {
+            return;
+        }
         mediaLoaded++;
         if (mediaLoaded === media.length) {
             scrollChatToBottom();
@@ -2224,7 +2229,7 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     }
 
     // TODO: Consider making this awaitable
-    Promise.race([Promise.all(mediaPromises), delay(debounce_timeout.standard)]).then(() => {
+    Promise.race([Promise.all(mediaPromises), delay(debounce_timeout.quick)]).then(() => {
         messageElement.find('.mes_media_wrapper').empty().append(mediaBlocks);
         doAdjustScroll();
     });

--- a/public/script.js
+++ b/public/script.js
@@ -1416,7 +1416,7 @@ export async function printMessages() {
     refreshSwipeButtons();
     applyStylePins();
     scrollChatToBottom();
-    delay(debounce_timeout.quick).then(() => scrollOnMediaLoad());
+    delay(debounce_timeout.short).then(() => scrollOnMediaLoad());
 }
 
 function scrollOnMediaLoad() {
@@ -2229,7 +2229,7 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     }
 
     // TODO: Consider making this awaitable
-    Promise.race([Promise.all(mediaPromises), delay(debounce_timeout.quick)]).then(() => {
+    Promise.race([Promise.all(mediaPromises), delay(debounce_timeout.short)]).then(() => {
         messageElement.find('.mes_media_wrapper').empty().append(mediaBlocks);
         doAdjustScroll();
     });

--- a/public/script.js
+++ b/public/script.js
@@ -183,7 +183,7 @@ import {
     trimSpaces,
     clamp,
 } from './scripts/utils.js';
-import { debounce_timeout, GENERATION_TYPE_TRIGGERS, IGNORE_SYMBOL, inject_ids, SWIPE_DIRECTION } from './scripts/constants.js';
+import { debounce_timeout, GENERATION_TYPE_TRIGGERS, IGNORE_SYMBOL, inject_ids, MEDIA_DISPLAY, MEDIA_TYPE, SWIPE_DIRECTION } from './scripts/constants.js';
 
 import { cancelDebouncedMetadataSave, doDailyExtensionUpdatesCheck, extension_settings, initExtensions, loadExtensionSettings, runGenerationInterceptors, saveMetadataDebounced } from './scripts/extensions.js';
 import { COMMENT_NAME_DEFAULT, CONNECT_API_MAP, executeSlashCommandsOnChatInput, initDefaultSlashCommands, isExecutingCommandsFromChatInput, pauseScriptExecution, stopScriptExecution, UNIQUE_APIS } from './scripts/slash-commands.js';
@@ -1927,21 +1927,10 @@ export function ensureMessageMediaIsArray(mes) {
      * @param {object} obj Object to add property to
      * @param {string} plainProperty Plain property name
      * @param {string} arrayProperty Array property to back the plain property
+     * @param {(value: any) => boolean} [filterFn] Optional filter function to apply when getting/setting the plain property
+     * @param {(value: any) => any} [mapFn] Optional map function to apply when getting/setting the plain property
      */
-    function addArrayAutoWrapper(obj, plainProperty, arrayProperty) {
-        // If the plain property exists as a plain property, migrate its value to the array property.
-        const hasPlainProperty = isPlainObjectProperty(obj, plainProperty);
-        if (hasPlainProperty) {
-            if (!Array.isArray(obj[arrayProperty])) {
-                obj[arrayProperty] = [];
-            }
-            const plainValue = obj[plainProperty];
-            delete obj[plainProperty];
-            if (plainValue) {
-                obj[arrayProperty].push(plainValue);
-            }
-        }
-
+    function addArrayAutoWrapper(obj, plainProperty, arrayProperty, filterFn = () => true, mapFn = (t) => t) {
         // If the plain property is already a getter, do nothing.
         const hasGetterProperty = isGetterObjectProperty(obj, plainProperty);
         if (hasGetterProperty) {
@@ -1953,7 +1942,8 @@ export function ensureMessageMediaIsArray(mes) {
             // Getting the plain property returns the first item in the array property, or undefined if the array is empty.
             get: function () {
                 console.trace(`Attempting to GET an array-wrapped property '${plainProperty}'. Use the array property '${arrayProperty}' instead.`);
-                return Array.isArray(this[arrayProperty]) && this[arrayProperty].length > 0 ? this[arrayProperty][0] : void 0;
+                const array = Array.isArray(this[arrayProperty]) ? this[arrayProperty].filter(filterFn).map(mapFn) : [];
+                return array.length > 0 ? array[0] : void 0;
             },
             // Setting the plain property is not supported, as it would be ambiguous.
             set: function () {
@@ -1966,29 +1956,116 @@ export function ensureMessageMediaIsArray(mes) {
         });
     }
 
+    /**
+     * Migrates image swipes from a single image property to an array.
+     * @param {ChatMessageExtra} obj
+     */
+    function migrateMediaToArray(obj) {
+        if (isPlainObjectProperty(obj, 'file')) {
+            if (!Array.isArray(obj.files)) {
+                obj.files = [];
+            }
+            const fileValue = obj.file;
+            delete obj.file;
+            if (fileValue) {
+                obj.files.push(fileValue);
+            }
+        }
+
+        if (Array.isArray(obj.image_swipes)) {
+            if (!Array.isArray(obj.media)) {
+                obj.media = [];
+            }
+            for (const swipe of obj.image_swipes) {
+                if (swipe && typeof swipe === 'string') {
+                    obj.media.push({ type: 'image', url: swipe });
+                }
+            }
+            delete obj.image_swipes;
+            obj.media = obj.media.filter((v, i, a) => i === a.findIndex(t => t.url === v.url));
+            obj.media_display = MEDIA_DISPLAY.GALLERY;
+        }
+
+        if (isPlainObjectProperty(obj, 'image')) {
+            if (!Array.isArray(obj.media)) {
+                obj.media = [];
+            }
+            const imageValue = obj.image;
+            delete obj.image;
+            if (imageValue && typeof imageValue === 'string') {
+                obj.media.push({ type: 'image', url: imageValue });
+            }
+            if (obj.media_display === MEDIA_DISPLAY.GALLERY) {
+                const selectedIndex = obj.media.findIndex(t => t.url === imageValue);
+                if (selectedIndex > -1) {
+                    obj.media_index = selectedIndex;
+                }
+            }
+        }
+
+        if (isPlainObjectProperty(obj, 'video')) {
+            if (!Array.isArray(obj.media)) {
+                obj.media = [];
+            }
+            const videoValue = obj.video;
+            delete obj.video;
+            if (videoValue && typeof videoValue === 'string') {
+                obj.media.push({ type: 'video', url: videoValue });
+            }
+        }
+    }
+
     if (!mes || !mes.extra || typeof mes.extra !== 'object') {
         return;
     }
 
+    migrateMediaToArray(mes.extra);
     addArrayAutoWrapper(mes.extra, 'file', 'files');
-    addArrayAutoWrapper(mes.extra, 'image', 'images');
-    addArrayAutoWrapper(mes.extra, 'video', 'videos');
+    addArrayAutoWrapper(mes.extra, 'image', 'media', (t) => t.type === 'image', (t) => t.url);
+    addArrayAutoWrapper(mes.extra, 'video', 'media', (t) => t.type === 'video', (t) => t.url);
+}
+
+/**
+ * Gets the media display setting for a message.
+ * @param {ChatMessage} mes Message object
+ * @returns {MEDIA_DISPLAY} Media display setting
+ */
+export function getMediaDisplay(mes) {
+    const value = mes?.extra?.media_display || power_user.media_display || MEDIA_DISPLAY.LIST;
+    return Object.values(MEDIA_DISPLAY).includes(value) ? value : MEDIA_DISPLAY.LIST;
+}
+
+/**
+ * Gets the media index for a message.
+ * @param {ChatMessage} mes Message object
+ * @returns {number} Media index
+ */
+export function getMediaIndex(mes) {
+    if (!Array.isArray(mes?.extra?.media)) {
+        return 0;
+    }
+    const value = mes.extra?.media_index;
+    if (isNaN(value) || value < 0 || value >= mes.extra.media.length) {
+        return 0;
+    }
+    return value;
 }
 
 /**
  * Appends image or file to the message element.
- * @param {object} mes Message object
+ * @param {ChatMessage} mes Message object
  * @param {JQuery<HTMLElement>} messageElement Message element
  * @param {boolean} [adjustScroll=true] Whether to adjust the scroll position after appending the media
  */
 export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     ensureMessageMediaIsArray(mes);
 
-    const hasImages = mes.extra && Array.isArray(mes.extra.images) && mes.extra.images.length > 0;
-    const hasVideos = mes.extra && Array.isArray(mes.extra.videos) && mes.extra.videos.length > 0;
-    const hasFiles = mes.extra && Array.isArray(mes.extra.files) && mes.extra.files.length > 0;
+    const hasMedia = Array.isArray(mes?.extra?.media) && mes.extra.media.length > 0;
+    const hasFiles = Array.isArray(mes?.extra?.files) && mes.extra.files.length > 0;
+    const mediaDisplay = getMediaDisplay(mes);
+    const hideMessageText = hasMedia && mes?.extra?.inline_image === false;
 
-    let chatHeight = adjustScroll && (hasImages || hasVideos || hasFiles) ? chatElement.prop('scrollHeight') : 0;
+    let chatHeight = adjustScroll && (hasMedia || hasFiles) ? chatElement.prop('scrollHeight') : 0;
     const doAdjustScroll = () => {
         if (!adjustScroll) {
             return;
@@ -2000,80 +2077,124 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         chatHeight = newChatHeight;
     };
 
-    // Add images to message
-    if (hasImages) {
-        messageElement.find('.mes_text').toggleClass('displayNone', !mes.extra.inline_image);
-        messageElement.find('.mes_img_container').remove();
+    // Remove existing media containers
+    messageElement.find('.mes_media_container').remove();
+    // Set media display attribute
+    messageElement.attr('data-media-display', mediaDisplay);
+    // Toggle text visibility
+    messageElement.find('.mes_text').toggleClass('displayNone', hideMessageText);
 
-        for (let index = 0; index < mes.extra.images.length; index++) {
-            const template = $('#message_image_template .mes_img_container').clone();
-            template.attr('data-index', index);
+    /**
+     * Appends a single image attachment to the message element.
+     * @param {MediaAttachment} attachment Image attachment object
+     * @param {number} index Index of the image attachment
+     * @returns {JQuery<HTMLElement>} The appended image container element
+     */
+    function appendImageAttachment(attachment, index) {
+        const template = $('#message_image_template .mes_img_container').clone();
+        template.attr('data-index', index);
 
-            const image = template.find('.mes_img');
-            image.off('load').on('load', function () {
-                image.removeAttr('alt');
-                image.removeClass('error');
-                doAdjustScroll();
-            });
-            image.off('error').on('error', function () {
-                image.attr('alt', '');
-                image.addClass('error');
-                doAdjustScroll();
-            });
-            image.attr('src', mes.extra.images[index]);
-            image.attr('title', mes.extra?.title || mes.title || '');
+        const image = template.find('.mes_img');
+        image.off('load').on('load', function () {
+            image.removeAttr('alt');
+            image.removeClass('error');
+            doAdjustScroll();
+        });
+        image.off('error').on('error', function () {
+            image.attr('alt', '');
+            image.addClass('error');
+            doAdjustScroll();
+        });
+        image.attr('src', attachment.url);
+        image.attr('title', attachment.title || mes.extra.title || '');
 
-            // Only display swipe buttons if there is a single image and multiple swipes
-            const imageSwipes = mes.extra.image_swipes;
-            if (mes.extra.images.length === 1 && Array.isArray(imageSwipes) && imageSwipes.length > 0) {
-                template.addClass('img_swipes');
-                const counter = template.find('.mes_img_swipe_counter');
-                const currentImage = imageSwipes.indexOf(mes.extra.images[0]) + 1;
-                counter.text(`${currentImage}/${imageSwipes.length}`);
-
-                const swipeLeft = template.find('.mes_img_swipe_left');
-                swipeLeft.off('click').on('click', function () {
-                    eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: SWIPE_DIRECTION.LEFT });
-                });
-
-                const swipeRight = template.find('.mes_img_swipe_right');
-                swipeRight.off('click').on('click', function () {
-                    eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: SWIPE_DIRECTION.RIGHT });
-                });
-            }
-
-            messageElement.find('.mes_img_wrapper').append(template);
-        }
-    } else {
-        messageElement.find('.mes_img_container').remove();
-        messageElement.find('.mes_text').removeClass('displayNone');
+        messageElement.find('.mes_img_wrapper').append(template);
+        return template;
     }
 
-    // Add videos to message
-    if (hasVideos) {
-        messageElement.find('.mes_video_container').remove();
-        for (let index = 0; index < mes.extra.videos.length; index++) {
-            const videoUrl = mes.extra.videos[index];
-            const template = $('#message_video_template .mes_video_container').clone();
-            template.attr('data-index', index);
-            const video = template.find('.mes_video');
-            video.off('loadedmetadata').on('loadedmetadata', function () {
-                if (!adjustScroll) {
-                    return;
-                }
-                doAdjustScroll();
-            });
+    /**
+     * Appends a single video attachment to the message element.
+     * @param {MediaAttachment} attachment Video attachment object
+     * @param {number} index Index of the video attachment
+     * @returns {JQuery<HTMLElement>} The appended video container element
+     */
+    function appendVideoAttachment(attachment, index) {
+        const template = $('#message_video_template .mes_video_container').clone();
+        template.attr('data-index', index);
 
-            video.attr('src', videoUrl);
-            messageElement.find('.mes_video_wrapper').append(template);
+        const video = template.find('.mes_video');
+        video.off('loadedmetadata').on('loadedmetadata', function () {
+            if (!adjustScroll) {
+                return;
+            }
+            doAdjustScroll();
+        });
+        video.off('error').on('error', function () {
+            video.addClass('error');
+            doAdjustScroll();
+        });
+        video.attr('src', attachment.url);
+        video.attr('title', attachment.title || mes.extra.title || '');
+
+        messageElement.find('.mes_video_wrapper').append(template);
+        return template;
+    }
+
+    /**
+     * Appends a media attachment to the message element.
+     * @param {MediaAttachment} attachment Media attachment object
+     * @param {number} index Index of the media attachment
+     * @returns {JQuery<HTMLElement>} The appended media container element
+     */
+    function appendMediaAttachment(attachment, index) {
+        if (!attachment.type) {
+            attachment.type = MEDIA_TYPE.IMAGE;
         }
-    } else {
-        messageElement.find('.mes_video_container').remove();
+        switch (attachment.type) {
+            case MEDIA_TYPE.IMAGE:
+                return appendImageAttachment(attachment, index);
+            case MEDIA_TYPE.VIDEO:
+                return appendVideoAttachment(attachment, index);
+        }
+
+        console.warn(`Unknown media type: ${attachment.type}, defaulting to image.`, attachment);
+        return appendImageAttachment(attachment, index);
+    }
+
+    // Only display swipe buttons if there is a single image and multiple swipes
+    if (hasMedia && mediaDisplay === MEDIA_DISPLAY.GALLERY) {
+        const mediaIndex = getMediaIndex(mes);
+        const selectedMedia = mes.extra.media[mediaIndex];
+
+        const galleryControls = $('#message_gallery_controls .mes_img_swipes').clone();
+        const counter = galleryControls.find('.mes_img_swipe_counter');
+        counter.text(`${mediaIndex + 1}/${mes.extra.media.length}`);
+
+        const swipeLeft = galleryControls.find('.mes_img_swipe_left');
+        swipeLeft.off('click').on('click', function () {
+            eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: SWIPE_DIRECTION.LEFT });
+        });
+
+        const swipeRight = galleryControls.find('.mes_img_swipe_right');
+        swipeRight.off('click').on('click', function () {
+            eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: SWIPE_DIRECTION.RIGHT });
+        });
+
+        const template = appendMediaAttachment(selectedMedia, mediaIndex);
+        template.addClass('img_swipes');
+        template.append(galleryControls);
+    }
+
+    // Add media as a list to message
+    if (hasMedia && mediaDisplay === MEDIA_DISPLAY.LIST) {
+        for (let index = 0; index < mes.extra.media.length; index++) {
+            const attachment = mes.extra.media[index];
+            appendImageAttachment(attachment, index);
+        }
     }
 
     // Add files to message
     if (hasFiles) {
-        messageElement.find('.mes_file_container').remove();
         for (let index = 0; index < mes.extra.files.length; index++) {
             const file = mes.extra.files[index];
             const template = $('#message_file_template .mes_file_container').clone();
@@ -2082,8 +2203,6 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
             template.find('.mes_file_size').text(humanFileSize(file.size)).attr('title', file.size);
             messageElement.find('.mes_file_wrapper').append(template);
         }
-    } else {
-        messageElement.find('.mes_file_container').remove();
     }
 }
 
@@ -3835,7 +3954,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         coreChat.pop();
     }
 
-    coreChat = await Promise.all(coreChat.map(async (chatItem, index) => {
+    coreChat = await Promise.all(coreChat.map(async (/** @type {ChatMessage} */ chatItem, index) => {
         let message = chatItem.mes;
         let regexType = chatItem.is_user ? regex_placement.USER_INPUT : regex_placement.AI_OUTPUT;
         let options = { isPrompt: true, depth: (coreChat.length - index - (isContinue ? 2 : 1)) };
@@ -3843,8 +3962,19 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         let regexedMessage = getRegexedString(message, regexType, options);
         regexedMessage = await appendFileContent(chatItem, regexedMessage);
 
+        const titles = [];
         if (chatItem?.extra?.append_title && chatItem?.extra?.title) {
-            regexedMessage = `${regexedMessage}\n\n${chatItem.extra.title}`;
+            titles.push(chatItem.extra.title);
+        }
+        if (Array.isArray(chatItem?.extra?.media)) {
+            for (const mediaItem of chatItem.extra.media) {
+                if (mediaItem?.title && mediaItem?.append_title) {
+                    titles.push(mediaItem.title);
+                }
+            }
+        }
+        if (titles.length > 0) {
+            regexedMessage = `${regexedMessage}\n\n${titles.join('\n\n')}`;
         }
 
         return {
@@ -6193,7 +6323,7 @@ export function syncSwipeToMes(messageId = null, swipeId = null) {
 /**
  * Saves the image to the message object.
  * @param {ParsedImage} img Image object
- * @param {object} mes Chat message object
+ * @param {ChatMessage} mes Chat message object
  * @typedef {{ image?: string, title?: string, inline?: boolean }} ParsedImage
  */
 function saveImageToMessage(img, mes) {
@@ -6201,10 +6331,10 @@ function saveImageToMessage(img, mes) {
         if (!mes.extra || typeof mes.extra !== 'object') {
             mes.extra = {};
         }
-        if (!Array.isArray(mes.extra.images)) {
-            mes.extra.images = [];
+        if (!Array.isArray(mes.extra.media)) {
+            mes.extra.media = [];
         }
-        mes.extra.images.push(img.image);
+        mes.extra.media.push({ url: img.image, type: 'image' });
         mes.extra.title = img.title;
         mes.extra.inline_image = img.inline;
     }
@@ -9064,9 +9194,7 @@ export async function swipe(_event, direction, { source, repeated, message = cha
         if (chat[mesId].extra && typeof chat[mesId].extra === 'object') {
             delete chat[mesId].extra.memory;
             delete chat[mesId].extra.display_text;
-            delete chat[mesId].extra.images;
-            delete chat[mesId].extra.image_swipes;
-            delete chat[mesId].extra.videos;
+            delete chat[mesId].extra.media;
             delete chat[mesId].extra.inline_image;
             delete chat[mesId].extra.files;
             delete chat[mesId].extra.fileLength;

--- a/public/script.js
+++ b/public/script.js
@@ -370,6 +370,7 @@ export const neutralCharacterName = 'Assistant';
 let default_user_name = 'User';
 export let name1 = default_user_name;
 export let name2 = systemUserName;
+/** @type {ChatMessage[]} */
 export let chat = [];
 export let isSwipingAllowed = true; //false when a swipe is in progress, or swiping is blocked.
 let chatSaveTimeout;
@@ -1978,11 +1979,11 @@ export function ensureMessageMediaIsArray(mes) {
             }
             for (const swipe of obj.image_swipes) {
                 if (swipe && typeof swipe === 'string') {
+                    obj.media_display = MEDIA_DISPLAY.GALLERY;
                     obj.media.push({ type: 'image', url: swipe });
                 }
             }
             delete obj.image_swipes;
-            obj.media_display = MEDIA_DISPLAY.GALLERY;
         }
 
         if (isPlainObjectProperty(obj, 'image')) {
@@ -3874,7 +3875,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         const prevStarted = chat[chat.length - 1]['gen_started'];
 
         if (prevFinished && prevStarted) {
-            const timePassed = prevFinished - prevStarted;
+            const timePassed = Number(prevFinished) - Number(prevStarted);
             generation_started = new Date(Date.now() - timePassed);
             chat[chat.length - 1]['gen_started'] = generation_started;
         }
@@ -9330,7 +9331,7 @@ export async function swipe(_event, direction, { source, repeated, message = cha
         if (run_generate && !is_send_press) {
             is_send_press = true;
             generation = Generate('swipe');
-        } else if (parseInt(chat[mesId]['swipe_id']) !== chat[mesId]['swipes'].length) {
+        } else if (Number(chat[mesId]['swipe_id']) !== chat[mesId]['swipes'].length) {
             saveChatDebounced();
         }
 
@@ -10974,7 +10975,7 @@ jQuery(async function () {
         const oldScroll = chatElement[0].scrollTop;
         const clone = structuredClone(chat[this_edit_mes_id]);
         clone.send_date = Date.now();
-        clone.mes = $(this).closest('.mes').find('.edit_textarea').val();
+        clone.mes = $(this).closest('.mes').find('.edit_textarea').val().toString();
 
         if (power_user.trim_spaces) {
             clone.mes = clone.mes.trim();

--- a/public/script.js
+++ b/public/script.js
@@ -1885,12 +1885,100 @@ export function updateMessageBlock(messageId, message, { rerenderMessage = true 
 }
 
 /**
+ * Ensures that the message media properties are arrays, adding getters/setters for single media items.
+ * @param {object} mes Message object
+ */
+export function ensureMessageMediaIsArray(mes) {
+    /**
+     * Determines if a property of an object is a plain property (not a getter/setter or non-enumerable).
+     * @param {object} obj Object to check
+     * @param {string} name Property name
+     * @returns {boolean} True if the property is a plain property, false otherwise
+     */
+    function isPlainObjectProperty(obj, name) {
+        const hasProperty = Object.hasOwn(obj, name);
+        if (hasProperty) {
+            const descriptor = Object.getOwnPropertyDescriptor(obj, name);
+            return descriptor && descriptor.enumerable && descriptor.configurable && descriptor.writable;
+        }
+        return false;
+    }
+
+    /**
+     * Determines if a property of an object is a getter (not a plain property).
+     * @param {object} obj Object to check
+     * @param {string} name Property name
+     * @returns {boolean} True if the property is a getter, false otherwise
+     */
+    function isGetterObjectProperty(obj, name) {
+        const hasProperty = Object.hasOwn(obj, name);
+        if (hasProperty) {
+            const descriptor = Object.getOwnPropertyDescriptor(obj, name);
+            return descriptor && typeof descriptor.get === 'function';
+        }
+        return false;
+    }
+
+    /**
+     * Adds a plain property to an object that wraps around an array property.
+     * @param {object} obj Object to add property to
+     * @param {string} plainProperty Plain property name
+     * @param {string} arrayProperty Array property to back the plain property
+     */
+    function addArrayAutoWrapper(obj, plainProperty, arrayProperty) {
+        // If the plain property exists as a plain property, migrate its value to the array property.
+        const hasPlainProperty = isPlainObjectProperty(obj, plainProperty);
+        if (hasPlainProperty) {
+            if (!Array.isArray(obj[arrayProperty])) {
+                obj[arrayProperty] = [];
+            }
+            const plainValue = obj[plainProperty];
+            delete obj[plainProperty];
+            if (plainValue) {
+                obj[arrayProperty].push(plainValue);
+            }
+        }
+
+        // If the plain property is already a getter, do nothing.
+        const hasGetterProperty = isGetterObjectProperty(obj, plainProperty);
+        if (hasGetterProperty) {
+            return;
+        }
+
+        // Define the plain property as a getter/setter that wraps around the array property.
+        Object.defineProperty(obj, plainProperty, {
+            // Getting the plain property returns the first item in the array property, or undefined if the array is empty.
+            get: function () {
+                console.trace(`Attempting to GET an array-wrapped property '${plainProperty}'. Use the array property '${arrayProperty}' instead.`);
+                return Array.isArray(this[arrayProperty]) && this[arrayProperty].length > 0 ? this[arrayProperty][0] : void 0;
+            },
+            // Setting the plain property is not supported, as it would be ambiguous.
+            set: function () {
+                console.trace(`Attempting to SET an array-wrapped property '${plainProperty}'. Use the array property '${arrayProperty}' instead.`);
+            },
+            // Exclude the property from JSON serialization and from being listed in for...in loops.
+            enumerable: false,
+            // Make the property non-configurable to prevent deletion or redefinition.
+            configurable: false,
+        });
+    }
+
+    if (!mes || !mes.extra || typeof mes.extra !== 'object') {
+        return;
+    }
+
+    addArrayAutoWrapper(mes.extra, 'file', 'files');
+}
+
+/**
  * Appends image or file to the message element.
  * @param {object} mes Message object
  * @param {JQuery<HTMLElement>} messageElement Message element
  * @param {boolean} [adjustScroll=true] Whether to adjust the scroll position after appending the media
  */
 export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
+    ensureMessageMediaIsArray(mes);
+
     // Add image to message
     if (mes.extra?.image) {
         const container = messageElement.find('.mes_img_container');
@@ -1969,16 +2057,17 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         messageElement.find('.mes_video_container').remove();
     }
 
-    // Add file to message
-    if (mes.extra?.file) {
+    // Add files to message
+    if (mes.extra && Array.isArray(mes.extra.files) && mes.extra.files.length > 0) {
         messageElement.find('.mes_file_container').remove();
-        const messageId = messageElement.attr('mesid');
-        const template = $('#message_file_template .mes_file_container').clone();
-        template.find('.mes_file_name').text(mes.extra.file.name);
-        template.find('.mes_file_size').text(humanFileSize(mes.extra.file.size));
-        template.find('.mes_file_download').attr('mesid', messageId);
-        template.find('.mes_file_delete').attr('mesid', messageId);
-        messageElement.find('.mes_block').append(template);
+        for (let index = 0; index < mes.extra.files.length; index++) {
+            const file = mes.extra.files[index];
+            const template = $('#message_file_template .mes_file_container').clone();
+            template.attr('data-index', index);
+            template.find('.mes_file_name').text(file.name).attr('title', file.name);
+            template.find('.mes_file_size').text(humanFileSize(file.size)).attr('title', file.size);
+            messageElement.find('.mes_block').append(template);
+        }
     } else {
         messageElement.find('.mes_file_container').remove();
     }
@@ -6721,6 +6810,7 @@ export async function getChat() {
             chat_metadata = chat[0]['chat_metadata'] ?? {};
 
             chat.shift();
+            chat.forEach(ensureMessageMediaIsArray);
         } else {
             chat_create_date = humanizedDateTime();
         }

--- a/public/script.js
+++ b/public/script.js
@@ -2028,7 +2028,7 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
             if (mes.extra.images.length === 1 && Array.isArray(imageSwipes) && imageSwipes.length > 0) {
                 template.addClass('img_swipes');
                 const counter = template.find('.mes_img_swipe_counter');
-                const currentImage = imageSwipes.indexOf(mes.extra.image) + 1;
+                const currentImage = imageSwipes.indexOf(mes.extra.images[0]) + 1;
                 counter.text(`${currentImage}/${imageSwipes.length}`);
 
                 const swipeLeft = template.find('.mes_img_swipe_left');

--- a/public/script.js
+++ b/public/script.js
@@ -2219,7 +2219,7 @@ export function addCopyToCodeBlocks(messageElement) {
 
 /**
  * Adds a single message to the chat.
- * @param {object} mes Message object
+ * @param {ChatMessage} mes Message object
  * @param {object} [options] Options
  * @param {string} [options.type='normal'] Message type
  * @param {number} [options.insertAfter=null] Message ID to insert the new message after
@@ -2271,8 +2271,8 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         avatarImg = mes['force_avatar'];
     }
 
-    // if mes.uses_system_ui is true, set an override on the sanitizer options
-    const sanitizerOverrides = mes.uses_system_ui ? { MESSAGE_ALLOW_SYSTEM_UI: true } : {};
+    // if mes.extra.uses_system_ui is true, set an override on the sanitizer options
+    const sanitizerOverrides = mes.extra?.uses_system_ui ? { MESSAGE_ALLOW_SYSTEM_UI: true } : {};
 
     messageText = messageFormatting(
         messageText,
@@ -2421,8 +2421,8 @@ export function formatCharacterAvatar(characterAvatar) {
 
 /**
  * Formats the title for the generation timer.
- * @param {Date} gen_started Date when generation was started
- * @param {Date} gen_finished Date when generation was finished
+ * @param {MessageTimestamp} gen_started Date when generation was started
+ * @param {MessageTimestamp} gen_finished Date when generation was finished
  * @param {number} tokenCount Number of tokens generated (0 if not available)
  * @param {number?} [reasoningDuration=null] Reasoning duration (null if no reasoning was done)
  * @param {number?} [timeToFirstToken=null] Time to first token

--- a/public/script.js
+++ b/public/script.js
@@ -2067,8 +2067,10 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     const hideMessageText = hasMedia && mes?.extra?.inline_image === false;
 
     let chatHeight = adjustScroll && (hasMedia || hasFiles) ? chatElement.prop('scrollHeight') : 0;
+    const previousScrollTop = chatElement.scrollTop();
     const doAdjustScroll = () => {
         if (!adjustScroll) {
+            chatElement.scrollTop(previousScrollTop);
             return;
         }
         const scrollPosition = chatElement.scrollTop();

--- a/public/script.js
+++ b/public/script.js
@@ -1982,7 +1982,6 @@ export function ensureMessageMediaIsArray(mes) {
                 }
             }
             delete obj.image_swipes;
-            obj.media = obj.media.filter((v, i, a) => i === a.findIndex(t => t.url === v.url));
             obj.media_display = MEDIA_DISPLAY.GALLERY;
         }
 
@@ -2001,6 +2000,7 @@ export function ensureMessageMediaIsArray(mes) {
                     obj.media_index = selectedIndex;
                 }
             }
+            obj.media = obj.media.filter((v, i, a) => i === a.findIndex(t => t.url === v.url));
         }
 
         if (isPlainObjectProperty(obj, 'video')) {

--- a/public/script.js
+++ b/public/script.js
@@ -1980,7 +1980,7 @@ export function ensureMessageMediaIsArray(mes) {
             for (const swipe of obj.image_swipes) {
                 if (swipe && typeof swipe === 'string') {
                     obj.media_display = MEDIA_DISPLAY.GALLERY;
-                    obj.media.push({ type: 'image', url: swipe });
+                    obj.media.push({ type: MEDIA_TYPE.IMAGE, url: swipe });
                 }
             }
             delete obj.image_swipes;
@@ -1993,7 +1993,7 @@ export function ensureMessageMediaIsArray(mes) {
             const imageValue = obj.image;
             delete obj.image;
             if (imageValue && typeof imageValue === 'string') {
-                obj.media.push({ type: 'image', url: imageValue });
+                obj.media.push({ type: MEDIA_TYPE.IMAGE, url: imageValue });
             }
             if (obj.media_display === MEDIA_DISPLAY.GALLERY) {
                 const selectedIndex = obj.media.findIndex(t => t.url === imageValue);
@@ -2011,7 +2011,7 @@ export function ensureMessageMediaIsArray(mes) {
             const videoValue = obj.video;
             delete obj.video;
             if (videoValue && typeof videoValue === 'string') {
-                obj.media.push({ type: 'video', url: videoValue });
+                obj.media.push({ type: MEDIA_TYPE.VIDEO, url: videoValue });
             }
         }
     }
@@ -2022,8 +2022,8 @@ export function ensureMessageMediaIsArray(mes) {
 
     migrateMediaToArray(mes.extra);
     addArrayAutoWrapper(mes.extra, 'file', 'files');
-    addArrayAutoWrapper(mes.extra, 'image', 'media', (t) => t.type === 'image', (t) => t.url);
-    addArrayAutoWrapper(mes.extra, 'video', 'media', (t) => t.type === 'video', (t) => t.url);
+    addArrayAutoWrapper(mes.extra, 'image', 'media', (t) => t.type === MEDIA_TYPE.IMAGE, (t) => t.url);
+    addArrayAutoWrapper(mes.extra, 'video', 'media', (t) => t.type === MEDIA_TYPE.VIDEO, (t) => t.url);
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -2190,7 +2190,7 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
     if (hasMedia && mediaDisplay === MEDIA_DISPLAY.LIST) {
         for (let index = 0; index < mes.extra.media.length; index++) {
             const attachment = mes.extra.media[index];
-            appendImageAttachment(attachment, index);
+            appendMediaAttachment(attachment, index);
         }
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -2171,16 +2171,6 @@ export function appendMediaToMessage(mes, messageElement, adjustScroll = true) {
         const counter = galleryControls.find('.mes_img_swipe_counter');
         counter.text(`${mediaIndex + 1}/${mes.extra.media.length}`);
 
-        const swipeLeft = galleryControls.find('.mes_img_swipe_left');
-        swipeLeft.off('click').on('click', function () {
-            eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: SWIPE_DIRECTION.LEFT });
-        });
-
-        const swipeRight = galleryControls.find('.mes_img_swipe_right');
-        swipeRight.off('click').on('click', function () {
-            eventSource.emit(event_types.IMAGE_SWIPED, { message: mes, element: messageElement, direction: SWIPE_DIRECTION.RIGHT });
-        });
-
         const template = appendMediaAttachment(selectedMedia, mediaIndex);
         template.addClass('img_swipes');
         template.append(galleryControls);

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -344,6 +344,7 @@ export async function convertSoloToGroupChat() {
 
         // Save group-chat marker
         if (index == 0) {
+            // @ts-ignore
             message.is_group = true;
         }
 

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -218,7 +218,12 @@ export async function populateFileAttachment(message, inputId = 'file_form_input
             // If file is video
             else if (file.type.startsWith('video/')) {
                 const videoUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
-                message.extra.video = videoUrl;
+
+                if (!Array.isArray(message.extra.videos)) {
+                    message.extra.videos = [];
+                }
+
+                message.extra.videos.push(videoUrl);
             } else {
                 const uniqueFileName = `${fileNamePrefix}.txt`;
 
@@ -1000,25 +1005,39 @@ async function deleteMessageImage(messageId, imageIndex, messageBlock) {
     appendMediaToMessage(message, messageBlock, false);
 }
 
-async function deleteMessageVideo() {
+/**
+ * Deletes video from a message.
+ * @param {number} messageId Message ID
+ * @param {number} videoIndex Video index
+ * @param {JQuery<HTMLElement>} messageBlock Message block element
+ */
+async function deleteMessageVideo(messageId, videoIndex, messageBlock) {
+    if (isNaN(messageId) || isNaN(videoIndex)) {
+        console.warn('Invalid message ID or video index');
+        return;
+    }
+
     const confirm = await Popup.show.confirm(t`Delete video from message?`, t`This action can't be undone.`);
     if (!confirm) {
         return;
     }
 
-    const mesBlock = $(this).closest('.mes');
-    const mesId = mesBlock.attr('mesid');
-    const message = chat[mesId];
+    const message = chat[messageId];
 
-    if (!message?.extra?.video) {
-        console.warn('Message has no video or it is empty');
+    if (!Array.isArray(message?.extra?.videos)) {
+        console.debug('Message has no videos');
         return;
     }
 
-    delete message.extra.video;
-    mesBlock.find('.mes_video_container').remove();
+    if (videoIndex < 0 || videoIndex >= message.extra.videos.length) {
+        console.warn('Invalid video index for message');
+        return;
+    }
+
+    message.extra.videos.splice(videoIndex, 1);
 
     await saveChatConditional();
+    appendMediaToMessage(message, messageBlock, false);
 }
 
 /**
@@ -2163,7 +2182,13 @@ export function initChatUtilities() {
         const imageIndex = Number(imageBlock.attr('data-index'));
         await deleteMessageImage(messageId, imageIndex, messageBlock);
     });
-    $(document).on('click', '.mes_video_delete', deleteMessageVideo);
+    $(document).on('click', '.mes_video_delete', async function() {
+        const messageBlock = $(this).closest('.mes');
+        const messageId = Number(messageBlock.attr('mesid'));
+        const videoBlock = $(this).closest('.mes_video_container');
+        const videoIndex = Number(videoBlock.attr('data-index'));
+        await deleteMessageVideo(messageId, videoIndex, messageBlock);
+    });
 
     $('#file_form_input').on('change', async () => {
         const fileInput = document.getElementById('file_form_input');

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -2246,7 +2246,7 @@ export function initChatUtilities() {
      * @property {JQuery<HTMLElement>} mediaBlock The closest media container block
      * @property {number} mediaIndex The media index within the message
      */
-    function getMediaContainerInfo(containerClass = '.mes_media_container'){
+    function getMediaContainerInfo(containerClass = '.mes_media_container') {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
         const mediaBlock = $(this).closest(containerClass);
@@ -2273,11 +2273,11 @@ export function initChatUtilities() {
         const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.LIST);
     });
-    chatElement.on('click','.mes_img_swipe_left', async function () {
+    chatElement.on('click', '.mes_img_swipe_left', async function () {
         const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await onImageSwiped(messageId, messageBlock, SWIPE_DIRECTION.LEFT);
     });
-    chatElement.on('click','.mes_img_swipe_right', async function () {
+    chatElement.on('click', '.mes_img_swipe_right', async function () {
         const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await onImageSwiped(messageId, messageBlock, SWIPE_DIRECTION.RIGHT);
     });
@@ -2299,13 +2299,26 @@ export function initChatUtilities() {
         event.preventDefault();
         event.stopPropagation();
 
+        await handleFileAttach(Array.from(event.clipboardData.files));
+    });
+
+    new DragAndDropHandler('#form_sheld', async (files) => {
+        await handleFileAttach(files);
+    });
+
+    /**
+     * Common handler for file attachments.
+     * @param {File[]} files Files to attach
+     * @returns {Promise<void>}
+     */
+    async function handleFileAttach(files) {
         const fileInput = document.getElementById('file_form_input');
         if (!(fileInput instanceof HTMLInputElement)) return;
 
         // Workaround for Firefox: Use a DataTransfer object to indirectly set fileInput.files
         const dataTransfer = new DataTransfer();
-        for (let i = 0; i < event.clipboardData.files.length; i++) {
-            dataTransfer.items.add(event.clipboardData.files[i]);
+        for (let i = 0; i < files.length; i++) {
+            dataTransfer.items.add(files[i]);
         }
 
         // Preserve existing non-duplicate files in the input
@@ -2317,7 +2330,7 @@ export function initChatUtilities() {
 
         fileInput.files = dataTransfer.files;
         await onFileAttach(fileInput.files);
-    });
+    }
 
     eventSource.on(event_types.CHAT_CHANGED, checkForCreatorNotesStyles);
 }

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -28,6 +28,7 @@ import {
     refreshSwipeButtons,
     getMediaIndex,
     getMediaDisplay,
+    chatElement,
 } from '../script.js';
 import { selected_group } from './group-chats.js';
 import { power_user } from './power-user.js';
@@ -2252,31 +2253,31 @@ export function initChatUtilities() {
         const mediaIndex = Number(mediaBlock.attr('data-index'));
         return { messageBlock, messageId, mediaBlock, mediaIndex };
     }
-    $(document).on('click', '.mes_img', async function () {
+    chatElement.on('click', '.mes_img', async function () {
         const { messageId, mediaIndex } = getMediaContainerInfo.call(this);
         expandMessageMedia(messageId, mediaIndex);
     });
-    $(document).on('click', '.mes_media_enlarge', async function () {
+    chatElement.on('click', '.mes_media_enlarge', async function () {
         const { messageId, mediaIndex } = getMediaContainerInfo.call(this);
         expandMessageMedia(messageId, mediaIndex).click();
     });
-    $(document).on('click', '.mes_media_delete', async function () {
+    chatElement.on('click', '.mes_media_delete', async function () {
         const { messageId, mediaIndex, messageBlock } = getMediaContainerInfo.call(this);
         await deleteMessageMedia(messageId, mediaIndex, messageBlock);
     });
-    $(document).on('click', '.mes_media_list', async function () {
+    chatElement.on('click', '.mes_media_list', async function () {
         const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.GALLERY);
     });
-    $(document).on('click', '.mes_media_gallery', async function () {
+    chatElement.on('click', '.mes_media_gallery', async function () {
         const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.LIST);
     });
-    $(document).on('click','.mes_img_swipe_left', async function () {
+    chatElement.on('click','.mes_img_swipe_left', async function () {
         const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await onImageSwiped(messageId, messageBlock, SWIPE_DIRECTION.LEFT);
     });
-    $(document).on('click','.mes_img_swipe_right', async function () {
+    chatElement.on('click','.mes_img_swipe_right', async function () {
         const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await onImageSwiped(messageId, messageBlock, SWIPE_DIRECTION.RIGHT);
     });

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -471,7 +471,7 @@ function embedMessageFile(messageId, messageBlock) {
         .on('change', parseAndUploadEmbed)
         .trigger('click');
 
-    async function parseAndUploadEmbed(/** @type {JQuery.EventBase} */ e) {
+    async function parseAndUploadEmbed(/** @type {JQuery.ChangeEvent} */ e) {
         if (!(e.target instanceof HTMLInputElement)) return;
         if (!e.target.files.length) return;
 
@@ -494,7 +494,7 @@ function embedMessageFile(messageId, messageBlock) {
 
 /**
  * Appends file content to the message text.
- * @param {object} message Message object
+ * @param {ChatMessage} message Message object
  * @param {string} messageText Message text
  * @returns {Promise<string>} Message text with file content appended.
  */

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -2314,5 +2314,4 @@ export function initChatUtilities() {
     });
 
     eventSource.on(event_types.CHAT_CHANGED, checkForCreatorNotesStyles);
-    eventSource.on(event_types.IMAGE_SWIPED, onImageSwiped);
 }

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -27,6 +27,7 @@ import {
     clearChat,
     refreshSwipeButtons,
     getMediaIndex,
+    getMediaDisplay,
 } from '../script.js';
 import { selected_group } from './group-chats.js';
 import { power_user } from './power-user.js';
@@ -2006,12 +2007,13 @@ async function onImageSwiped(messageId, element, direction) {
         return;
     }
 
-    if (message?.extra?.media_display !== MEDIA_DISPLAY.GALLERY) {
+    const currentIndex = getMediaIndex(message);
+    const mediaDisplay = getMediaDisplay(message);
+
+    if (mediaDisplay !== MEDIA_DISPLAY.GALLERY) {
         console.warn('Image swiping is only supported for gallery media display');
         return;
     }
-
-    const currentIndex = getMediaIndex(message);
 
     // Switch to previous image or wrap around if at the beginning
     if (direction === SWIPE_DIRECTION.LEFT) {
@@ -2026,7 +2028,7 @@ async function onImageSwiped(messageId, element, direction) {
     }
 
     // Show a message that swipe right no longer automatically generates an image
-    if (media.length > 1 && direction === SWIPE_DIRECTION.RIGHT && message.extra.media_index === 0) {
+    if (media.length > 0 && direction === SWIPE_DIRECTION.RIGHT && message.extra.media_index === 0) {
         const key = 'imageSwipeNoticeShown';
         const hasSeenNotice = accountStorage.getItem(key);
         if (!hasSeenNotice) {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -207,7 +207,12 @@ export async function populateFileAttachment(message, inputId = 'file_form_input
             // If file is image
             if (file.type.startsWith('image/')) {
                 const imageUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
-                message.extra.image = imageUrl;
+
+                if (!Array.isArray(message.extra.images)) {
+                    message.extra.images = [];
+                }
+
+                message.extra.images.push(imageUrl);
                 message.extra.inline_image = true;
             }
             // If file is video
@@ -413,7 +418,7 @@ async function deleteMessageFile(messageBlock, messageId, fileIndex) {
     await saveChatConditional();
     await deleteFileFromServer(url);
 
-    appendMediaToMessage(message, messageBlock);
+    appendMediaToMessage(message, messageBlock, false);
 }
 
 /**
@@ -484,7 +489,7 @@ function embedMessageFile(messageId, messageBlock) {
 
         await populateFileAttachment(message, 'embed_file_input');
         await eventSource.emit(event_types.MESSAGE_FILE_EMBEDDED, messageId);
-        appendMediaToMessage(message, messageBlock);
+        appendMediaToMessage(message, messageBlock, false);
         await saveChatConditional();
     }
 }
@@ -858,11 +863,26 @@ export function isExternalMediaAllowed() {
     return !power_user.forbid_external_media;
 }
 
-function expandMessageImage(event) {
-    const mesBlock = $(event.currentTarget).closest('.mes');
-    const mesId = mesBlock.attr('mesid');
-    const message = chat[mesId];
-    const imgSrc = message?.extra?.image;
+/**
+ * Expands the message image.
+ * @param {number} messageId Message ID
+ * @param {number} imageIndex Image index
+ * @returns {HTMLImageElement} Enlarged image element
+ */
+function expandMessageImage(messageId, imageIndex) {
+    if (isNaN(messageId) || isNaN(imageIndex)) {
+        console.warn('Invalid message ID or image index');
+        return;
+    }
+
+    const message = chat[messageId];
+
+    if (!Array.isArray(message?.extra?.images) || message.extra.images.length === 0) {
+        console.warn('Message has no images to expand');
+        return;
+    }
+
+    const imgSrc = message.extra.images[imageIndex];
     const title = message?.extra?.title;
 
     if (!imgSrc) {
@@ -907,11 +927,18 @@ function expandMessageImage(event) {
     return img;
 }
 
-function expandAndZoomMessageImage(event) {
-    expandMessageImage(event).click();
-}
+/**
+ * Deletes an image from a message.
+ * @param {number} messageId Message ID
+ * @param {number} imageIndex Image index
+ * @param {JQuery<HTMLElement>} messageBlock Message block element
+ */
+async function deleteMessageImage(messageId, imageIndex, messageBlock) {
+    if (isNaN(messageId) || isNaN(imageIndex)) {
+        console.warn('Invalid message ID or image index');
+        return;
+    }
 
-async function deleteMessageImage() {
     const value = await callGenericPopup('<h3>Delete image from message?<br>This action can\'t be undone.</h3>', POPUP_TYPE.TEXT, '', {
         okButton: t`Delete one`,
         customButtons: [
@@ -932,37 +959,45 @@ async function deleteMessageImage() {
         return;
     }
 
-    const mesBlock = $(this).closest('.mes');
-    const mesId = mesBlock.attr('mesid');
-    const message = chat[mesId];
+    const message = chat[messageId];
 
-    let isLastImage = true;
-
-    if (Array.isArray(message.extra.image_swipes)) {
-        const indexOf = message.extra.image_swipes.indexOf(message.extra.image);
-        if (indexOf > -1) {
-            message.extra.image_swipes.splice(indexOf, 1);
-            isLastImage = message.extra.image_swipes.length === 0;
-            if (!isLastImage) {
-                const newIndex = Math.min(indexOf, message.extra.image_swipes.length - 1);
-                message.extra.image = message.extra.image_swipes[newIndex];
-            }
-        }
+    if (!Array.isArray(message?.extra?.images)) {
+        console.debug('Message has no images');
+        return;
     }
 
-    if (isLastImage || value === POPUP_RESULT.CUSTOM1) {
-        delete message.extra.image;
+    if (imageIndex < 0 || imageIndex >= message.extra.images.length) {
+        console.warn('Invalid image index for message');
+        return;
+    }
+
+    if (imageIndex === 0 && Array.isArray(message.extra.image_swipes) && message.extra.image_swipes.length > 0) {
+        const indexOf = message.extra.image_swipes.indexOf(message.extra.images[imageIndex]);
+        if (indexOf > -1) {
+            message.extra.image_swipes.splice(indexOf, 1);
+            const isLastImage = message.extra.image_swipes.length === 0;
+            if (!isLastImage) {
+                const newIndex = Math.min(indexOf, message.extra.image_swipes.length - 1);
+                message.extra.images[imageIndex] = message.extra.image_swipes[newIndex];
+            } else {
+                message.extra.images.splice(imageIndex, 1);
+                delete message.extra.image_swipes;
+            }
+        }
+    } else {
+        message.extra.images.splice(imageIndex, 1);
+    }
+
+    if (value === POPUP_RESULT.CUSTOM1) {
+        delete message.extra.images;
         delete message.extra.inline_image;
         delete message.extra.title;
         delete message.extra.append_title;
         delete message.extra.image_swipes;
-        mesBlock.find('.mes_img_container').removeClass('img_extra');
-        mesBlock.find('.mes_img').attr('src', '');
-    } else {
-        appendMediaToMessage(message, mesBlock);
     }
 
     await saveChatConditional();
+    appendMediaToMessage(message, messageBlock, false);
 }
 
 async function deleteMessageVideo() {
@@ -2107,9 +2142,27 @@ export function initChatUtilities() {
         openGlobalStylesPreferenceDialog();
     });
 
-    $(document).on('click', '.mes_img', expandMessageImage);
-    $(document).on('click', '.mes_img_enlarge', expandAndZoomMessageImage);
-    $(document).on('click', '.mes_img_delete', deleteMessageImage);
+    $(document).on('click', '.mes_img', async function () {
+        const messageBlock = $(this).closest('.mes');
+        const messageId = Number(messageBlock.attr('mesid'));
+        const imageBlock = $(this).closest('.mes_img_container');
+        const imageIndex = Number(imageBlock.attr('data-index'));
+        expandMessageImage(messageId, imageIndex);
+    });
+    $(document).on('click', '.mes_img_enlarge', async function() {
+        const messageBlock = $(this).closest('.mes');
+        const messageId = Number(messageBlock.attr('mesid'));
+        const imageBlock = $(this).closest('.mes_img_container');
+        const imageIndex = Number(imageBlock.attr('data-index'));
+        expandMessageImage(messageId, imageIndex).click();
+    });
+    $(document).on('click', '.mes_img_delete', async function () {
+        const messageBlock = $(this).closest('.mes');
+        const messageId = Number(messageBlock.attr('mesid'));
+        const imageBlock = $(this).closest('.mes_img_container');
+        const imageIndex = Number(imageBlock.attr('data-index'));
+        await deleteMessageImage(messageId, imageIndex, messageBlock);
+    });
     $(document).on('click', '.mes_video_delete', deleteMessageVideo);
 
     $('#file_form_input').on('change', async () => {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -1981,13 +1981,12 @@ export function addDOMPurifyHooks() {
 
 /**
  * Switches an image to the next or previous one in the swipe list.
- * @param {object} args Event arguments
- * @param {ChatMessage} args.message Message object
- * @param {JQuery<HTMLElement>} args.element Message element
- * @param {string} args.direction Swipe direction
+ * @param {number} messageId Message ID
+ * @param {JQuery<HTMLElement>} element Message element
+ * @param {string} direction Swipe direction
  * @returns {Promise<void>}
  */
-async function onImageSwiped({ message, element, direction }) {
+async function onImageSwiped(messageId, element, direction) {
     const animationClass = 'fa-fade';
     const messageMedia = element.find('.mes_img, .mes_video');
 
@@ -1996,9 +1995,10 @@ async function onImageSwiped({ message, element, direction }) {
         return;
     }
 
+    const message = chat[messageId];
     const media = message?.extra?.media;
 
-    if (!Array.isArray(media) || media.length === 0) {
+    if (!message || !Array.isArray(media) || media.length === 0) {
         console.warn('No media found in the message');
         return;
     }
@@ -2036,6 +2036,7 @@ async function onImageSwiped({ message, element, direction }) {
     }
 
     await saveChatConditional();
+    await eventSource.emit(event_types.IMAGE_SWIPED, { message, element, direction });
     appendMediaToMessage(message, element, false);
 }
 
@@ -2265,6 +2266,14 @@ export function initChatUtilities() {
     $(document).on('click', '.mes_media_gallery', async function () {
         const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.LIST);
+    });
+    $(document).on('click','.mes_img_swipe_left', async function () {
+        const { messageId, messageBlock } = getMediaContainerInfo.call(this);
+        await onImageSwiped(messageId, messageBlock, SWIPE_DIRECTION.LEFT);
+    });
+    $(document).on('click','.mes_img_swipe_right', async function () {
+        const { messageId, messageBlock } = getMediaContainerInfo.call(this);
+        await onImageSwiped(messageId, messageBlock, SWIPE_DIRECTION.RIGHT);
     });
 
     $('#file_form_input').on('change', async () => {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -2230,35 +2230,40 @@ export function initChatUtilities() {
         openGlobalStylesPreferenceDialog();
     });
 
-    $(document).on('click', '.mes_img', async function () {
+    /**
+     * Returns information about the closest media container.
+     * @returns {MediaContainerInfo} Information about the media container
+     * @typedef {object} MediaContainerInfo
+     * @property {JQuery<HTMLElement>} messageBlock The closest message block
+     * @property {number} messageId The message ID
+     * @property {JQuery<HTMLElement>} mediaBlock The closest media container block
+     * @property {number} mediaIndex The media index within the message
+     */
+    function getMediaContainerInfo(containerClass = '.mes_media_container'){
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        const mediaBlock = $(this).closest('.mes_media_container');
+        const mediaBlock = $(this).closest(containerClass);
         const mediaIndex = Number(mediaBlock.attr('data-index'));
+        return { messageBlock, messageId, mediaBlock, mediaIndex };
+    }
+    $(document).on('click', '.mes_img', async function () {
+        const { messageId, mediaIndex } = getMediaContainerInfo.call(this);
         expandMessageMedia(messageId, mediaIndex);
     });
     $(document).on('click', '.mes_media_enlarge', async function () {
-        const messageBlock = $(this).closest('.mes');
-        const messageId = Number(messageBlock.attr('mesid'));
-        const mediaBlock = $(this).closest('.mes_media_container');
-        const mediaIndex = Number(mediaBlock.attr('data-index'));
+        const { messageId, mediaIndex } = getMediaContainerInfo.call(this);
         expandMessageMedia(messageId, mediaIndex).click();
     });
     $(document).on('click', '.mes_media_delete', async function () {
-        const messageBlock = $(this).closest('.mes');
-        const messageId = Number(messageBlock.attr('mesid'));
-        const mediaBlock = $(this).closest('.mes_media_container');
-        const mediaIndex = Number(mediaBlock.attr('data-index'));
+        const { messageId, mediaIndex, messageBlock } = getMediaContainerInfo.call(this);
         await deleteMessageMedia(messageId, mediaIndex, messageBlock);
     });
     $(document).on('click', '.mes_media_list', async function () {
-        const messageBlock = $(this).closest('.mes');
-        const messageId = Number(messageBlock.attr('mesid'));
+        const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.GALLERY);
     });
     $(document).on('click', '.mes_media_gallery', async function () {
-        const messageBlock = $(this).closest('.mes');
-        const messageId = Number(messageBlock.attr('mesid'));
+        const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.LIST);
     });
 

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -2042,7 +2042,7 @@ async function onImageSwiped(messageId, element, direction) {
 
     await saveChatConditional();
     await eventSource.emit(event_types.IMAGE_SWIPED, { message, element, direction });
-    appendMediaToMessage(message, element, false);
+    appendMediaToMessage(message, element);
 }
 
 export function initChatUtilities() {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -193,56 +193,59 @@ export async function unhideChatMessage(messageId, _messageBlock) {
 export async function populateFileAttachment(message, inputId = 'file_form_input') {
     try {
         if (!message) return;
-        if (!message.extra) message.extra = {};
+        if (!message.extra || typeof message.extra !== 'object') message.extra = {};
         const fileInput = document.getElementById(inputId);
         if (!(fileInput instanceof HTMLInputElement)) return;
-        const file = fileInput.files[0];
-        if (!file) return;
 
-        const slug = getStringHash(file.name);
-        const fileNamePrefix = `${Date.now()}_${slug}`;
-        const fileBase64 = await getBase64Async(file);
-        let base64Data = fileBase64.split(',')[1];
-        const extension = getFileExtension(file);
+        for (const file of fileInput.files) {
+            const slug = getStringHash(file.name);
+            const fileNamePrefix = `${Date.now()}_${slug}`;
+            const fileBase64 = await getBase64Async(file);
+            let base64Data = fileBase64.split(',')[1];
+            const extension = getFileExtension(file);
 
-        // If file is image
-        if (file.type.startsWith('image/')) {
-            const imageUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
-            message.extra.image = imageUrl;
-            message.extra.inline_image = true;
-        }
-        // If file is video
-        else if (file.type.startsWith('video/')) {
-            const videoUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
-            message.extra.video = videoUrl;
-        } else {
-            const uniqueFileName = `${fileNamePrefix}.txt`;
+            // If file is image
+            if (file.type.startsWith('image/')) {
+                const imageUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
+                message.extra.image = imageUrl;
+                message.extra.inline_image = true;
+            }
+            // If file is video
+            else if (file.type.startsWith('video/')) {
+                const videoUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
+                message.extra.video = videoUrl;
+            } else {
+                const uniqueFileName = `${fileNamePrefix}.txt`;
 
-            if (isConvertible(file.type)) {
-                try {
-                    const converter = getConverter(file.type);
-                    const fileText = await converter(file);
-                    base64Data = convertTextToBase64(fileText);
-                } catch (error) {
-                    toastr.error(String(error), t`Could not convert file`);
-                    console.error('Could not convert file', error);
+                if (isConvertible(file.type)) {
+                    try {
+                        const converter = getConverter(file.type);
+                        const fileText = await converter(file);
+                        base64Data = convertTextToBase64(fileText);
+                    } catch (error) {
+                        toastr.error(String(error), t`Could not convert file`);
+                        console.error('Could not convert file', error);
+                    }
                 }
+
+                const fileUrl = await uploadFileAttachment(uniqueFileName, base64Data);
+
+                if (!fileUrl) {
+                    return;
+                }
+
+                if (!Array.isArray(message.extra.files)) {
+                    message.extra.files = [];
+                }
+
+                message.extra.files.push({
+                    url: fileUrl,
+                    size: file.size,
+                    name: file.name,
+                    created: Date.now(),
+                });
             }
-
-            const fileUrl = await uploadFileAttachment(uniqueFileName, base64Data);
-
-            if (!fileUrl) {
-                return;
-            }
-
-            message.extra.file = {
-                url: fileUrl,
-                size: file.size,
-                name: file.name,
-                created: Date.now(),
-            };
         }
-
     } catch (error) {
         console.error('Could not upload file', error);
         toastr.error(t`Either the file is corrupted or its format is not supported.`, t`Could not upload the file`);
@@ -314,16 +317,16 @@ export async function getFileAttachment(url) {
  */
 async function validateFile(file) {
     const fileText = await file.text();
-    const isImage = file.type.startsWith('image/');
+    const isMedia = file.type.startsWith('image/') || file.type.startsWith('video/');
     const isBinary = /^[\x00-\x08\x0E-\x1F\x7F-\xFF]*$/.test(fileText);
 
-    if (!isImage && file.size > fileSizeLimit) {
+    if (!isMedia && file.size > fileSizeLimit) {
         toastr.error(t`File is too big. Maximum size is ${humanFileSize(fileSizeLimit)}.`);
         return false;
     }
 
     // If file is binary
-    if (isBinary && !isImage && !isConvertible(file.type)) {
+    if (isBinary && !isMedia && !isConvertible(file.type)) {
         toastr.error(t`Binary files are not supported. Select a text file or image.`);
         return false;
     }
@@ -340,22 +343,28 @@ export function hasPendingFileAttachment() {
 
 /**
  * Displays file information in the message sending form.
- * @param {File} file File object
+ * @param {FileList} fileList File object
  * @returns {Promise<void>}
  */
-async function onFileAttach(file) {
-    if (!file) return;
+async function onFileAttach(fileList) {
+    if (!fileList || fileList.length === 0) return;
 
-    const isValid = await validateFile(file);
+    for (const file of fileList) {
+        const isValid = await validateFile(file);
 
-    // If file is binary
-    if (!isValid) {
-        $('#file_form').trigger('reset');
-        return;
+        // If file is binary
+        if (!isValid) {
+            toastr.warning(t`File ${file.name} is not supported.`);
+            $('#file_form').trigger('reset');
+            return;
+        }
     }
 
-    $('#file_form .file_name').text(file.name);
-    $('#file_form .file_size').text(humanFileSize(file.size));
+    const name = fileList.length === 1 ? fileList[0].name : t`${fileList.length} files selected`;
+    const size = [...fileList].reduce((acc, file) => acc + file.size, 0);
+    const title = [...fileList].map(x => x.name).join('\n');
+    $('#file_form .file_name').text(name).attr('title', title);
+    $('#file_form .file_size').text(humanFileSize(size)).attr('title', size);
     $('#file_form').removeClass('displayNone');
 
     // Reset form on chat change (if not on a welcome screen)
@@ -368,10 +377,17 @@ async function onFileAttach(file) {
 }
 
 /**
- * Deletes file from message.
+ * Deletes file from a message.
+ * @param {JQuery<HTMLElement>} messageBlock Message block element
  * @param {number} messageId Message ID
+ * @param {number} fileIndex File index
  */
-async function deleteMessageFile(messageId) {
+async function deleteMessageFile(messageBlock, messageId, fileIndex) {
+    if (isNaN(messageId) || isNaN(fileIndex)) {
+        console.warn('Invalid message ID or file index');
+        return;
+    }
+
     const confirm = await callGenericPopup('Are you sure you want to delete this file?', POPUP_TYPE.CONFIRM);
 
     if (confirm !== POPUP_RESULT.AFFIRMATIVE) {
@@ -381,26 +397,49 @@ async function deleteMessageFile(messageId) {
 
     const message = chat[messageId];
 
-    if (!message?.extra?.file) {
-        console.debug('Message has no file');
+    if (!Array.isArray(message?.extra?.files)) {
+        console.debug('Message has no files');
         return;
     }
 
-    const url = message.extra.file.url;
+    if (fileIndex < 0 || fileIndex >= message.extra.files.length) {
+        console.warn('Invalid file index for message');
+        return;
+    }
 
-    delete message.extra.file;
-    $(`.mes[mesid="${messageId}"] .mes_file_container`).remove();
+    const url = message.extra.files[fileIndex]?.url;
+    message.extra.files.splice(fileIndex, 1);
+
     await saveChatConditional();
     await deleteFileFromServer(url);
-}
 
+    appendMediaToMessage(message, messageBlock);
+}
 
 /**
  * Opens file from message in a modal.
  * @param {number} messageId Message ID
+ * @param {number} fileIndex File index
  */
-async function viewMessageFile(messageId) {
-    const messageFile = chat[messageId]?.extra?.file;
+async function viewMessageFile(messageId, fileIndex) {
+    if (isNaN(messageId) || isNaN(fileIndex)) {
+        console.warn('Invalid message ID or file index');
+        return;
+    }
+
+    const message = chat[messageId];
+
+    if (!Array.isArray(message?.extra?.files)) {
+        console.debug('Message has no files');
+        return;
+    }
+
+    if (fileIndex < 0 || fileIndex >= message.extra.files.length) {
+        console.warn('Invalid file index for message');
+        return;
+    }
+
+    const messageFile = message.extra.files[fileIndex];
 
     if (!messageFile) {
         console.debug('Message has no file or it is empty');
@@ -429,15 +468,18 @@ function embedMessageFile(messageId, messageBlock) {
         .on('change', parseAndUploadEmbed)
         .trigger('click');
 
-    async function parseAndUploadEmbed(e) {
-        const file = e.target.files[0];
-        if (!file) return;
+    async function parseAndUploadEmbed(/** @type {JQuery.EventBase} */ e) {
+        if (!(e.target instanceof HTMLInputElement)) return;
+        if (!e.target.files.length) return;
 
-        const isValid = await validateFile(file);
+        for (const file of e.target.files) {
+            const isValid = await validateFile(file);
 
-        if (!isValid) {
-            $('#file_form').trigger('reset');
-            return;
+            if (!isValid) {
+                toastr.warning(t`File ${file.name} is not supported.`);
+                $('#file_form').trigger('reset');
+                return;
+            }
         }
 
         await populateFileAttachment(message, 'embed_file_input');
@@ -454,14 +496,23 @@ function embedMessageFile(messageId, messageBlock) {
  * @returns {Promise<string>} Message text with file content appended.
  */
 export async function appendFileContent(message, messageText) {
-    if (message.extra?.file) {
-        const fileText = message.extra.file.text || (await getFileAttachment(message.extra.file.url));
-
-        if (fileText) {
-            const fileWrapped = `${fileText}\n\n`;
-            message.extra.fileLength = fileWrapped.length;
-            messageText = fileWrapped + messageText;
+    if (!message || !message.extra || typeof message.extra !== 'object') {
+        return messageText;
+    }
+    if (message.extra.fileLength >= 0) {
+        delete message.extra.fileLength;
+    }
+    if (Array.isArray(message.extra?.files) && message.extra.files.length > 0) {
+        const fileTexts = [];
+        for (const file of message.extra.files) {
+            const fileText = file.text || (await getFileAttachment(file.url));
+            if (fileText) {
+                fileTexts.push(fileText);
+            }
         }
+        const mergedFileTexts = fileTexts.join('\n\n') + '\n\n';
+        message.extra.fileLength = mergedFileTexts.length;
+        return mergedFileTexts + messageText;
     }
     return messageText;
 }
@@ -1881,13 +1932,17 @@ export function initChatUtilities() {
     $(document).on('click', '.mes_file_delete', async function () {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        await deleteMessageFile(messageId);
+        const fileBlock = $(this).closest('.mes_file_container');
+        const fileIndex = Number(fileBlock.attr('data-index'));
+        await deleteMessageFile(messageBlock, messageId, fileIndex);
     });
 
     $(document).on('click', '.mes_file_open', async function () {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        await viewMessageFile(messageId);
+        const fileBlock = $(this).closest('.mes_file_container');
+        const fileIndex = Number(fileBlock.attr('data-index'));
+        await viewMessageFile(messageId, fileIndex);
     });
 
     $(document).on('click', '.assistant_note_export', async function () {
@@ -2060,8 +2115,7 @@ export function initChatUtilities() {
     $('#file_form_input').on('change', async () => {
         const fileInput = document.getElementById('file_form_input');
         if (!(fileInput instanceof HTMLInputElement)) return;
-        const file = fileInput.files[0];
-        await onFileAttach(file);
+        await onFileAttach(fileInput.files);
     });
     $('#file_form').on('reset', function () {
         $('#file_form').addClass('displayNone');
@@ -2085,7 +2139,7 @@ export function initChatUtilities() {
         }
 
         fileInput.files = dataTransfer.files;
-        await onFileAttach(fileInput.files[0]);
+        await onFileAttach(fileInput.files);
     });
 
     eventSource.on(event_types.CHAT_CHANGED, checkForCreatorNotesStyles);

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -43,6 +43,7 @@ import {
     getFileText,
     getFileExtension,
     convertTextToBase64,
+    isSameFile,
 } from './utils.js';
 import { extension_settings, renderExtensionTemplateAsync, saveMetadataDebounced } from './extensions.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
@@ -2214,6 +2215,13 @@ export function initChatUtilities() {
         const dataTransfer = new DataTransfer();
         for (let i = 0; i < event.clipboardData.files.length; i++) {
             dataTransfer.items.add(event.clipboardData.files[i]);
+        }
+
+        // Preserve existing non-duplicate files in the input
+        for (const file of fileInput.files) {
+            if (!Array.from(dataTransfer.files).some(f => isSameFile(f, file))) {
+                dataTransfer.items.add(file);
+            }
         }
 
         fileInput.files = dataTransfer.files;

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -26,6 +26,7 @@ import {
     printMessages,
     clearChat,
     refreshSwipeButtons,
+    getMediaIndex,
 } from '../script.js';
 import { selected_group } from './group-chats.js';
 import { power_user } from './power-user.js';
@@ -44,6 +45,7 @@ import {
     getFileExtension,
     convertTextToBase64,
     isSameFile,
+    clamp,
 } from './utils.js';
 import { extension_settings, renderExtensionTemplateAsync, saveMetadataDebounced } from './extensions.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
@@ -53,6 +55,7 @@ import { renderTemplateAsync } from './templates.js';
 import { t } from './i18n.js';
 import { humanizedDateTime } from './RossAscends-mods.js';
 import { accountStorage } from './util/AccountStorage.js';
+import { MEDIA_DISPLAY, MEDIA_TYPE, SWIPE_DIRECTION } from './constants.js';
 
 /**
  * @typedef {Object} FileAttachment
@@ -188,7 +191,7 @@ export async function unhideChatMessage(messageId, _messageBlock) {
 
 /**
  * Adds a file attachment to the message.
- * @param {object} message Message object
+ * @param {ChatMessage} message Message object
  * @returns {Promise<void>} A promise that resolves when file is uploaded.
  */
 export async function populateFileAttachment(message, inputId = 'file_form_input') {
@@ -205,26 +208,15 @@ export async function populateFileAttachment(message, inputId = 'file_form_input
             let base64Data = fileBase64.split(',')[1];
             const extension = getFileExtension(file);
 
-            // If file is image
-            if (file.type.startsWith('image/')) {
+            const mediaType = MEDIA_TYPE.getFromMime(file.type);
+            if (mediaType) {
                 const imageUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
-
-                if (!Array.isArray(message.extra.images)) {
-                    message.extra.images = [];
+                if (!Array.isArray(message.extra.media)) {
+                    message.extra.media = [];
                 }
-
-                message.extra.images.push(imageUrl);
+                message.extra.media.push({ url: imageUrl, type: mediaType });
+                message.extra.media_index = message.extra.media.length - 1;
                 message.extra.inline_image = true;
-            }
-            // If file is video
-            else if (file.type.startsWith('video/')) {
-                const videoUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
-
-                if (!Array.isArray(message.extra.videos)) {
-                    message.extra.videos = [];
-                }
-
-                message.extra.videos.push(videoUrl);
             } else {
                 const uniqueFileName = `${fileNamePrefix}.txt`;
 
@@ -870,39 +862,70 @@ export function isExternalMediaAllowed() {
 }
 
 /**
- * Expands the message image.
+ * Expands the message media attachment.
  * @param {number} messageId Message ID
- * @param {number} imageIndex Image index
- * @returns {HTMLImageElement} Enlarged image element
+ * @param {number} mediaIndex Media index
+ * @returns {HTMLElement} Enlarged media element
  */
-function expandMessageImage(messageId, imageIndex) {
-    if (isNaN(messageId) || isNaN(imageIndex)) {
-        console.warn('Invalid message ID or image index');
+function expandMessageMedia(messageId, mediaIndex) {
+    if (isNaN(messageId) || isNaN(mediaIndex)) {
+        console.warn('Invalid message ID or media index');
         return;
     }
 
+    /** @type {ChatMessage} */
     const message = chat[messageId];
 
-    if (!Array.isArray(message?.extra?.images) || message.extra.images.length === 0) {
-        console.warn('Message has no images to expand');
+    if (!Array.isArray(message?.extra?.media) || message.extra.media.length === 0) {
+        console.warn('Message has no media to expand');
         return;
     }
 
-    const imgSrc = message.extra.images[imageIndex];
-    const title = message?.extra?.title;
+    const mediaAttachment = message.extra.media[mediaIndex];
+    const title = mediaAttachment.title || message.extra.title;
 
-    if (!imgSrc) {
+    if (!mediaAttachment) {
         return;
     }
 
-    const img = document.createElement('img');
-    img.classList.add('img_enlarged');
-    img.src = imgSrc;
-    const imgHolder = document.createElement('div');
-    imgHolder.classList.add('img_enlarged_holder');
-    imgHolder.append(img);
+    /**
+     * Gets the media element based on its type.
+     * @returns {HTMLElement} Media element
+     */
+    function getMediaElement() {
+        function getImageElement() {
+            const img = document.createElement('img');
+            img.src = mediaAttachment.url;
+            img.classList.add('img_enlarged');
+            return img;
+        }
+
+        function getVideoElement() {
+            const video = document.createElement('video');
+            video.src = mediaAttachment.url;
+            video.classList.add('img_enlarged');
+            video.controls = true;
+            video.autoplay = true;
+            return video;
+        }
+
+        switch (mediaAttachment.type) {
+            case MEDIA_TYPE.IMAGE:
+                return getImageElement();
+            case MEDIA_TYPE.VIDEO:
+                return getVideoElement();
+        }
+
+        console.warn('Unsupported media type for enlargement:', mediaAttachment.type);
+        return getImageElement();
+    }
+
+    const mediaElement = getMediaElement();
+    const mediaHolder = document.createElement('div');
+    mediaHolder.classList.add('img_enlarged_holder');
+    mediaHolder.append(mediaElement);
     const imgContainer = $('<div><pre><code class="img_enlarged_title"></code></pre></div>');
-    imgContainer.prepend(imgHolder);
+    imgContainer.prepend(mediaHolder);
     imgContainer.addClass('img_enlarged_container');
 
     const codeTitle = imgContainer.find('.img_enlarged_title');
@@ -916,9 +939,9 @@ function expandMessageImage(messageId, imageIndex) {
     popup.dlg.style.width = 'unset';
     popup.dlg.style.height = 'unset';
 
-    img.addEventListener('click', event => {
-        const shouldZoom = !img.classList.contains('zoomed');
-        img.classList.toggle('zoomed', shouldZoom);
+    mediaElement.addEventListener('click', event => {
+        const shouldZoom = !mediaElement.classList.contains('zoomed') && mediaElement.nodeName === 'IMG';
+        mediaElement.classList.toggle('zoomed', shouldZoom);
         event.stopPropagation();
     });
     codeTitle[0]?.addEventListener('click', event => {
@@ -930,23 +953,24 @@ function expandMessageImage(messageId, imageIndex) {
     });
 
     popup.show();
-    return img;
+    return mediaElement;
 }
 
 /**
  * Deletes an image from a message.
  * @param {number} messageId Message ID
- * @param {number} imageIndex Image index
+ * @param {number} mediaIndex Image index
  * @param {JQuery<HTMLElement>} messageBlock Message block element
  */
-async function deleteMessageImage(messageId, imageIndex, messageBlock) {
-    if (isNaN(messageId) || isNaN(imageIndex)) {
-        console.warn('Invalid message ID or image index');
+async function deleteMessageMedia(messageId, mediaIndex, messageBlock) {
+    if (isNaN(messageId) || isNaN(mediaIndex)) {
+        console.warn('Invalid message ID or media index');
         return;
     }
 
-    const value = await callGenericPopup('<h3>Delete image from message?<br>This action can\'t be undone.</h3>', POPUP_TYPE.TEXT, '', {
+    const value = await Popup.show.confirm(t`Delete media from message?`, t`This action can't be undone.`, {
         okButton: t`Delete one`,
+        cancelButton: false,
         customButtons: [
             {
                 text: t`Delete all`,
@@ -965,41 +989,31 @@ async function deleteMessageImage(messageId, imageIndex, messageBlock) {
         return;
     }
 
+    /** @type {ChatMessage} */
     const message = chat[messageId];
 
-    if (!Array.isArray(message?.extra?.images)) {
-        console.debug('Message has no images');
+    if (!Array.isArray(message?.extra?.media)) {
+        console.debug('Message has no media');
         return;
     }
 
-    if (imageIndex < 0 || imageIndex >= message.extra.images.length) {
-        console.warn('Invalid image index for message');
+    if (mediaIndex < 0 || mediaIndex >= message.extra.media.length) {
+        console.warn('Invalid media index for message');
         return;
     }
 
-    if (imageIndex === 0 && Array.isArray(message.extra.image_swipes) && message.extra.image_swipes.length > 0) {
-        const indexOf = message.extra.image_swipes.indexOf(message.extra.images[imageIndex]);
-        if (indexOf > -1) {
-            message.extra.image_swipes.splice(indexOf, 1);
-            const isLastImage = message.extra.image_swipes.length === 0;
-            if (!isLastImage) {
-                const newIndex = Math.min(indexOf, message.extra.image_swipes.length - 1);
-                message.extra.images[imageIndex] = message.extra.image_swipes[newIndex];
-            } else {
-                message.extra.images.splice(imageIndex, 1);
-                delete message.extra.image_swipes;
-            }
-        }
-    } else {
-        message.extra.images.splice(imageIndex, 1);
+    message.extra.media.splice(mediaIndex, 1);
+
+    if (message.extra.media_index === mediaIndex) {
+        const newIndex = mediaIndex > 0 ? mediaIndex - 1 : 0;
+        message.extra.media_index = clamp(newIndex, 0, message.extra.media.length - 1);
     }
 
     if (value === POPUP_RESULT.CUSTOM1) {
-        delete message.extra.images;
+        delete message.extra.media;
         delete message.extra.inline_image;
         delete message.extra.title;
         delete message.extra.append_title;
-        delete message.extra.image_swipes;
     }
 
     await saveChatConditional();
@@ -1007,36 +1021,30 @@ async function deleteMessageImage(messageId, imageIndex, messageBlock) {
 }
 
 /**
- * Deletes video from a message.
+ * Switches the media display mode for a message.
  * @param {number} messageId Message ID
- * @param {number} videoIndex Video index
  * @param {JQuery<HTMLElement>} messageBlock Message block element
+ * @param {MEDIA_DISPLAY} targetDisplay Target display mode
  */
-async function deleteMessageVideo(messageId, videoIndex, messageBlock) {
-    if (isNaN(messageId) || isNaN(videoIndex)) {
-        console.warn('Invalid message ID or video index');
+async function switchMessageMediaDisplay(messageId, messageBlock, targetDisplay) {
+    if (isNaN(messageId)) {
+        console.warn('Invalid message ID');
         return;
     }
 
-    const confirm = await Popup.show.confirm(t`Delete video from message?`, t`This action can't be undone.`);
-    if (!confirm) {
-        return;
-    }
-
+    /** @type {ChatMessage} */
     const message = chat[messageId];
 
-    if (!Array.isArray(message?.extra?.videos)) {
-        console.debug('Message has no videos');
+    if (!message) {
+        console.warn('Message not found for ID', messageId);
         return;
     }
 
-    if (videoIndex < 0 || videoIndex >= message.extra.videos.length) {
-        console.warn('Invalid video index for message');
-        return;
+    if (!message.extra || typeof message.extra !== 'object') {
+        message.extra = {};
     }
 
-    message.extra.videos.splice(videoIndex, 1);
-
+    message.extra.media_display = targetDisplay;
     await saveChatConditional();
     appendMediaToMessage(message, messageBlock, false);
 }
@@ -1971,6 +1979,66 @@ export function addDOMPurifyHooks() {
     });
 }
 
+/**
+ * Switches an image to the next or previous one in the swipe list.
+ * @param {object} args Event arguments
+ * @param {ChatMessage} args.message Message object
+ * @param {JQuery<HTMLElement>} args.element Message element
+ * @param {string} args.direction Swipe direction
+ * @returns {Promise<void>}
+ */
+async function onImageSwiped({ message, element, direction }) {
+    const animationClass = 'fa-fade';
+    const messageMedia = element.find('.mes_img, .mes_video');
+
+    // Current image is already animating
+    if (messageMedia.hasClass(animationClass)) {
+        return;
+    }
+
+    const media = message?.extra?.media;
+
+    if (!Array.isArray(media) || media.length === 0) {
+        console.warn('No media found in the message');
+        return;
+    }
+
+    if (message?.extra?.media_display !== MEDIA_DISPLAY.GALLERY) {
+        console.warn('Image swiping is only supported for gallery media display');
+        return;
+    }
+
+    const currentIndex = getMediaIndex(message);
+
+    // Switch to previous image or wrap around if at the beginning
+    if (direction === SWIPE_DIRECTION.LEFT) {
+        const newIndex = currentIndex === 0 ? media.length - 1 : currentIndex - 1;
+        message.extra.media_index = newIndex;
+    }
+
+    // Switch to next image or generate a new one if at the end
+    if (direction === SWIPE_DIRECTION.RIGHT) {
+        const newIndex = currentIndex === media.length - 1 ? 0 : currentIndex + 1;
+        message.extra.media_index = newIndex >= media.length ? 0 : newIndex;
+    }
+
+    // Show a message that swipe right no longer automatically generates an image
+    if (media.length > 1 && direction === SWIPE_DIRECTION.RIGHT && message.extra.media_index === 0) {
+        const key = 'imageSwipeNoticeShown';
+        const hasSeenNotice = accountStorage.getItem(key);
+        if (!hasSeenNotice) {
+            await Popup.show.text(
+                t`Image swiping no longer automatically generates new images.`,
+                t`Use the 'Generate Image' (paintbrush) button in the message actions menu to generate more images. This message will not be shown again.`,
+            );
+            accountStorage.setItem(key, 'true');
+        }
+    }
+
+    await saveChatConditional();
+    appendMediaToMessage(message, element, false);
+}
+
 export function initChatUtilities() {
     $(document).on('click', '.mes_hide', async function () {
         const messageBlock = $(this).closest('.mes');
@@ -2165,30 +2233,33 @@ export function initChatUtilities() {
     $(document).on('click', '.mes_img', async function () {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        const imageBlock = $(this).closest('.mes_img_container');
-        const imageIndex = Number(imageBlock.attr('data-index'));
-        expandMessageImage(messageId, imageIndex);
+        const mediaBlock = $(this).closest('.mes_media_container');
+        const mediaIndex = Number(mediaBlock.attr('data-index'));
+        expandMessageMedia(messageId, mediaIndex);
     });
-    $(document).on('click', '.mes_img_enlarge', async function() {
+    $(document).on('click', '.mes_media_enlarge', async function () {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        const imageBlock = $(this).closest('.mes_img_container');
-        const imageIndex = Number(imageBlock.attr('data-index'));
-        expandMessageImage(messageId, imageIndex).click();
+        const mediaBlock = $(this).closest('.mes_media_container');
+        const mediaIndex = Number(mediaBlock.attr('data-index'));
+        expandMessageMedia(messageId, mediaIndex).click();
     });
-    $(document).on('click', '.mes_img_delete', async function () {
+    $(document).on('click', '.mes_media_delete', async function () {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        const imageBlock = $(this).closest('.mes_img_container');
-        const imageIndex = Number(imageBlock.attr('data-index'));
-        await deleteMessageImage(messageId, imageIndex, messageBlock);
+        const mediaBlock = $(this).closest('.mes_media_container');
+        const mediaIndex = Number(mediaBlock.attr('data-index'));
+        await deleteMessageMedia(messageId, mediaIndex, messageBlock);
     });
-    $(document).on('click', '.mes_video_delete', async function() {
+    $(document).on('click', '.mes_media_list', async function () {
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        const videoBlock = $(this).closest('.mes_video_container');
-        const videoIndex = Number(videoBlock.attr('data-index'));
-        await deleteMessageVideo(messageId, videoIndex, messageBlock);
+        await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.GALLERY);
+    });
+    $(document).on('click', '.mes_media_gallery', async function () {
+        const messageBlock = $(this).closest('.mes');
+        const messageId = Number(messageBlock.attr('mesid'));
+        await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.LIST);
     });
 
     $('#file_form_input').on('change', async () => {
@@ -2229,4 +2300,5 @@ export function initChatUtilities() {
     });
 
     eventSource.on(event_types.CHAT_CHANGED, checkForCreatorNotesStyles);
+    eventSource.on(event_types.IMAGE_SWIPED, onImageSwiped);
 }

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -882,7 +882,7 @@ function expandMessageMedia(messageId, mediaIndex) {
     }
 
     const mediaAttachment = message.extra.media[mediaIndex];
-    const title = mediaAttachment.title || message.extra.title;
+    const title = mediaAttachment.title || message.extra.title || '';
 
     if (!mediaAttachment) {
         return;
@@ -924,31 +924,34 @@ function expandMessageMedia(messageId, mediaIndex) {
     const mediaHolder = document.createElement('div');
     mediaHolder.classList.add('img_enlarged_holder');
     mediaHolder.append(mediaElement);
-    const imgContainer = $('<div><pre><code class="img_enlarged_title"></code></pre></div>');
-    imgContainer.prepend(mediaHolder);
-    imgContainer.addClass('img_enlarged_container');
-
-    const codeTitle = imgContainer.find('.img_enlarged_title');
-    codeTitle.addClass('txt').text(title);
-    const titleEmpty = !title || title.trim().length === 0;
-    imgContainer.find('pre').toggle(!titleEmpty);
-    addCopyToCodeBlocks(imgContainer);
-
-    const popup = new Popup(imgContainer, POPUP_TYPE.DISPLAY, '', { large: true, transparent: true });
-
-    popup.dlg.style.width = 'unset';
-    popup.dlg.style.height = 'unset';
+    const mediaContainer = document.createElement('div');
+    mediaContainer.classList.add('img_enlarged_container');
+    mediaContainer.append(mediaHolder);
 
     mediaElement.addEventListener('click', event => {
         const shouldZoom = !mediaElement.classList.contains('zoomed') && mediaElement.nodeName === 'IMG';
         mediaElement.classList.toggle('zoomed', shouldZoom);
         event.stopPropagation();
     });
-    codeTitle[0]?.addEventListener('click', event => {
-        event.stopPropagation();
-    });
 
-    popup.dlg.addEventListener('click', event => {
+    if (title.trim().length > 0) {
+        const mediaTitlePre = document.createElement('pre');
+        const mediaTitleCode = document.createElement('code');
+        mediaTitleCode.classList.add('img_enlarged_title', 'txt');
+        mediaTitleCode.textContent = title;
+        mediaTitlePre.append(mediaTitleCode);
+        mediaTitleCode.addEventListener('click', event => {
+            event.stopPropagation();
+        });
+        mediaContainer.append(mediaTitlePre);
+        addCopyToCodeBlocks(mediaContainer);
+    }
+
+    const popup = new Popup(mediaContainer, POPUP_TYPE.DISPLAY, '', { large: true, transparent: true });
+
+    popup.dlg.style.width = 'unset';
+    popup.dlg.style.height = 'unset';
+    popup.dlg.addEventListener('click', () => {
         popup.completeCancelled();
     });
 

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -241,7 +241,7 @@ export async function populateFileAttachment(message, inputId = 'file_form_input
                 const fileUrl = await uploadFileAttachment(uniqueFileName, base64Data);
 
                 if (!fileUrl) {
-                    return;
+                    continue;
                 }
 
                 if (!Array.isArray(message.extra.files)) {

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -68,6 +68,32 @@ export const COMETAPI_IGNORE_PATTERNS = [
 ];
 
 /**
+ * @enum {string}
+ * @readonly
+ */
+export const MEDIA_DISPLAY = {
+    LIST: 'list',
+    GALLERY: 'gallery',
+};
+
+/**
+ * @readonly
+ */
+export const MEDIA_TYPE = {
+    getFromMime: (/** @type {string} */ mimeType) => {
+        if (mimeType.startsWith('image/')) {
+            return MEDIA_TYPE.IMAGE;
+        }
+        if (mimeType.startsWith('video/')) {
+            return MEDIA_TYPE.VIDEO;
+        }
+        return null;
+    },
+    IMAGE: 'image',
+    VIDEO: 'video',
+};
+
+/**
  * @type {{readonly LEFT: 'left', readonly RIGHT: 'right'}}
  */
 export const SWIPE_DIRECTION = {

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -119,15 +119,20 @@ async function wrapCaptionTemplate(caption) {
 
 /**
  * Appends caption to an existing message.
- * @param {Object} data Message data
+ * @param {Object} message Message data
+ * @param {number} imageIndex Index of the image to caption
  * @returns {Promise<void>}
  */
-async function captionExistingMessage(data) {
-    if (!(data?.extra?.image)) {
+async function captionExistingMessage(message, imageIndex) {
+    if (!Array.isArray(message?.extra?.images) || message.extra.images.length === 0) {
         return;
     }
 
-    const imageData = await fetch(data.extra.image);
+    if (imageIndex === undefined || isNaN(imageIndex) || imageIndex < 0 || imageIndex >= message.extra.images.length) {
+        imageIndex = 0;
+    }
+
+    const imageData = await fetch(message.extra.images[imageIndex]);
     const blob = await imageData.blob();
     const type = imageData.headers.get('Content-Type');
     const file = new File([blob], 'image.png', { type });
@@ -140,17 +145,17 @@ async function captionExistingMessage(data) {
 
     const wrappedCaption = await wrapCaptionTemplate(caption);
 
-    const messageText = String(data.mes).trim();
+    const messageText = String(message.mes).trim();
 
     if (!messageText) {
-        data.extra.inline_image = false;
-        data.mes = wrappedCaption;
-        data.extra.title = wrappedCaption;
+        message.extra.inline_image = false;
+        message.mes = wrappedCaption;
+        message.extra.title = wrappedCaption;
     }
     else {
-        data.extra.inline_image = true;
-        data.extra.append_title = true;
-        data.extra.title = wrappedCaption;
+        message.extra.inline_image = true;
+        message.extra.append_title = true;
+        message.extra.title = wrappedCaption;
     }
 }
 
@@ -169,7 +174,7 @@ async function sendCaptionedMessage(caption, image) {
         send_date: getMessageTimeStamp(),
         mes: messageText,
         extra: {
-            image: image,
+            images: [image],
             title: messageText,
             inline_image: !!extension_settings.caption.show_in_chat,
         },
@@ -365,13 +370,15 @@ function onRefineModeInput() {
  */
 async function captionCommandCallback(args, prompt) {
     const quiet = isTrueBoolean(args?.quiet);
-    const mesId = args?.mesId ?? args?.id;
+    const messageId = args?.mesId ?? args?.id;
+    const index = Number(args?.index ?? 0);
 
-    if (!isNaN(Number(mesId))) {
-        const message = getContext().chat[mesId];
-        if (message?.extra?.image) {
+    if (!isNaN(Number(messageId))) {
+        const message = getContext().chat[messageId];
+        if (Array.isArray(message?.extra?.images) && message.extra.images.length > 0) {
             try {
-                const fetchResult = await fetch(message.extra.image);
+                const imageUrl = message.extra.images[index] || message.extra.images[0];
+                const fetchResult = await fetch(imageUrl);
                 const blob = await fetchResult.blob();
                 const file = new File([blob], 'image.jpg', { type: blob.type });
                 return await getCaptionForFile(file, prompt, quiet);
@@ -636,13 +643,13 @@ jQuery(async function () {
         saveSettingsDebounced();
     });
 
-    const onMessageEvent = async (index) => {
+    const onMessageEvent = async (messageId) => {
         if (!extension_settings.caption.auto_mode) {
             return;
         }
 
-        const data = getContext().chat[index];
-        await captionExistingMessage(data);
+        const message = getContext().chat[messageId];
+        await captionExistingMessage(message, 0);
     };
 
     eventSource.on(event_types.MESSAGE_SENT, onMessageEvent);
@@ -651,13 +658,15 @@ jQuery(async function () {
     $(document).on('click', '.mes_img_caption', async function () {
         const animationClass = 'fa-fade';
         const messageBlock = $(this).closest('.mes');
-        const messageImg = messageBlock.find('.mes_img');
+        const imageBlock = $(this).closest('.mes_img_container');
+        const messageImg = imageBlock.find('.mes_img');
         if (messageImg.hasClass(animationClass)) return;
         messageImg.addClass(animationClass);
         try {
-            const index = Number(messageBlock.attr('mesid'));
-            const data = getContext().chat[index];
-            await captionExistingMessage(data);
+            const messageId = Number(messageBlock.attr('mesid'));
+            const imageIndex = Number(imageBlock.attr('data-index'));
+            const data = getContext().chat[messageId];
+            await captionExistingMessage(data, imageIndex);
             appendMediaToMessage(data, messageBlock, false);
             await saveChatConditional();
         } catch (e) {
@@ -680,6 +689,11 @@ jQuery(async function () {
                 description: 'get image from a message with this ID',
                 typeList: [ARGUMENT_TYPE.NUMBER],
                 enumProvider: commonEnumProviders.messages(),
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'index',
+                description: 'index of the image in the message to caption (starting from 0)',
+                typeList: [ARGUMENT_TYPE.NUMBER],
             }),
         ],
         unnamedArgumentList: [

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -719,6 +719,7 @@ jQuery(async function () {
                 name: 'index',
                 description: 'index of the image in the message to caption (starting from 0)',
                 typeList: [ARGUMENT_TYPE.NUMBER],
+                enumProvider: commonEnumProviders.messageMedia(),
             }),
         ],
         unnamedArgumentList: [

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -10,6 +10,7 @@ import { SlashCommand } from '../../slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '../../slash-commands/SlashCommandArgument.js';
 import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { callGenericPopup, Popup, POPUP_TYPE } from '../../popup.js';
+import { MEDIA_DISPLAY, MEDIA_TYPE } from '../../constants.js';
 export { MODULE_NAME };
 
 const MODULE_NAME = 'caption';
@@ -119,20 +120,26 @@ async function wrapCaptionTemplate(caption) {
 
 /**
  * Appends caption to an existing message.
- * @param {Object} message Message data
- * @param {number} imageIndex Index of the image to caption
+ * @param {ChatMessage} message Message data
+ * @param {number} mediaIndex Index of the image to caption
  * @returns {Promise<void>}
  */
-async function captionExistingMessage(message, imageIndex) {
-    if (!Array.isArray(message?.extra?.images) || message.extra.images.length === 0) {
+async function captionExistingMessage(message, mediaIndex) {
+    if (!Array.isArray(message?.extra?.media) || message.extra.media.length === 0) {
         return;
     }
 
-    if (imageIndex === undefined || isNaN(imageIndex) || imageIndex < 0 || imageIndex >= message.extra.images.length) {
-        imageIndex = 0;
+    if (mediaIndex === undefined || isNaN(mediaIndex) || mediaIndex < 0 || mediaIndex >= message.extra.media.length) {
+        mediaIndex = 0;
     }
 
-    const imageData = await fetch(message.extra.images[imageIndex]);
+    const mediaAttachment = message.extra.media[mediaIndex];
+
+    if (!mediaAttachment || !mediaAttachment.url || mediaAttachment.type === MEDIA_TYPE.VIDEO) {
+        return;
+    }
+
+    const imageData = await fetch(mediaAttachment.url);
     const blob = await imageData.blob();
     const type = imageData.headers.get('Content-Type');
     const file = new File([blob], 'image.png', { type });
@@ -150,12 +157,12 @@ async function captionExistingMessage(message, imageIndex) {
     if (!messageText) {
         message.extra.inline_image = false;
         message.mes = wrappedCaption;
-        message.extra.title = wrappedCaption;
+        mediaAttachment.title = wrappedCaption;
     }
     else {
         message.extra.inline_image = true;
-        message.extra.append_title = true;
-        message.extra.title = wrappedCaption;
+        mediaAttachment.append_title = true;
+        mediaAttachment.title = wrappedCaption;
     }
 }
 
@@ -168,14 +175,23 @@ async function sendCaptionedMessage(caption, image) {
     const messageText = await wrapCaptionTemplate(caption);
 
     const context = getContext();
+
+    /** @type {MediaAttachment} */
+    const mediaAttachment = {
+        url: image,
+        type: MEDIA_TYPE.IMAGE,
+        title: messageText,
+    };
+    /** @type {ChatMessage} */
     const message = {
         name: context.name1,
         is_user: true,
         send_date: getMessageTimeStamp(),
         mes: messageText,
         extra: {
-            images: [image],
-            title: messageText,
+            media: [mediaAttachment],
+            media_display: MEDIA_DISPLAY.GALLERY,
+            media_index: 0,
             inline_image: !!extension_settings.caption.show_in_chat,
         },
     };
@@ -374,11 +390,20 @@ async function captionCommandCallback(args, prompt) {
     const index = Number(args?.index ?? 0);
 
     if (!isNaN(Number(messageId))) {
+        /** @type {ChatMessage} */
         const message = getContext().chat[messageId];
-        if (Array.isArray(message?.extra?.images) && message.extra.images.length > 0) {
+        if (Array.isArray(message?.extra?.media) && message.extra.media.length > 0) {
             try {
-                const imageUrl = message.extra.images[index] || message.extra.images[0];
-                const fetchResult = await fetch(imageUrl);
+                const mediaAttachment = message.extra.media[index] || message.extra.media[0];
+                if (!mediaAttachment || !mediaAttachment.url) {
+                    toastr.error('The specified message does not contain an image.');
+                    return '';
+                }
+                if (mediaAttachment.type === MEDIA_TYPE.VIDEO) {
+                    toastr.error('The specified media is a video. Captioning videos is not supported.');
+                    return '';
+                }
+                const fetchResult = await fetch(mediaAttachment.url);
                 const blob = await fetchResult.blob();
                 const file = new File([blob], 'image.jpg', { type: blob.type });
                 return await getCaptionForFile(file, prompt, quiet);

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -54,7 +54,7 @@ import {
 } from '../../slash-commands/SlashCommandArgument.js';
 import { debounce_timeout, VIDEO_EXTENSIONS } from '../../constants.js';
 import { SlashCommandEnumValue } from '../../slash-commands/SlashCommandEnumValue.js';
-import { callGenericPopup, Popup, POPUP_TYPE } from '../../popup.js';
+import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from '../../popup.js';
 import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { ToolManager } from '../../tool-calling.js';
 import { MacrosParser } from '../../macros.js';
@@ -4072,7 +4072,7 @@ async function sendMessage(prompt, image, generationType, additionalNegativePref
         send_date: getMessageTimeStamp(),
         mes: messageText,
         extra: {
-            image: image,
+            images: [image],
             title: prompt,
             generationType: generationType,
             negative: additionalNegativePrefix,
@@ -4082,7 +4082,7 @@ async function sendMessage(prompt, image, generationType, additionalNegativePref
     };
     if (isVideo(format)) {
         message.extra.video = image;
-        delete message.extra.image;
+        delete message.extra.images;
         delete message.extra.image_swipes;
         delete message.extra.inline_image;
     }
@@ -4231,7 +4231,7 @@ async function sdMessageButton(e) {
         ? context.groups[Object.keys(context.groups).filter(x => context.groups[x].id === context.groupId)[0]]?.id?.toString()
         : context.characters[context.characterId]?.name;
     const messageText = message?.mes;
-    const hasSavedImage = message?.extra?.image && message?.extra?.title;
+    const hasSavedImage = Array.isArray(message?.extra?.images) && message.extra.images.length > 0 && message?.extra?.title;
     const hasSavedNegative = message?.extra?.negative;
 
     if ($icon.hasClass(busyClass)) {
@@ -4242,6 +4242,28 @@ async function sdMessageButton(e) {
 
     let dimensions = null;
     buttonAbortController = new AbortController();
+
+    const canAddSwipe = Array.isArray(message.extra.images) && message.extra.images.length === 1;
+    const targets = { images: POPUP_RESULT.CUSTOM1, swipes: POPUP_RESULT.CUSTOM2 };
+    let saveTarget = targets.images;
+
+    if (canAddSwipe) {
+        const popupResult = await Popup.show.confirm(
+            t`An image attachment already exists.`,
+            t`Do you want to add the new image to the swipe list or as a second image?`,
+            {
+                okButton: false,
+                customButtons: [
+                    { text: t`Add to Swipes`, result: targets.swipes, classes: ['popup-button-ok'] },
+                    { text: t`Add Another Image`, result: targets.images },
+                ],
+                cancelButton: t`Cancel`,
+            });
+        if (!popupResult) {
+            return;
+        }
+        saveTarget = popupResult;
+    }
 
     try {
         setBusyIcon(true);
@@ -4277,29 +4299,49 @@ async function sdMessageButton(e) {
             message.extra = {};
         }
 
-        // Add image to the swipe list if it's not already there
+        // Ensure images array exists
+        if (!Array.isArray(message.extra.images)) {
+            message.extra.images = [];
+        }
+
+        // Ensure swipes array exists
         if (!Array.isArray(message.extra.image_swipes)) {
             message.extra.image_swipes = [];
         }
 
-        const swipes = message.extra.image_swipes;
+        // If already contains an image and it's not inline - leave it as is
+        message.extra.inline_image = !(message.extra.images.length && !message.extra.inline_image);
 
-        if (message.extra.image && !swipes.includes(message.extra.image)) {
-            swipes.push(message.extra.image);
-        }
-
+        // Determine if the format is a video
         const isVideoFormat = isVideo(format);
 
-        if (isVideoFormat) {
-            message.extra.video = image;
-        } else {
-            swipes.push(image);
+        // Add image to swipe list if applicable
+        if (!isVideoFormat && canAddSwipe && saveTarget === targets.swipes) {
+            // Add the first image to the swipe list if it's not already there
+            if (!message.extra.image_swipes.includes(message.extra.images[0])) {
+                message.extra.image_swipes.push(message.extra.images[0]);
+            }
 
-            // If already contains an image and it's not inline - leave it as is
-            message.extra.inline_image = !(message.extra.image && !message.extra.inline_image);
-            message.extra.image = image;
+            // Add the new image to the swipe list and set it as the current image
+            message.extra.image_swipes.push(image);
+            message.extra.images[0] = image;
         }
 
+        // Add image to array only if it's not a video and not being added to swipes
+        if (!isVideoFormat && (!canAddSwipe || saveTarget === targets.images)) {
+            message.extra.images.push(image);
+            // If it's the first image, also add it to the swipe list so it can be swiped later
+            if (message.extra.images.length === 1) {
+                message.extra.image_swipes.push(image);
+            }
+        }
+
+        // Set video data if the format is a video
+        if (isVideoFormat) {
+            message.extra.video = image;
+        }
+
+        // Save prompt data for future use
         message.extra.title = prompt;
         message.extra.generationType = generationType;
         message.extra.negative = negative;
@@ -4353,14 +4395,25 @@ async function onImageSwiped({ message, element, direction }) {
         return;
     }
 
+    const images = message?.extra?.images;
     const swipes = message?.extra?.image_swipes;
+
+    if (!Array.isArray(images) || images.length === 0) {
+        console.warn('No images found in the message');
+        return;
+    }
+
+    if (images.length > 1) {
+        console.warn('Image swiping is not supported for messages with multiple images');
+        return;
+    }
 
     if (!Array.isArray(swipes)) {
         console.warn('No image swipes found in the message');
         return;
     }
 
-    const currentIndex = swipes.indexOf(message.extra.image);
+    const currentIndex = swipes.indexOf(images[0]);
 
     if (currentIndex === -1) {
         console.warn('Current image not found in the swipes');
@@ -4370,7 +4423,7 @@ async function onImageSwiped({ message, element, direction }) {
     // Switch to previous image or wrap around if at the beginning
     if (direction === 'left') {
         const newIndex = currentIndex === 0 ? swipes.length - 1 : currentIndex - 1;
-        message.extra.image = swipes[newIndex];
+        images[0] = swipes[newIndex];
 
         // Update the image in the message
         appendMediaToMessage(message, element, false);
@@ -4422,7 +4475,7 @@ async function onImageSwiped({ message, element, direction }) {
             swipes.push(imagePath);
         }
 
-        message.extra.image = swipes[newIndex];
+        images[0] = swipes[newIndex];
         appendMediaToMessage(message, element, false);
     }
 

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -4243,7 +4243,7 @@ async function sdMessageButton(e) {
     let dimensions = null;
     buttonAbortController = new AbortController();
 
-    const canAddSwipe = Array.isArray(message.extra.images) && message.extra.images.length === 1;
+    const canAddSwipe = Array.isArray(message?.extra?.images) && message.extra.images.length === 1;
     const targets = { images: POPUP_RESULT.CUSTOM1, swipes: POPUP_RESULT.CUSTOM2 };
     let saveTarget = targets.images;
 

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -52,9 +52,9 @@ import {
     SlashCommandArgument,
     SlashCommandNamedArgument,
 } from '../../slash-commands/SlashCommandArgument.js';
-import { debounce_timeout, SWIPE_DIRECTION, VIDEO_EXTENSIONS } from '../../constants.js';
+import { debounce_timeout, MEDIA_DISPLAY, MEDIA_TYPE, VIDEO_EXTENSIONS } from '../../constants.js';
 import { SlashCommandEnumValue } from '../../slash-commands/SlashCommandEnumValue.js';
-import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from '../../popup.js';
+import { callGenericPopup, Popup, POPUP_TYPE } from '../../popup.js';
 import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { ToolManager } from '../../tool-calling.js';
 import { MacrosParser } from '../../macros.js';
@@ -466,6 +466,12 @@ async function loadSettings() {
 
     if (!Array.isArray(extension_settings.sd.styles)) {
         extension_settings.sd.styles = defaultStyles;
+    }
+
+    // Preserve an original seed if exists
+    if (extension_settings.sd.original_seed >= 0) {
+        extension_settings.sd.seed = extension_settings.sd.original_seed;
+        delete extension_settings.sd.original_seed;
     }
 
     $('#sd_source').val(extension_settings.sd.source);
@@ -4065,6 +4071,16 @@ async function sendMessage(prompt, image, generationType, additionalNegativePref
     const name = context.groupId ? systemUserName : context.name2;
     const template = extension_settings.sd.prompts[generationMode.MESSAGE] || '{{prompt}}';
     const messageText = substituteParamsExtended(template, { char: name, prompt: prompt, prefixedPrompt: prefixedPrompt });
+    const mediaType = isVideo(format) ? MEDIA_TYPE.VIDEO : MEDIA_TYPE.IMAGE;
+    /** @type {MediaAttachment} */
+    const mediaAttachment = {
+        url: image,
+        type: mediaType,
+        title: prompt,
+        generation_type: generationType,
+        negative: additionalNegativePrefix,
+    };
+    /** @type {ChatMessage} */
     const message = {
         name: name,
         is_user: false,
@@ -4072,20 +4088,12 @@ async function sendMessage(prompt, image, generationType, additionalNegativePref
         send_date: getMessageTimeStamp(),
         mes: messageText,
         extra: {
-            images: [image],
-            title: prompt,
-            generationType: generationType,
-            negative: additionalNegativePrefix,
+            media: [mediaAttachment],
+            media_display: MEDIA_DISPLAY.GALLERY,
+            media_index: 0,
             inline_image: false,
-            image_swipes: [image],
         },
     };
-    if (isVideo(format)) {
-        message.extra.videos = [image];
-        delete message.extra.images;
-        delete message.extra.image_swipes;
-        delete message.extra.inline_image;
-    }
     context.chat.push(message);
     const messageId = context.chat.length - 1;
     await eventSource.emit(event_types.MESSAGE_RECEIVED, messageId, 'extension');
@@ -4215,143 +4223,76 @@ function isValidState() {
 
 let buttonAbortController = null;
 
+/**
+ * "Paintbrush" button handler to generate a new image for a message.
+ * @param {JQuery.ClickEvent} e The click event object.
+ * @returns {Promise<void>} A promise that resolves when the image generation process is complete.
+ */
 async function sdMessageButton(e) {
+    /**
+     * Sets the icon to indicate busy or idle state.
+     * @param {boolean} isBusy Whether the icon should indicate a busy state.
+     */
     function setBusyIcon(isBusy) {
-        $icon.toggleClass('fa-paintbrush', !isBusy);
-        $icon.toggleClass(busyClass, isBusy);
+        $icon.toggleClass(classes.idle, !isBusy);
+        $icon.toggleClass(classes.busy, isBusy);
     }
 
-    const busyClass = 'fa-hourglass';
+    const classes = { busy: 'fa-hourglass', idle: 'fa-paintbrush' };
     const context = getContext();
     const $icon = $(e.currentTarget);
-    const $mes = $icon.closest('.mes');
-    const message_id = $mes.attr('mesid');
-    const message = context.chat[message_id];
-    const characterFileName = context.groupId
-        ? context.groups[Object.keys(context.groups).filter(x => context.groups[x].id === context.groupId)[0]]?.id?.toString()
-        : context.characters[context.characterId]?.name;
-    const messageText = message?.mes;
-    const hasSavedImage = Array.isArray(message?.extra?.images) && message.extra.images.length > 0 && message?.extra?.title;
-    const hasSavedNegative = message?.extra?.negative;
 
-    if ($icon.hasClass(busyClass)) {
+    if ($icon.hasClass(classes.busy)) {
         buttonAbortController?.abort('Aborted by user');
         console.log('Previous image is still being generated...');
         return;
     }
 
-    let dimensions = null;
+    const messageElement = $icon.closest('.mes');
+    const messageId = Number(messageElement.attr('mesid'));
+
+    /** @type {ChatMessage} */
+    const message = context.chat[messageId];
+
+    if (!message) {
+        console.error('Could not find message for SD generation button');
+        return;
+    }
+
+    if (!message.extra || typeof message.extra !== 'object') {
+        message.extra = {};
+    }
+
+    if (!Array.isArray(message.extra.media)) {
+        message.extra.media = [];
+    }
+
+    /** @type {MediaAttachment} */
+    const selectedMedia = message.extra.media.length > 0
+        ? (message.extra.media[message.extra.media_index] ?? message.extra.media[message.extra.media.length - 1])
+        : { url: '', title: message.mes, type: MEDIA_TYPE.IMAGE, generation_type: generationMode.FREE };
+
     buttonAbortController = new AbortController();
+    const newMediaAttachment = await generateMediaSwipe(
+        selectedMedia,
+        message,
+        () => setBusyIcon(true),
+        () => setBusyIcon(false),
+        buttonAbortController,
+    );
 
-    const canAddSwipe = Array.isArray(message?.extra?.images) && message.extra.images.length === 1;
-    const targets = { images: POPUP_RESULT.CUSTOM1, swipes: POPUP_RESULT.CUSTOM2 };
-    let saveTarget = targets.images;
-
-    if (canAddSwipe) {
-        const popupResult = await Popup.show.confirm(
-            t`An image attachment already exists.`,
-            t`Do you want to add the new image to the swipe list or as a second image?`,
-            {
-                okButton: false,
-                customButtons: [
-                    { text: t`Add to Swipes`, result: targets.swipes, classes: ['popup-button-ok'] },
-                    { text: t`Add Another Image`, result: targets.images },
-                ],
-                cancelButton: t`Cancel`,
-            });
-        if (!popupResult) {
-            return;
-        }
-        saveTarget = popupResult;
+    if (!newMediaAttachment) {
+        return;
     }
 
-    try {
-        setBusyIcon(true);
-        if (hasSavedImage) {
-            const prompt = await refinePrompt(message.extra.title, false);
-            const negative = hasSavedNegative ? await refinePrompt(message.extra.negative, true) : '';
-            message.extra.title = prompt;
+    // If already contains an image and it's not inline - leave it as is
+    message.extra.inline_image = !(message.extra.media.length && !message.extra.inline_image);
+    message.extra.media.push(newMediaAttachment);
+    message.extra.media_index = message.extra.media.length - 1;
 
-            const generationType = message?.extra?.generationType ?? generationMode.FREE;
-            console.log('Regenerating an image, using existing prompt:', prompt);
-            dimensions = setTypeSpecificDimensions(generationType);
-            await sendGenerationRequest(generationType, prompt, negative, characterFileName, saveGeneratedImage, initiators.action, buttonAbortController?.signal);
-        }
-        else {
-            console.log('doing /sd raw last');
-            await generatePicture(initiators.action, {}, 'raw_last', messageText, saveGeneratedImage);
-        }
-    }
-    catch (error) {
-        console.error('Could not generate inline image: ', error);
-    }
-    finally {
-        setBusyIcon(false);
+    appendMediaToMessage(message, messageElement, false);
 
-        if (dimensions) {
-            restoreOriginalDimensions(dimensions);
-        }
-    }
-
-    function saveGeneratedImage(prompt, image, generationType, negative, _initiator, _prefixedPrompt, format) {
-        // Some message sources may not create the extra object
-        if (typeof message.extra !== 'object' || message.extra === null) {
-            message.extra = {};
-        }
-
-        // Ensure images array exists
-        if (!Array.isArray(message.extra.images)) {
-            message.extra.images = [];
-        }
-
-        // Ensure swipes array exists
-        if (!Array.isArray(message.extra.image_swipes)) {
-            message.extra.image_swipes = [];
-        }
-
-        // If already contains an image and it's not inline - leave it as is
-        message.extra.inline_image = !(message.extra.images.length && !message.extra.inline_image);
-
-        // Determine if the format is a video
-        const isVideoFormat = isVideo(format);
-
-        // Add image to swipe list if applicable
-        if (!isVideoFormat && canAddSwipe && saveTarget === targets.swipes) {
-            // Add the first image to the swipe list if it's not already there
-            if (!message.extra.image_swipes.includes(message.extra.images[0])) {
-                message.extra.image_swipes.push(message.extra.images[0]);
-            }
-
-            // Add the new image to the swipe list and set it as the current image
-            message.extra.image_swipes.push(image);
-            message.extra.images[0] = image;
-        }
-
-        // Add image to array only if it's not a video and not being added to swipes
-        if (!isVideoFormat && (!canAddSwipe || saveTarget === targets.images)) {
-            message.extra.images.push(image);
-            // If it's the first image, also add it to the swipe list so it can be swiped later
-            if (message.extra.images.length === 1) {
-                message.extra.image_swipes.push(image);
-            }
-        }
-
-        // Set video data if the format is a video
-        if (isVideoFormat) {
-            if (!Array.isArray(message.extra.videos)) {
-                message.extra.videos = [];
-            }
-            message.extra.videos.push(image);
-        }
-
-        // Save prompt data for future use
-        message.extra.title = prompt;
-        message.extra.generationType = generationType;
-        message.extra.negative = negative;
-        appendMediaToMessage(message, $mes);
-
-        return context.saveChat();
-    }
+    await context.saveChat();
 }
 
 async function onCharacterPromptShareInput() {
@@ -4381,108 +4322,61 @@ async function writePromptFields(characterId) {
 }
 
 /**
- * Switches an image to the next or previous one in the swipe list.
- * @param {object} args Event arguments
- * @param {any} args.message Message object
- * @param {JQuery<HTMLElement>} args.element Message element
- * @param {string} args.direction Swipe direction
- * @returns {Promise<void>}
+ * Generates a new media attachment based on the provided media attachment metadata.
+ * @param {MediaAttachment} mediaAttachment - The media attachment metadata.
+ * @param {ChatMessage} message - The chat message containing the media attachment.
+ * @param {Function} onStart - Callback function to be called when generation starts.
+ * @param {Function} onComplete - Callback function to be called when generation completes.
+ * @param {AbortController} abortController - An AbortController to handle cancellation of the generation process.
+ * @returns {Promise<MediaAttachment|null>} - A promise that resolves to the newly generated media attachment, or null if generation failed or was aborted.
  */
-async function onImageSwiped({ message, element, direction }) {
-    const context = getContext();
-    const animationClass = 'fa-fade';
-    const messageImg = element.find('.mes_img');
+async function generateMediaSwipe(mediaAttachment, message, onStart, onComplete, abortController = new AbortController()) {
+    const stopButton = document.getElementById('sd_stop_gen');
+    const stopListener = () => abortController.abort('Aborted by user');
+    const generationType = mediaAttachment.generation_type ?? message?.extra?.generationType ?? generationMode.FREE;
+    const dimensions = setTypeSpecificDimensions(generationType);
+    extension_settings.sd.original_seed = extension_settings.sd.seed;
+    extension_settings.sd.seed = extension_settings.sd.seed >= 0 ? Math.round(Math.random() * (Math.pow(2, 32) - 1)) : -1;
 
-    // Current image is already animating
-    if (messageImg.hasClass(animationClass)) {
-        return;
+    /** @type {MediaAttachment} */
+    const result = {
+        url: '',
+        type: MEDIA_TYPE.IMAGE,
+    };
+
+    try {
+        $(stopButton).show();
+        eventSource.once(CUSTOM_STOP_EVENT, stopListener);
+        const callback = (_a, _b, _c, _d, _e, _f, format) => { result.type = isVideo(format) ? MEDIA_TYPE.VIDEO : MEDIA_TYPE.IMAGE; };
+        const savedPrompt = mediaAttachment.title ?? message.extra.title ?? '';
+        const prompt = await refinePrompt(savedPrompt, false);
+        const savedNegative = mediaAttachment.negative ?? message.extra.negative ?? '';
+        const negative = savedNegative ? await refinePrompt(savedNegative, true) : '';
+
+        const context = getContext();
+        const characterName = context.groupId
+            ? context.groups[Object.keys(context.groups).filter(x => context.groups[x].id === context.groupId)[0]]?.id?.toString()
+            : context.characters[context.characterId]?.name;
+
+        onStart();
+        result.url = await sendGenerationRequest(generationType, prompt, negative, characterName, callback, initiators.swipe, abortController.signal);
+        result.generation_type = generationType;
+        result.title = prompt;
+        result.negative = negative;
+    } finally {
+        onComplete();
+        $(stopButton).hide();
+        eventSource.removeListener(CUSTOM_STOP_EVENT, stopListener);
+        restoreOriginalDimensions(dimensions);
+        extension_settings.sd.seed = extension_settings.sd.original_seed;
+        delete extension_settings.sd.original_seed;
     }
 
-    const images = message?.extra?.images;
-    const swipes = message?.extra?.image_swipes;
-
-    if (!Array.isArray(images) || images.length === 0) {
-        console.warn('No images found in the message');
-        return;
+    if (!result.url) {
+        return null;
     }
 
-    if (images.length > 1) {
-        console.warn('Image swiping is not supported for messages with multiple images');
-        return;
-    }
-
-    if (!Array.isArray(swipes)) {
-        console.warn('No image swipes found in the message');
-        return;
-    }
-
-    const currentIndex = swipes.indexOf(images[0]);
-
-    if (currentIndex === -1) {
-        console.warn('Current image not found in the swipes');
-        return;
-    }
-
-    // Switch to previous image or wrap around if at the beginning
-    if (direction === SWIPE_DIRECTION.LEFT) {
-        const newIndex = currentIndex === 0 ? swipes.length - 1 : currentIndex - 1;
-        images[0] = swipes[newIndex];
-
-        // Update the image in the message
-        appendMediaToMessage(message, element, false);
-    }
-
-    // Switch to next image or generate a new one if at the end
-    if (direction === SWIPE_DIRECTION.RIGHT) {
-        const newIndex = currentIndex === swipes.length - 1 ? swipes.length : currentIndex + 1;
-
-        if (newIndex === swipes.length) {
-            const abortController = new AbortController();
-            const swipeControls = element.find('.mes_img_swipes');
-            const stopButton = document.getElementById('sd_stop_gen');
-            const stopListener = () => abortController.abort('Aborted by user');
-            const generationType = message?.extra?.generationType ?? generationMode.FREE;
-            const dimensions = setTypeSpecificDimensions(generationType);
-            const originalSeed = extension_settings.sd.seed;
-            extension_settings.sd.seed = extension_settings.sd.seed >= 0 ? Math.round(Math.random() * (Math.pow(2, 32) - 1)) : -1;
-            let imagePath = '';
-
-            try {
-                $(stopButton).show();
-                eventSource.once(CUSTOM_STOP_EVENT, stopListener);
-                const callback = () => { };
-                const hasNegative = message.extra.negative;
-                const prompt = await refinePrompt(message.extra.title, false);
-                const negativePromptPrefix = hasNegative ? await refinePrompt(message.extra.negative, true) : '';
-                message.extra.title = prompt;
-                const characterName = context.groupId
-                    ? context.groups[Object.keys(context.groups).filter(x => context.groups[x].id === context.groupId)[0]]?.id?.toString()
-                    : context.characters[context.characterId]?.name;
-
-                messageImg.addClass(animationClass);
-                swipeControls.hide();
-                imagePath = await sendGenerationRequest(generationType, prompt, negativePromptPrefix, characterName, callback, initiators.swipe, abortController.signal);
-            } finally {
-                $(stopButton).hide();
-                messageImg.removeClass(animationClass);
-                swipeControls.show();
-                eventSource.removeListener(CUSTOM_STOP_EVENT, stopListener);
-                restoreOriginalDimensions(dimensions);
-                extension_settings.sd.seed = originalSeed;
-            }
-
-            if (!imagePath) {
-                return;
-            }
-
-            swipes.push(imagePath);
-        }
-
-        images[0] = swipes[newIndex];
-        appendMediaToMessage(message, element, false);
-    }
-
-    await context.saveChat();
+    return result;
 }
 
 /**
@@ -4969,8 +4863,6 @@ jQuery(async () => {
             await loadSettingOptions();
         }
     });
-
-    eventSource.on(event_types.IMAGE_SWIPED, onImageSwiped);
 
     eventSource.on(event_types.CHAT_CHANGED, onChatChanged);
 

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -52,7 +52,7 @@ import {
     SlashCommandArgument,
     SlashCommandNamedArgument,
 } from '../../slash-commands/SlashCommandArgument.js';
-import { debounce_timeout, VIDEO_EXTENSIONS } from '../../constants.js';
+import { debounce_timeout, SWIPE_DIRECTION, VIDEO_EXTENSIONS } from '../../constants.js';
 import { SlashCommandEnumValue } from '../../slash-commands/SlashCommandEnumValue.js';
 import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from '../../popup.js';
 import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
@@ -4081,7 +4081,7 @@ async function sendMessage(prompt, image, generationType, additionalNegativePref
         },
     };
     if (isVideo(format)) {
-        message.extra.video = image;
+        message.extra.videos = [image];
         delete message.extra.images;
         delete message.extra.image_swipes;
         delete message.extra.inline_image;
@@ -4338,7 +4338,10 @@ async function sdMessageButton(e) {
 
         // Set video data if the format is a video
         if (isVideoFormat) {
-            message.extra.video = image;
+            if (!Array.isArray(message.extra.videos)) {
+                message.extra.videos = [];
+            }
+            message.extra.videos.push(image);
         }
 
         // Save prompt data for future use
@@ -4421,7 +4424,7 @@ async function onImageSwiped({ message, element, direction }) {
     }
 
     // Switch to previous image or wrap around if at the beginning
-    if (direction === 'left') {
+    if (direction === SWIPE_DIRECTION.LEFT) {
         const newIndex = currentIndex === 0 ? swipes.length - 1 : currentIndex - 1;
         images[0] = swipes[newIndex];
 
@@ -4430,7 +4433,7 @@ async function onImageSwiped({ message, element, direction }) {
     }
 
     // Switch to next image or generate a new one if at the end
-    if (direction === 'right') {
+    if (direction === SWIPE_DIRECTION.RIGHT) {
         const newIndex = currentIndex === swipes.length - 1 ? swipes.length : currentIndex + 1;
 
         if (newIndex === swipes.length) {

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -426,7 +426,7 @@ function getStringHash(str) {
 
 /**
  * Retrieves files from the chat and inserts them into the vector index.
- * @param {object[]} chat Array of chat messages
+ * @param {ChatMessage[]} chat Array of chat messages
  * @returns {Promise<void>}
  */
 async function processFiles(chat) {
@@ -624,7 +624,7 @@ async function vectorizeFile(fileText, fileName, collectionId, chunkSize, overla
 
 /**
  * Removes the most relevant messages from the chat and displays them in the extension prompt
- * @param {object[]} chat Array of chat messages
+ * @param {ChatMessage[]} chat Array of chat messages
  * @param {number} _contextSize Context size (unused)
  * @param {function} _abort Abort function (unused)
  * @param {string} type Generation type
@@ -750,7 +750,7 @@ const onChatEvent = debounce(async () => await moduleWorker.update(), debounce_t
 
 /**
  * Gets the text to query from the chat
- * @param {object[]} chat Chat messages
+ * @param {ChatMessage[]} chat Chat messages
  * @param {'file'|'chat'|'world-info'} initiator Initiator of the query
  * @returns {Promise<string>} Text to query
  */

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -443,39 +443,49 @@ async function processFiles(chat) {
         }
 
         for (const message of chat) {
-            // Message has no file
-            if (!message?.extra?.file) {
+            // Message has no files
+            if (!Array.isArray(message?.extra?.files) || !message.extra.files.length) {
                 continue;
             }
 
             // Trim file inserted by the script
-            const fileText = String(message.mes)
-                .substring(0, message.extra.fileLength).trim();
+            const allFileText = String(message.mes || '').substring(0, message.extra.fileLength).trim();
 
             // Convert kilobytes to string length
             const thresholdLength = settings.size_threshold * 1024;
 
             // File is too small
-            if (fileText.length < thresholdLength) {
+            if (allFileText.length < thresholdLength) {
                 continue;
             }
 
             message.mes = message.mes.substring(message.extra.fileLength);
 
-            const fileName = message.extra.file.name;
-            const fileUrl = message.extra.file.url;
-            const collectionId = getFileCollectionId(fileUrl);
-            const hashesInCollection = await getSavedHashes(collectionId);
+            const allFileChunks = [];
+            const queryText = await getQueryText(chat, 'file');
 
-            // File is already in the collection
-            if (!hashesInCollection.length) {
-                await vectorizeFile(fileText, fileName, collectionId, settings.chunk_size, settings.overlap_percent);
+            for (const file of message.extra.files) {
+                const fileName = file.name;
+                const fileUrl = file.url;
+                const collectionId = getFileCollectionId(fileUrl);
+                const hashesInCollection = await getSavedHashes(collectionId);
+
+                // File is not vectorized yet
+                if (!hashesInCollection.length) {
+                    const fileText = file.text || (await getFileAttachment(fileUrl));
+                    if (!fileText) {
+                        continue;
+                    }
+                    await vectorizeFile(fileText, fileName, collectionId, settings.chunk_size, settings.overlap_percent);
+                }
+
+                const fileChunks = await retrieveFileChunks(queryText, collectionId);
+                if (fileChunks) {
+                    allFileChunks.push(fileChunks);
+                }
             }
 
-            const queryText = await getQueryText(chat, 'file');
-            const fileChunks = await retrieveFileChunks(queryText, collectionId);
-
-            message.mes = `${fileChunks}\n\n${message.mes}`;
+            message.mes = `${allFileChunks.join('\n\n')}\n\n${message.mes}`;
         }
     } catch (error) {
         console.error('Vectors: Failed to retrieve files', error);
@@ -745,8 +755,13 @@ const onChatEvent = debounce(async () => await moduleWorker.update(), debounce_t
  * @returns {Promise<string>} Text to query
  */
 async function getQueryText(chat, initiator) {
+    const getTextWithoutAttachments = (x) => {
+        const fileLength = x?.extra?.fileLength || 0;
+        return String(x?.mes || '').substring(fileLength).trim();
+    };
+
     let hashedMessages = chat
-        .map(x => ({ text: String(substituteParams(x.mes)), hash: getStringHash(substituteParams(x.mes)), index: chat.indexOf(x) }))
+        .map(x => ({ text: substituteParams(getTextWithoutAttachments(x)), hash: getStringHash(substituteParams(getTextWithoutAttachments(x))), index: chat.indexOf(x) }))
         .filter(x => x.text)
         .reverse()
         .slice(0, settings.query);
@@ -1313,7 +1328,7 @@ async function onViewStatsClick() {
 async function onVectorizeAllFilesClick() {
     try {
         const dataBank = getDataBankAttachments();
-        const chatAttachments = getContext().chat.filter(x => x.extra?.file).map(x => x.extra.file);
+        const chatAttachments = getContext().chat.filter(x => Array.isArray(x.extra?.files)).map(x => x.extra.files).flat();
         const allFiles = [...dataBank, ...chatAttachments];
 
         /**
@@ -1390,7 +1405,7 @@ async function onVectorizeAllFilesClick() {
 async function onPurgeFilesClick() {
     try {
         const dataBank = getDataBankAttachments();
-        const chatAttachments = getContext().chat.filter(x => x.extra?.file).map(x => x.extra.file);
+        const chatAttachments = getContext().chat.filter(x => Array.isArray(x.extra?.files)).map(x => x.extra.files).flat();
         const allFiles = [...dataBank, ...chatAttachments];
 
         for (const file of allFiles) {

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -78,6 +78,7 @@ import {
     shouldAutoContinue,
     unshallowCharacter,
     chatElement,
+    ensureMessageMediaIsArray,
 } from '../script.js';
 import { printTagList, createTagMapFromList, applyTagsOnCharacterSelect, tag_map, applyTagsOnGroupSelect } from './tags.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
@@ -267,6 +268,7 @@ export async function getGroupChat(groupId, reload = false) {
     } else if (Array.isArray(data) && data.length) {
         data[0].is_group = true;
         chat.splice(0, chat.length, ...data);
+        chat.forEach(ensureMessageMediaIsArray);
         chatElement.find('.mes').remove();
         await printMessages();
     }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -540,9 +540,9 @@ function setOpenAIMessages(chat) {
         if (role == 'user' && oai_settings.wrap_in_quotes) content = `"${content}"`;
         const name = chat[j]['name'];
         const images = chat[j]?.extra?.images;
-        const video = chat[j]?.extra?.video;
+        const videos = chat[j]?.extra?.videos;
         const invocations = chat[j]?.extra?.tool_invocations;
-        messages[i] = { 'role': role, 'content': content, name: name, 'images': images, 'video': video, 'invocations': invocations };
+        messages[i] = { 'role': role, 'content': content, name: name, 'images': images, 'videos': videos, 'invocations': invocations };
         j++;
     }
 
@@ -858,8 +858,10 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
             }
         }
 
-        if (videoInlining && chatPrompt.video) {
-            await chatMessage.addVideo(chatPrompt.video);
+        if (videoInlining && Array.isArray(chatPrompt.videos)) {
+            for (const video of chatPrompt.videos) {
+                await chatMessage.addVideo(video);
+            }
         }
 
         if (canUseTools && Array.isArray(chatPrompt.invocations)) {
@@ -2943,6 +2945,13 @@ class Message {
 
     async addVideo(video) {
         const textContent = this.content;
+        if (!Array.isArray(this.content)) {
+            this.content = [];
+            if (typeof textContent === 'string') {
+                this.content.push({ type: 'text', text: textContent });
+            }
+        }
+
         const isDataUrl = isDataURL(video);
         if (!isDataUrl) {
             try {
@@ -2957,10 +2966,7 @@ class Message {
         }
 
         // Note: No compression for videos (unlike images)
-        this.content = [
-            { type: 'text', text: textContent },
-            { type: 'video_url', video_url: { 'url': video } },
-        ];
+        this.content.push({ type: 'video_url', video_url: { 'url': video } });
 
         try {
             // Convservative estimate for video token cost without knowing duration

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -15,6 +15,8 @@ import {
     Generate,
     getExtensionPrompt,
     getExtensionPromptMaxDepth,
+    getMediaDisplay,
+    getMediaIndex,
     getRequestHeaders,
     getStoppingStrings,
     is_send_press,
@@ -74,7 +76,7 @@ import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from './popup.js';
 import { t } from './i18n.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
-import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL } from './constants.js';
+import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
 
 export {
     openai_messages_count,
@@ -539,10 +541,11 @@ function setOpenAIMessages(chat) {
         // Apply the "wrap in quotes" option
         if (role == 'user' && oai_settings.wrap_in_quotes) content = `"${content}"`;
         const name = chat[j]['name'];
-        const images = chat[j]?.extra?.images;
-        const videos = chat[j]?.extra?.videos;
+        const media = chat[j]?.extra?.media;
+        const mediaDisplay = getMediaDisplay(chat[j]);
+        const mediaIndex = getMediaIndex(chat[j]);
         const invocations = chat[j]?.extra?.tool_invocations;
-        messages[i] = { 'role': role, 'content': content, name: name, 'images': images, 'videos': videos, 'invocations': invocations };
+        messages[i] = { 'role': role, 'content': content, name: name, 'media': media, 'mediaDisplay': mediaDisplay, 'mediaIndex': mediaIndex, 'invocations': invocations };
         j++;
     }
 
@@ -852,15 +855,34 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
             await chatMessage.setName(messageName);
         }
 
-        if (imageInlining && Array.isArray(chatPrompt.images)) {
-            for (const image of chatPrompt.images) {
-                await chatMessage.addImage(image);
+        /**
+         * Inline a media attachment into the chat message.
+         * @param {MediaAttachment} media - The media attachment to inline.
+         */
+        async function inlineMediaAttachment(media) {
+            if (!media || !media.url) {
+                return;
+            }
+            if (!media.type) {
+                media.type = MEDIA_TYPE.IMAGE;
+            }
+            if (imageInlining && media.type === MEDIA_TYPE.IMAGE) {
+                await chatMessage.addImage(media.url);
+            }
+            if (videoInlining && media.type === MEDIA_TYPE.VIDEO) {
+                await chatMessage.addVideo(media.url);
             }
         }
 
-        if (videoInlining && Array.isArray(chatPrompt.videos)) {
-            for (const video of chatPrompt.videos) {
-                await chatMessage.addVideo(video);
+        if (Array.isArray(chatPrompt.media) && chatPrompt.media.length) {
+            if (chatPrompt.mediaDisplay === MEDIA_DISPLAY.LIST) {
+                for (const media of chatPrompt.media) {
+                    await inlineMediaAttachment(media);
+                }
+            }
+            if (chatPrompt.mediaDisplay === MEDIA_DISPLAY.GALLERY) {
+                const media = chatPrompt.media[chatPrompt.mediaIndex];
+                await inlineMediaAttachment(media);
             }
         }
 
@@ -2943,6 +2965,11 @@ class Message {
         }
     }
 
+    /**
+     * Adds a video to the message.
+     * @param {string} video Video URL or Data URL.
+     * @returns {Promise<void>}
+     */
     async addVideo(video) {
         const textContent = this.content;
         if (!Array.isArray(this.content)) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -539,10 +539,10 @@ function setOpenAIMessages(chat) {
         // Apply the "wrap in quotes" option
         if (role == 'user' && oai_settings.wrap_in_quotes) content = `"${content}"`;
         const name = chat[j]['name'];
-        const image = chat[j]?.extra?.image;
+        const images = chat[j]?.extra?.images;
         const video = chat[j]?.extra?.video;
         const invocations = chat[j]?.extra?.tool_invocations;
-        messages[i] = { 'role': role, 'content': content, name: name, 'image': image, 'video': video, 'invocations': invocations };
+        messages[i] = { 'role': role, 'content': content, name: name, 'images': images, 'video': video, 'invocations': invocations };
         j++;
     }
 
@@ -852,8 +852,10 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
             await chatMessage.setName(messageName);
         }
 
-        if (imageInlining && chatPrompt.image) {
-            await chatMessage.addImage(chatPrompt.image);
+        if (imageInlining && Array.isArray(chatPrompt.images)) {
+            for (const image of chatPrompt.images) {
+                await chatMessage.addImage(image);
+            }
         }
 
         if (videoInlining && chatPrompt.video) {
@@ -2905,6 +2907,13 @@ class Message {
      */
     async addImage(image) {
         const textContent = this.content;
+        if (!Array.isArray(this.content)) {
+            this.content = [];
+            if (typeof textContent === 'string') {
+                this.content.push({ type: 'text', text: textContent });
+            }
+        }
+
         const isDataUrl = isDataURL(image);
         if (!isDataUrl) {
             try {
@@ -2921,10 +2930,7 @@ class Message {
         image = await this.compressImage(image);
 
         const quality = oai_settings.inline_image_quality || default_settings.inline_image_quality;
-        this.content = [
-            { type: 'text', text: textContent },
-            { type: 'image_url', image_url: { 'url': image, 'detail': quality } },
-        ];
+        this.content.push({ type: 'image_url', image_url: { 'url': image, 'detail': quality } });
 
         try {
             const tokens = await this.getImageTokenCost(image, quality);

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -63,6 +63,7 @@ import { fuzzySearchCategories } from './filters.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { DEFAULT_REASONING_TEMPLATE, loadReasoningTemplates } from './reasoning.js';
 import { bindModelTemplates } from './chat-templates.js';
+import { MEDIA_DISPLAY } from './constants.js';
 
 export const toastPositionClasses = [
     'toast-top-left',
@@ -337,6 +338,7 @@ export const power_user = {
     external_media_forbidden_overrides: [],
     pin_styles: true,
     click_to_edit: false,
+    media_display: MEDIA_DISPLAY.LIST,
 };
 
 let themes = [];

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1182,14 +1182,14 @@ function applyFontScale(type) {
 }
 
 /**
- * Shows a toast notification prompting the user to reload the chat if media display settings have changed
- * and there are messages with media attachments that haven't been processed with the new display format.
+ * Checks if the chat needs to be reloaded to apply media display settings.
+ * @returns {boolean} True if the chat needs reload to apply media display settings
  */
-function showMediaDisplayReloadPrompt() {
+function isMediaDisplayReloadNeeded() {
     // A user is not currently in a chat.
     const chatId = getCurrentChatId();
     if (!chatId) {
-        return;
+        return false;
     }
 
     const firstDisplayedIndex = getFirstDisplayedMessageId();
@@ -1203,13 +1203,22 @@ function showMediaDisplayReloadPrompt() {
         return hasMediaAttachments && lacksMediaDisplay;
     });
 
-    if (hasUnprocessedMediaMessages) {
-        toastr.info(
-            t`Reload the chat to apply the changes. Click here to reload.`,
-            t`Media Style changed`,
-            { onclick: () => void reloadCurrentChat() },
-        );
+    return hasUnprocessedMediaMessages;
+}
+
+/**
+ * Shows a toast notification prompting the user to reload the chat if media display settings have changed
+ * and there are messages with media attachments that haven't been processed with the new display format.
+ */
+function showMediaDisplayReloadPrompt() {
+    if (!isMediaDisplayReloadNeeded()) {
+        return;
     }
+    toastr.info(
+        t`Reload the chat to apply the changes. Click here to reload.`,
+        t`Media Style changed`,
+        { onclick: () => void reloadCurrentChat() },
+    );
 }
 
 function applyTheme(name) {
@@ -4168,10 +4177,12 @@ jQuery(() => {
         await exportTheme();
     });
 
-    $('#media_display').on('input', function () {
+    $('#media_display').on('input', async function () {
         power_user.media_display = $(this).val().toString();
-        reloadCurrentChat();
         saveSettingsDebounced();
+        if (isMediaDisplayReloadNeeded()) {
+            await reloadCurrentChat();
+        }
     });
 
     $(document).on('click', '#debug_table [data-debug-function]', function () {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -64,6 +64,7 @@ import { accountStorage } from './util/AccountStorage.js';
 import { DEFAULT_REASONING_TEMPLATE, loadReasoningTemplates } from './reasoning.js';
 import { bindModelTemplates } from './chat-templates.js';
 import { MEDIA_DISPLAY } from './constants.js';
+import { t } from './i18n.js';
 
 export const toastPositionClasses = [
     'toast-top-left',
@@ -1180,6 +1181,37 @@ function applyFontScale(type) {
     $('#font_scale').val(power_user.font_scale);
 }
 
+/**
+ * Shows a toast notification prompting the user to reload the chat if media display settings have changed
+ * and there are messages with media attachments that haven't been processed with the new display format.
+ */
+function showMediaDisplayReloadPrompt() {
+    // A user is not currently in a chat.
+    const chatId = getCurrentChatId();
+    if (!chatId) {
+        return;
+    }
+
+    const firstDisplayedIndex = getFirstDisplayedMessageId();
+    const hasUnprocessedMediaMessages = chat.some((message, index) => {
+        // Skip messages that are not currently displayed
+        if (index < firstDisplayedIndex) {
+            return false;
+        }
+        const hasMediaAttachments = Array.isArray(message?.extra?.media) && message.extra.media.length > 0;
+        const lacksMediaDisplay = !message?.extra?.media_display;
+        return hasMediaAttachments && lacksMediaDisplay;
+    });
+
+    if (hasUnprocessedMediaMessages) {
+        toastr.info(
+            t`Reload the chat to apply the changes. Click here to reload.`,
+            t`Media Style changed`,
+            { onclick: () => void reloadCurrentChat() },
+        );
+    }
+}
+
 function applyTheme(name) {
     const theme = themes.find(x => x.name == name);
 
@@ -1369,14 +1401,25 @@ function applyTheme(name) {
                 $('#click_to_edit').prop('checked', power_user.click_to_edit);
             },
         },
+        {
+            key: 'media_display',
+            action: (oldValue, newValue) => {
+                $('#media_display').val(power_user.media_display);
+                if (oldValue !== newValue) {
+                    showMediaDisplayReloadPrompt();
+                }
+            },
+        },
     ];
 
     for (const { key, selector, type, action } of themeProperties) {
         if (theme[key] !== undefined) {
-            power_user[key] = theme[key];
-            if (selector) $(selector).attr('color', power_user[key]);
+            const oldValue = power_user[key];
+            const newValue = theme[key];
+            power_user[key] = newValue;
+            if (selector) $(selector).attr('color', newValue);
             if (type) applyThemeColor(type);
-            if (action) action();
+            if (action) action(oldValue, newValue);
         } else {
             console.debug(`Empty theme key: ${key}`);
         }
@@ -1716,6 +1759,7 @@ export async function loadPowerUserSettings(settings, data) {
     $('#forbid_external_media').prop('checked', power_user.forbid_external_media);
     $('#pin_styles').prop('checked', power_user.pin_styles);
     $('#click_to_edit').prop('checked', power_user.click_to_edit);
+    $('#media_display').val(power_user.media_display);
 
     for (const theme of themes) {
         const option = document.createElement('option');
@@ -2508,6 +2552,7 @@ function getThemeObject(name) {
         compact_input_area: power_user.compact_input_area,
         show_swipe_num_all_messages: power_user.show_swipe_num_all_messages,
         click_to_edit: power_user.click_to_edit,
+        media_display: power_user.media_display,
     };
 }
 
@@ -4121,6 +4166,12 @@ jQuery(() => {
 
     $('#ui_preset_export_button').on('click', async function () {
         await exportTheme();
+    });
+
+    $('#media_display').on('input', function () {
+        power_user.media_display = $(this).val().toString();
+        reloadCurrentChat();
+        saveSettingsDebounced();
     });
 
     $(document).on('click', '#debug_table [data-debug-function]', function () {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -409,7 +409,7 @@ export class ReasoningHandler {
         if (!power_user.reasoning.prefix || !power_user.reasoning.suffix)
             return mesChanged;
 
-        /** @type {{ mes: string, [key: string]: any}} */
+        /** @type {ChatMessage} */
         const message = chat[messageId];
         if (!message) return mesChanged;
 
@@ -1259,7 +1259,7 @@ export function parseReasoningFromString(str, { strict = true } = {}) {
 /**
  * Parse reasoning in an array of swipe strings if auto-parsing is enabled.
  * @param {string[]} swipes Array of swipe strings
- * @param {{extra: ReasoningMessageExtra}[]} swipeInfoArray Array of swipe info objects
+ * @param {{extra: Partial<ReasoningMessageExtra>}[]} swipeInfoArray Array of swipe info objects
  * @param {number?} duration Duration of the reasoning
  * @typedef {object} ReasoningMessageExtra Extra reasoning data
  * @property {string} reasoning Reasoning block

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3866,11 +3866,6 @@ async function addSwipeCallback(args, value) {
         return '';
     }
 
-    if (lastMessage.extra?.image) {
-        toastr.warning(t`Can't add swipes to message containing an image.`);
-        return '';
-    }
-
     if (!Array.isArray(lastMessage.swipes)) {
         lastMessage.swipes = [lastMessage.mes];
         lastMessage.swipe_info = [{}];

--- a/public/scripts/slash-commands/SlashCommandCommonEnumsProvider.js
+++ b/public/scripts/slash-commands/SlashCommandCommonEnumsProvider.js
@@ -40,6 +40,7 @@ export const enumIcons = {
     server: '🖥️',
     popup: '🗔',
     image: '🖼️',
+    video: '🎥',
     key: '🔑',
 
     true: '✔️',
@@ -260,6 +261,22 @@ export const commonEnumProviders = {
             ...allowIdAfter ? [new SlashCommandEnumValue(String(chat.length), '>> After Last Message >>', enumTypes.enum, '➕')] : [],
             ...allowVars ? commonEnumProviders.variables('all')(executor, scope) : [],
         ];
+    },
+
+    /**
+     * Media items attached to a specific message
+     * @returns {(executor:SlashCommandExecutor, scope:SlashCommandScope) => SlashCommandEnumValue[]}
+     */
+    messageMedia: () => (executor, _scope) => {
+        const messageId = Number(executor.namedArgumentList.find(it => ['mesId', 'id'].includes(it.name))?.value || '');
+        if (isNaN(messageId) || messageId === null || messageId < 0 || messageId >= chat.length) {
+            return [];
+        }
+        const message = chat[messageId];
+        if (!Array.isArray(message?.extra?.media)) {
+            return [];
+        }
+        return message.extra.media.map((media, index) => new SlashCommandEnumValue(index.toString(), media.title || message.extra.title || '[Untitled]', enumTypes.enum, enumIcons[media.type] || enumIcons.file));
     },
 
     /**

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -59,6 +59,8 @@ import {
     refreshSwipeButtons,
     isSwipingAllowed,
     ensureMessageMediaIsArray,
+    getMediaDisplay,
+    getMediaIndex,
 } from '../script.js';
 import {
     extension_settings,
@@ -211,6 +213,8 @@ export function getContext() {
         updateMessageBlock,
         appendMediaToMessage,
         ensureMessageMediaIsArray,
+        getMediaDisplay,
+        getMediaIndex,
         swipe: {
             left: swipe_left,
             right: swipe_right,

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -58,6 +58,7 @@ import {
     deleteMessage,
     refreshSwipeButtons,
     isSwipingAllowed,
+    ensureMessageMediaIsArray,
 } from '../script.js';
 import {
     extension_settings,
@@ -209,6 +210,7 @@ export function getContext() {
         humanizedDateTime,
         updateMessageBlock,
         appendMediaToMessage,
+        ensureMessageMediaIsArray,
         swipe: {
             left: swipe_left,
             right: swipe_right,

--- a/public/scripts/system-messages.js
+++ b/public/scripts/system-messages.js
@@ -5,8 +5,9 @@ import { getSlashCommandsHelp } from './slash-commands.js';
 import { SlashCommandBrowser } from './slash-commands/SlashCommandBrowser.js';
 import { renderTemplateAsync } from './templates.js';
 
-// Initialized in getSystemMessages()
+/** @type {Record<string, ChatMessage>} */
 export const system_messages = {};
+/** @type {ChatMessage[]} */
 export const SAFETY_CHAT = [];
 
 /**
@@ -29,6 +30,7 @@ export const system_message_types = {
 };
 
 export async function initSystemMessages() {
+    /** @type {Record<string, ChatMessage>} */
     const result = {
         help: {
             name: systemUserName,
@@ -65,14 +67,15 @@ export async function initSystemMessages() {
             is_system: true,
             mes: await renderTemplateAsync('macros'),
         },
-        welcome:
-        {
+        welcome: {
             name: systemUserName,
             force_avatar: system_avatar,
             is_user: false,
             is_system: true,
-            uses_system_ui: true,
             mes: await renderTemplateAsync('welcome', { displayVersion }),
+            extra: {
+                uses_system_ui: true,
+            },
         },
         empty: {
             name: systemUserName,
@@ -93,9 +96,9 @@ export async function initSystemMessages() {
             force_avatar: system_avatar,
             is_user: false,
             is_system: true,
-            uses_system_ui: true,
             mes: await renderTemplateAsync('welcomePrompt'),
             extra: {
+                uses_system_ui: true,
                 isSmallSys: true,
             },
         },
@@ -105,8 +108,8 @@ export async function initSystemMessages() {
             is_user: false,
             is_system: true,
             mes: await renderTemplateAsync('assistantNote'),
-            uses_system_ui: true,
             extra: {
+                uses_system_ui: true,
                 isSmallSys: true,
             },
         },
@@ -114,12 +117,13 @@ export async function initSystemMessages() {
 
     Object.assign(system_messages, result);
 
+    /** @type {ChatMessage} */
     const safetyMessage = {
         name: systemUserName,
         force_avatar: system_avatar,
         is_system: true,
         is_user: false,
-        create_date: 0,
+        send_date: getMessageTimeStamp(),
         mes: t`You deleted a character/chat and arrived back here for safety reasons! Pick another character!`,
     };
     SAFETY_CHAT.splice(0, SAFETY_CHAT.length, safetyMessage);
@@ -130,8 +134,8 @@ export async function initSystemMessages() {
  * Gets a system message by type.
  * @param {string} type Type of system message
  * @param {string} [text] Text to be sent
- * @param {object} [extra] Additional data to be added to the message
- * @returns {object} System message object
+ * @param {ChatMessageExtra} [extra] Additional data to be added to the message
+ * @returns {ChatMessage} System message object
  */
 export function getSystemMessageByType(type, text, extra = {}) {
     const systemMessage = system_messages[type];
@@ -150,7 +154,7 @@ export function getSystemMessageByType(type, text, extra = {}) {
         newMessage.mes = getSlashCommandsHelp();
     }
 
-    if (!newMessage.extra) {
+    if (!newMessage.extra || typeof newMessage.extra !== 'object') {
         newMessage.extra = {};
     }
 
@@ -163,7 +167,7 @@ export function getSystemMessageByType(type, text, extra = {}) {
  * Sends a system message to the chat.
  * @param {string} type Type of system message
  * @param {string} [text] Text to be sent
- * @param {object} [extra] Additional data to be added to the message
+ * @param {ChatMessageExtra} [extra] Additional data to be added to the message
  */
 export function sendSystemMessage(type, text, extra = {}) {
     const newMessage = getSystemMessageByType(type, text, extra);

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -408,6 +408,16 @@ export async function urlContentToDataUri(url, params) {
 }
 
 /**
+ * Fuzzily compares two files for equality. Only checks attributes, not contents.
+ * @param {File} a First file
+ * @param {File} b Second file
+ * @returns {boolean} True if the files are probably the same, false otherwise.
+ */
+export function isSameFile(a, b) {
+    return a.lastModified === b.lastModified && a.name === b.name && a.size === b.size && a.type === b.type;
+}
+
+/**
  * Returns a promise that resolves to the file's text.
  * @param {Blob} file The file to read.
  * @returns {Promise<string>} A promise that resolves to the file's text.

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1019,7 +1019,7 @@ const dateCache = new Map();
 /**
  * Cached version of moment() to avoid re-parsing the same date strings.
  * Important: Moment objects are mutable, so use clone() before modifying them!
- * @param {string|number} timestamp String or number representing a date.
+ * @param {MessageTimestamp} timestamp String or number representing a date.
  * @returns {import('moment').Moment} Moment object
  */
 export function timestampToMoment(timestamp) {
@@ -1036,11 +1036,16 @@ export function timestampToMoment(timestamp) {
 
 /**
  * Parses a timestamp and returns a moment object representing the parsed date and time.
- * @param {string|number} timestamp - The timestamp to parse. It can be a string or a number.
+ * @param {MessageTimestamp} timestamp - The timestamp to parse. It can be a string or a number.
  * @returns {string} - If the timestamp is valid, returns an ISO 8601 string.
  */
 function parseTimestamp(timestamp) {
     if (!timestamp) return;
+
+    // Date object
+    if (timestamp instanceof Date) {
+        return timestamp.toISOString();
+    }
 
     // Unix time (legacy TAI / tags)
     if (typeof timestamp === 'number' || /^\d+$/.test(timestamp)) {

--- a/public/style.css
+++ b/public/style.css
@@ -5063,9 +5063,12 @@ a:hover {
 .mes_img_container:focus-within .mes_img_controls,
 .mes_video_container:hover .mes_video_controls,
 .mes_video_container:has(.mes_video.error) .mes_img_swipes,
-.mes_video_container:hover .mes_img_swipes,
-.mes_video_container:focus-within .mes_img_swipes {
+.mes_video_container:hover .mes_img_swipes {
     opacity: 1;
+}
+
+.mes_media_container:has(.error) .mes_img_swipes{
+    background: none;
 }
 
 .mes .mes_img_container {

--- a/public/style.css
+++ b/public/style.css
@@ -388,6 +388,11 @@ input[type='checkbox']:focus-visible {
     margin-bottom: 10px;
 }
 
+.mes_text p:last-child,
+.mes_reasoning p:last-child {
+    margin-bottom: 0;
+}
+
 .mes_text li tt,
 .mes_reasoning li tt {
     display: inline-block;
@@ -4971,6 +4976,11 @@ a:hover {
     flex-direction: row;
     align-items: center;
     flex-wrap: wrap;
+    gap: 0.5em;
+}
+
+.mes_media_wrapper:not(:empty)~.mes_file_wrapper:not(:empty) {
+    margin-top: 5px;
 }
 
 .mes .mes_img_container,
@@ -4981,7 +4991,8 @@ a:hover {
     position: relative;
     width: fit-content;
     transition: all var(--animation-duration);
-    margin: 0.5rem;
+    border-radius: 5px;
+    overflow: hidden;
 }
 
 .mes .mes_video_container:has(.mes_video[src]) {
@@ -4989,7 +5000,6 @@ a:hover {
 }
 
 .mes_img {
-    border-radius: 5px;
     max-width: 100%;
     max-height: 40vh;
     image-rendering: -webkit-optimize-contrast;
@@ -5017,15 +5027,13 @@ a:hover {
     padding: 10px;
     z-index: 1;
     transition: opacity var(--animation-duration) ease-in-out;
-    background: linear-gradient(rgba(0, 0, 0, 0.9), transparent);
-    border-radius: 5px 5px 0 0;
+    background: linear-gradient(rgba(0, 0, 0, 0.8), transparent);
 }
 
 .mes_img_swipes {
     top: unset;
     bottom: 0;
-    background: linear-gradient(transparent, rgba(0, 0, 0, 0.9));
-    border-radius: 0 0 5px 5px;
+    background: linear-gradient(transparent, rgba(0, 0, 0, 0.8));
 }
 
 .mes_img_swipes .right_menu_button,
@@ -5067,7 +5075,8 @@ a:hover {
     opacity: 1;
 }
 
-.mes_media_container:has(.error) .mes_img_swipes{
+.mes_media_container:has(.error) .mes_img_controls,
+.mes_media_container:has(.error) .mes_img_swipes {
     background: none;
 }
 
@@ -5166,7 +5175,6 @@ body:not(.caption) .mes_img_caption {
 .mes_video {
     max-width: 100%;
     max-height: 400px;
-    border-radius: 5px;
     background: #000;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -4980,7 +4980,7 @@ a:hover {
 }
 
 .mes_media_wrapper:not(:empty)~.mes_file_wrapper:not(:empty) {
-    margin-top: 5px;
+    margin-top: 0.5em;
 }
 
 .mes .mes_img_container,

--- a/public/style.css
+++ b/public/style.css
@@ -637,6 +637,16 @@ input[type='checkbox']:focus-visible {
     display: flex;
 }
 
+.mes .mes_media_gallery,
+.mes .mes_media_list {
+    display: none;
+}
+
+.mes[data-media-display="gallery"] .mes_media_gallery,
+.mes[data-media-display="list"] .mes_media_list {
+    display: flex;
+}
+
 small {
     color: var(--SmartThemeBodyColor);
     opacity: 0.7;
@@ -5049,7 +5059,10 @@ a:hover {
 .mes_img_container:focus-within .mes_img_swipes,
 .mes_img_container:hover .mes_img_controls,
 .mes_img_container:focus-within .mes_img_controls,
-.mes_video_container:hover .mes_video_controls {
+.mes_video_container:hover .mes_video_controls,
+.mes_video_container:has(.mes_video.error) .mes_img_swipes,
+.mes_video_container:hover .mes_img_swipes,
+.mes_video_container:focus-within .mes_img_swipes {
     opacity: 1;
 }
 
@@ -5061,8 +5074,7 @@ body:not(.caption) .mes_img_caption {
     display: none;
 }
 
-.mes_img_container:not(.img_swipes) .mes_img_swipes,
-body:not(.sd) .mes_img_swipes {
+.mes_img_container:not(.img_swipes) .mes_img_swipes {
     display: none;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -4981,7 +4981,7 @@ a:hover {
     position: relative;
     width: fit-content;
     transition: all var(--animation-duration);
-    padding: 0.5rem;
+    margin: 0.5rem;
 }
 
 .mes .mes_video_container:has(.mes_video[src]) {
@@ -5006,7 +5006,7 @@ a:hover {
 .mes_img_controls,
 .mes_video_controls {
     position: absolute;
-    top: 0.1em;
+    top: 0;
     left: 0;
     width: 100%;
     display: flex;
@@ -5014,14 +5014,18 @@ a:hover {
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: 1em;
+    padding: 10px;
     z-index: 1;
     transition: opacity var(--animation-duration) ease-in-out;
+    background: linear-gradient(rgba(0, 0, 0, 0.9), transparent);
+    border-radius: 5px 5px 0 0;
 }
 
 .mes_img_swipes {
     top: unset;
-    bottom: 0.1rem;
+    bottom: 0;
+    background: linear-gradient(transparent, rgba(0, 0, 0, 0.9));
+    border-radius: 0 0 5px 5px;
 }
 
 .mes_img_swipes .right_menu_button,

--- a/public/style.css
+++ b/public/style.css
@@ -4962,13 +4962,11 @@ a:hover {
 }
 
 /* Message images/video */
-.mes .mes_img_wrapper:empty,
-.mes .mes_video_wrapper:empty {
+.mes .mes_media_wrapper:empty {
     display: none;
 }
 
-.mes .mes_img_wrapper,
-.mes .mes_video_wrapper {
+.mes .mes_media_wrapper {
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/public/style.css
+++ b/public/style.css
@@ -4952,11 +4952,13 @@ a:hover {
 }
 
 /* Message images/video */
-.mes .mes_img_wrapper:empty {
+.mes .mes_img_wrapper:empty,
+.mes .mes_video_wrapper:empty {
     display: none;
 }
 
-.mes .mes_img_wrapper {
+.mes .mes_img_wrapper,
+.mes .mes_video_wrapper {
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/public/style.css
+++ b/public/style.css
@@ -4952,6 +4952,17 @@ a:hover {
 }
 
 /* Message images/video */
+.mes .mes_img_wrapper:empty {
+    display: none;
+}
+
+.mes .mes_img_wrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
 .mes .mes_img_container,
 .mes .mes_video_container {
     max-width: 100%;
@@ -5040,7 +5051,7 @@ a:hover {
     opacity: 1;
 }
 
-.mes .mes_img_container.img_extra {
+.mes .mes_img_container {
     display: flex;
 }
 

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -57,6 +57,11 @@ const sha256 = str => crypto.createHash('sha256').update(str).digest('hex');
  */
 
 /**
+ * @typedef {object} DataMaidMedia - The media object.
+ * @property {string} url - The media URL
+ */
+
+/**
  * @typedef {object} DataMaidChatMetadata - The chat metadata object.
  * @property {DataMaidFile[]} [attachments] - The array of attachments, if any.
  * @property {string[]} [chat_backgrounds] - The array of chat background image links, if any.
@@ -64,11 +69,10 @@ const sha256 = str => crypto.createHash('sha256').update(str).digest('hex');
 
 /**
  * @typedef {object} DataMaidMessageExtra - The extra data object.
- * @property {string} [image] - The link to the image, if any - DEPRECATED, use `images` instead.
- * @property {string[]} [images] - The links to the images, if any.
- * @property {string} [video] - The link to the video, if any - DEPRECATED, use `videos` instead.
- * @property {string[]} [videos] - The links to the videos, if any.
- * @property {string[]} [image_swipes] - The links to the image swipes, if any.
+ * @property {string} [image] - The link to the image, if any - DEPRECATED, use `media` instead.
+ * @property {string} [video] - The link to the video, if any - DEPRECATED, use `media` instead.
+ * @property {string[]} [image_swipes] - The links to the image swipes, if any - DEPRECATED, use `media` instead.
+ * @property {DataMaidMedia[]} [media] - The links to the media, if any.
  * @property {DataMaidFile} [file] - The file object, if any - DEPRECATED, use `files` instead.
  * @property {DataMaidFile[]} [files] - The array of file objects, if any.
  */
@@ -170,28 +174,25 @@ export class DataMaidService {
         const result = [];
 
         try {
-            const messages = await this.#parseAllChats(x => !!x?.extra?.image || Array.isArray(x?.extra?.images) || !!x?.extra?.video  || Array.isArray(x?.extra?.videos) || Array.isArray(x?.extra?.image_swipes));
+            const messages = await this.#parseAllChats(x => !!x?.extra?.image || !!x?.extra?.video || Array.isArray(x?.extra?.image_swipes));
             const knownImages = new Set();
             for (const message of messages) {
                 if (message?.extra?.image) {
                     knownImages.add(message.extra.image);
                 }
-                if (Array.isArray(message?.extra?.images)) {
-                    for (const image of message.extra.images) {
-                        knownImages.add(image);
-                    }
-                }
                 if (message?.extra?.video) {
                     knownImages.add(message.extra.video);
-                }
-                if (Array.isArray(message?.extra?.videos)) {
-                    for (const video of message.extra.videos) {
-                        knownImages.add(video);
-                    }
                 }
                 if (Array.isArray(message?.extra?.image_swipes)) {
                     for (const swipe of message.extra.image_swipes) {
                         knownImages.add(swipe);
+                    }
+                }
+                if (Array.isArray(message?.extra?.media)) {
+                    for (const media of message.extra.media) {
+                        if (media?.url) {
+                            knownImages.add(media.url);
+                        }
                     }
                 }
             }

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -174,7 +174,7 @@ export class DataMaidService {
         const result = [];
 
         try {
-            const messages = await this.#parseAllChats(x => !!x?.extra?.image || !!x?.extra?.video || Array.isArray(x?.extra?.image_swipes));
+            const messages = await this.#parseAllChats(x => !!x?.extra?.image || !!x?.extra?.video || Array.isArray(x?.extra?.image_swipes) || Array.isArray(x?.extra?.media));
             const knownImages = new Set();
             for (const message of messages) {
                 if (message?.extra?.image) {

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -65,7 +65,8 @@ const sha256 = str => crypto.createHash('sha256').update(str).digest('hex');
  * @typedef {object} DataMaidMessageExtra - The extra data object.
  * @property {string} [image] - The link to the image, if any - DEPRECATED, use `images` instead.
  * @property {string[]} [images] - The links to the images, if any.
- * @property {string} [video] - The link to the video, if any.
+ * @property {string} [video] - The link to the video, if any - DEPRECATED, use `videos` instead.
+ * @property {string[]} [videos] - The links to the videos, if any.
  * @property {string[]} [image_swipes] - The links to the image swipes, if any.
  * @property {DataMaidFile} [file] - The file object, if any - DEPRECATED, use `files` instead.
  * @property {DataMaidFile[]} [files] - The array of file objects, if any.
@@ -168,18 +169,23 @@ export class DataMaidService {
         const result = [];
 
         try {
-            const messages = await this.#parseAllChats(x => !!x?.extra?.image || Array.isArray(x?.extra?.images) || !!x?.extra?.video || Array.isArray(x?.extra?.image_swipes));
+            const messages = await this.#parseAllChats(x => !!x?.extra?.image || Array.isArray(x?.extra?.images) || !!x?.extra?.video  || Array.isArray(x?.extra?.videos) || Array.isArray(x?.extra?.image_swipes));
             const knownImages = new Set();
             for (const message of messages) {
                 if (message?.extra?.image) {
                     knownImages.add(message.extra.image);
                 }
-                if (message?.extra?.video) {
-                    knownImages.add(message.extra.video);
-                }
                 if (Array.isArray(message?.extra?.images)) {
                     for (const image of message.extra.images) {
                         knownImages.add(image);
+                    }
+                }
+                if (message?.extra?.video) {
+                    knownImages.add(message.extra.video);
+                }
+                if (Array.isArray(message?.extra?.videos)) {
+                    for (const video of message.extra.videos) {
+                        knownImages.add(video);
                     }
                 }
                 if (Array.isArray(message?.extra?.image_swipes)) {

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -66,7 +66,8 @@ const sha256 = str => crypto.createHash('sha256').update(str).digest('hex');
  * @property {string} [image] - The link to the image, if any.
  * @property {string} [video] - The link to the video, if any.
  * @property {string[]} [image_swipes] - The links to the image swipes, if any.
- * @property {DataMaidFile} [file] - The file object, if any.
+ * @property {DataMaidFile} [file] - The file object, if any - DEPRECATED, use `files` instead.
+ * @property {DataMaidFile[]} [files] - The array of file objects, if any.
  */
 
 /**
@@ -221,11 +222,18 @@ export class DataMaidService {
         const result = [];
 
         try {
-            const messages = await this.#parseAllChats(x => !!x?.extra?.file?.url);
+            const messages = await this.#parseAllChats(x => !!x?.extra?.file?.url || (Array.isArray(x?.extra?.files) && x.extra.files.length > 0));
             const knownFiles = new Set();
             for (const message of messages) {
                 if (message?.extra?.file?.url) {
                     knownFiles.add(message.extra.file.url);
+                }
+                if (Array.isArray(message?.extra?.files)) {
+                    for (const file of message.extra.files) {
+                        if (file?.url) {
+                            knownFiles.add(file.url);
+                        }
+                    }
                 }
             }
             const metadata = await this.#parseAllMetadata(x => Array.isArray(x?.attachments) && x.attachments.length > 0);

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -59,6 +59,7 @@ const sha256 = str => crypto.createHash('sha256').update(str).digest('hex');
 /**
  * @typedef {object} DataMaidChatMetadata - The chat metadata object.
  * @property {DataMaidFile[]} [attachments] - The array of attachments, if any.
+ * @property {string[]} [chat_backgrounds] - The array of chat background image links, if any.
  */
 
 /**
@@ -191,6 +192,16 @@ export class DataMaidService {
                 if (Array.isArray(message?.extra?.image_swipes)) {
                     for (const swipe of message.extra.image_swipes) {
                         knownImages.add(swipe);
+                    }
+                }
+            }
+            const metadata = await this.#parseAllMetadata(x => Array.isArray(x?.chat_backgrounds) && x.chat_backgrounds.length > 0);
+            for (const meta of metadata) {
+                if (Array.isArray(meta?.chat_backgrounds)) {
+                    for (const background of meta.chat_backgrounds) {
+                        if (background) {
+                            knownImages.add(background);
+                        }
                     }
                 }
             }

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -63,7 +63,8 @@ const sha256 = str => crypto.createHash('sha256').update(str).digest('hex');
 
 /**
  * @typedef {object} DataMaidMessageExtra - The extra data object.
- * @property {string} [image] - The link to the image, if any.
+ * @property {string} [image] - The link to the image, if any - DEPRECATED, use `images` instead.
+ * @property {string[]} [images] - The links to the images, if any.
  * @property {string} [video] - The link to the video, if any.
  * @property {string[]} [image_swipes] - The links to the image swipes, if any.
  * @property {DataMaidFile} [file] - The file object, if any - DEPRECATED, use `files` instead.
@@ -167,7 +168,7 @@ export class DataMaidService {
         const result = [];
 
         try {
-            const messages = await this.#parseAllChats(x => !!x?.extra?.image || !!x?.extra?.video || Array.isArray(x?.extra?.image_swipes));
+            const messages = await this.#parseAllChats(x => !!x?.extra?.image || Array.isArray(x?.extra?.images) || !!x?.extra?.video || Array.isArray(x?.extra?.image_swipes));
             const knownImages = new Set();
             for (const message of messages) {
                 if (message?.extra?.image) {
@@ -175,6 +176,11 @@ export class DataMaidService {
                 }
                 if (message?.extra?.video) {
                     knownImages.add(message.extra.video);
+                }
+                if (Array.isArray(message?.extra?.images)) {
+                    for (const image of message.extra.images) {
+                        knownImages.add(image);
+                    }
                 }
                 if (Array.isArray(message?.extra?.image_swipes)) {
                     for (const swipe of message.extra.image_swipes) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

A new take on #3635. Introduces array properties in message extra object for 3 types of media (img, vid, file) and read-only polyfills for consumers of old formats (third-party extensions). Data will be auto-migrated when loaded or appendMediaToMessage is called. Image swipes dilemma is solved by allowing to image swipe only when there's one image at max. Using image generation via the paintbrush icon gives a choice on where to add an image if it's eligible for image swipes. Also updates built-in extensions (Vector, Caption, ImgGen) to support writing to new fields.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
