### PR TITLE
fix: reorder regex import target popup

### DIFF
--- a/public/scripts/extensions/regex/importTarget.html
+++ b/public/scripts/extensions/regex/importTarget.html
@@ -9,16 +9,16 @@
                 Global Scripts
             </span>
         </label>
-        <label for="regex_import_target_scoped">
-            <input type="radio" name="regex_import_target" id="regex_import_target_scoped" value="scoped" />
-            <span data-i18n="ext_regex_scoped_scripts">
-                Scoped Scripts
-            </span>
-        </label>
         <label for="regex_import_target_preset">
             <input type="radio" name="regex_import_target" id="regex_import_target_preset" value="preset" />
             <span data-i18n="ext_regex_preset_scripts">
                 Preset Scripts
+            </span>
+        </label>
+        <label for="regex_import_target_scoped">
+            <input type="radio" name="regex_import_target" id="regex_import_target_scoped" value="scoped" />
+            <span data-i18n="ext_regex_scoped_scripts">
+                Scoped Scripts
             </span>
         </label>
     </div>


### PR DESCRIPTION
- reorder regex import target popup to `global -> preset -> scoped`, which is missed in #4672

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
