### PR TITLE
Preserve media playback state when running appendMediaToMessage

### DIFF
--- a/public/global.d.ts
+++ b/public/global.d.ts
@@ -85,6 +85,14 @@ declare global {
         captioned?: boolean;
     }
 
+    /** Media playback state */
+    interface MediaState {
+        /** Current playback time */
+        currentTime: number;
+        /** Whether the media is paused */
+        paused: boolean;
+    }
+
     // Global namespace modules
     interface Window {
         ai: any;

--- a/public/script.js
+++ b/public/script.js
@@ -2247,6 +2247,9 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
         const media = mediaWrapper.find('video, audio');
         media.each((_, element) => {
             if (element instanceof HTMLMediaElement) {
+                if (!element.currentSrc || element.readyState === HTMLMediaElement.HAVE_NOTHING) {
+                    return;
+                }
                 const state = { currentTime: element.currentTime, paused: element.paused };
                 states.set(element.currentSrc, state);
             }
@@ -2262,10 +2265,17 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
         const media = mediaWrapper.find('video, audio');
         media.each((_, element) => {
             if (element instanceof HTMLMediaElement && states.has(element.currentSrc)) {
-                const state = states.get(element.currentSrc);
-                element.currentTime = state.currentTime;
-                if (!state.paused) {
-                    element.play();
+                const restoreState = () => {
+                    const state = states.get(element.currentSrc);
+                    element.currentTime = state.currentTime;
+                    if (!state.paused) {
+                        element.play();
+                    }
+                };
+                if (element.readyState < HTMLMediaElement.HAVE_METADATA) {
+                    element.addEventListener('loadedmetadata', () => restoreState(), { once: true });
+                } else {
+                    restoreState();
                 }
             }
         });

--- a/public/script.js
+++ b/public/script.js
@@ -2246,15 +2246,15 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
      * @property {boolean} paused Whether the media is paused
      */
     function saveMediaStates() {
-        const times = new Map();
+        const states = new Map();
         const media = mediaWrapper.find('video, audio');
         media.each((_, element) => {
             if (element instanceof HTMLMediaElement) {
                 const state = { currentTime: element.currentTime, paused: element.paused };
-                times.set(element.currentSrc, state);
+                states.set(element.currentSrc, state);
             }
         });
-        return times;
+        return states;
     }
 
     /**

--- a/public/script.js
+++ b/public/script.js
@@ -2241,9 +2241,6 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
     /**
      * Saves the current playback times of media elements in the message.
      * @returns {Map<string, MediaState>} Media playback times by source URL
-     * @typedef {object} MediaState
-     * @property {number} currentTime Current playback time
-     * @property {boolean} paused Whether the media is paused
      */
     function saveMediaStates() {
         const states = new Map();

--- a/public/script.js
+++ b/public/script.js
@@ -2264,8 +2264,11 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
     function restoreMediaStates(states) {
         const media = mediaWrapper.find('video, audio');
         media.each((_, element) => {
-            if (element instanceof HTMLMediaElement && states.has(element.currentSrc)) {
+            if (element instanceof HTMLMediaElement) {
                 const restoreState = () => {
+                    if (!states.has(element.currentSrc)) {
+                        return;
+                    }
                     const state = states.get(element.currentSrc);
                     element.currentTime = state.currentTime;
                     if (!state.paused) {

--- a/public/script.js
+++ b/public/script.js
@@ -2247,7 +2247,7 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
      */
     function saveMediaStates() {
         const times = new Map();
-        const media = messageElement.find('.mes_media_container video, .mes_media_container audio');
+        const media = mediaWrapper.find('video, audio');
         media.each((_, element) => {
             if (element instanceof HTMLMediaElement) {
                 const state = { currentTime: element.currentTime, paused: element.paused };
@@ -2262,7 +2262,7 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
      * @param {Map<string, MediaState>} states Media playback times by source URL
      */
     function restoreMediaStates(states) {
-        const media = messageElement.find('.mes_media_container video, .mes_media_container audio');
+        const media = mediaWrapper.find('video, audio');
         media.each((_, element) => {
             if (element instanceof HTMLMediaElement && states.has(element.currentSrc)) {
                 const state = states.get(element.currentSrc);

--- a/public/script.js
+++ b/public/script.js
@@ -2077,9 +2077,12 @@ export function getMediaIndex(mes) {
 export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROLL_BEHAVIOR.ADJUST) {
     ensureMessageMediaIsArray(mes);
 
+    const fileWrapper = messageElement.find('.mes_file_wrapper');
+    const mediaWrapper = messageElement.find('.mes_media_wrapper');
+
     const hasMedia = Array.isArray(mes?.extra?.media) && mes.extra.media.length > 0;
     const hasFiles = Array.isArray(mes?.extra?.files) && mes.extra.files.length > 0;
-    const mediaDisplay = getMediaDisplay(mes);
+    const mediaDisplay = hasMedia ? getMediaDisplay(mes) : null;
     const hideMessageText = hasMedia && mes?.extra?.inline_image === false;
 
     const mediaBlocks = [];
@@ -2235,6 +2238,42 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
         return appendImageAttachment(attachment, index);
     }
 
+    /**
+     * Saves the current playback times of media elements in the message.
+     * @returns {Map<string, MediaState>} Media playback times by source URL
+     * @typedef {object} MediaState
+     * @property {number} currentTime Current playback time
+     * @property {boolean} paused Whether the media is paused
+     */
+    function saveMediaStates() {
+        const times = new Map();
+        const media = messageElement.find('.mes_media_container video, .mes_media_container audio');
+        media.each((_, element) => {
+            if (element instanceof HTMLMediaElement) {
+                const state = { currentTime: element.currentTime, paused: element.paused };
+                times.set(element.currentSrc, state);
+            }
+        });
+        return times;
+    }
+
+    /**
+     * Restores the playback times of media elements in the message.
+     * @param {Map<string, MediaState>} states Media playback times by source URL
+     */
+    function restoreMediaStates(states) {
+        const media = messageElement.find('.mes_media_container video, .mes_media_container audio');
+        media.each((_, element) => {
+            if (element instanceof HTMLMediaElement && states.has(element.currentSrc)) {
+                const state = states.get(element.currentSrc);
+                element.currentTime = state.currentTime;
+                if (!state.paused) {
+                    element.play();
+                }
+            }
+        });
+    }
+
     // Add media gallery to message
     if (hasMedia && mediaDisplay === MEDIA_DISPLAY.GALLERY) {
         const mediaIndex = getMediaIndex(mes);
@@ -2258,7 +2297,7 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
     }
 
     // Remove existing file containers
-    messageElement.find('.mes_file_wrapper').empty();
+    fileWrapper.empty();
 
     // Add files to message
     if (hasFiles) {
@@ -2268,13 +2307,22 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
             template.attr('data-index', index);
             template.find('.mes_file_name').text(file.name).attr('title', file.name);
             template.find('.mes_file_size').text(humanFileSize(file.size)).attr('title', file.size);
-            messageElement.find('.mes_file_wrapper').append(template);
+            fileWrapper.append(template);
         }
+    }
+
+    // Early return if no media
+    if (!hasMedia) {
+        mediaWrapper.empty();
+        doAdjustScroll();
+        return;
     }
 
     // TODO: Consider making this awaitable
     Promise.race([Promise.all(mediaPromises), delay(debounce_timeout.short)]).then(() => {
-        messageElement.find('.mes_media_wrapper').empty().append(mediaBlocks);
+        const states = saveMediaStates();
+        mediaWrapper.empty().append(mediaBlocks);
+        restoreMediaStates(states);
         doAdjustScroll();
     });
 }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Save current time and playback state of audios/videos when re-rendering media blocks in a message.
2. Don't set `data-media-display` message block attribute when message got no media.
3. Add early sync return when message got no media.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
