### PR TITLE
Prevent Esc from closing editor during composition

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -10873,7 +10873,7 @@ jQuery(async function () {
     });
 
     $(document).on('keyup', function (e) {
-        if (e.key === 'Escape') {
+        if (e.key === 'Escape' && !e.isComposing) {
             const isEditVisible = $('#curEditTextarea').is(':visible') || $('.reasoning_edit_textarea').length > 0;
             if (isEditVisible && power_user.auto_save_msg_edits === false) {
                 closeMessageEditor('all');

--- a/public/script.js
+++ b/public/script.js
@@ -10872,7 +10872,7 @@ jQuery(async function () {
         }
     });
 
-    $(document).on('keyup', function (e) {
+    $(document).on('keydown', function (e) {
         if (e.key === 'Escape' && !e.isComposing) {
             const isEditVisible = $('#curEditTextarea').is(':visible') || $('.reasoning_edit_textarea').length > 0;
             if (isEditVisible && power_user.auto_save_msg_edits === false) {


### PR DESCRIPTION
When using a Chinese IME, pressing the Escape key during composition should cancel the composition, not close the message editor.

This fix adds a check for `!e.isComposing` to the event listener for the Escape key in `public/script.js`. The event listener is also changed from `keyup` to `keydown`. This ensures that the editor is only closed when the Escape key is pressed outside of an IME composition session.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
