### PR TITLE
`feat/multi-file` Added a toggle between the old gallery and new image list.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4671,6 +4671,13 @@
                                         <option value="2" data-i18n="Document">Document</option>
                                     </select>
                                 </div>
+                                <div class="flex-container alignitemscenter" title="Default display style for media attachments in chat messages. Extensions can override this setting." data-i18n="[title]Default display style for media attachments in chat messages. Extensions can override this setting.">
+                                    <span data-i18n="Media Style:">Media Style:</span>
+                                    <select id="media_display" class="widthNatural flex1 margin0 text_pole">
+                                        <option value="list" data-i18n="List">List</option>
+                                        <option value="gallery" data-i18n="Gallery">Gallery</option>
+                                    </select>
+                                </div>
                                 <div class="flex-container alignItemsBaseline">
                                     <span data-i18n="Notifications:">Notifications:</span>
                                     <select id="toastr_position" class="widthNatural flex1 margin0 text_pole">
@@ -5117,10 +5124,6 @@
                                 <label class="checkbox_label" for="forbid_external_media" title="Disallow embedded media from other domains in chat messages." data-i18n="[title]Disallow embedded media from other domains in chat messages">
                                     <input id="forbid_external_media" type="checkbox" />
                                     <small data-i18n="Forbid External Media">Forbid External Media</small>
-                                </label>
-                                <label for="media_display" class="checkbox_label" title="Sets the default media view to gallery or list." data-i18n="[title]Sets the default media view to gallery or list.">
-                                    <input id="media_display" type="checkbox" />
-                                    <small data-i18n="Toggle Gallery">Toggle Gallery</small>
                                 </label>
                                 <label class="checkbox_label" for="allow_name2_display">
                                     <input id="allow_name2_display" type="checkbox" />

--- a/public/index.html
+++ b/public/index.html
@@ -5118,6 +5118,10 @@
                                     <input id="forbid_external_media" type="checkbox" />
                                     <small data-i18n="Forbid External Media">Forbid External Media</small>
                                 </label>
+                                <label for="media_display" class="checkbox_label" title="Sets the default media view to gallery or list." data-i18n="[title]Sets the default media view to gallery or list.">
+                                    <input id="media_display" type="checkbox" />
+                                    <small data-i18n="Toggle Gallery">Toggle Gallery</small>
+                                </label>
                                 <label class="checkbox_label" for="allow_name2_display">
                                     <input id="allow_name2_display" type="checkbox" />
                                     <small data-i18n="Allow {{char}}: in bot messages">Show {{char}}: in responses</small>

--- a/public/script.js
+++ b/public/script.js
@@ -1982,7 +1982,7 @@ export function ensureMessageMediaIsArray(mes) {
                 }
             }
             delete obj.image_swipes;
-            obj.media_display = MEDIA_DISPLAY.GALLERY;
+            obj.media_display = power_user.media_display;
         }
 
         if (isPlainObjectProperty(obj, 'image')) {

--- a/public/script.js
+++ b/public/script.js
@@ -370,6 +370,7 @@ export const neutralCharacterName = 'Assistant';
 let default_user_name = 'User';
 export let name1 = default_user_name;
 export let name2 = systemUserName;
+/** @type {ChatMessage[]} */
 export let chat = [];
 export let isSwipingAllowed = true; //false when a swipe is in progress, or swiping is blocked.
 let chatSaveTimeout;
@@ -3874,7 +3875,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         const prevStarted = chat[chat.length - 1]['gen_started'];
 
         if (prevFinished && prevStarted) {
-            const timePassed = prevFinished - prevStarted;
+            const timePassed = Number(prevFinished) - Number(prevStarted);
             generation_started = new Date(Date.now() - timePassed);
             chat[chat.length - 1]['gen_started'] = generation_started;
         }
@@ -9330,7 +9331,7 @@ export async function swipe(_event, direction, { source, repeated, message = cha
         if (run_generate && !is_send_press) {
             is_send_press = true;
             generation = Generate('swipe');
-        } else if (parseInt(chat[mesId]['swipe_id']) !== chat[mesId]['swipes'].length) {
+        } else if (Number(chat[mesId]['swipe_id']) !== chat[mesId]['swipes'].length) {
             saveChatDebounced();
         }
 
@@ -10974,7 +10975,7 @@ jQuery(async function () {
         const oldScroll = chatElement[0].scrollTop;
         const clone = structuredClone(chat[this_edit_mes_id]);
         clone.send_date = Date.now();
-        clone.mes = $(this).closest('.mes').find('.edit_textarea').val();
+        clone.mes = $(this).closest('.mes').find('.edit_textarea').val().toString();
 
         if (power_user.trim_spaces) {
             clone.mes = clone.mes.trim();

--- a/public/script.js
+++ b/public/script.js
@@ -1978,11 +1978,11 @@ export function ensureMessageMediaIsArray(mes) {
             }
             for (const swipe of obj.image_swipes) {
                 if (swipe && typeof swipe === 'string') {
+                    obj.media_display = MEDIA_DISPLAY.GALLERY;
                     obj.media.push({ type: 'image', url: swipe });
                 }
             }
             delete obj.image_swipes;
-            obj.media_display = power_user.media_display;
         }
 
         if (isPlainObjectProperty(obj, 'image')) {

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -344,6 +344,7 @@ export async function convertSoloToGroupChat() {
 
         // Save group-chat marker
         if (index == 0) {
+            // @ts-ignore
             message.is_group = true;
         }
 

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -2230,36 +2230,36 @@ export function initChatUtilities() {
         openGlobalStylesPreferenceDialog();
     });
 
-    $(document).on('click', '.mes_img', async function () {
+    /**
+     * Returns information about the closest .mes_container.
+     * @returns {object}
+     */
+    function getContainerInfo(containerClass = '.mes_media_container'){
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
-        const mediaBlock = $(this).closest('.mes_media_container');
+        const mediaBlock = $(this).closest(containerClass);
         const mediaIndex = Number(mediaBlock.attr('data-index'));
-        expandMessageMedia(messageId, mediaIndex);
+        return { messageBlock, messageId, mediaBlock, mediaIndex };
+    }
+    $(document).on('click', '.mes_img', async function () {
+        const info = getContainerInfo.call(this);
+        expandMessageMedia(info['messageId'], info['mediaIndex']);
     });
     $(document).on('click', '.mes_media_enlarge', async function () {
-        const messageBlock = $(this).closest('.mes');
-        const messageId = Number(messageBlock.attr('mesid'));
-        const mediaBlock = $(this).closest('.mes_media_container');
-        const mediaIndex = Number(mediaBlock.attr('data-index'));
-        expandMessageMedia(messageId, mediaIndex).click();
+        const info = getContainerInfo.call(this);
+        expandMessageMedia(info['messageId'], info['mediaIndex']).click();
     });
     $(document).on('click', '.mes_media_delete', async function () {
-        const messageBlock = $(this).closest('.mes');
-        const messageId = Number(messageBlock.attr('mesid'));
-        const mediaBlock = $(this).closest('.mes_media_container');
-        const mediaIndex = Number(mediaBlock.attr('data-index'));
-        await deleteMessageMedia(messageId, mediaIndex, messageBlock);
+        const info = getContainerInfo.call(this);
+        await deleteMessageMedia(info['messageId'], info['mediaIndex'], info['messageBlock']);
     });
     $(document).on('click', '.mes_media_list', async function () {
-        const messageBlock = $(this).closest('.mes');
-        const messageId = Number(messageBlock.attr('mesid'));
-        await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.GALLERY);
+        const info = getContainerInfo.call(this);
+        await switchMessageMediaDisplay(info['messageId'], info['messageBlock'], MEDIA_DISPLAY.GALLERY);
     });
     $(document).on('click', '.mes_media_gallery', async function () {
-        const messageBlock = $(this).closest('.mes');
-        const messageId = Number(messageBlock.attr('mesid'));
-        await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.LIST);
+        const info = getContainerInfo.call(this);
+        await switchMessageMediaDisplay(info['messageId'], info['messageBlock'], MEDIA_DISPLAY.LIST);
     });
 
     $('#file_form_input').on('change', async () => {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -2232,7 +2232,12 @@ export function initChatUtilities() {
 
     /**
      * Returns information about the closest .mes_container.
-     * @returns {object}
+     * @returns {MediaContainerInfo} Information about the media container
+     * @typedef {object} MediaContainerInfo
+     * @property {JQuery<HTMLElement>} messageBlock The closest message block
+     * @property {number} messageId The message ID
+     * @property {JQuery<HTMLElement>} mediaBlock The closest media container block
+     * @property {number} mediaIndex The media index within the message
      */
     function getContainerInfo(containerClass = '.mes_media_container'){
         const messageBlock = $(this).closest('.mes');
@@ -2242,24 +2247,24 @@ export function initChatUtilities() {
         return { messageBlock, messageId, mediaBlock, mediaIndex };
     }
     $(document).on('click', '.mes_img', async function () {
-        const info = getContainerInfo.call(this);
-        expandMessageMedia(info['messageId'], info['mediaIndex']);
+        const { messageId, mediaIndex } = getContainerInfo.call(this);
+        expandMessageMedia(messageId, mediaIndex);
     });
     $(document).on('click', '.mes_media_enlarge', async function () {
-        const info = getContainerInfo.call(this);
-        expandMessageMedia(info['messageId'], info['mediaIndex']).click();
+        const { messageId, mediaIndex } = getContainerInfo.call(this);
+        expandMessageMedia(messageId, mediaIndex).click();
     });
     $(document).on('click', '.mes_media_delete', async function () {
-        const info = getContainerInfo.call(this);
-        await deleteMessageMedia(info['messageId'], info['mediaIndex'], info['messageBlock']);
+        const { messageId, mediaIndex, messageBlock } = getContainerInfo.call(this);
+        await deleteMessageMedia(messageId, mediaIndex, messageBlock);
     });
     $(document).on('click', '.mes_media_list', async function () {
-        const info = getContainerInfo.call(this);
-        await switchMessageMediaDisplay(info['messageId'], info['messageBlock'], MEDIA_DISPLAY.GALLERY);
+        const { messageId, messageBlock } = getContainerInfo.call(this);
+        await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.GALLERY);
     });
     $(document).on('click', '.mes_media_gallery', async function () {
-        const info = getContainerInfo.call(this);
-        await switchMessageMediaDisplay(info['messageId'], info['messageBlock'], MEDIA_DISPLAY.LIST);
+        const { messageId, messageBlock } = getContainerInfo.call(this);
+        await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.LIST);
     });
 
     $('#file_form_input').on('change', async () => {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -2231,7 +2231,7 @@ export function initChatUtilities() {
     });
 
     /**
-     * Returns information about the closest .mes_container.
+     * Returns information about the closest media container.
      * @returns {MediaContainerInfo} Information about the media container
      * @typedef {object} MediaContainerInfo
      * @property {JQuery<HTMLElement>} messageBlock The closest message block
@@ -2239,7 +2239,7 @@ export function initChatUtilities() {
      * @property {JQuery<HTMLElement>} mediaBlock The closest media container block
      * @property {number} mediaIndex The media index within the message
      */
-    function getContainerInfo(containerClass = '.mes_media_container'){
+    function getMediaContainerInfo(containerClass = '.mes_media_container'){
         const messageBlock = $(this).closest('.mes');
         const messageId = Number(messageBlock.attr('mesid'));
         const mediaBlock = $(this).closest(containerClass);
@@ -2247,23 +2247,23 @@ export function initChatUtilities() {
         return { messageBlock, messageId, mediaBlock, mediaIndex };
     }
     $(document).on('click', '.mes_img', async function () {
-        const { messageId, mediaIndex } = getContainerInfo.call(this);
+        const { messageId, mediaIndex } = getMediaContainerInfo.call(this);
         expandMessageMedia(messageId, mediaIndex);
     });
     $(document).on('click', '.mes_media_enlarge', async function () {
-        const { messageId, mediaIndex } = getContainerInfo.call(this);
+        const { messageId, mediaIndex } = getMediaContainerInfo.call(this);
         expandMessageMedia(messageId, mediaIndex).click();
     });
     $(document).on('click', '.mes_media_delete', async function () {
-        const { messageId, mediaIndex, messageBlock } = getContainerInfo.call(this);
+        const { messageId, mediaIndex, messageBlock } = getMediaContainerInfo.call(this);
         await deleteMessageMedia(messageId, mediaIndex, messageBlock);
     });
     $(document).on('click', '.mes_media_list', async function () {
-        const { messageId, messageBlock } = getContainerInfo.call(this);
+        const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.GALLERY);
     });
     $(document).on('click', '.mes_media_gallery', async function () {
-        const { messageId, messageBlock } = getContainerInfo.call(this);
+        const { messageId, messageBlock } = getMediaContainerInfo.call(this);
         await switchMessageMediaDisplay(messageId, messageBlock, MEDIA_DISPLAY.LIST);
     });
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -64,6 +64,7 @@ import { accountStorage } from './util/AccountStorage.js';
 import { DEFAULT_REASONING_TEMPLATE, loadReasoningTemplates } from './reasoning.js';
 import { bindModelTemplates } from './chat-templates.js';
 import { MEDIA_DISPLAY } from './constants.js';
+import { t } from './i18n.js';
 
 export const toastPositionClasses = [
     'toast-top-left',
@@ -1180,6 +1181,37 @@ function applyFontScale(type) {
     $('#font_scale').val(power_user.font_scale);
 }
 
+/**
+ * Shows a toast notification prompting the user to reload the chat if media display settings have changed
+ * and there are messages with media attachments that haven't been processed with the new display format.
+ */
+function showMediaDisplayReloadPrompt() {
+    // A user is not currently in a chat.
+    const chatId = getCurrentChatId();
+    if (!chatId) {
+        return;
+    }
+
+    const firstDisplayedIndex = getFirstDisplayedMessageId();
+    const hasUnprocessedMediaMessages = chat.some((message, index) => {
+        // Skip messages that are not currently displayed
+        if (index < firstDisplayedIndex) {
+            return false;
+        }
+        const hasMediaAttachments = Array.isArray(message?.extra?.media) && message.extra.media.length > 0;
+        const lacksMediaDisplay = !message?.extra?.media_display;
+        return hasMediaAttachments && lacksMediaDisplay;
+    });
+
+    if (hasUnprocessedMediaMessages) {
+        toastr.info(
+            t`Reload the chat to apply the changes. Click here to reload.`,
+            t`Media Style changed`,
+            { onclick: () => void reloadCurrentChat() },
+        );
+    }
+}
+
 function applyTheme(name) {
     const theme = themes.find(x => x.name == name);
 
@@ -1369,14 +1401,25 @@ function applyTheme(name) {
                 $('#click_to_edit').prop('checked', power_user.click_to_edit);
             },
         },
+        {
+            key: 'media_display',
+            action: (oldValue, newValue) => {
+                $('#media_display').val(power_user.media_display);
+                if (oldValue !== newValue) {
+                    showMediaDisplayReloadPrompt();
+                }
+            },
+        },
     ];
 
     for (const { key, selector, type, action } of themeProperties) {
         if (theme[key] !== undefined) {
-            power_user[key] = theme[key];
-            if (selector) $(selector).attr('color', power_user[key]);
+            const oldValue = power_user[key];
+            const newValue = theme[key];
+            power_user[key] = newValue;
+            if (selector) $(selector).attr('color', newValue);
             if (type) applyThemeColor(type);
-            if (action) action();
+            if (action) action(oldValue, newValue);
         } else {
             console.debug(`Empty theme key: ${key}`);
         }

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1716,7 +1716,7 @@ export async function loadPowerUserSettings(settings, data) {
     $('#forbid_external_media').prop('checked', power_user.forbid_external_media);
     $('#pin_styles').prop('checked', power_user.pin_styles);
     $('#click_to_edit').prop('checked', power_user.click_to_edit);
-    $('#media_display').prop('checked', (power_user.media_display == MEDIA_DISPLAY.GALLERY));
+    $('#media_display').val(power_user.media_display);
 
     for (const theme of themes) {
         const option = document.createElement('option');
@@ -4126,7 +4126,7 @@ jQuery(() => {
     });
 
     $('#media_display').on('input', function () {
-        power_user.media_display = ($(this).prop('checked')) ? MEDIA_DISPLAY.GALLERY : MEDIA_DISPLAY.LIST;
+        power_user.media_display = $(this).val().toString();
         reloadCurrentChat();
         saveSettingsDebounced();
     });

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1716,6 +1716,7 @@ export async function loadPowerUserSettings(settings, data) {
     $('#forbid_external_media').prop('checked', power_user.forbid_external_media);
     $('#pin_styles').prop('checked', power_user.pin_styles);
     $('#click_to_edit').prop('checked', power_user.click_to_edit);
+    $('#media_display').prop('checked', (power_user.media_display == MEDIA_DISPLAY.GALLERY));
 
     for (const theme of themes) {
         const option = document.createElement('option');
@@ -2508,6 +2509,7 @@ function getThemeObject(name) {
         compact_input_area: power_user.compact_input_area,
         show_swipe_num_all_messages: power_user.show_swipe_num_all_messages,
         click_to_edit: power_user.click_to_edit,
+        media_display: power_user.media_display,
     };
 }
 
@@ -4121,6 +4123,12 @@ jQuery(() => {
 
     $('#ui_preset_export_button').on('click', async function () {
         await exportTheme();
+    });
+
+    $('#media_display').on('input', function () {
+        power_user.media_display = ($(this).prop('checked')) ? MEDIA_DISPLAY.GALLERY : MEDIA_DISPLAY.LIST;
+        reloadCurrentChat();
+        saveSettingsDebounced();
     });
 
     $(document).on('click', '#debug_table [data-debug-function]', function () {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -409,7 +409,7 @@ export class ReasoningHandler {
         if (!power_user.reasoning.prefix || !power_user.reasoning.suffix)
             return mesChanged;
 
-        /** @type {{ mes: string, [key: string]: any}} */
+        /** @type {ChatMessage} */
         const message = chat[messageId];
         if (!message) return mesChanged;
 
@@ -1259,7 +1259,7 @@ export function parseReasoningFromString(str, { strict = true } = {}) {
 /**
  * Parse reasoning in an array of swipe strings if auto-parsing is enabled.
  * @param {string[]} swipes Array of swipe strings
- * @param {{extra: ReasoningMessageExtra}[]} swipeInfoArray Array of swipe info objects
+ * @param {{extra: Partial<ReasoningMessageExtra>}[]} swipeInfoArray Array of swipe info objects
  * @param {number?} duration Duration of the reasoning
  * @typedef {object} ReasoningMessageExtra Extra reasoning data
  * @property {string} reasoning Reasoning block

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1019,7 +1019,7 @@ const dateCache = new Map();
 /**
  * Cached version of moment() to avoid re-parsing the same date strings.
  * Important: Moment objects are mutable, so use clone() before modifying them!
- * @param {string|number} timestamp String or number representing a date.
+ * @param {MessageTimestamp} timestamp String or number representing a date.
  * @returns {import('moment').Moment} Moment object
  */
 export function timestampToMoment(timestamp) {
@@ -1036,11 +1036,16 @@ export function timestampToMoment(timestamp) {
 
 /**
  * Parses a timestamp and returns a moment object representing the parsed date and time.
- * @param {string|number} timestamp - The timestamp to parse. It can be a string or a number.
+ * @param {MessageTimestamp} timestamp - The timestamp to parse. It can be a string or a number.
  * @returns {string} - If the timestamp is valid, returns an ISO 8601 string.
  */
 function parseTimestamp(timestamp) {
     if (!timestamp) return;
+
+    // Date object
+    if (timestamp instanceof Date) {
+        return timestamp.toISOString();
+    }
 
     // Unix time (legacy TAI / tags)
     if (typeof timestamp === 'number' || /^\d+$/.test(timestamp)) {


### PR DESCRIPTION
Suggestion for #4719

This PR now only adds a toggle for the default view.

~~Although this seems to function, please consider this PR untested pseudo-code.~~
~~I prefer the old gallery over the new multi-image view, Please consider keeping both available through a toggle.~~

~~In this PR, I added a toggle to `Chat/Message Handling`.~~

~~Both `image_swipes` and `images` can now be displayed in either a galley or list view.~~

### TODO:

~~- `.mes_container` needs distinct styles for `images` and `image-swipes`.~~

#### Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
