### PR TITLE
Trigger CHARACTER_RENAMED_IN_PAST_CHAT for group chats

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -716,6 +716,8 @@ export async function renameGroupMember(oldAvatar, newAvatar, newName) {
                     }
 
                     if (hadChanges) {
+                        await eventSource.emit(event_types.CHARACTER_RENAMED_IN_PAST_CHAT, messages, oldAvatar, newAvatar);
+
                         const saveChatResponse = await fetch('/api/chats/group/save', {
                             method: 'POST',
                             headers: getRequestHeaders(),


### PR DESCRIPTION
It just fires the event `CHARACTER_RENAMED_IN_PAST_CHAT` inside `renameGroupMember`. Useful if an extension wants to update its metadata on a character rename.
- [Update](https://github.com/SillyTavern/SillyTavern/commit/8607b5ee47be9757317a92b9a6552a9d5057c8db) - Trigger CHARACTER_RENAMED_IN_PAST_CHAT for group chats

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
