### PR TITLE
Add max-height and scrolling to world info entry key input fields

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -237,6 +237,14 @@
     display: none;
 }
 
+.world_entry .select2-selection--multiple,
+.world_entry textarea.keyprimarytextpole,
+.world_entry textarea.keysecondarytextpole {
+    max-height: 160px;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
 span.select2-container .select2-selection__choice__display:has(> .regex_item),
 span.select2-container .select2-results__option:has(> .result_block .regex_item) {
     background-color: #D27D2D30;


### PR DESCRIPTION
Tiny fix because I was shown how weird WI entries can look with tons of key entries - in both modes.
Makes sense to simply limit the height.
I personally chose 160px as decent enough, but honestly that choice is kinda arbitrary.

- Added 160px max-height to select2 multiple selection, primary key, and secondary key text areas in world entries
- Enabled vertical scrolling with hidden horizontal overflow for better UX with long content

## Copilot Summary
This pull request introduces a minor UI improvement to the world info editor. The change ensures that multi-select dropdowns and certain textareas within `.world_entry` have a maximum height and scrollbars, which will help prevent these fields from growing too large and improve usability.

* UI enhancements for world info editor:
  * Added `max-height`, vertical scrollbar, and hidden horizontal overflow to `.select2-selection--multiple` and specific textareas in `.world_entry` to improve field usability.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
