### PR TITLE
Add new WORLDINFO_SCAN_DONE event with mutable state for extensions

### DIFF
--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -91,6 +91,7 @@ export const event_types = {
     PRESET_RENAMED_BEFORE: 'preset_renamed_before',
     MAIN_API_CHANGED: 'main_api_changed',
     WORLDINFO_ENTRIES_LOADED: 'worldinfo_entries_loaded',
+    WORLDINFO_SCAN_DONE: 'worldinfo_scan_done',
     MEDIA_ATTACHMENT_DELETED: 'media_attachment_deleted',
 };
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4867,7 +4867,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
             },
             new: {
                 all: newEntries,
-                sucessful: successfulNewEntries,
+                successful: successfulNewEntries,
             },
             activated: {
                 entries: allActivatedEntries,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4845,6 +4845,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
         }
 
         // Final check if we should really continue scan, and extend the current WI recurse buffer
+        const curScanState = nextScanState;
         scanState = nextScanState;
         if (scanState) {
             const text = successfulNewEntriesForRecursion
@@ -4856,6 +4857,45 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
         } else {
             logNextState('[WI] Scan done. No new entries to prompt. Stopping.');
         }
+
+        // Fire an event after each scan loop, so extensions can hook into the current scanning state
+        const args = {
+            state: {
+                current: curScanState,
+                next: scanState,
+                loopCount: count,
+            },
+            new: {
+                all: newEntries,
+                sucessful: successfulNewEntries,
+            },
+            activated: {
+                entries: allActivatedEntries,
+                text: allActivatedText,
+            },
+            sortedEntries,
+            recursionDelay: {
+                availableLevels: availableRecursionDelayLevels,
+                currentLevel: currentRecursionDelayLevel,
+            },
+            budget: {
+                current: budget,
+                overflowed: token_budget_overflowed,
+            },
+            timedEffects,
+        };
+        await eventSource.emit(event_types.WORLDINFO_SCAN_DONE, args);
+
+        // Some fields are allowed to be changed by listeners, those will be handled here manually. They can be updated via changed the args from the listeners.
+        // Any array provided directly can be modified by updating it's elements, adding or removing elements. This has to be done consistently.
+        if (args.state.next !== scanState) {
+            logNextState('[WI] Scan state changed from', scanState, 'to', args.state.next);
+            scanState = args.state.next;
+        }
+        allActivatedText = args.activated.text;
+        currentRecursionDelayLevel = args.recursionDelay.currentLevel;
+        budget = args.budget.current;
+        token_budget_overflowed = args.budget.overflowed;
     }
 
     console.debug('[WI] --- BUILDING PROMPT ---');

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4845,7 +4845,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
         }
 
         // Final check if we should really continue scan, and extend the current WI recurse buffer
-        const curScanState = nextScanState;
+        const curScanState = scanState;
         scanState = nextScanState;
         if (scanState) {
             const text = successfulNewEntriesForRecursion


### PR DESCRIPTION
Curtesy to @aikohanasaki

Doesn't really change the logic.

> [!NOTE]
> For any extensions wanting to subscribe to this, core code does not provide any state checks that any of the changed info is consistent or can be processed after an extension modifies the event data via a listener.
>
> Make sure to check the multiple knobs that need to be twisted. 

## Copilot Summary
This pull request adds a new event to the world info scanning process and exposes detailed scanning state for extension hooks. The main change is the introduction of the `WORLDINFO_SCAN_DONE` event, which allows extensions to interact with and modify the scan state after each scan loop.

**Event system enhancements:**

* Added a new event type `WORLDINFO_SCAN_DONE` to the `event_types` object in `events.js`, enabling extensions to hook into the world info scanning process.

**World info scanning process improvements:**

* In `checkWorldInfo`, after each scan loop, the function now emits the `WORLDINFO_SCAN_DONE` event with comprehensive scan state data, including current/next state, new entries, activated entries, sorting, recursion delay, budget, and timed effects.
* Listeners to the `WORLDINFO_SCAN_DONE` event can modify certain aspects of the scan state (such as the next state, activated text, recursion delay level, and budget) by updating the provided arguments, allowing for greater extensibility.
* Introduced a local variable `curScanState` to accurately capture and pass the current scan state to event listeners.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
