### PR TITLE
Fix: Prevent data loss on bulk regex move to scoped scripts

### DIFF
--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -1855,6 +1855,10 @@ jQuery(async () => {
     });
 
     $('#bulk_regex_move_to_scoped').on('click', async () => {
+        if (this_chid === undefined) {
+            toastr.error(t`No character selected.`);
+            return;
+        }
         const confirm = await callGenericPopup(t`Are you sure you want to move the selected regex scripts to scoped?`, POPUP_TYPE.CONFIRM);
         if (!confirm) {
             return;

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -1859,6 +1859,10 @@ jQuery(async () => {
             toastr.error(t`No character selected.`);
             return;
         }
+        if (selected_group) {
+            toastr.error(t`Cannot edit scoped scripts in group chats.`);
+            return;
+        }
         const confirm = await callGenericPopup(t`Are you sure you want to move the selected regex scripts to scoped?`, POPUP_TYPE.CONFIRM);
         if (!confirm) {
             return;


### PR DESCRIPTION
### What was the bug?

The "Move to scoped scripts" button for bulkedit of regex was missing a safety check. If a user selected multiple regex scripts and clicked "Move to scoped scripts" without an active character loaded or if a group chat is selected, the scripts would be deleted from their source list but would not be added to the non-existent scoped list. This resulted in data loss.

This safety check already existed for the single-script "Move to scoped" action, but not for the bulk action.



### What does this PR do?

This PR copies the existing safety check from the single-move handler and adds it to the bulk-move handler.
If the user clicks on "move to scoped scripts" without an active character or if a group is activated, a warning message pops up and prevents user from proceeding. The scripts remain in their original list, preventing data loss.


### How to test:
Activate Silly Tavern without selecting a character or select a group chat. Navigate to regex section and click on "Move to scoped scripts" in bulkedit bar. Error message will pop out and the user will not be able to proceed with moving scripts.


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
