### PR TITLE
Fixed bug in `syncMesToSwipe`. `""` is falsy and a valid message.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6004,7 +6004,7 @@ export function syncMesToSwipe(messageId = null) {
     }
     // If the swipe is not present yet, exit out (will likely be copied later)
     // "" is falsy. An empty string is a valid message.
-    if (typeof targetMessage.swipes[targetMessage.swipe_id] != 'string' || !targetMessage.swipe_info[targetMessage.swipe_id]) {
+    if (typeof targetMessage.swipes[targetMessage.swipe_id] !== 'string' || !targetMessage.swipe_info[targetMessage.swipe_id]) {
         return false;
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -6003,7 +6003,8 @@ export function syncMesToSwipe(messageId = null) {
         return false;
     }
     // If the swipe is not present yet, exit out (will likely be copied later)
-    if (!targetMessage.swipes[targetMessage.swipe_id] || !targetMessage.swipe_info[targetMessage.swipe_id]) {
+    // "" is falsy. An empty string is a valid message.
+    if (typeof targetMessage.swipes[targetMessage.swipe_id] != 'string' || !targetMessage.swipe_info[targetMessage.swipe_id]) {
         return false;
     }
 


### PR DESCRIPTION
Fixed bug in `syncMesToSwipe`. `""` is falsy and a valid message.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
