### PR TITLE
Raise max response length to 128k for GPT-5 models

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -648,7 +648,7 @@
                                         Max Response Length (tokens)
                                     </div>
                                     <div class="wide100p">
-                                        <input type="number" id="openai_max_tokens" name="openai_max_tokens" class="text_pole" min="1" max="65536" step="1">
+                                        <input type="number" id="openai_max_tokens" name="openai_max_tokens" class="text_pole" min="1" max="128000" step="1">
                                     </div>
                                 </div>
                                 <div class="range-block" data-source="openai,custom,xai,aimlapi,moonshot,azure_openai">


### PR DESCRIPTION
Increase the maximum value of the "Max Response Length" input box in the Chat Completions UI from 65,536 to 128,000.

This change allows users to leverage the full output length supported by the GPT-5 series of models[^1].

[^1]: https://platform.openai.com/docs/models/gpt-5

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).