### PR TITLE
fix #3199: firefox using cached images instead of new images. 

### DIFF
--- a/src/endpoints/thumbnails.js
+++ b/src/endpoints/thumbnails.js
@@ -8,8 +8,7 @@ import sanitize from 'sanitize-filename';
 import { Jimp, JimpMime } from '../jimp.js';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 
-import { getConfigValue } from '../util.js';
-import { isFirefox } from '../express-common.js';
+import { getConfigValue, invalidateFirefoxCache } from '../util.js';
 
 const thumbnailsEnabled = !!getConfigValue('thumbnails.enabled', true, 'boolean');
 const quality = Math.min(100, Math.max(1, parseInt(getConfigValue('thumbnails.quality', 95, 'number'))));
@@ -223,6 +222,9 @@ router.get('/', async function (request, response) {
             const contentType = mime.lookup(pathToOriginalFile) || 'image/png';
             const originalFile = await fsPromises.readFile(pathToOriginalFile);
             response.setHeader('Content-Type', contentType);
+
+            invalidateFirefoxCache(pathToOriginalFile, request, response);
+
             return response.send(originalFile);
         }
 
@@ -240,9 +242,7 @@ router.get('/', async function (request, response) {
         const cachedFile = await fsPromises.readFile(pathToCachedFile);
         response.setHeader('Content-Type', contentType);
 
-        if (isFirefox(request) && contentType.startsWith('image/')) {
-            response.setHeader('Cache-Control', 'must-understand, no-store');
-        }
+        invalidateFirefoxCache(file, request, response);
 
         return response.send(cachedFile);
     } catch (error) {

--- a/src/endpoints/thumbnails.js
+++ b/src/endpoints/thumbnails.js
@@ -9,6 +9,7 @@ import { Jimp, JimpMime } from '../jimp.js';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 
 import { getConfigValue } from '../util.js';
+import { isFirefox } from '../express-common.js';
 
 const thumbnailsEnabled = !!getConfigValue('thumbnails.enabled', true, 'boolean');
 const quality = Math.min(100, Math.max(1, parseInt(getConfigValue('thumbnails.quality', 95, 'number'))));
@@ -238,6 +239,11 @@ router.get('/', async function (request, response) {
         const contentType = mime.lookup(pathToCachedFile) || 'image/jpeg';
         const cachedFile = await fsPromises.readFile(pathToCachedFile);
         response.setHeader('Content-Type', contentType);
+
+        if (isFirefox(request) && contentType.startsWith('image/')) {
+            response.setHeader('Cache-Control', 'must-understand, no-store');
+        }
+
         return response.send(cachedFile);
     } catch (error) {
         console.error('Failed getting thumbnail', error);

--- a/src/express-common.js
+++ b/src/express-common.js
@@ -43,7 +43,7 @@ export function getRealIpFromHeader(req) {
 
 /**
  * Checks if the request is coming from a Firefox browser.
- * @param {import('express').Request} req
+ * @param {import('express').Request} req Request object
  * @returns {boolean} True if the request is from Firefox, false otherwise.
  */
 export function isFirefox(req) {

--- a/src/express-common.js
+++ b/src/express-common.js
@@ -40,3 +40,13 @@ export function getRealIpFromHeader(req) {
 
     return getIpFromRequest(req);
 }
+
+/**
+ * Checks if the request is coming from a Firefox browser.
+ * @param {import('express').Request} req
+ * @returns {boolean} True if the request is from Firefox, false otherwise.
+ */
+export function isFirefox(req) {
+    const userAgent = req.headers['user-agent'] || '';
+    return /firefox/i.test(userAgent);
+}

--- a/src/users.js
+++ b/src/users.js
@@ -20,6 +20,7 @@ import { getConfigValue, color, delay, generateTimestamp } from './util.js';
 import { readSecret, writeSecret } from './endpoints/secrets.js';
 import { getContentOfType } from './endpoints/content-manager.js';
 import { serverDirectory } from './server-directory.js';
+import { isFirefox } from './express-common.js';
 
 export const KEY_PREFIX = 'user:';
 const AVATAR_PREFIX = 'avatar:';
@@ -955,9 +956,11 @@ function createRouteHandler(directoryFn) {
 
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control
             // Without this, firefox ignores updated images even on refresh.
-            const mimeType = mime.lookup(filePath);
-            if (mimeType && mimeType.startsWith('image/')) {
-                res.setHeader('Cache-Control', 'must-understand, no-store');
+            if (isFirefox(req)) {
+                const mimeType = mime.lookup(filePath);
+                if (mimeType && mimeType.startsWith('image/')) {
+                    res.setHeader('Cache-Control', 'must-understand, no-store');
+                }
             }
 
             return res.sendFile(filePath, { root: directory });

--- a/src/users.js
+++ b/src/users.js
@@ -16,11 +16,10 @@ import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import sanitize from 'sanitize-filename';
 
 import { USER_DIRECTORY_TEMPLATE, DEFAULT_USER, PUBLIC_DIRECTORIES, SETTINGS_FILE, UPLOADS_DIRECTORY } from './constants.js';
-import { getConfigValue, color, delay, generateTimestamp } from './util.js';
+import { getConfigValue, color, delay, generateTimestamp, invalidateFirefoxCache } from './util.js';
 import { readSecret, writeSecret } from './endpoints/secrets.js';
 import { getContentOfType } from './endpoints/content-manager.js';
 import { serverDirectory } from './server-directory.js';
-import { isFirefox } from './express-common.js';
 
 export const KEY_PREFIX = 'user:';
 const AVATAR_PREFIX = 'avatar:';
@@ -954,15 +953,7 @@ function createRouteHandler(directoryFn) {
                 return res.sendStatus(404);
             }
 
-            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control
-            // Without this, firefox ignores updated images even on refresh.
-            if (isFirefox(req)) {
-                const mimeType = mime.lookup(filePath);
-                if (mimeType && mimeType.startsWith('image/')) {
-                    res.setHeader('Cache-Control', 'must-understand, no-store');
-                }
-            }
-
+            invalidateFirefoxCache(filePath, req, res);
             return res.sendFile(filePath, { root: directory });
         } catch (error) {
             return res.sendStatus(500);

--- a/src/users.js
+++ b/src/users.js
@@ -952,6 +952,14 @@ function createRouteHandler(directoryFn) {
             if (!exists) {
                 return res.sendStatus(404);
             }
+
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control
+            // Without this, firefox ignores updated images even on refresh.
+            const mimeType = mime.lookup(filePath);
+            if (mimeType && mimeType.startsWith('image/')) {
+                res.setHeader('Cache-Control', 'must-understand, no-store');
+            }
+
             return res.sendFile(filePath, { root: directory });
         } catch (error) {
             return res.sendStatus(500);

--- a/src/util.js
+++ b/src/util.js
@@ -1306,8 +1306,8 @@ export function flattenSchema(schema, api) {
  * @param {import('express').Response} response
  */
 export function invalidateFirefoxCache(file, request, response) {
-    const mimeType = mime.lookup(file);
-    if (mimeType && isFirefox(request) && mimeType.startsWith('image/')) {
+    const mimeType = isFirefox(request) && mime.lookup(file);
+    if (mimeType && mimeType.startsWith('image/')) {
         response.setHeader('Cache-Control', 'must-understand, no-store');
     }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1301,9 +1301,9 @@ export function flattenSchema(schema, api) {
  * If the file is an image, and the request's user agent matches Firefox, then the response's headers are set to invalidate the cache.
  * Without this, Firefox ignores updated images even after a refresh.
  * https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control
- * @param {string} file
- * @param {import('express').Request} request
- * @param {import('express').Response} response
+ * @param {string} file File path
+ * @param {import('express').Request} request Request object
+ * @param {import('express').Response} response Response object
  */
 export function invalidateFirefoxCache(file, request, response) {
     const mimeType = isFirefox(request) && mime.lookup(file);

--- a/src/util.js
+++ b/src/util.js
@@ -19,6 +19,7 @@ import chalk from 'chalk';
 import bytes from 'bytes';
 import { LOG_LEVELS, CHAT_COMPLETION_SOURCES } from './constants.js';
 import { serverDirectory } from './server-directory.js';
+import { isFirefox } from './express-common.js';
 
 /**
  * Parsed config object.
@@ -1294,4 +1295,19 @@ export function flattenSchema(schema, api) {
     const flattenedSchema = resolve(schemaCopy);
     delete flattenedSchema.$schema;
     return flattenedSchema;
+}
+
+/**
+ * If the file is an image, and the request's user agent matches Firefox, then the response's headers are set to invalidate the cache.
+ * Without this, Firefox ignores updated images even after a refresh.
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control
+ * @param {string} file
+ * @param {import('express').Request} request
+ * @param {import('express').Response} response
+ */
+export function invalidateFirefoxCache(file, request, response) {
+    const mimeType = mime.lookup(file);
+    if (mimeType && isFirefox(request) && mimeType.startsWith('image/')) {
+        response.setHeader('Cache-Control', 'must-understand, no-store');
+    }
 }


### PR DESCRIPTION
I was able to reproduce https://github.com/SillyTavern/SillyTavern/issues/3199.

With this fix, images will update without a refresh on Firefox.

This invalidates all image caches.
If the extra image requests are a problem, I can keep a list of image hashes and set `Cache-Control: must-understand, no-store` when a new hash is seen in `createRouteHandler`.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
