### PR TITLE
Fixed layout thrashing when `Stream Fade-In` and `Auto-scroll Chat` are enabled.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1451,7 +1451,7 @@ function scrollOnMediaLoad() {
         }
         mediaLoaded++;
         if (mediaLoaded === media.length) {
-            scrollChatToBottom();
+            scrollChatToBottom({ waitForFrame: true });
         }
     }
 }
@@ -2600,30 +2600,45 @@ function formatGenerationTimer(gen_started, gen_finished, tokenCount, reasoningD
 
 let requestId = null;
 
-export function scrollChatToBottom() {
-    if (power_user.auto_scroll_chat_to_bottom) {
-
-        //Do not check truthiness. requestId can loop to zero.
-        if (requestId !== null) cancelAnimationFrame(requestId);
-
-        // This prevents layout thrashing.
-        // https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame#return_value
-        // https://gist.github.com/paulirish/5d52fb081b3570c81e3a#file-what-forces-layout-md
-        requestId = requestAnimationFrame(() => {
-            let position = chatElement[0].scrollHeight;
-
-            if (power_user.waifuMode) {
-                const lastMessage = chatElement.find('.mes').last();
-                if (lastMessage.length) {
-                    const lastMessagePosition = lastMessage.position().top;
-                    position = chatElement.scrollTop() + lastMessagePosition;
-                }
-            }
-
-            chatElement.scrollTop(position);
-            requestId = null;
-        });
+/**
+ * Scrolls the chat to the bottom if configured to do so.
+ * @param {object} [options] Options
+ * @param {boolean} [options.waitForFrame] If true, waits for the animation frame before scrolling
+ */
+export function scrollChatToBottom({ waitForFrame } = {}) {
+    if (!power_user.auto_scroll_chat_to_bottom) {
+        return;
     }
+
+    const doScroll = () => {
+        let position = chatElement[0].scrollHeight;
+
+        if (power_user.waifuMode) {
+            const lastMessage = chatElement.find('.mes').last();
+            if (lastMessage.length) {
+                const lastMessagePosition = lastMessage.position().top;
+                position = chatElement.scrollTop() + lastMessagePosition;
+            }
+        }
+
+        chatElement.scrollTop(position);
+        requestId = null;
+    };
+
+    // Do not check truthiness. requestId can loop to zero.
+    if (requestId !== null) {
+        cancelAnimationFrame(requestId);
+    }
+
+    if (!waitForFrame) {
+        doScroll();
+        return;
+    }
+
+    // This prevents layout thrashing.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame#return_value
+    // https://gist.github.com/paulirish/5d52fb081b3570c81e3a#file-what-forces-layout-md
+    requestId = requestAnimationFrame(() => doScroll());
 }
 
 /**
@@ -3285,7 +3300,7 @@ class StreamingProcessor {
             this.markUIGenStarted();
         }
         hideSwipeButtons({ hideCounters: true });
-        scrollChatToBottom();
+        scrollChatToBottom({ waitForFrame: true });
         return messageId;
     }
 
@@ -3388,7 +3403,7 @@ class StreamingProcessor {
         }
 
         if (!scrollLock) {
-            scrollChatToBottom();
+            scrollChatToBottom({ waitForFrame: true });
         }
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -2598,19 +2598,31 @@ function formatGenerationTimer(gen_started, gen_finished, tokenCount, reasoningD
     return { timerValue, timerTitle };
 }
 
+let requestId = null;
+
 export function scrollChatToBottom() {
     if (power_user.auto_scroll_chat_to_bottom) {
-        let position = chatElement[0].scrollHeight;
 
-        if (power_user.waifuMode) {
-            const lastMessage = chatElement.find('.mes').last();
-            if (lastMessage.length) {
-                const lastMessagePosition = lastMessage.position().top;
-                position = chatElement.scrollTop() + lastMessagePosition;
+        //Do not check truthiness. requestId can loop to zero.
+        if (requestId !== null) cancelAnimationFrame(requestId);
+
+        // This prevents layout thrashing.
+        // https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame#return_value
+        // https://gist.github.com/paulirish/5d52fb081b3570c81e3a#file-what-forces-layout-md
+        requestId = requestAnimationFrame(() => {
+            let position = chatElement[0].scrollHeight;
+
+            if (power_user.waifuMode) {
+                const lastMessage = chatElement.find('.mes').last();
+                if (lastMessage.length) {
+                    const lastMessagePosition = lastMessage.position().top;
+                    position = chatElement.scrollTop() + lastMessagePosition;
+                }
             }
-        }
 
-        chatElement.scrollTop(position);
+            chatElement.scrollTop(position);
+            requestId = null;
+        });
     }
 }
 


### PR DESCRIPTION
Scheduling `scrollChatToBottom` after the animation frame prevents layout thrashing.

https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame#return_value
https://gist.github.com/paulirish/5d52fb081b3570c81e3a#file-what-forces-layout-md
## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).