### PR TITLE
Add Gemini 3 for Vertex AI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3337,6 +3337,9 @@
                                 <h4 data-i18n="Google Model">Google Model</h4>
                                 <select id="model_vertexai_select">
                                     <!-- data-mode="full" is for models that require a service account -->
+                                    <optgroup label="Gemini 3.0">
+                                        <option value="gemini-3-pro-preview">gemini-3-pro-preview</option>
+                                    </optgroup>
                                     <optgroup label="Gemini 2.5">
                                         <option value="gemini-2.5-pro">gemini-2.5-pro</option>
                                         <option value="gemini-2.5-flash">gemini-2.5-flash</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -132,6 +132,7 @@
                         <option data-type="google" value="gemini-2.0-flash-lite-preview">gemini-2.0-flash-lite-preview</option>
                         <option data-type="google" value="learnlm-2.0-flash-experimental">learnlm-2.0-flash-experimental</option>
                         <option data-type="google" value="gemini-robotics-er-1.5-preview">gemini-robotics-er-1.5-preview</option>
+                        <option data-type="vertexai" value="gemini-3-pro-preview">gemini-3-pro-preview</option>
                         <option data-type="vertexai" value="gemini-2.5-pro">gemini-2.5-pro</option>
                         <option data-type="vertexai" value="gemini-2.5-flash">gemini-2.5-flash</option>
                         <option data-type="vertexai" value="gemini-2.5-flash-lite">gemini-2.5-flash-lite</option>


### PR DESCRIPTION
Gemini 3 Pro Preview is also available on Vertex AI.
(I haven't done a test for the express mode as I don't have an express mode token, sorry)

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
