### PR TITLE
TC: Add a toggle for empty json schemas

### DIFF
--- a/default/content/presets/textgen/Default.json
+++ b/default/content/presets/textgen/Default.json
@@ -45,6 +45,7 @@
     "negative_prompt": "",
     "grammar_string": "",
     "json_schema": null,
+    "json_schema_allow_empty": false,
     "banned_tokens": "",
     "sampler_priority": [
         "repetition_penalty",

--- a/default/content/presets/textgen/Deterministic.json
+++ b/default/content/presets/textgen/Deterministic.json
@@ -45,6 +45,7 @@
     "negative_prompt": "",
     "grammar_string": "",
     "json_schema": null,
+    "json_schema_allow_empty": false,
     "banned_tokens": "",
     "sampler_priority": [
         "repetition_penalty",

--- a/default/content/presets/textgen/Neutral.json
+++ b/default/content/presets/textgen/Neutral.json
@@ -45,6 +45,7 @@
     "negative_prompt": "",
     "grammar_string": "",
     "json_schema": null,
+    "json_schema_allow_empty": false,
     "banned_tokens": "",
     "sampler_priority": [
         "repetition_penalty",

--- a/default/content/presets/textgen/Universal-Creative.json
+++ b/default/content/presets/textgen/Universal-Creative.json
@@ -45,6 +45,7 @@
     "negative_prompt": "",
     "grammar_string": "",
     "json_schema": null,
+    "json_schema_allow_empty": false,
     "banned_tokens": "",
     "sampler_priority": [
         "repetition_penalty",

--- a/default/content/presets/textgen/Universal-Light.json
+++ b/default/content/presets/textgen/Universal-Light.json
@@ -45,6 +45,7 @@
     "negative_prompt": "",
     "grammar_string": "",
     "json_schema": null,
+    "json_schema_allow_empty": false,
     "banned_tokens": "",
     "sampler_priority": [
         "repetition_penalty",

--- a/default/content/presets/textgen/Universal-Super-Creative.json
+++ b/default/content/presets/textgen/Universal-Super-Creative.json
@@ -45,6 +45,7 @@
     "negative_prompt": "",
     "grammar_string": "",
     "json_schema": null,
+    "json_schema_allow_empty": false,
     "banned_tokens": "",
     "sampler_priority": [
         "repetition_penalty",

--- a/public/index.html
+++ b/public/index.html
@@ -1707,6 +1707,10 @@
                                             </a>
                                         </h4>
                                         <textarea id="tabby_json_schema" rows="4" class="text_pole textarea_compact monospace" data-i18n="[placeholder]Type in the desired JSON schema" placeholder="Type in the desired JSON schema"></textarea>
+                                        <label for="json_schema_allow_empty_textgenerationwebui" class="checkbox_label" title="Treat empty JSON object as a valid JSON schema." data-tg-type="all">
+                                            <input type="checkbox" id="json_schema_allow_empty_textgenerationwebui" />
+                                            <small data-i18n="Allow empty schema objects">Allow empty schema objects</small>
+                                        </label>
                                     </div>
                                     <div id="sampler_order_block_kcpp" data-tg-type="koboldcpp" data-tg-samplers="sampler_order" class="range-block flexFlowColumn wide100p">
                                         <hr class="wide100p">


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1.14.0 release hotifx

Fixes backwards compatibility with https://github.com/SillyTavern/SillyTavern/pull/4746

Due to most existing presets having an empty object in JSON schema, must enable a checkbox to allow using it as a JSON schema of the Text Completion generation request.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
