### PR TITLE
Support multiple images in single API response

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5641,7 +5641,7 @@ function extractTitleFromData(data) {
  * @param {object} [options] Extraction options
  * @param {string} [options.mainApi] Main API to use
  * @param {string} [options.chatCompletionSource] Chat completion source
- * @returns {string[]|undefined} Extracted images or undefined if none found
+ * @returns {string[]} Extracted images or empty array
  */
 function extractImagesFromData(data, { mainApi = null, chatCompletionSource = null } = {}) {
     switch (mainApi ?? main_api) {
@@ -5651,7 +5651,7 @@ function extractImagesFromData(data, { mainApi = null, chatCompletionSource = nu
                 case chat_completion_sources.MAKERSUITE: {
                     const inlineData = data?.responseContent?.parts?.filter(x => x.inlineData)?.map(x => x.inlineData);
                     if (Array.isArray(inlineData) && inlineData.length > 0) {
-                        return inlineData.map(x => `data:${x.mimeType};base64,${x.data}`);
+                        return inlineData.map(x => `data:${x.mimeType};base64,${x.data}`).filter(isDataURL);
                     }
                 } break;
                 case chat_completion_sources.OPENROUTER: {
@@ -5665,7 +5665,7 @@ function extractImagesFromData(data, { mainApi = null, chatCompletionSource = nu
         } break;
     }
 
-    return undefined;
+    return [];
 }
 
 /**

--- a/public/script.js
+++ b/public/script.js
@@ -6021,14 +6021,14 @@ async function processImageAttachment(message, { imageUrls }) {
         return;
     }
 
-    for (const imageUrl of imageUrls) {
+    for (const [index, imageUrl] of imageUrls.entries()) {
         if (!imageUrl) {
             continue;
         }
 
         let url = imageUrl;
         if (isDataURL(url)) {
-            const fileName = `inline_image_${Date.now().toString()}`;
+            const fileName = `inline_image_${Date.now().toString()}_${index}`;
             const [mime, base64] = /^data:(.*?);base64,(.*)$/.exec(imageUrl).slice(1);
             url = await saveBase64AsFile(base64, message.name, fileName, mime.split('/')[1]);
         }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2600,7 +2600,7 @@ export function getStreamingReply(data, state, { chatCompletionSource = null, ov
     } else if ([chat_completion_sources.MAKERSUITE, chat_completion_sources.VERTEXAI].includes(chat_completion_source)) {
         const inlineData = data?.candidates?.[0]?.content?.parts?.filter(x => x.inlineData)?.map(x => x.inlineData) || [];
         if (Array.isArray(inlineData) && inlineData.length > 0) {
-            state.images.push(...inlineData.map(x => `data:${x.mimeType};base64,${x.data}`));
+            state.images.push(...inlineData.map(x => `data:${x.mimeType};base64,${x.data}`).filter(isDataURL));
         }
         if (show_thoughts) {
             state.reasoning += (data?.candidates?.[0]?.content?.parts?.filter(x => x.thought)?.map(x => x.text)?.[0] || '');

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1142,7 +1142,7 @@ export function splitRecursive(input, length, delimiters = ['\n\n', '\n', ' ', '
  */
 export function isDataURL(str) {
     const regex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z-]+=[a-z0-9-]+)*;?)?(base64)?,([a-z0-9!$&',()*+;=\-_%.~:@/?#]+)?$/i;
-    return regex.test(str);
+    return typeof str === 'string' && regex.test(str);
 }
 
 /**

--- a/public/style.css
+++ b/public/style.css
@@ -4977,6 +4977,7 @@ a:hover {
     align-items: center;
     flex-wrap: wrap;
     gap: 0.5em;
+    padding-right: var(--mes-right-spacing);
 }
 
 .mes_media_wrapper:not(:empty)~.mes_file_wrapper:not(:empty) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Something I forgot to handle in #4719 

APIs like Gemini and OpenRouter should support returning several images at once... But they do so when they wanna, even if asked. So YMMV.

<img width="757" height="478" alt="image" src="https://github.com/user-attachments/assets/a73e97c2-a104-494c-96e2-ae484643ad25" />

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
