### PR TITLE
Gallery: Add video uploads to gallery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
                 "is-docker": "^3.0.0",
                 "localforage": "^1.10.0",
                 "lodash": "^4.17.21",
-                "mime-types": "^3.0.1",
+                "mime-types": "^3.0.2",
                 "moment": "^2.30.1",
                 "morphdom": "^2.7.7",
                 "multer": "^2.0.2",
@@ -6432,15 +6432,19 @@
             }
         },
         "node_modules/mime-types": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
             "license": "MIT",
             "dependencies": {
                 "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/mime-types/node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "is-docker": "^3.0.0",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",
-        "mime-types": "^3.0.1",
+        "mime-types": "^3.0.2",
         "moment": "^2.30.1",
         "morphdom": "^2.7.7",
         "multer": "^2.0.2",
@@ -164,7 +164,7 @@
         "@types/yargs": "^17.0.33",
         "@types/yauzl": "^2.10.3",
         "eslint": "^8.57.1",
-        "eslint-plugin-jsdoc": "^48.10.0",
-        "eslint-plugin-jest": "^27.9.0"
+        "eslint-plugin-jest": "^27.9.0",
+        "eslint-plugin-jsdoc": "^48.10.0"
     }
 }

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -118,6 +118,17 @@ export const MEDIA_TYPE = {
 };
 
 /**
+ * Bitwise flag-style media request types.
+ * @enum {number}
+ * @readonly
+ */
+export const MEDIA_REQUEST_TYPE = {
+    IMAGE: 0b001,
+    VIDEO: 0b010,
+    AUDIO: 0b100,
+};
+
+/**
  * Scroll behavior options when appending media to messages.
  * @enum {string}
  * @readonly

--- a/public/scripts/extensions/gallery/index.js
+++ b/public/scripts/extensions/gallery/index.js
@@ -136,7 +136,9 @@ async function getGalleryItems(url) {
         };
 
         if (isVideo(file)) {
-            item.srct = await getVideoThumbnail(item.src);
+            // 150px of max height with some allowance for various aspect ratios
+            const maxSide = Math.round(150 * 1.5);
+            item.srct = await getVideoThumbnail(item.src, maxSide, maxSide);
         }
 
         items.push(item);

--- a/public/scripts/extensions/gallery/index.js
+++ b/public/scripts/extensions/gallery/index.js
@@ -8,7 +8,7 @@ import {
     animation_easing,
 } from '../../../script.js';
 import { groups, selected_group } from '../../group-chats.js';
-import { loadFileToDocument, delay, getBase64Async, getSanitizedFilename, saveBase64AsFile, getFileExtension } from '../../utils.js';
+import { loadFileToDocument, delay, getBase64Async, getSanitizedFilename, saveBase64AsFile, getFileExtension, getVideoThumbnail, clamp } from '../../utils.js';
 import { loadMovingUIState } from '../../power-user.js';
 import { dragElement } from '../../RossAscends-mods.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
@@ -19,17 +19,14 @@ import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnum
 import { t, translate } from '../../i18n.js';
 import { Popup } from '../../popup.js';
 import { deleteMediaFromServer } from '../../chats.js';
+import { MEDIA_REQUEST_TYPE, VIDEO_EXTENSIONS } from '../../constants.js';
 
+const isVideo = (/** @type {string} */ url) => VIDEO_EXTENSIONS.some(ext => new RegExp(`.${ext}$`, 'i').test(url));
 const extensionName = 'gallery';
 const extensionFolderPath = `scripts/extensions/${extensionName}/`;
 let firstTime = true;
 let deleteModeActive = false;
 
-// Exposed defaults for future tweaking
-let thumbnailHeight = 150;
-let paginationVisiblePages = 10;
-let paginationMaxLinesPerPage = 2;
-let galleryMaxRows = 3;
 
 // Remove all draggables associated with the gallery
 $('#movingDivs').on('click', '.dragClose', function () {
@@ -122,17 +119,28 @@ async function getGalleryItems(url) {
             folder: url,
             sortField: sortObj.field,
             sortOrder: sortObj.order,
+            type: MEDIA_REQUEST_TYPE.IMAGE | MEDIA_REQUEST_TYPE.VIDEO,
         }),
     });
 
     url = await getSanitizedFilename(url);
 
     const data = await response.json();
-    const items = data.map((file) => ({
-        src: `user/images/${url}/${file}`,
-        srct: `user/images/${url}/${file}`,
-        title: '', // Optional title for each item
-    }));
+    const items = [];
+
+    for (const file of data) {
+        const item = {
+            src: `user/images/${url}/${file}`,
+            srct: `user/images/${url}/${file}`,
+            title: '', // Optional title for each item
+        };
+
+        if (isVideo(file)) {
+            item.srct = await getVideoThumbnail(item.src);
+        }
+
+        items.push(item);
+    }
 
     return items;
 }
@@ -198,6 +206,12 @@ function getSortOrder() {
  * @returns {Promise<void>} - Promise representing the completion of the gallery initialization.
  */
 async function initGallery(items, url) {
+    // Exposed defaults for future tweaking
+    const thumbnailHeight = 150;
+    const paginationVisiblePages = 5;
+    const paginationMaxLinesPerPage = 2;
+    const galleryMaxRows = clamp(Math.floor((window.innerHeight * 0.9 - 75) / thumbnailHeight), 1, 10);
+
     const nonce = `nonce-${Math.random().toString(36).substring(2, 15)}`;
     const gallery = $('#dragGallery');
     gallery.addClass(nonce);
@@ -210,6 +224,7 @@ async function initGallery(items, url) {
         galleryMaxRows: galleryMaxRows,
         galleryPaginationTopButtons: false,
         galleryNavigationOverlayButtons: true,
+        galleryPaginationMode: 'rectangles',
         galleryTheme: {
             navigationBar: { background: 'none', borderTop: '', borderBottom: '', borderRight: '', borderLeft: '' },
             navigationBreadcrumb: { background: '#111', color: '#fff', colorHover: '#ccc', borderRadius: '4px' },
@@ -399,7 +414,7 @@ async function makeMovable(url) {
     // Create a hidden file input
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
-    fileInput.accept = 'image/*';
+    fileInput.accept = 'image/*,video/*';
     fileInput.multiple = true;
     fileInput.style.display = 'none';
 
@@ -617,12 +632,19 @@ function makeDragImg(id, url) {
     const newElement = document.importNode(template.content, true);
 
     // Step 2: Append the given image
-    const imgElem = document.createElement('img');
-    imgElem.src = url;
+    const mediaElement = isVideo(url)
+        ? document.createElement('video')
+        : document.createElement('img');
+    mediaElement.src = url;
+    if (mediaElement instanceof HTMLVideoElement) {
+        mediaElement.controls = true;
+        mediaElement.autoplay = true;
+    }
+
     let uniqueId = `draggable_${id}`;
     const draggableElem = /** @type {HTMLElement} */ (newElement.querySelector('.draggable'));
     if (draggableElem) {
-        draggableElem.appendChild(imgElem);
+        draggableElem.appendChild(mediaElement);
 
         // Find a unique id for the draggable element
 

--- a/public/scripts/extensions/gallery/index.js
+++ b/public/scripts/extensions/gallery/index.js
@@ -136,9 +136,13 @@ async function getGalleryItems(url) {
         };
 
         if (isVideo(file)) {
-            // 150px of max height with some allowance for various aspect ratios
-            const maxSide = Math.round(150 * 1.5);
-            item.srct = await getVideoThumbnail(item.src, maxSide, maxSide);
+            try {
+                // 150px of max height with some allowance for various aspect ratios
+                const maxSide = Math.round(150 * 1.5);
+                item.srct = await getVideoThumbnail(item.src, maxSide, maxSide);
+            } catch (error) {
+                console.error('Failed to generate video thumbnail for gallery:', error);
+            }
         }
 
         items.push(item);
@@ -175,7 +179,7 @@ async function getGalleryFolders() {
  */
 async function deleteGalleryItem(url) {
     const isDeleted = await deleteMediaFromServer(url, false);
-    if (isDeleted){
+    if (isDeleted) {
         toastr.success(t`Image deleted successfully.`);
     }
 }

--- a/public/scripts/extensions/gallery/style.css
+++ b/public/scripts/extensions/gallery/style.css
@@ -49,3 +49,7 @@
     opacity: 1;
     filter: unset;
 }
+
+.galleryImageDraggable video {
+    width: 100%;
+}

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -27,7 +27,7 @@ export const shiftDownByOne = (e, i, a) => a[i] = e - 1;
  */
 export const PAGINATION_TEMPLATE = '<%= rangeStart %>-<%= rangeEnd %> .. <%= totalNumber %>';
 
-export const localizePagination = function(container) {
+export const localizePagination = function (container) {
     container.find('[title="Next page"]').attr('title', t`Next page`);
     container.find('[title="Previous page"]').attr('title', t`Previous page`);
     container.find('[title="First page"]').attr('title', t`First page`);
@@ -58,7 +58,7 @@ export function canUseNegativeLookbehind() {
  * @param {number[]} sizeChangerOptions Array of page size options
  * @returns {string} The rendered dropdown element as a string
  */
-export const renderPaginationDropdown = function(pageSize, sizeChangerOptions) {
+export const renderPaginationDropdown = function (pageSize, sizeChangerOptions) {
     const sizeSelect = document.createElement('select');
     sizeSelect.classList.add('J-paginationjs-size-select');
 
@@ -80,7 +80,7 @@ export const renderPaginationDropdown = function(pageSize, sizeChangerOptions) {
     return sizeSelect.outerHTML;
 };
 
-export const paginationDropdownChangeHandler = function(event, size) {
+export const paginationDropdownChangeHandler = function (event, size) {
     let dropdown = $(event?.originalEvent?.currentTarget || event.delegateTarget).find('select');
     dropdown.find('[selected]').removeAttr('selected');
     dropdown.find(`[value=${size}]`).attr('selected', '');
@@ -2438,6 +2438,7 @@ export async function fetchFaFile(name) {
         .map(rule => rule.selectorText.split(/,\s*/).map(selector => selector.split('::').shift().slice(1)))
     ;
 }
+
 export async function fetchFa() {
     return [...new Set((await Promise.all([
         fetchFaFile('fontawesome.min.css'),
@@ -2834,4 +2835,5 @@ export async function importFromExternalUrl(url, { preserveFileName = null } = {
             break;
     }
 }
+
 export const clamp = (value, min, max) => Math.min(Math.max(value, min), max);

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1209,9 +1209,12 @@ export function getVideoDurationFromDataURL(dataUrl) {
 /**
  * Gets a thumbnail image from a video URL.
  * @param {string} videoUrl URL of the video
+ * @param {number|null} [maxWidth=null] Maximum width of the thumbnail
+ * @param {number|null} [maxHeight=null] Maximum height of the thumbnail
+ * @param {string} [type='image/jpeg'] MIME type of the thumbnail
  * @returns {Promise<string>} Promise that resolves to a data URL of the video thumbnail
  */
-export function getVideoThumbnail(videoUrl) {
+export function getVideoThumbnail(videoUrl, maxWidth = null, maxHeight = null, type = 'image/jpeg') {
     const video = document.createElement('video');
     video.src = videoUrl;
     return new Promise((resolve, reject) => {
@@ -1222,18 +1225,63 @@ export function getVideoThumbnail(videoUrl) {
         video.onseeked = function () {
             // Create a canvas to draw the thumbnail
             const canvas = document.createElement('canvas');
-            canvas.width = video.videoWidth;
-            canvas.height = video.videoHeight;
             const ctx = canvas.getContext('2d');
-            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+            const { thumbnailWidth, thumbnailHeight } = calculateThumbnailSize(video.videoWidth, video.videoHeight, maxWidth, maxHeight);
+
+            canvas.width = thumbnailWidth;
+            canvas.height = thumbnailHeight;
+            ctx.imageSmoothingEnabled = true;
+            ctx.imageSmoothingQuality = 'high';
+            ctx.fillStyle = 'black';
+            ctx.fillRect(0, 0, thumbnailWidth, thumbnailHeight);
+            ctx.drawImage(video, 0, 0, thumbnailWidth, thumbnailHeight);
             // Get the data URL of the thumbnail
-            const dataUrl = canvas.toDataURL('image/jpeg');
+            const dataUrl = canvas.toDataURL(type);
             resolve(dataUrl);
         };
         video.onerror = function () {
             reject(new Error('Failed to load video'));
         };
     });
+}
+
+/**
+ * Calculates the thumbnail size for a media element while maintaining aspect ratio.
+ * @param {number} width Media width
+ * @param {number} height Media height
+ * @param {number?} maxWidth Max width (null = no limit)
+ * @param {number?} maxHeight Max height (null = no limit)
+ * @returns {{ thumbnailWidth: number, thumbnailHeight: number }} Thumbnail size
+ */
+export function calculateThumbnailSize(width, height, maxWidth, maxHeight) {
+    // Calculate the thumbnail dimensions while maintaining the aspect ratio
+    const aspectRatio = width / height;
+    let thumbnailWidth = maxWidth;
+    let thumbnailHeight = maxHeight;
+
+    if (maxWidth === null) {
+        thumbnailWidth = width;
+        maxWidth = width;
+    }
+
+    if (maxHeight === null) {
+        thumbnailHeight = height;
+        maxHeight = height;
+    }
+
+    // Do not upscale if image is already smaller than max dimensions
+    if (width <= maxWidth && height <= maxHeight) {
+        thumbnailWidth = width;
+        thumbnailHeight = height;
+    } else {
+        if (width > height) {
+            thumbnailHeight = maxWidth / aspectRatio;
+        } else {
+            thumbnailWidth = maxHeight * aspectRatio;
+        }
+    }
+
+    return { thumbnailWidth: Math.round(thumbnailWidth), thumbnailHeight: Math.round(thumbnailHeight) };
 }
 
 /**
@@ -1720,33 +1768,7 @@ export function createThumbnail(dataUrl, maxWidth = null, maxHeight = null, type
         img.onload = () => {
             const canvas = document.createElement('canvas');
             const ctx = canvas.getContext('2d');
-
-            // Calculate the thumbnail dimensions while maintaining the aspect ratio
-            const aspectRatio = img.width / img.height;
-            let thumbnailWidth = maxWidth;
-            let thumbnailHeight = maxHeight;
-
-            if (maxWidth === null) {
-                thumbnailWidth = img.width;
-                maxWidth = img.width;
-            }
-
-            if (maxHeight === null) {
-                thumbnailHeight = img.height;
-                maxHeight = img.height;
-            }
-
-            // Do not upscale if image is already smaller than max dimensions
-            if (img.width <= maxWidth && img.height <= maxHeight) {
-                thumbnailWidth = img.width;
-                thumbnailHeight = img.height;
-            } else {
-                if (img.width > img.height) {
-                    thumbnailHeight = maxWidth / aspectRatio;
-                } else {
-                    thumbnailWidth = maxHeight * aspectRatio;
-                }
-            }
+            const { thumbnailWidth, thumbnailHeight } = calculateThumbnailSize(img.width, img.height, maxWidth, maxHeight);
 
             // Set the canvas dimensions and draw the resized image
             canvas.width = thumbnailWidth;

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1207,6 +1207,36 @@ export function getVideoDurationFromDataURL(dataUrl) {
 }
 
 /**
+ * Gets a thumbnail image from a video URL.
+ * @param {string} videoUrl URL of the video
+ * @returns {Promise<string>} Promise that resolves to a data URL of the video thumbnail
+ */
+export function getVideoThumbnail(videoUrl) {
+    const video = document.createElement('video');
+    video.src = videoUrl;
+    return new Promise((resolve, reject) => {
+        video.onloadeddata = function () {
+            // Set the time to capture the thumbnail at the middle of the video
+            video.currentTime = video.duration / 2;
+        };
+        video.onseeked = function () {
+            // Create a canvas to draw the thumbnail
+            const canvas = document.createElement('canvas');
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+            // Get the data URL of the thumbnail
+            const dataUrl = canvas.toDataURL('image/jpeg');
+            resolve(dataUrl);
+        };
+        video.onerror = function () {
+            reject(new Error('Failed to load video'));
+        };
+    });
+}
+
+/**
  * Gets the duration of an audio from a data URL.
  * @param {string} dataUrl Audio data URL
  * @returns {Promise<number>} Duration in seconds

--- a/src/constants.js
+++ b/src/constants.js
@@ -513,6 +513,16 @@ export const MEDIA_EXTENSIONS = [
     'aiff',
 ];
 
+/**
+ * Bitwise flag-style media request types.
+ */
+export const MEDIA_REQUEST_TYPE = {
+    IMAGE: 0b001,
+    VIDEO: 0b010,
+    AUDIO: 0b100,
+};
+
+
 export const ZAI_ENDPOINT = {
     COMMON: 'common',
     CODING: 'coding',

--- a/src/endpoints/images.js
+++ b/src/endpoints/images.js
@@ -6,7 +6,7 @@ import express from 'express';
 import sanitize from 'sanitize-filename';
 
 import { clientRelativePath, removeFileExtension, getImages, isPathUnderParent } from '../util.js';
-import { MEDIA_EXTENSIONS } from '../constants.js';
+import { MEDIA_EXTENSIONS, MEDIA_REQUEST_TYPE } from '../constants.js';
 
 /**
  * Ensure the directory for the provided file path exists.
@@ -93,6 +93,7 @@ router.post('/list/:folder?', (request, response) => {
         }
 
         const directoryPath = path.join(request.user.directories.userImages, sanitize(request.body.folder));
+        const type = Number(request.body.type ?? MEDIA_REQUEST_TYPE.IMAGE);
         const sort = request.body.sortField || 'date';
         const order = request.body.sortOrder || 'asc';
 
@@ -100,7 +101,7 @@ router.post('/list/:folder?', (request, response) => {
             fs.mkdirSync(directoryPath, { recursive: true });
         }
 
-        const images = getImages(directoryPath, sort);
+        const images = getImages(directoryPath, sort, type);
         if (order === 'desc') {
             images.reverse();
         }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Updates `mime-types` package to fix incorrect MIME type resolution for mp4 files: https://github.com/jshttp/mime-types/releases/tag/v3.0.2
2. Added a utility function to get a thumbnail frame as a data URL from a video.
3. Adds `type` parameter to `/api/images/list` endpoint that it as a bitwise flag of media types to be listed. Falls back to just `IMAGE` for backwards compat if not provided.
4. Changed gallery extension to also load and display video media files from a specified folder.
5. Adds dynamic calculation of displayed gallery rows based on the screen height (height * 90% - 70px) divided by a thumbnail height (150px).
6. Adds ability to upload videos with either drag and drop or "Add Image" button.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
