### PR TITLE
Feat/Link sampler selection lock to TC API Type

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -251,7 +251,7 @@ import { currentUser, setUserControls } from './scripts/user.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup, fixToastrForDialogs } from './scripts/popup.js';
 import { renderTemplate, renderTemplateAsync } from './scripts/templates.js';
 import { initScrapers } from './scripts/scrapers.js';
-import { initCustomSelectedSamplers, validateDisabledSamplers } from './scripts/samplerSelect.js';
+import { initCustomSelectedSamplers, loadApiSelectedSamplers, validateDisabledSamplers } from './scripts/samplerSelect.js';
 import { DragAndDropHandler } from './scripts/dragdrop.js';
 import { INTERACTABLE_CONTROL_CLASS, initKeyboard } from './scripts/keyboard.js';
 import { initDynamicStyles } from './scripts/dynamic-styles.js';
@@ -7395,6 +7395,7 @@ export async function getSettings() {
         loadNovelSettings(data, settings.nai_settings ?? settings);
 
         // TextGen
+        await loadApiSelectedSamplers();
         loadTextGenSettings(data, settings);
 
         // OpenAI

--- a/public/script.js
+++ b/public/script.js
@@ -251,7 +251,7 @@ import { currentUser, setUserControls } from './scripts/user.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup, fixToastrForDialogs } from './scripts/popup.js';
 import { renderTemplate, renderTemplateAsync } from './scripts/templates.js';
 import { initScrapers } from './scripts/scrapers.js';
-import { initCustomSelectedSamplers, loadApiSelectedSamplers, validateDisabledSamplers } from './scripts/samplerSelect.js';
+import { initCustomSelectedSamplers, validateDisabledSamplers } from './scripts/samplerSelect.js';
 import { DragAndDropHandler } from './scripts/dragdrop.js';
 import { INTERACTABLE_CONTROL_CLASS, initKeyboard } from './scripts/keyboard.js';
 import { initDynamicStyles } from './scripts/dynamic-styles.js';
@@ -7395,8 +7395,7 @@ export async function getSettings() {
         loadNovelSettings(data, settings.nai_settings ?? settings);
 
         // TextGen
-        await loadApiSelectedSamplers();
-        loadTextGenSettings(data, settings);
+        await loadTextGenSettings(data, settings);
 
         // OpenAI
         loadOpenAISettings(data, settings.oai_settings ?? settings);

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -47,8 +47,8 @@ const CC_COMMANDS = [
 ];
 
 const TC_COMMANDS = [
-    'preset',
     'api',
+    'preset',
     'api-url',
     'model',
     'sysprompt',

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -27,7 +27,6 @@ import { oai_settings, openai_setting_names, openai_settings } from './openai.js
 import { POPUP_RESULT, POPUP_TYPE, Popup } from './popup.js';
 import { context_presets, getContextSettings, power_user } from './power-user.js';
 import { reasoning_templates } from './reasoning.js';
-import { getManualPresetSamplers, resetPresetSelectedSamplers, setPresetSamplersState } from './samplerSelect.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument } from './slash-commands/SlashCommandArgument.js';
 import { enumIcons } from './slash-commands/SlashCommandCommonEnumsProvider.js';
@@ -1070,16 +1069,6 @@ export async function initPresetManager() {
             // This is a horrible mess, but prevents the renamed preset from being corrupted.
             $('#update_oai_preset').trigger('click');
             return;
-        }
-
-        if (apiId === 'textgenerationwebui') {
-            const manualSamplersIterable = Object.entries(getManualPresetSamplers(oldName));
-
-            for (const [sampler, value] of manualSamplersIterable) {
-                setPresetSamplersState(sampler, value, newName);
-            }
-
-            await resetPresetSelectedSamplers(oldName, true);
         }
 
         const successToast = !presetManager.isAdvancedFormatting() ? t`Preset renamed` : t`Template renamed`;

--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -14,8 +14,11 @@ import { localforage } from '../lib.js';
 
 const forcedOnColoring = 'color: #89db35;';
 const forcedOffColoring = 'color: #e84f62;';
-
-let userDisabledSamplers, userShownSamplers;
+const SELECT_SAMPLER = {
+    DATA: 'selectsampler',
+    SHOWN: 'shown',
+    HIDDEN: 'hidden',
+}
 
 const textGenObjectStore = localforage.createInstance({ name: 'SillyTavern_TextCompletions' });
 let selectedSamplers = {};
@@ -38,10 +41,6 @@ async function showSamplerSelectPopup() {
 
     $('#resetSelectedSamplers').off('click').on('click', async function () {
         console.log('saw sampler select reset click');
-        userDisabledSamplers = [];
-        userShownSamplers = [];
-        power_user.selectSamplers.forceShown = [];
-        power_user.selectSamplers.forceHidden = [];
 
         if (main_api === 'textgenerationwebui') {
             $('#prioritizeManuallySelectedSamplers').toggleClass('toggleEnabled', false);
@@ -49,15 +48,6 @@ async function showSamplerSelectPopup() {
         }
 
         await validateDisabledSamplers(true);
-    });
-
-    $('#textgen_type').on('change', async function () {
-        console.log('changed TG Type, resetting custom samplers'); //unfortunate, but necessary unless we save custom samplers for each TGTytpe
-        userDisabledSamplers = [];
-        userShownSamplers = [];
-        power_user.selectSamplers.forceShown = [];
-        power_user.selectSamplers.forceHidden = [];
-        await validateDisabledSamplers();
     });
 
     if (main_api === 'textgenerationwebui') {
@@ -79,135 +69,140 @@ async function showSamplerSelectPopup() {
     if (main_api === 'textgenerationwebui') await saveApiSelectedSamplers();
 }
 
+function getRelatedDOMElement(samplerName) {
+    let relatedDOMElement = $(`#${samplerName}_${main_api}`).parent();
+    let targetDisplayType = 'flex';
+    let displayname;
+
+    if (samplerName === 'json_schema') {
+        relatedDOMElement = $('#json_schema_block');
+        targetDisplayType = 'block';
+        displayname = 'JSON Schema Block';
+    }
+
+    if (samplerName === 'grammar_string') {
+        relatedDOMElement = $('#grammar_block_ooba');
+        targetDisplayType = 'block';
+        displayname = 'Grammar Block';
+    }
+
+    if (samplerName === 'guidance_scale') {
+        relatedDOMElement = $('#cfg_block_ooba');
+        targetDisplayType = 'block';
+        displayname = 'CFG Block';
+    }
+
+    if (samplerName === 'mirostat_mode') {
+        relatedDOMElement = $('#mirostat_block_ooba');
+        targetDisplayType = 'block';
+        displayname = 'Mirostat Block';
+    }
+
+    if (samplerName === 'dry_multiplier') {
+        relatedDOMElement = $('#dryBlock');
+        targetDisplayType = 'block';
+        displayname = 'DRY Rep Pen Block';
+    }
+
+    if (samplerName === 'xtc_probability') {
+        relatedDOMElement = $('#xtc_block');
+        targetDisplayType = 'block';
+        displayname = 'XTC Block';
+    }
+
+    if (samplerName === 'dynatemp') {
+        relatedDOMElement = $('#dynatemp_block_ooba');
+        targetDisplayType = 'block';
+        displayname = 'DynaTemp Block';
+    }
+
+    if (samplerName === 'banned_tokens') {
+        relatedDOMElement = $('#banned_tokens_block_ooba');
+        targetDisplayType = 'block';
+    }
+
+    if (samplerName === 'sampler_order') { //this is for kcpp sampler order
+        relatedDOMElement = $('#sampler_order_block_kcpp');
+        displayname = 'KCPP Sampler Order Block';
+    }
+
+    if (samplerName === 'samplers') { //this is for lcpp sampler order
+        relatedDOMElement = $('#sampler_order_block_lcpp');
+        displayname = 'LCPP Sampler Order Block';
+    }
+
+    if (samplerName === 'sampler_priority') { //this is for ooba's sampler priority
+        relatedDOMElement = $('#sampler_priority_block_ooba');
+        displayname = 'Ooba Sampler Priority Block';
+    }
+
+    if (samplerName === 'samplers_priorities') { //this is for aphrodite's sampler priority
+        relatedDOMElement = $('#sampler_priority_block_aphrodite');
+        displayname = 'Aphrodite Sampler Priority Block';
+    }
+
+    if (samplerName === 'penalty_alpha') { //contrastive search only has one sampler, does it need its own block?
+        relatedDOMElement = $('#contrastiveSearchBlock');
+        displayname = 'Contrast Search Block';
+    }
+
+    if (samplerName === 'num_beams') { // num_beams is the killswitch for Beam Search
+        relatedDOMElement = $('#beamSearchBlock');
+        targetDisplayType = 'block';
+        displayname = 'Beam Search Block';
+    }
+
+    if (samplerName === 'smoothing_factor') { // num_beams is the killswitch for Beam Search
+        relatedDOMElement = $('#smoothingBlock');
+        targetDisplayType = 'block';
+        displayname = 'Smoothing Block';
+    }
+
+    return { relatedDOMElement, targetDisplayType, displayname };
+}
+
 function setSamplerListListeners() {
     // Goal 2: hide unchecked samplers from DOM
     let listContainer = $('#apiSamplersList');
     listContainer.find('input').off('change').on('change', async function () {
-
         const samplerName = this.name.replace('_checkbox', '');
-        let relatedDOMElement = $(`#${samplerName}_${main_api}`).parent();
-        let targetDisplayType = 'flex';
-
-        if (samplerName === 'json_schema') {
-            relatedDOMElement = $('#json_schema_block');
-            targetDisplayType = 'block';
-        }
-
-        if (samplerName === 'grammar_string') {
-            relatedDOMElement = $('#grammar_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (samplerName === 'guidance_scale') {
-            relatedDOMElement = $('#cfg_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (samplerName === 'mirostat_mode') {
-            relatedDOMElement = $('#mirostat_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (samplerName === 'dry_multiplier') {
-            relatedDOMElement = $('#dryBlock');
-            targetDisplayType = 'block';
-        }
-
-        if (samplerName === 'xtc_probability') {
-            relatedDOMElement = $('#xtc_block');
-            targetDisplayType = 'block';
-        }
-
-        if (samplerName === 'dynatemp') {
-            relatedDOMElement = $('#dynatemp_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (samplerName === 'banned_tokens') {
-            relatedDOMElement = $('#banned_tokens_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (samplerName === 'sampler_order') { //this is for kcpp sampler order
-            relatedDOMElement = $('#sampler_order_block_kcpp');
-        }
-
-        if (samplerName === 'samplers') { //this is for lcpp sampler order
-            relatedDOMElement = $('#sampler_order_block_lcpp');
-        }
-
-        if (samplerName === 'sampler_priority') { //this is for ooba's sampler priority
-            relatedDOMElement = $('#sampler_priority_block_ooba');
-        }
-
-        if (samplerName === 'samplers_priorities') { //this is for aphrodite's sampler priority
-            relatedDOMElement = $('#sampler_priority_block_aphrodite');
-        }
-
-        if (samplerName === 'penalty_alpha') { //contrastive search only has one sampler, does it need its own block?
-            relatedDOMElement = $('#contrastiveSearchBlock');
-        }
-
-        if (samplerName === 'num_beams') { // num_beams is the killswitch for Beam Search
-            relatedDOMElement = $('#beamSearchBlock');
-            targetDisplayType = 'block';
-        }
-
-        if (samplerName === 'smoothing_factor') { // num_beams is the killswitch for Beam Search
-            relatedDOMElement = $('#smoothingBlock');
-            targetDisplayType = 'block';
-        }
+        const { relatedDOMElement, targetDisplayType } = getRelatedDOMElement(samplerName);
 
         // Get the current state of the custom data attribute
-        const previousState = relatedDOMElement.data('selectsampler');
+        const previousState = relatedDOMElement.data(SELECT_SAMPLER.DATA);
+        const isChecked = $(this).prop('checked');
+        const popupInputLabel = $(this).parent().find('.sampler_name');
 
-        if ($(this).prop('checked') === false) {
-            //console.log('saw clicking checkbox from on to off...');
-            if (previousState === 'shown') {
-                console.log('saw previously custom shown sampler');
-                //console.log('removing from custom force show list');
-                relatedDOMElement.removeData('selectsampler');
-                $(this).parent().find('.sampler_name').removeAttr('style');
-                power_user?.selectSamplers?.forceShown.splice(power_user?.selectSamplers?.forceShown.indexOf(samplerName), 1);
-                console.log(power_user?.selectSamplers?.forceShown);
+        if (isChecked === false) {
+            if (previousState === SELECT_SAMPLER.SHOWN) {
+                console.log('saw previously custom shown sampler => new state:', isChecked, samplerName);
+                relatedDOMElement.removeData(SELECT_SAMPLER.DATA);
+                popupInputLabel.removeAttr('style');
             } else {
-                console.log('saw previous untouched sampler');
-                //console.log(`adding ${samplerName} to force hide list`);
-                relatedDOMElement.data('selectsampler', 'hidden');
-                console.log(relatedDOMElement.data('selectsampler'));
-                power_user.selectSamplers.forceHidden.push(samplerName);
-                $(this).parent().find('.sampler_name').attr('style', forcedOffColoring);
-                console.log(power_user.selectSamplers.forceHidden);
+                console.log('saw previous untouched sampler => new state:', isChecked, samplerName);
+                relatedDOMElement.data(SELECT_SAMPLER.DATA, SELECT_SAMPLER.HIDDEN);
+                popupInputLabel.attr('style', forcedOffColoring);
             }
-        } else { // going from unchecked to checked
-            //console.log('saw clicking checkbox from off to on...');
-            if (previousState === 'hidden') {
-                console.log('saw previously custom hidden sampler');
-                //console.log('removing from custom force hide list');
-                relatedDOMElement.removeData('selectsampler');
-                $(this).parent().find('.sampler_name').removeAttr('style');
-                power_user?.selectSamplers?.forceHidden.splice(power_user?.selectSamplers?.forceHidden.indexOf(samplerName), 1);
-                console.log(power_user?.selectSamplers?.forceHidden);
+        } else {
+            if (previousState === SELECT_SAMPLER.HIDDEN) {
+                console.log('saw previously custom hidden sampler => new state:', isChecked, samplerName);
+                relatedDOMElement.removeData(SELECT_SAMPLER.DATA);
+                popupInputLabel.removeAttr('style');
             } else {
-                console.log('saw previous untouched sampler');
-                //console.log(`adding ${samplerName} to force shown list`);
-                relatedDOMElement.data('selectsampler', 'shown');
-                console.log(relatedDOMElement.data('selectsampler'));
-                power_user.selectSamplers.forceShown.push(samplerName);
-                $(this).parent().find('.sampler_name').attr('style', forcedOnColoring);
-                console.log(power_user.selectSamplers.forceShown);
+                console.log('saw previous untouched sampler => new state:', isChecked, samplerName);
+                relatedDOMElement.data(SELECT_SAMPLER.DATA, SELECT_SAMPLER.SHOWN);
+                popupInputLabel.attr('style', forcedOnColoring);
             }
         }
+
         await saveSettingsDebounced();
 
-        const shouldDisplay = $(this).prop('checked') ? targetDisplayType : 'none';
+        const shouldDisplay = isChecked ? targetDisplayType : 'none';
         relatedDOMElement.css('display', shouldDisplay);
 
-        if (main_api === 'textgenerationwebui') {
-            setApiSamplersState(samplerName, shouldDisplay !== 'none');
-        }
+        if (main_api === 'textgenerationwebui') setApiSamplersState(samplerName, shouldDisplay !== 'none');
 
-        console.log(samplerName, relatedDOMElement.data('selectsampler'), shouldDisplay);
+        console.log(samplerName, relatedDOMElement.data(SELECT_SAMPLER.DATA), shouldDisplay);
     });
 
 }
@@ -241,111 +236,38 @@ async function listSamplers(main_api, arrayOnly = false) {
     const prioritizeManualSamplerSelect = (main_api === 'textgenerationwebui') ? isSamplerManualPriorityEnabled() : false;
 
     const samplersListHTML = availableSamplers.reduce((html, sampler) => {
-        let customColor, displayname;
-        let targetDOMelement = $(`#${sampler}_${main_api}`);
-
-        if (sampler === 'sampler_order') { //this is for kcpp sampler order
-            targetDOMelement = $('#sampler_order_block_kcpp');
-            displayname = 'KCPP Sampler Order Block';
-        }
-
-        if (sampler === 'samplers') { //this is for lcpp sampler order
-            targetDOMelement = $('#sampler_order_block_lcpp');
-            displayname = 'LCPP Sampler Order Block';
-        }
-
-        if (sampler === 'sampler_priority') { //this is for ooba's sampler priority
-            targetDOMelement = $('#sampler_priority_block_ooba');
-            displayname = 'Ooba Sampler Priority Block';
-        }
-
-        if (sampler === 'samplers_priorities') { //this is for aphrodite's sampler priority
-            targetDOMelement = $('#sampler_priority_block_aphrodite');
-            displayname = 'Aphrodite Sampler Priority Block';
-        }
-
-        if (sampler === 'penalty_alpha') { //contrastive search only has one sampler, does it need its own block?
-            targetDOMelement = $('#contrastiveSearchBlock');
-            displayname = 'Contrast Search Block';
-        }
-
-        if (sampler === 'num_beams') { // num_beams is the killswitch for Beam Search
-            targetDOMelement = $('#beamSearchBlock');
-            displayname = 'Beam Search Block';
-        }
-
-        if (sampler === 'smoothing_factor') { // num_beams is the killswitch for Beam Search
-            targetDOMelement = $('#smoothingBlock');
-            displayname = 'Smoothing Block';
-        }
-
-        if (sampler === 'dry_multiplier') {
-            targetDOMelement = $('#dryBlock');
-            displayname = 'DRY Rep Pen Block';
-        }
-        if (sampler === 'xtc_probability') {
-            targetDOMelement = $('#xtc_block');
-            displayname = 'XTC Block';
-        }
-
-        if (sampler === 'dynatemp') {
-            targetDOMelement = $('#dynatemp_block_ooba');
-            displayname = 'DynaTemp Block';
-        }
-
-        if (sampler === 'json_schema') {
-            targetDOMelement = $('#json_schema_block');
-            displayname = 'JSON Schema Block';
-        }
-
-        if (sampler === 'grammar_string') {
-            targetDOMelement = $('#grammar_block_ooba');
-            displayname = 'Grammar Block';
-        }
-
-        if (sampler === 'guidance_scale') {
-            targetDOMelement = $('#cfg_block_ooba');
-            displayname = 'CFG Block';
-        }
-
-        if (sampler === 'mirostat_mode') {
-            targetDOMelement = $('#mirostat_block_ooba');
-            displayname = 'Mirostat Block';
-        }
+        let customColor;
+        let { relatedDOMElement, displayname } = getRelatedDOMElement(sampler);
 
         const isManuallyActivated = samplersActivatedManually.includes(sampler);
-        const isInForceHiddenArray = userDisabledSamplers.includes(sampler);
-        const isInForceShownArray = userShownSamplers.includes(sampler);
-        let isVisibleInDOM = isElementVisibleInDOM(targetDOMelement[0]);
-        const isInDefaultState = () => {
-            if (isVisibleInDOM && isInForceShownArray) { return false; }
-            else if (!isVisibleInDOM && isInForceHiddenArray) { return false; }
-            else { return true; }
-        };
+        const displayModified = relatedDOMElement.data(SELECT_SAMPLER.DATA);
+        const isInDefaultState = !displayModified;
 
         const shouldBeChecked = () => {
+            let finalState = isElementVisibleInDOM(relatedDOMElement[0]);
+
             if (prioritizeManualSamplerSelect) {
-                return isManuallyActivated;
+                finalState = isManuallyActivated;
             }
-            else if (isInForceHiddenArray) {
-                customColor = forcedOffColoring;
-                return false;
+
+            else if (!isInDefaultState) {
+                finalState = displayModified === SELECT_SAMPLER.SHOWN;
+                customColor = finalState ? forcedOnColoring : forcedOffColoring;
             }
-            else if (isInForceShownArray) {
-                customColor = forcedOnColoring;
-                return true;
-            }
-            else { return isVisibleInDOM; }
+
+            return finalState;
         };
-        console.log(sampler, targetDOMelement.prop('id'), isInDefaultState(), isInForceShownArray, isInForceHiddenArray, shouldBeChecked());
-        if (displayname === undefined) { displayname = sampler; }
+
+        console.log(sampler, relatedDOMElement.prop('id'), isInDefaultState, shouldBeChecked());
+
+        if (displayname === undefined) displayname = sampler;
         if (main_api === 'textgenerationwebui') setApiSamplersState(sampler, shouldBeChecked());
+
         return html + `
-        <div class="sampler_view_list_item wide50p flex-container">
+        <label class="sampler_view_list_item wide50p flex-container">
             <input type="checkbox" name="${sampler}_checkbox" ${shouldBeChecked() ? 'checked' : ''}>
             <small class="sampler_name" style="${customColor}">${displayname}</small>
-        </div>
-        `;
+        </label>`;
     }, '');
 
     return samplersListHTML;
@@ -365,99 +287,21 @@ export async function validateDisabledSamplers(redraw = false) {
     const prioritizeManualSamplerSelect = (main_api === 'textgenerationwebui') ? isSamplerManualPriorityEnabled() : false;
 
     for (const sampler of APISamplers) {
-        let relatedDOMElement = $(`#${sampler}_${main_api}`).parent();
-        let targetDisplayType = 'flex';
-
-        if (sampler === 'json_schema') {
-            relatedDOMElement = $('#json_schema_block');
-            targetDisplayType = 'block';
-        }
-
-        if (sampler === 'grammar_string') {
-            relatedDOMElement = $('#grammar_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (sampler === 'guidance_scale') {
-            relatedDOMElement = $('#cfg_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (sampler === 'mirostat_mode') {
-            relatedDOMElement = $('#mirostat_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (sampler === 'dynatemp') {
-            relatedDOMElement = $('#dynatemp_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (sampler === 'banned_tokens') {
-            relatedDOMElement = $('#banned_tokens_block_ooba');
-            targetDisplayType = 'block';
-        }
-
-        if (sampler === 'sampler_order') { //this is for kcpp sampler order
-            relatedDOMElement = $('#sampler_order_block_kcpp');
-        }
-
-        if (sampler === 'samplers') { //this is for lcpp sampler order
-            relatedDOMElement = $('#sampler_order_block_lcpp');
-        }
-
-        if (sampler === 'sampler_priority') { //this is for ooba's sampler priority
-            relatedDOMElement = $('#sampler_priority_block_ooba');
-        }
-
-        if (sampler === 'samplers_priorities') { //this is for aphrodite's sampler priority
-            relatedDOMElement = $('#sampler_priority_block_aphrodite');
-        }
-
-        if (sampler === 'dry_multiplier') {
-            relatedDOMElement = $('#dryBlock');
-            targetDisplayType = 'block';
-        }
-
-        if (sampler === 'xtc_probability') {
-            relatedDOMElement = $('#xtc_block');
-            targetDisplayType = 'block';
-        }
-
-        if (sampler === 'penalty_alpha') { //contrastive search only has one sampler, does it need its own block?
-            relatedDOMElement = $('#contrastiveSearchBlock');
-        }
-
-        if (sampler === 'num_beams') { // num_beams is the killswitch for Beam Search
-            relatedDOMElement = $('#beamSearchBlock');
-        }
-
-        if (sampler === 'smoothing_factor') { // num_beams is the killswitch for Beam Search
-            relatedDOMElement = $('#smoothingBlock');
-        }
-
-        if (power_user?.selectSamplers?.forceHidden.includes(sampler)) {
-            //default handling for standard sliders
-            relatedDOMElement.data('selectsampler', 'hidden');
-            relatedDOMElement.css('display', 'none');
-        } else if (power_user?.selectSamplers?.forceShown.includes(sampler)) {
-            relatedDOMElement.data('selectsampler', 'shown');
-            relatedDOMElement.css('display', targetDisplayType);
-        } else {
-            if (relatedDOMElement.data('selectsampler') === 'hidden') {
-                relatedDOMElement.removeAttr('selectsampler');
-                relatedDOMElement.css('display', targetDisplayType);
-            }
-            if (relatedDOMElement.data('selectsampler') === 'shown') {
-                relatedDOMElement.removeAttr('selectsampler');
-                relatedDOMElement.css('display', 'none');
-            }
-        }
+        const { relatedDOMElement, targetDisplayType } = getRelatedDOMElement(sampler);
 
         if (prioritizeManualSamplerSelect) {
             const isManuallyActivated = samplersActivatedManually.includes(sampler);
             relatedDOMElement.css('display', isManuallyActivated ? targetDisplayType : 'none');
+        } else {
+            const selectSamplerData = relatedDOMElement.data(SELECT_SAMPLER.DATA);
+            relatedDOMElement.css('display', selectSamplerData === SELECT_SAMPLER.SHOWN ? targetDisplayType : 'none');
         }
+
+        relatedDOMElement.removeData(SELECT_SAMPLER.DATA);
+    }
+
+    if (!prioritizeManualSamplerSelect && main_api === 'textgenerationwebui') {
+        showTGSamplerControls();
     }
 
     if (redraw) {
@@ -595,11 +439,6 @@ export function isSamplerManualPriorityEnabled(tcApiType = '') {
 }
 
 export async function initCustomSelectedSamplers() {
-    userDisabledSamplers = power_user?.selectSamplers?.forceHidden || [];
-    userShownSamplers = power_user?.selectSamplers?.forceShown || [];
-    power_user.selectSamplers = {};
-    power_user.selectSamplers.forceHidden = userDisabledSamplers;
-    power_user.selectSamplers.forceShown = userShownSamplers;
     await saveSettingsDebounced();
     $('#samplerSelectButton').off('click').on('click', showSamplerSelectPopup);
 }

--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -461,8 +461,6 @@ export async function validateDisabledSamplers(redraw = false) {
     }
 
     if (redraw) {
-        // if (main_api === 'textgenerationwebui') showTGSamplerControls();
-
         let samplersHTML = await listSamplers(main_api);
         $('#apiSamplersList').empty().append(samplersHTML.toString());
         setSamplerListListeners();

--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -45,7 +45,7 @@ async function showSamplerSelectPopup() {
 
         if (main_api === 'textgenerationwebui') {
             $('#prioritizeManuallySelectedSamplers').toggleClass('toggleEnabled', false);
-            await resetPresetSelectedSamplers(null, true);
+            await resetApiSelectedSamplers(null, true);
         }
 
         await validateDisabledSamplers(true);
@@ -76,7 +76,7 @@ async function showSamplerSelectPopup() {
     }
 
     await showPromise;
-    if (main_api === 'textgenerationwebui') await savePresetSelectedSamplers();
+    if (main_api === 'textgenerationwebui') await saveApiSelectedSamplers();
 }
 
 function setSamplerListListeners() {
@@ -204,7 +204,7 @@ function setSamplerListListeners() {
         relatedDOMElement.css('display', shouldDisplay);
 
         if (main_api === 'textgenerationwebui') {
-            setPresetSamplersState(samplerName, shouldDisplay !== 'none');
+            setApiSamplersState(samplerName, shouldDisplay !== 'none');
         }
 
         console.log(samplerName, relatedDOMElement.data('selectsampler'), shouldDisplay);
@@ -237,7 +237,7 @@ async function listSamplers(main_api, arrayOnly = false) {
         return availableSamplers;
     }
 
-    const samplersActivatedManually = (main_api === 'textgenerationwebui') ? getManualActivePresetSamplers() : [];
+    const samplersActivatedManually = (main_api === 'textgenerationwebui') ? getActiveManualApiSamplers() : [];
     const prioritizeManualSamplerSelect = (main_api === 'textgenerationwebui') ? isSamplerManualPriorityEnabled() : false;
 
     const samplersListHTML = availableSamplers.reduce((html, sampler) => {
@@ -339,7 +339,7 @@ async function listSamplers(main_api, arrayOnly = false) {
         };
         console.log(sampler, targetDOMelement.prop('id'), isInDefaultState(), isInForceShownArray, isInForceHiddenArray, shouldBeChecked());
         if (displayname === undefined) { displayname = sampler; }
-        if (main_api === 'textgenerationwebui') setPresetSamplersState(sampler, shouldBeChecked());
+        if (main_api === 'textgenerationwebui') setApiSamplersState(sampler, shouldBeChecked());
         return html + `
         <div class="sampler_view_list_item wide50p flex-container">
             <input type="checkbox" name="${sampler}_checkbox" ${shouldBeChecked() ? 'checked' : ''}>
@@ -361,7 +361,7 @@ export async function validateDisabledSamplers(redraw = false) {
         return;
     }
 
-    const samplersActivatedManually = (main_api === 'textgenerationwebui') ? getManualActivePresetSamplers() : [];
+    const samplersActivatedManually = (main_api === 'textgenerationwebui') ? getActiveManualApiSamplers() : [];
     const prioritizeManualSamplerSelect = (main_api === 'textgenerationwebui') ? isSamplerManualPriorityEnabled() : false;
 
     for (const sampler of APISamplers) {
@@ -436,7 +436,6 @@ export async function validateDisabledSamplers(redraw = false) {
             relatedDOMElement = $('#smoothingBlock');
         }
 
-
         if (power_user?.selectSamplers?.forceHidden.includes(sampler)) {
             //default handling for standard sliders
             relatedDOMElement.data('selectsampler', 'hidden');
@@ -462,7 +461,7 @@ export async function validateDisabledSamplers(redraw = false) {
     }
 
     if (redraw) {
-        if (main_api === 'textgenerationwebui') showTGSamplerControls();
+        // if (main_api === 'textgenerationwebui') showTGSamplerControls();
 
         let samplersHTML = await listSamplers(main_api);
         $('#apiSamplersList').empty().append(samplersHTML.toString());
@@ -474,8 +473,9 @@ export async function validateDisabledSamplers(redraw = false) {
 
 /**
  * Initializes the configuration object for manually selected samplers.
+ * @returns void
  */
-export async function loadPresetSelectedSamplers() {
+export async function loadApiSelectedSamplers() {
     try {
         console.debug('Text Completions: loading selected samplers');
         selectedSamplers = await textGenObjectStore.getItem('selectedSamplers') || {};
@@ -487,8 +487,9 @@ export async function loadPresetSelectedSamplers() {
 
 /**
  * Synchronizes the local forage instance with the selected samplers configuration object.
+ * @returns void
  */
-export async function savePresetSelectedSamplers() {
+export async function saveApiSelectedSamplers() {
     try {
         console.debug('Text Completions: saving selected samplers');
         await textGenObjectStore.setItem('selectedSamplers', selectedSamplers);
@@ -499,18 +500,19 @@ export async function savePresetSelectedSamplers() {
 
 /**
  * Resets the selected samplers configuration object from the local forage instance.
- * @param {string?} presetName Name of the target preset - It picks the current active TC preset name by default
+ * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
  * @param {boolean} silent Suppresses the toastr message confirming that the data was deleted.
+ * @returns void
  */
-export async function resetPresetSelectedSamplers(presetName = '', silent = false) {
+export async function resetApiSelectedSamplers(tcApiType = '', silent = false) {
     try {
-        if (!textgenerationwebui_settings?.preset && !presetName) return;
-        if (!presetName) presetName = textgenerationwebui_settings.preset;
-        if (!selectedSamplers[presetName]) return;
+        if (!textgenerationwebui_settings?.type && !tcApiType) return;
+        if (!tcApiType) tcApiType = textgenerationwebui_settings.type;
+        if (!selectedSamplers[tcApiType]) return;
 
         console.debug('Text Completions: resetting selected samplers');
-        delete selectedSamplers[presetName];
-        await savePresetSelectedSamplers();
+        delete selectedSamplers[tcApiType];
+        await saveApiSelectedSamplers();
         if (!silent) toastr.success('Selected samplers cleared.');
     } catch (error) {
         console.log('Text Completions: unable to reset selected preset samplers', error);
@@ -521,43 +523,43 @@ export async function resetPresetSelectedSamplers(presetName = '', silent = fals
  * Saves the visibility state for selected samplers into the configuration object.
  * @param {string} samplerName Target sampler key name
  * @param {string|boolean} state Visibility state of the target sampler
- * @param {string?} presetName Name of the target preset - It picks the current active TC preset name by default
+ * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
  * @returns void
  */
-export function setPresetSamplersState(samplerName, state, presetName = '') {
-    if (!textgenerationwebui_settings?.preset && !presetName) return;
-    if (!presetName) presetName = textgenerationwebui_settings.preset;
-    if (!selectedSamplers[presetName]) selectedSamplers[presetName] = {};
+export function setApiSamplersState(samplerName, state, tcApiType = '') {
+    if (!textgenerationwebui_settings?.type && !tcApiType) return;
+    if (!tcApiType) tcApiType = textgenerationwebui_settings.type;
+    if (!selectedSamplers[tcApiType]) selectedSamplers[tcApiType] = {};
 
-    const presetSamplers = selectedSamplers[presetName];
+    const presetSamplers = selectedSamplers[tcApiType];
     presetSamplers[samplerName] = String(state) === 'true';
 }
 
 /**
- * Returns the local forage object belonging to the active/selected TC preset
- * @param {string?} presetName Name of the target preset - It picks the current active TC preset name by default
+ * Returns the local forage object belonging to the active/selected TC API Type
+ * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
  * @returns {object} Full localforage object with manual selections
  */
-export function getManualPresetSamplers(presetName = '') {
-    if (!textgenerationwebui_settings?.preset && !presetName) return {};
-    if (!presetName) presetName = textgenerationwebui_settings.preset;
-    if (!selectedSamplers[presetName]) selectedSamplers[presetName] = {};
+export function getAllManualApiSamplers(tcApiType = '') {
+    if (!textgenerationwebui_settings?.type && !tcApiType) return {};
+    if (!tcApiType) tcApiType = textgenerationwebui_settings.type;
+    if (!selectedSamplers[tcApiType]) selectedSamplers[tcApiType] = {};
 
-    return selectedSamplers[presetName];
+    return selectedSamplers[tcApiType];
 }
 
 /**
- * Returns the key names of all the preset samplers activated manually.
- * @param {string?} presetName Name of the target preset - It picks the current active TC preset name by default
+ * Returns the key names of all the manually activated API Type samplers.
+ * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
  * @returns {string[]} Array of sampler key names
  */
-export function getManualActivePresetSamplers(presetName = '') {
-    if (!textgenerationwebui_settings?.preset && !presetName) return [];
-    if (!presetName) presetName = textgenerationwebui_settings.preset;
-    if (!selectedSamplers[presetName]) selectedSamplers[presetName] = {};
+export function getActiveManualApiSamplers(tcApiType = '') {
+    if (!textgenerationwebui_settings?.type && !tcApiType) return [];
+    if (!tcApiType) tcApiType = textgenerationwebui_settings.type;
+    if (!selectedSamplers[tcApiType]) selectedSamplers[tcApiType] = {};
 
     try {
-        const presetSamplers = Object.entries(selectedSamplers[presetName]);
+        const presetSamplers = Object.entries(selectedSamplers[tcApiType]);
 
         return presetSamplers
             .filter(([key, val]) => val === true && key !== 'st_manual_priority')
@@ -570,28 +572,28 @@ export function getManualActivePresetSamplers(presetName = '') {
 
 /**
  * @param {string|boolean} state Target state of the feature
- * @param {string?} presetName Name of the target preset - It picks the current active TC preset name by default
+ * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
  * @returns void
  */
-export function toggleSamplerManualPriority(state = false, presetName = '') {
-    if (!textgenerationwebui_settings?.preset && !presetName) return;
-    if (!presetName) presetName = textgenerationwebui_settings.preset;
-    if (!selectedSamplers[presetName]) selectedSamplers[presetName] = {};
+export function toggleSamplerManualPriority(state = false, tcApiType = '') {
+    if (!textgenerationwebui_settings?.type && !tcApiType) return;
+    if (!tcApiType) tcApiType = textgenerationwebui_settings.type;
+    if (!selectedSamplers[tcApiType]) selectedSamplers[tcApiType] = {};
 
-    const presetSamplers = selectedSamplers[presetName];
+    const presetSamplers = selectedSamplers[tcApiType];
     presetSamplers.st_manual_priority = String(state) === 'true';
 }
 
 /**
- * @param {string?} presetName Name of the target preset - It picks the current active TC preset name by default
+ * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
  * @returns {boolean}
  */
-export function isSamplerManualPriorityEnabled(presetName = '') {
-    if (!textgenerationwebui_settings?.preset && !presetName) return false;
-    if (!presetName) presetName = textgenerationwebui_settings.preset;
-    if (!selectedSamplers[presetName]) selectedSamplers[presetName] = {};
+export function isSamplerManualPriorityEnabled(tcApiType = '') {
+    if (!textgenerationwebui_settings?.type && !tcApiType) return false;
+    if (!tcApiType) tcApiType = textgenerationwebui_settings.type;
+    if (!selectedSamplers[tcApiType]) selectedSamplers[tcApiType] = {};
 
-    return selectedSamplers[presetName]?.st_manual_priority ?? false;
+    return selectedSamplers[tcApiType]?.st_manual_priority ?? false;
 }
 
 export async function initCustomSelectedSamplers() {

--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -2,7 +2,6 @@ import {
     main_api,
     saveSettingsDebounced,
 } from '../script.js';
-import { power_user } from './power-user.js';
 //import { BIAS_CACHE, displayLogitBias, getLogitBiasListResult } from './logit-bias.js';
 //import { getEventSourceStream } from './sse-stream.js';
 //import { getSortableDelay, onlyUnique } from './utils.js';
@@ -18,7 +17,7 @@ const SELECT_SAMPLER = {
     DATA: 'selectsampler',
     SHOWN: 'shown',
     HIDDEN: 'hidden',
-}
+};
 
 const textGenObjectStore = localforage.createInstance({ name: 'SillyTavern_TextCompletions' });
 let selectedSamplers = {};

--- a/public/scripts/templates/samplerSelector.html
+++ b/public/scripts/templates/samplerSelector.html
@@ -10,7 +10,7 @@
                 <i class="fa-solid fa-lock"></i>
                 <span data-i18n="Prioritize">Prioritize</span>
             </div>
-            <div class="margin5 fa-solid fa-exclamation-circle" data-i18n="[title]Toggle on to force the samplers selected in this menu to be shown when switching to this preset. By default, SillyTavern automatically selects samplers used or needed by the selected API Type in the API Connections panel." title="Toggle on to force the samplers selected in this menu to be shown when switching to this preset. By default, SillyTavern automatically selects samplers used or needed by the selected API Type in the API Connections panel."></div>
+            <div class="margin5 fa-solid fa-exclamation-circle" data-i18n="[title]Toggle on to force the samplers selected in this menu to be shown when switching to the current API Type (API Connections Panel). By default, SillyTavern automatically selects samplers used or needed by the selected API Type." title="Toggle on to force the samplers selected in this menu to be shown when switching to the current API Type (API Connections Panel). By default, SillyTavern automatically selects samplers used or needed by the selected API Type."></div>
         </div>
         <!--<div class="flex-container alignItemsBaseline">
             <div class="menu_button menu_button_icon" title="Create a new sampler">

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -571,8 +571,7 @@ export function loadTextGenSettings(data, loadedSettings) {
 
     $('#textgen_type').val(settings.type);
     $('#openrouter_providers_text').val(settings.openrouter_providers).trigger('change');
-    loadApiSelectedSamplers();
-    showSamplerControls();
+    showSamplerControls(settings.type);
     BIAS_CACHE.delete(BIAS_KEY);
     displayLogitBias(settings.logit_bias, BIAS_KEY);
 
@@ -1080,8 +1079,10 @@ export function initTextGenSettings() {
  * @returns void
  */
 function showSamplerControls(apiType = null) {
-    $('#textgenerationwebui_api-settings [data-tg-samplers]:not([data-tg-type])').each(function() {
-        $(this).show();
+    $('#textgenerationwebui_api-settings [data-tg-samplers]').each(function(idx, elem) {
+        const typeSpecificControlled = $(elem).data('tg-type') !== undefined;
+
+        if (!typeSpecificControlled) $(this).show();
     });
 
     showTypeSpecificControls(apiType ?? settings.type);
@@ -1105,18 +1106,18 @@ function showSamplerControls(apiType = null) {
     });
 }
 
-function showTypeSpecificControls(type) {
+function showTypeSpecificControls(apiType) {
     $('[data-tg-type]').each(function () {
         const mode = String($(this).attr('data-tg-type-mode') ?? '').toLowerCase().trim();
         const tgTypes = $(this).attr('data-tg-type').split(',').map(x => x.trim());
-
+ 
         if (mode === 'except') {
-            $(this)[tgTypes.includes(type) ? 'hide' : 'show']();
+            $(this)[tgTypes.includes(apiType) ? 'hide' : 'show']();
             return;
         }
 
         for (const tgType of tgTypes) {
-            if (tgType === type || tgType == 'all') {
+            if (tgType === apiType || tgType == 'all') {
                 $(this).show();
                 return;
             } else {

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -20,7 +20,7 @@ import { autoSelectInstructPreset, selectContextPreset, selectInstructPreset } f
 import { BIAS_CACHE, createNewLogitBiasEntry, displayLogitBias, getLogitBiasListResult } from './logit-bias.js';
 
 import { power_user, registerDebugFunction } from './power-user.js';
-import { getActiveManualApiSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
+import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
 import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels } from './textgen-models.js';
@@ -529,7 +529,8 @@ function calculateLogitBias() {
     return result;
 }
 
-export function loadTextGenSettings(data, loadedSettings) {
+export async function loadTextGenSettings(data, loadedSettings) {
+    await loadApiSelectedSamplers();
     textgenerationwebui_presets = convertPresets(data.textgenerationwebui_presets);
     textgenerationwebui_preset_names = data.textgenerationwebui_preset_names ?? [];
     Object.assign(settings, loadedSettings.textgenerationwebui_settings ?? {});

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -20,7 +20,7 @@ import { autoSelectInstructPreset, selectContextPreset, selectInstructPreset } f
 import { BIAS_CACHE, createNewLogitBiasEntry, displayLogitBias, getLogitBiasListResult } from './logit-bias.js';
 
 import { power_user, registerDebugFunction } from './power-user.js';
-import { getActiveManualApiSamplers, isSamplerManualPriorityEnabled, loadApiSelectedSamplers } from './samplerSelect.js';
+import { getActiveManualApiSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
 import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels } from './textgen-models.js';
@@ -777,8 +777,6 @@ async function getStatusTextgen() {
 }
 
 export function initTextGenSettings() {
-    loadApiSelectedSamplers();
-
     $('#send_banned_tokens_textgenerationwebui').on('change', function () {
         const checked = !!$(this).prop('checked');
         toggleBannedStringsKillSwitch(checked,

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1110,7 +1110,7 @@ function showTypeSpecificControls(apiType) {
     $('[data-tg-type]').each(function () {
         const mode = String($(this).attr('data-tg-type-mode') ?? '').toLowerCase().trim();
         const tgTypes = $(this).attr('data-tg-type').split(',').map(x => x.trim());
- 
+
         if (mode === 'except') {
             $(this)[tgTypes.includes(apiType) ? 'hide' : 'show']();
             return;

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -20,7 +20,7 @@ import { autoSelectInstructPreset, selectContextPreset, selectInstructPreset } f
 import { BIAS_CACHE, createNewLogitBiasEntry, displayLogitBias, getLogitBiasListResult } from './logit-bias.js';
 
 import { power_user, registerDebugFunction } from './power-user.js';
-import { getManualActivePresetSamplers, isSamplerManualPriorityEnabled, loadPresetSelectedSamplers } from './samplerSelect.js';
+import { getActiveManualApiSamplers, isSamplerManualPriorityEnabled, loadApiSelectedSamplers } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
 import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels } from './textgen-models.js';
@@ -372,7 +372,6 @@ async function selectPreset(name) {
         setSettingByName(name, value, true);
     }
     setGenerationParamsFromPreset(preset);
-    showSamplerControls(null, true);
     BIAS_CACHE.delete(BIAS_KEY);
     displayLogitBias(preset.logit_bias, BIAS_KEY);
     saveSettingsDebounced();
@@ -572,7 +571,7 @@ export function loadTextGenSettings(data, loadedSettings) {
 
     $('#textgen_type').val(settings.type);
     $('#openrouter_providers_text').val(settings.openrouter_providers).trigger('change');
-    loadPresetSelectedSamplers();
+    loadApiSelectedSamplers();
     showSamplerControls();
     BIAS_CACHE.delete(BIAS_KEY);
     displayLogitBias(settings.logit_bias, BIAS_KEY);
@@ -779,7 +778,7 @@ async function getStatusTextgen() {
 }
 
 export function initTextGenSettings() {
-    loadPresetSelectedSamplers();
+    loadApiSelectedSamplers();
 
     $('#send_banned_tokens_textgenerationwebui').on('change', function () {
         const checked = !!$(this).prop('checked');
@@ -1078,21 +1077,17 @@ export function initTextGenSettings() {
 /**
  * Hides and shows preset samplers from the left panel.
  * @param {string?} apiType API Type selected in API Connections - Currently selected one by default
- * @param {boolean?} isPresetSwitch Wheter the trigger comes from a preset switch - false by default
  * @returns void
  */
-function showSamplerControls(apiType = null, isPresetSwitch = false) {
-    const prioritizeManualSamplerSelect = isSamplerManualPriorityEnabled();
-
-    if (isPresetSwitch && !prioritizeManualSamplerSelect) return;
-
+function showSamplerControls(apiType = null) {
     $('#textgenerationwebui_api-settings [data-tg-samplers]:not([data-tg-type])').each(function() {
         $(this).show();
     });
 
     showTypeSpecificControls(apiType ?? settings.type);
 
-    const samplersActivatedManually = getManualActivePresetSamplers();
+    const prioritizeManualSamplerSelect = isSamplerManualPriorityEnabled(apiType ?? settings.type);
+    const samplersActivatedManually = getActiveManualApiSamplers(apiType ?? settings.type);
 
     if (!samplersActivatedManually?.length || !prioritizeManualSamplerSelect) return;
 


### PR DESCRIPTION
## Changes
As requested, sampler selection lock is no longer tied to preset samplers, it is now linked to Text Completion API Type.
A lot of changes had to be made in `samplerSelect.js`, the logic of using `power_user.selectSamplers`, `userShownSamplers`, `userDisabledSamplers`, `selectsampler` as JQuery data, and `selectedSamplers` (localforage) was constantly conflicting. `power_user.selectSamplers` and the other two (that were also `power_user`) were replaced with directly using the data stored in `selectsampler` for each sampler block. It is virtually the same, as `power_user.selectSamplers` was never really saved into user settings, but reset every time you change API Type or load ST.

## Commits
- [Update](https://github.com/SillyTavern/SillyTavern/commit/9c70ab2d5ebb4b549c22a1072ff2c7abf1654a88) - Revert connection profile change TC commands load order
> This change was made to prevent preset tied samplers from breaking, such thing doesn't exist anymore.
- [Update](https://github.com/SillyTavern/SillyTavern/commit/884611ab490e2e4472992816106e82ea2d68080f) - Unlink preset renaming logic from sampler selection lock
- [Update](https://github.com/SillyTavern/SillyTavern/commit/c733081e49dd67146c16d33d2aab3161c670a78b) - Link TC sampler selection lock to API Type
- [Fix](https://github.com/SillyTavern/SillyTavern/commit/fa14fd7232d2ce4714d5c91f0f0243065e8b84a7) - Clean comments
- [Update](https://github.com/SillyTavern/SillyTavern/commit/7c1c1eb99ef1593b128eae8e3786599abd3b41a3) - Use localforage selectedSamplers and data selectsampler as main sampler selection storage
- [Fix](https://github.com/SillyTavern/SillyTavern/commit/b7f6b17d0c6df4ab10bf4b198fa279614afe26f5) - ESLint errors

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
