### PR TITLE
Feat: Improve multiline input handling in popups

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7267,7 +7267,7 @@ export function setUserName(value, { toastPersonaNameChange = true } = {}) {
 
 async function doOnboarding(avatarId) {
     const template = $('#onboarding_template .onboarding');
-    let userName = await callGenericPopup(template, POPUP_TYPE.INPUT, currentUser?.name || name1, { rows: 2, wider: true, cancelButton: false });
+    let userName = await callGenericPopup(template, POPUP_TYPE.INPUT, currentUser?.name || name1, { wider: true, cancelButton: false });
 
     if (userName) {
         userName = String(userName).replace('\n', ' ');

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -306,7 +306,7 @@ async function captionMultimodal(base64Img, externalPrompt) {
     let prompt = externalPrompt || extension_settings.caption.prompt || PROMPT_DEFAULT;
 
     if (!externalPrompt && extension_settings.caption.prompt_ask) {
-        const customPrompt = await callGenericPopup('Enter a comment or question:', POPUP_TYPE.INPUT, prompt, { rows: 2 });
+        const customPrompt = await callGenericPopup('Enter a comment or question:', POPUP_TYPE.INPUT, prompt, { rows: 4 });
         if (!customPrompt) {
             throw new Error('User aborted the caption sending.');
         }

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -286,7 +286,7 @@ async function createConnectionProfile(forceName = null) {
     });
     const isNameTaken = (n) => extension_settings.connectionManager.profiles.some(p => p.name === n);
     const suggestedName = getUniqueName(collapseSpaces(`${profile.api ?? ''} ${profile.model ?? ''} - ${profile.preset ?? ''}`), isNameTaken);
-    let name = forceName ?? await callGenericPopup(template, POPUP_TYPE.INPUT, suggestedName, { rows: 2 });
+    let name = forceName ?? await callGenericPopup(template, POPUP_TYPE.INPUT, suggestedName);
     // If it's cancelled, it will be false
     if (!name) {
         return null;
@@ -607,7 +607,6 @@ async function renderDetailsContent(detailsContent) {
         }, {});
         const template = $(await renderExtensionTemplateAsync(MODULE_NAME, 'edit', { name: profile.name, settings }));
         let newName = await callGenericPopup(template, POPUP_TYPE.INPUT, profile.name, {
-            rows: 2,
             customButtons: [{
                 text: t`Save and Update`,
                 classes: ['popup-button-ok'],

--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -461,6 +461,13 @@ export class Popup {
                     if (input instanceof HTMLInputElement && !shouldSendOnEnter())
                         return;
 
+                    // If this is a multiline input popup, we should still not simply send on enter, that'd be weird.
+                    // Let's still make it possible if CTRL is toggled though
+                    if ((textarea instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)
+                        && !evt.ctrlKey && this.mainInput.rows > 1) {
+                        return;
+                    }
+
                     evt.preventDefault();
                     evt.stopPropagation();
                     const result = Number(document.activeElement.getAttribute('data-result') ?? this.defaultResult);
@@ -688,7 +695,7 @@ export class Popup {
     };
 }
 
-class PopupUtils {
+export class PopupUtils {
     /**
      * Builds popup content with header and text below
      *

--- a/public/scripts/scrapers.js
+++ b/public/scripts/scrapers.js
@@ -528,7 +528,7 @@ class YouTubeScraper {
     async scrape() {
         let lang = '';
         const template = $(await renderExtensionTemplateAsync('attachments', 'youtube-scrape', {}));
-        const videoUrl = await callGenericPopup(template, POPUP_TYPE.INPUT, '', { wide: false, large: false, okButton: 'Scrape', cancelButton: 'Cancel', rows: 2 });
+        const videoUrl = await callGenericPopup(template, POPUP_TYPE.INPUT, '', { wide: false, large: false, okButton: 'Scrape', cancelButton: 'Cancel' });
 
         template.find('input[name="youtubeLanguageCode"]').on('input', function () {
             lang = String($(this).val()).trim();


### PR DESCRIPTION
Not sure this was intended in the past before or wasn't. There were some other checks on when to actually use "Send as Enter" in popups.
But when I tested working with popups, I felt it was quite unintuitive. If a popup has a single-line input as the main input, then pressing enter should send and commit the popup. Makes sense.
If the input is multiple and text easily being editable with linebreaks, it should **not** commit and send the input simply because Enter is pressed. That would feel very counter-intuitive.

Still kept a short-hand to send without clicking the button, but a more sane keybind.

### Changes

- Added Ctrl+Enter requirement for submission in multiline input popups to prevent accidental sends
- Exported PopupUtils class for external use

## Copilot Summary
This pull request improves the user experience for multiline input popups and makes a utility class available for import elsewhere. The most important changes are grouped below.

Multiline input behavior improvements:

* Updated the `Popup` class in `public/scripts/popup.js` so that pressing Enter in a multiline input does not automatically send the input unless the Ctrl key is held, making interactions more intuitive for users.

Codebase modernization:

* Changed `PopupUtils` from a regular class to an exported class in `public/scripts/popup.js`, allowing it to be imported and used in other modules.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).