### PR TITLE
/api-url: Add VertexAI region management

### DIFF
--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2552,6 +2552,7 @@ export function initDefaultSlashCommands() {
                 enumList: [
                     new SlashCommandEnumValue('custom', 'custom OpenAI-compatible', enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'openai')), 'O'),
                     new SlashCommandEnumValue('zai', 'Z.AI', enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'zai')), 'Z'),
+                    new SlashCommandEnumValue('vertexai', 'Google Vertex AI', enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'vertexai')), 'V'),
                     new SlashCommandEnumValue('kobold', 'KoboldAI Classic', enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'kobold')), 'K'),
                     ...Object.values(textgen_types).map(api => new SlashCommandEnumValue(api, null, enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'textgenerationwebui')), 'T')),
                 ],
@@ -2579,13 +2580,13 @@ export function initDefaultSlashCommands() {
         ],
         helpString: `
             <div>
-                ${t`Set the API url / server url for the currently selected API, including the port. If no argument is provided, it will return the current API url.`}
+                ${t`Set the API URL / server URL / endpoint for the currently selected API, including the port. If no argument is provided, it will return the current API url.`}
             </div>
             <div>
                 ${t`If a manual API is provided to <b>set</b> the URL, make sure to set <code>connect=false</code>, as auto-connect only works for the currently selected API, or consider switching to it with <code>/api</code> first.`}
             </div>
             <div>
-                ${t`This slash command works for most of the Text Completion sources, KoboldAI Classic, and also Custom OpenAI compatible and Z.AI for the Chat Completion sources. If unsure which APIs are supported, check the auto-completion of the optional <code>api</code> argument of this command.`}
+                ${t`This slash command works for most of the Text Completion sources, KoboldAI Classic, and also Custom OpenAI compatible, Z.AI, and Google Vertex AI for the Chat Completion sources. If unsure which APIs are supported, check the auto-completion of the optional <code>api</code> argument of this command.`}
             </div>
         `,
     }));
@@ -5184,6 +5185,37 @@ async function setApiUrlCallback({ api = null, connect = 'true', quiet = 'false'
         }
 
         return oai_settings.zai_endpoint || ZAI_ENDPOINT.COMMON;
+    }
+
+    const isCurrentlyVertexAI = main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.VERTEXAI;
+    if (api === chat_completion_sources.VERTEXAI || (!api && isCurrentlyVertexAI)) {
+        const defaultRegion = 'us-central1';
+        const dataList = Array
+            .from(document.querySelectorAll('#vertexai_region_suggestions option'))
+            .map(e => e instanceof HTMLOptionElement ? e.value : '')
+            .filter(x => x);
+
+        if (!url) {
+            return oai_settings.vertexai_region || defaultRegion;
+        }
+
+        const permittedValues = Object.values(dataList);
+        if (!permittedValues.includes(url)) {
+            !isQuiet && toastr.info(t`Generation requests may fail.`, t`Unknown VertexAI region '${url}'`);
+        }
+
+        if (!isCurrentlyVertexAI && autoConnect) {
+            toastr.warning(t`VertexAI is not the currently selected API, so we cannot do an auto-connect. Consider switching to it via /api beforehand.`);
+            return '';
+        }
+
+        $('#vertexai_region').val(url).trigger('input');
+
+        if (autoConnect) {
+            $('#api_button_openai').trigger('click');
+        }
+
+        return oai_settings.vertexai_region || defaultRegion;
     }
 
     // Special handling for Kobold Classic API

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -5190,7 +5190,7 @@ async function setApiUrlCallback({ api = null, connect = 'true', quiet = 'false'
     const isCurrentlyVertexAI = main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.VERTEXAI;
     if (api === chat_completion_sources.VERTEXAI || (!api && isCurrentlyVertexAI)) {
         const defaultRegion = 'us-central1';
-        const dataList = Array
+        const permittedValues = Array
             .from(document.querySelectorAll('#vertexai_region_suggestions option'))
             .map(e => e instanceof HTMLOptionElement ? e.value : '')
             .filter(x => x);
@@ -5199,7 +5199,6 @@ async function setApiUrlCallback({ api = null, connect = 'true', quiet = 'false'
             return oai_settings.vertexai_region || defaultRegion;
         }
 
-        const permittedValues = Object.values(dataList);
         if (!permittedValues.includes(url)) {
             !isQuiet && toastr.info(t`Generation requests may fail.`, t`Unknown VertexAI region '${url}'`);
         }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Adds VertexAI region manipulation via `/api-url` command. Useful for Connection Profiles.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
