### PR TITLE
Deprecate gpt-3.5-turbo-instruct under Chat Completions API

### DIFF
--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -26,37 +26,6 @@ import { getConfigValue, isValidUrl } from '../util.js';
  */
 const tokenizersCache = {};
 
-/**
- * @type {string[]}
- */
-export const TEXT_COMPLETION_MODELS = [
-    'gpt-3.5-turbo-instruct',
-    'gpt-3.5-turbo-instruct-0914',
-    'text-davinci-003',
-    'text-davinci-002',
-    'text-davinci-001',
-    'text-curie-001',
-    'text-babbage-001',
-    'text-ada-001',
-    'code-davinci-002',
-    'code-davinci-001',
-    'code-cushman-002',
-    'code-cushman-001',
-    'text-davinci-edit-001',
-    'code-davinci-edit-001',
-    'text-embedding-ada-002',
-    'text-similarity-davinci-001',
-    'text-similarity-curie-001',
-    'text-similarity-babbage-001',
-    'text-similarity-ada-001',
-    'text-search-davinci-doc-001',
-    'text-search-curie-doc-001',
-    'text-search-babbage-doc-001',
-    'text-search-ada-doc-001',
-    'code-search-babbage-code-001',
-    'code-search-ada-code-001',
-];
-
 const CHARS_PER_TOKEN = 3.35;
 const IS_DOWNLOAD_ALLOWED = getConfigValue('enableDownloadableTokenizers', true, 'boolean');
 const gunzip = promisify(zlib.gunzip);
@@ -459,10 +428,6 @@ export function getTokenizerModel(requestModel) {
 
     if (requestModel.includes('gpt-3.5-turbo')) {
         return 'gpt-3.5-turbo';
-    }
-
-    if (TEXT_COMPLETION_MODELS.includes(requestModel)) {
-        return requestModel;
     }
 
     if (requestModel.includes('claude')) {

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -906,31 +906,6 @@ export function mergeMessages(messages, names, { strict = false, placeholders = 
 }
 
 /**
- * Convert a prompt from the ChatML objects to the format used by Text Completion API.
- * @param {object[]} messages Array of messages
- * @returns {string} Prompt for Text Completion API
- */
-export function convertTextCompletionPrompt(messages) {
-    if (typeof messages === 'string') {
-        return messages;
-    }
-
-    const messageStrings = [];
-    messages.forEach(m => {
-        if (m.role === 'system' && m.name === undefined) {
-            messageStrings.push('System: ' + m.content);
-        }
-        else if (m.role === 'system' && m.name !== undefined) {
-            messageStrings.push(m.name + ': ' + m.content);
-        }
-        else {
-            messageStrings.push(m.role + ': ' + m.content);
-        }
-    });
-    return messageStrings.join('\n') + '\nassistant:';
-}
-
-/**
  * Append cache_control object to a Claude messages at depth. Directly modifies the messages array.
  * @param {any[]} messages Messages to modify
  * @param {number} cachingAtDepth Depth at which caching is supposed to occur


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Will announce deprecation in the release notes before merging. Users of this model can switch to Text Completion (generic/compatible) endpoint. Official retirement date is 2026-09-28, so we still have plenty of time to process this.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
