### PR TITLE
Enhanced CharX Import with Asset Extraction

### DIFF
--- a/src/charx.js
+++ b/src/charx.js
@@ -7,6 +7,7 @@ import { extractFileFromZipBuffer, extractFilesFromZipBuffer, normalizeZipEntryP
 import { DEFAULT_AVATAR_PATH } from './constants.js';
 import { invalidateThumbnail } from './endpoints/thumbnails.js';
 
+// 'embeded://' is intentional - RisuAI exports use this misspelling
 const CHARX_EMBEDDED_URI_PREFIXES = ['embeded://', 'embedded://', '__asset:'];
 const CHARX_IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'webp', 'gif', 'apng', 'avif', 'bmp', 'jfif']);
 const CHARX_SPRITE_TYPES = new Set(['emotion', 'expression']);
@@ -151,6 +152,29 @@ export class CharXParser {
         return ext.trim().toLowerCase().replace(/^\./, '');
     }
 
+    /**
+     * Strip trailing image extension from asset name if present.
+     * Handles cases like "image.png" with ext "png" → "image" (avoids "image.png.png")
+     * @param {string} name - Asset name that may contain extension
+     * @param {string} expectedExt - The expected extension (lowercase, no dot)
+     * @returns {string} Name with trailing extension stripped if it matched
+     */
+    stripTrailingImageExtension(name, expectedExt) {
+        if (!name || !expectedExt) return name;
+        const lower = name.toLowerCase();
+        // Check if name ends with the expected extension
+        if (lower.endsWith(`.${expectedExt}`)) {
+            return name.slice(0, -(expectedExt.length + 1));
+        }
+        // Also check for any known image extension at the end
+        for (const ext of CHARX_IMAGE_EXTENSIONS) {
+            if (lower.endsWith(`.${ext}`)) {
+                return name.slice(0, -(ext.length + 1));
+            }
+        }
+        return name;
+    }
+
     deriveCharXAssetExtension(assetExt, zipPath) {
         const metaExt = this.normalizeExtString(assetExt);
         const pathExt = this.normalizeExtString(path.extname(zipPath || ''));
@@ -245,8 +269,6 @@ export class CharXParser {
                 storageCategory = 'sprite';
             } else if (CHARX_BACKGROUND_TYPES.has(asset.type)) {
                 storageCategory = 'background';
-            } else if (asset.type) {
-                storageCategory = 'misc';
             } else {
                 storageCategory = 'misc';
             }
@@ -254,11 +276,13 @@ export class CharXParser {
             // Use hyphens for sprites so ST's expression label extraction works correctly
             // (sprites.js extracts label via regex that splits on dash or dot)
             const useHyphens = storageCategory === 'sprite';
+            // Strip trailing extension from name if present (e.g., "image.png" with ext "png")
+            const nameWithoutExt = this.stripTrailingImageExtension(asset.name, ext);
             acc.push({
                 ...asset,
                 ext,
                 storageCategory,
-                baseName: this.getCharXAssetBaseName(asset.name, `${storageCategory}-${asset.order ?? 0}`, useHyphens),
+                baseName: this.getCharXAssetBaseName(nameWithoutExt, `${storageCategory}-${asset.order ?? 0}`, useHyphens),
             });
 
             return acc;
@@ -267,24 +291,23 @@ export class CharXParser {
 }
 
 /**
- * Gets a unique file path by appending a numeric suffix if needed.
- * Uses underscore separator for compatibility with ST's sprite naming.
+ * Delete existing file with same base name (any extension) before overwriting.
+ * Matches ST's sprite upload behavior in sprites.js.
  * @param {string} dirPath - Directory path
  * @param {string} baseName - Base filename without extension
- * @param {string} ext - File extension without dot
- * @returns {string} Full unique file path
  */
-function getUniqueAssetPath(dirPath, baseName, ext) {
-    const safeExt = ext || 'png';
-    let suffix = 0;
-    let candidate = `${baseName}.${safeExt}`;
-
-    while (fs.existsSync(path.join(dirPath, candidate))) {
-        suffix++;
-        candidate = `${baseName}_${suffix}.${safeExt}`;
+function deleteExistingByBaseName(dirPath, baseName) {
+    try {
+        const files = fs.readdirSync(dirPath);
+        for (const file of files) {
+            if (path.parse(file).name === baseName) {
+                fs.unlinkSync(path.join(dirPath, file));
+                console.debug(`CharX: Overwriting existing ${file}`);
+            }
+        }
+    } catch {
+        // Directory doesn't exist yet or other error, that's fine
     }
-
-    return path.join(dirPath, candidate);
 }
 
 /**
@@ -341,40 +364,50 @@ export function persistCharXAssets(assets, bufferMap, directories, characterFold
             continue;
         }
 
-        if (asset.storageCategory === 'sprite') {
-            const targetDir = ensureSpritesPath();
-            if (!targetDir) {
+        try {
+            if (asset.storageCategory === 'sprite') {
+                const targetDir = ensureSpritesPath();
+                if (!targetDir) {
+                    continue;
+                }
+                // Delete existing sprite with same base name (any extension) - matches sprites.js behavior
+                deleteExistingByBaseName(targetDir, asset.baseName);
+                const filePath = path.join(targetDir, `${asset.baseName}.${asset.ext || 'png'}`);
+                writeFileAtomicSync(filePath, buffer);
+                console.debug(`CharX: Saved sprite "${asset.name}" (${asset.type}) as ${path.basename(filePath)}`);
+                summary.sprites += 1;
                 continue;
             }
-            const filePath = getUniqueAssetPath(targetDir, asset.baseName, asset.ext);
-            writeFileAtomicSync(filePath, buffer);
-            console.debug(`CharX: Saved sprite "${asset.name}" (${asset.type}) as ${path.basename(filePath)}`);
-            summary.sprites += 1;
-            continue;
-        }
 
-        if (asset.storageCategory === 'background') {
-            if (!ensureDirectory(directories.backgrounds)) {
+            if (asset.storageCategory === 'background') {
+                if (!ensureDirectory(directories.backgrounds)) {
+                    continue;
+                }
+                const backgroundBaseName = `${characterFolder}_${asset.baseName}`;
+                // Delete existing background with same base name
+                deleteExistingByBaseName(directories.backgrounds, backgroundBaseName);
+                const fileName = `${backgroundBaseName}.${asset.ext || 'png'}`;
+                const filePath = path.join(directories.backgrounds, fileName);
+                writeFileAtomicSync(filePath, buffer);
+                invalidateThumbnail(directories, 'bg', fileName);
+                console.debug(`CharX: Saved background "${asset.name}" as ${fileName}`);
+                summary.backgrounds += 1;
                 continue;
             }
-            const backgroundBaseName = `${characterFolder}_${asset.baseName}`;
-            const filePath = getUniqueAssetPath(directories.backgrounds, backgroundBaseName, asset.ext);
-            writeFileAtomicSync(filePath, buffer);
-            invalidateThumbnail(directories, 'bg', path.basename(filePath));
-            console.debug(`CharX: Saved background "${asset.name}" as ${path.basename(filePath)}`);
-            summary.backgrounds += 1;
-            continue;
-        }
 
-        if (asset.storageCategory === 'misc') {
-            const miscDir = ensureMiscPath();
-            if (!miscDir) {
-                continue;
+            if (asset.storageCategory === 'misc') {
+                const miscDir = ensureMiscPath();
+                if (!miscDir) {
+                    continue;
+                }
+                // Overwrite existing misc asset with same name
+                const filePath = path.join(miscDir, `${asset.baseName}.${asset.ext || 'png'}`);
+                writeFileAtomicSync(filePath, buffer);
+                console.debug(`CharX: Saved misc asset "${asset.name}" (${asset.type}) as ${path.basename(filePath)}`);
+                summary.misc += 1;
             }
-            const filePath = getUniqueAssetPath(miscDir, asset.baseName, asset.ext);
-            writeFileAtomicSync(filePath, buffer);
-            console.debug(`CharX: Saved misc asset "${asset.name}" (${asset.type}) as ${path.basename(filePath)}`);
-            summary.misc += 1;
+        } catch (error) {
+            console.warn(`CharX: Failed to save asset "${asset.name}": ${error.message}`);
         }
     }
 

--- a/src/charx.js
+++ b/src/charx.js
@@ -24,7 +24,6 @@ function findZipStart(buffer) {
     const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
     const index = buf.indexOf(ZIP_SIGNATURE);
     if (index > 0) {
-        console.debug(`CharX: Found ZIP signature at offset ${index} (SFX archive)`);
         return buf.slice(index);
     }
     return buf;
@@ -72,23 +71,15 @@ export class CharXParser {
             throw new Error('Failed to extract card.json from CharX file');
         }
 
-        console.debug('CharX: Parsing card.json');
         const card = JSON.parse(cardBuffer.toString());
 
         if (card.spec === undefined) {
             throw new Error('Invalid CharX card file: missing spec field');
         }
 
-        console.debug(`CharX: Card spec=${card.spec}, name=${card.data?.name || card.name}`);
-
         const embeddedAssets = this.collectCharXAssets(card);
-        console.debug(`CharX: Found ${embeddedAssets.length} total assets`);
-
         const iconAsset = this.pickCharXIconAsset(embeddedAssets);
-        console.debug('CharX: Icon asset:', iconAsset ? `${iconAsset.name} (${iconAsset.zipPath})` : 'none');
-
         const auxiliaryAssets = this.mapCharXAssetsForStorage(embeddedAssets);
-        console.debug(`CharX: Mapped ${auxiliaryAssets.length} auxiliary assets for storage`);
 
         const archivePaths = new Set();
 
@@ -101,11 +92,9 @@ export class CharXParser {
             }
         }
 
-        console.debug(`CharX: Extracting ${archivePaths.size} asset files from archive`);
         let extractedBuffers = new Map();
         if (archivePaths.size > 0) {
             extractedBuffers = await extractFilesFromZipBuffer(this.#data, [...archivePaths]);
-            console.debug(`CharX: Extracted ${extractedBuffers.size} asset files`);
         }
 
         /** @type {string|Buffer} */
@@ -301,7 +290,6 @@ function deleteExistingByBaseName(dirPath, baseName) {
         for (const file of files) {
             if (path.parse(file).name === baseName) {
                 fs.unlinkSync(path.join(dirPath, file));
-                console.debug(`CharX: Overwriting existing ${file}`);
             }
         }
     } catch {
@@ -373,7 +361,6 @@ export function persistCharXAssets(assets, bufferMap, directories, characterFold
                 deleteExistingByBaseName(targetDir, asset.baseName);
                 const filePath = path.join(targetDir, `${asset.baseName}.${asset.ext || 'png'}`);
                 writeFileAtomicSync(filePath, buffer);
-                console.debug(`CharX: Saved sprite "${asset.name}" (${asset.type}) as ${path.basename(filePath)}`);
                 summary.sprites += 1;
                 continue;
             }
@@ -389,7 +376,6 @@ export function persistCharXAssets(assets, bufferMap, directories, characterFold
                 const fileName = `${asset.baseName}.${asset.ext || 'png'}`;
                 const filePath = path.join(backgroundDir, fileName);
                 writeFileAtomicSync(filePath, buffer);
-                console.debug(`CharX: Saved background "${asset.name}" as ${fileName}`);
                 summary.backgrounds += 1;
                 continue;
             }
@@ -402,7 +388,6 @@ export function persistCharXAssets(assets, bufferMap, directories, characterFold
                 // Overwrite existing misc asset with same name
                 const filePath = path.join(miscDir, `${asset.baseName}.${asset.ext || 'png'}`);
                 writeFileAtomicSync(filePath, buffer);
-                console.debug(`CharX: Saved misc asset "${asset.name}" (${asset.type}) as ${path.basename(filePath)}`);
                 summary.misc += 1;
             }
         } catch (error) {

--- a/src/charx.js
+++ b/src/charx.js
@@ -5,7 +5,6 @@ import sanitize from 'sanitize-filename';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import { extractFileFromZipBuffer, extractFilesFromZipBuffer, normalizeZipEntryPath, ensureDirectory } from './util.js';
 import { DEFAULT_AVATAR_PATH } from './constants.js';
-import { invalidateThumbnail } from './endpoints/thumbnails.js';
 
 // 'embeded://' is intentional - RisuAI exports use this misspelling
 const CHARX_EMBEDDED_URI_PREFIXES = ['embeded://', 'embedded://', '__asset:'];

--- a/src/charx.js
+++ b/src/charx.js
@@ -1,0 +1,354 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import _ from 'lodash';
+import sanitize from 'sanitize-filename';
+import { sync as writeFileAtomicSync } from 'write-file-atomic';
+import { extractFileFromZipBuffer, extractFilesFromZipBuffer, normalizeZipEntryPath } from './util.js';
+import { DEFAULT_AVATAR_PATH } from './constants.js';
+import { invalidateThumbnail } from './endpoints/thumbnails.js';
+
+const CHARX_EMBEDDED_URI_PREFIXES = ['embeded://', 'embedded://', '__asset:'];
+const CHARX_IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'webp', 'gif', 'apng', 'avif', 'bmp', 'jfif']);
+const CHARX_SPRITE_TYPES = new Set(['emotion', 'expression']);
+const CHARX_BACKGROUND_TYPES = new Set(['background']);
+
+// ZIP local file header signature: PK\x03\x04
+const ZIP_SIGNATURE = Buffer.from([0x50, 0x4B, 0x03, 0x04]);
+
+/**
+ * Find ZIP data start in buffer (handles SFX/self-extracting archives).
+ * @param {Buffer} buffer
+ * @returns {Buffer} Buffer starting at ZIP signature, or original if not found
+ */
+function findZipStart(buffer) {
+    const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
+    const index = buf.indexOf(ZIP_SIGNATURE);
+    if (index > 0) {
+        console.debug(`CharX: Found ZIP signature at offset ${index} (SFX archive)`);
+        return buf.slice(index);
+    }
+    return buf;
+}
+
+export class CharXParser {
+    #data;
+
+    /**
+     * @param {ArrayBuffer|Buffer} data
+     */
+    constructor(data) {
+        // Handle SFX (self-extracting) ZIP archives by finding the actual ZIP start
+        this.#data = findZipStart(Buffer.isBuffer(data) ? data : Buffer.from(data));
+    }
+
+    async parse() {
+        console.info('Importing from CharX');
+        const cardBuffer = await extractFileFromZipBuffer(this.#data, 'card.json');
+
+        if (!cardBuffer) {
+            throw new Error('Failed to extract card.json from CharX file');
+        }
+
+        console.debug('CharX: Parsing card.json');
+        const card = JSON.parse(cardBuffer.toString());
+
+        if (card.spec === undefined) {
+            throw new Error('Invalid CharX card file: missing spec field');
+        }
+
+        console.debug(`CharX: Card spec=${card.spec}, name=${card.data?.name || card.name}`);
+
+        const embeddedAssets = this.collectCharXAssets(card);
+        console.debug(`CharX: Found ${embeddedAssets.length} total assets`);
+
+        const iconAsset = this.pickCharXIconAsset(embeddedAssets);
+        console.debug('CharX: Icon asset:', iconAsset ? `${iconAsset.name} (${iconAsset.zipPath})` : 'none');
+
+        const auxiliaryAssets = this.mapCharXAssetsForStorage(embeddedAssets);
+        console.debug(`CharX: Mapped ${auxiliaryAssets.length} auxiliary assets for storage`);
+
+        const archivePaths = new Set();
+
+        if (iconAsset?.zipPath) {
+            archivePaths.add(iconAsset.zipPath);
+        }
+        for (const asset of auxiliaryAssets) {
+            if (asset?.zipPath) {
+                archivePaths.add(asset.zipPath);
+            }
+        }
+
+        console.debug(`CharX: Extracting ${archivePaths.size} asset files from archive`);
+        let extractedBuffers = new Map();
+        if (archivePaths.size > 0) {
+            extractedBuffers = await extractFilesFromZipBuffer(this.#data, [...archivePaths]);
+            console.debug(`CharX: Extracted ${extractedBuffers.size} asset files`);
+        }
+
+        /** @type {string|Buffer} */
+        let avatar = fs.readFileSync(DEFAULT_AVATAR_PATH);
+        if (iconAsset?.zipPath) {
+            const iconBuffer = extractedBuffers.get(iconAsset.zipPath);
+            if (iconBuffer) {
+                avatar = iconBuffer;
+            }
+        }
+
+        return { card, avatar, auxiliaryAssets, extractedBuffers };
+    }
+
+    getEmbeddedZipPathFromUri(uri) {
+        if (typeof uri !== 'string') {
+            return null;
+        }
+
+        const trimmed = uri.trim();
+        if (!trimmed) {
+            return null;
+        }
+
+        const lower = trimmed.toLowerCase();
+        for (const prefix of CHARX_EMBEDDED_URI_PREFIXES) {
+            if (lower.startsWith(prefix)) {
+                const rawPath = trimmed.slice(prefix.length);
+                return normalizeZipEntryPath(rawPath);
+            }
+        }
+
+        return null;
+    }
+
+    deriveCharXAssetExtension(assetExt, zipPath) {
+        const metaExt = typeof assetExt === 'string' ? assetExt.trim().toLowerCase() : '';
+        const pathExt = path.extname(zipPath || '').replace('.', '').toLowerCase();
+        return metaExt || pathExt;
+    }
+
+    collectCharXAssets(card) {
+        const assets = _.get(card, 'data.assets');
+        if (!Array.isArray(assets)) {
+            return [];
+        }
+
+        return assets.map((asset, index) => {
+            if (!asset) {
+                return null;
+            }
+
+            const zipPath = this.getEmbeddedZipPathFromUri(asset.uri);
+            if (!zipPath) {
+                return null;
+            }
+
+            const ext = this.deriveCharXAssetExtension(asset.ext, zipPath);
+            const type = typeof asset.type === 'string' ? asset.type.toLowerCase() : '';
+            const name = typeof asset.name === 'string' ? asset.name : '';
+
+            return {
+                type,
+                name,
+                ext,
+                zipPath,
+                order: index,
+            };
+        }).filter(Boolean);
+    }
+
+    pickCharXIconAsset(assets) {
+        const iconAssets = assets.filter(asset => asset.type === 'icon' && CHARX_IMAGE_EXTENSIONS.has(asset.ext) && asset.zipPath);
+        if (iconAssets.length === 0) {
+            return null;
+        }
+
+        const mainIcon = iconAssets.find(asset => asset.name?.toLowerCase() === 'main');
+        return mainIcon || iconAssets[0];
+    }
+
+    /**
+     * Normalize asset name for filesystem storage.
+     * @param {string} name - Original asset name
+     * @param {string} fallback - Fallback name if normalization fails
+     * @param {boolean} useHyphens - Use hyphens instead of underscores (for sprites)
+     * @returns {string} Normalized filename base (without extension)
+     */
+    getCharXAssetBaseName(name, fallback, useHyphens = false) {
+        const cleaned = (String(name ?? '').trim() || '');
+        if (!cleaned) {
+            return fallback.toLowerCase();
+        }
+
+        const separator = useHyphens ? '-' : '_';
+        // Convert to lowercase, replace spaces/special chars with separator
+        let base = cleaned
+            .toLowerCase()
+            .replace(/\s+/g, separator)
+            .replace(/[^a-z0-9_.-]/g, separator)
+            .replace(new RegExp(`${separator}+`, 'g'), separator)
+            .replace(new RegExp(`^${separator}+|${separator}+$`, 'g'), '');
+
+        // For sprites using hyphens, also convert any remaining underscores to hyphens
+        if (useHyphens) {
+            base = base.replace(/_/g, '-');
+        }
+
+        if (!base) {
+            return fallback.toLowerCase();
+        }
+
+        const sanitized = sanitize(base);
+        return (sanitized || fallback).toLowerCase();
+    }
+
+    mapCharXAssetsForStorage(assets) {
+        return assets.reduce((acc, asset) => {
+            if (!asset?.zipPath) {
+                return acc;
+            }
+
+            const ext = (asset.ext || '').toLowerCase();
+            if (!CHARX_IMAGE_EXTENSIONS.has(ext)) {
+                return acc;
+            }
+
+            if (asset.type === 'icon' || asset.type === 'user_icon') {
+                return acc;
+            }
+
+            let storageCategory;
+            if (CHARX_SPRITE_TYPES.has(asset.type)) {
+                storageCategory = 'sprite';
+            } else if (CHARX_BACKGROUND_TYPES.has(asset.type)) {
+                storageCategory = 'background';
+            } else if (asset.type) {
+                storageCategory = 'misc';
+            } else {
+                storageCategory = 'misc';
+            }
+
+            // Use hyphens for sprites so ST's expression label extraction works correctly
+            // (sprites.js extracts label via regex that splits on dash or dot)
+            const useHyphens = storageCategory === 'sprite';
+            acc.push({
+                ...asset,
+                ext,
+                storageCategory,
+                baseName: this.getCharXAssetBaseName(asset.name, `${storageCategory}-${asset.order ?? 0}`, useHyphens),
+            });
+
+            return acc;
+        }, []);
+    }
+}
+
+function ensureFolder(dirPath) {
+    try {
+        if (!fs.existsSync(dirPath)) {
+            fs.mkdirSync(dirPath, { recursive: true });
+        } else if (!fs.statSync(dirPath).isDirectory()) {
+            console.warn(`CharX: Path ${dirPath} exists and is not a directory.`);
+            return false;
+        }
+        return true;
+    } catch (error) {
+        console.error(`CharX: Failed to prepare directory ${dirPath}`, error);
+        return false;
+    }
+}
+
+function getUniqueAssetPath(dirPath, baseName, ext) {
+    const safeExt = ext || 'png';
+    let suffix = 0;
+    let candidate = `${baseName}.${safeExt}`;
+
+    while (fs.existsSync(path.join(dirPath, candidate))) {
+        suffix++;
+        candidate = `${baseName}_${suffix}.${safeExt}`;
+    }
+
+    return path.join(dirPath, candidate);
+}
+
+export function persistCharXAssets(assets, bufferMap, directories, characterFolder) {
+    /** @type {{sprites: number, backgrounds: number, misc: number}} */
+    const summary = { sprites: 0, backgrounds: 0, misc: 0 };
+    if (!Array.isArray(assets) || assets.length === 0) {
+        return summary;
+    }
+
+    let spritesPath = null;
+    let miscPath = null;
+
+    const ensureSpritesPath = () => {
+        if (spritesPath) {
+            return spritesPath;
+        }
+        const candidate = path.join(directories.characters, characterFolder);
+        if (!ensureFolder(candidate)) {
+            return null;
+        }
+        spritesPath = candidate;
+        return spritesPath;
+    };
+
+    const ensureMiscPath = () => {
+        if (miscPath) {
+            return miscPath;
+        }
+        // Use the image gallery path: user/images/{characterName}/
+        const candidate = path.join(directories.userImages, characterFolder);
+        if (!ensureFolder(candidate)) {
+            return null;
+        }
+        miscPath = candidate;
+        return miscPath;
+    };
+
+    for (const asset of assets) {
+        if (!asset?.zipPath) {
+            continue;
+        }
+        const buffer = bufferMap.get(asset.zipPath);
+        if (!buffer) {
+            console.warn(`CharX: Asset ${asset.zipPath} missing or unsupported, skipping.`);
+            continue;
+        }
+
+        if (asset.storageCategory === 'sprite') {
+            const targetDir = ensureSpritesPath();
+            if (!targetDir) {
+                continue;
+            }
+            const filePath = getUniqueAssetPath(targetDir, asset.baseName, asset.ext);
+            writeFileAtomicSync(filePath, buffer);
+            console.debug(`CharX: Saved sprite "${asset.name}" (${asset.type}) as ${path.basename(filePath)}`);
+            summary.sprites += 1;
+            continue;
+        }
+
+        if (asset.storageCategory === 'background') {
+            if (!ensureFolder(directories.backgrounds)) {
+                continue;
+            }
+            const backgroundBaseName = `${characterFolder}_${asset.baseName}`;
+            const filePath = getUniqueAssetPath(directories.backgrounds, backgroundBaseName, asset.ext);
+            writeFileAtomicSync(filePath, buffer);
+            invalidateThumbnail(directories, 'bg', path.basename(filePath));
+            console.debug(`CharX: Saved background "${asset.name}" as ${path.basename(filePath)}`);
+            summary.backgrounds += 1;
+            continue;
+        }
+
+        if (asset.storageCategory === 'misc') {
+            const miscDir = ensureMiscPath();
+            if (!miscDir) {
+                continue;
+            }
+            const filePath = getUniqueAssetPath(miscDir, asset.baseName, asset.ext);
+            writeFileAtomicSync(filePath, buffer);
+            console.debug(`CharX: Saved misc asset "${asset.name}" (${asset.type}) as ${path.basename(filePath)}`);
+            summary.misc += 1;
+        }
+    }
+
+    return summary;
+}

--- a/src/charx.js
+++ b/src/charx.js
@@ -86,7 +86,7 @@ export class CharXParser {
         }
 
         /** @type {string|Buffer} */
-        let avatar = fs.readFileSync(DEFAULT_AVATAR_PATH);
+        let avatar = DEFAULT_AVATAR_PATH;
         if (iconAsset?.zipPath) {
             const iconBuffer = extractedBuffers.get(iconAsset.zipPath);
             if (iconBuffer) {
@@ -118,9 +118,19 @@ export class CharXParser {
         return null;
     }
 
+    /**
+     * Normalize extension string: lowercase, strip leading dot.
+     * @param {string} ext
+     * @returns {string}
+     */
+    normalizeExtString(ext) {
+        if (typeof ext !== 'string') return '';
+        return ext.trim().toLowerCase().replace(/^\./, '');
+    }
+
     deriveCharXAssetExtension(assetExt, zipPath) {
-        const metaExt = typeof assetExt === 'string' ? assetExt.trim().toLowerCase() : '';
-        const pathExt = path.extname(zipPath || '').replace('.', '').toLowerCase();
+        const metaExt = this.normalizeExtString(assetExt);
+        const pathExt = this.normalizeExtString(path.extname(zipPath || ''));
         return metaExt || pathExt;
     }
 
@@ -178,18 +188,11 @@ export class CharXParser {
         }
 
         const separator = useHyphens ? '-' : '_';
-        // Convert to lowercase, replace spaces/special chars with separator
-        let base = cleaned
+        // Convert to lowercase, collapse non-alphanumeric runs to separator, trim edges
+        const base = cleaned
             .toLowerCase()
-            .replace(/\s+/g, separator)
-            .replace(/[^a-z0-9_.-]/g, separator)
-            .replace(new RegExp(`${separator}+`, 'g'), separator)
-            .replace(new RegExp(`^${separator}+|${separator}+$`, 'g'), '');
-
-        // For sprites using hyphens, also convert any remaining underscores to hyphens
-        if (useHyphens) {
-            base = base.replace(/_/g, '-');
-        }
+            .replace(/[^a-z0-9]+/g, separator)
+            .replace(new RegExp(`^${separator}|${separator}$`, 'g'), '');
 
         if (!base) {
             return fallback.toLowerCase();
@@ -268,6 +271,15 @@ function getUniqueAssetPath(dirPath, baseName, ext) {
     return path.join(dirPath, candidate);
 }
 
+/**
+ * Persist extracted CharX assets to appropriate ST directories.
+ * Note: Uses sync writes consistent with ST's existing file handling.
+ * @param {Array} assets - Mapped assets from CharXParser
+ * @param {Map<string, Buffer>} bufferMap - Extracted file buffers
+ * @param {Object} directories - User directories object
+ * @param {string} characterFolder - Character folder name (sanitized)
+ * @returns {{sprites: number, backgrounds: number, misc: number}}
+ */
 export function persistCharXAssets(assets, bufferMap, directories, characterFolder) {
     /** @type {{sprites: number, backgrounds: number, misc: number}} */
     const summary = { sprites: 0, backgrounds: 0, misc: 0 };

--- a/src/charx.js
+++ b/src/charx.js
@@ -380,16 +380,16 @@ export function persistCharXAssets(assets, bufferMap, directories, characterFold
             }
 
             if (asset.storageCategory === 'background') {
-                if (!ensureDirectory(directories.backgrounds)) {
+                // Store in character-specific backgrounds folder: characters/{charName}/backgrounds/
+                const backgroundDir = path.join(directories.characters, characterFolder, 'backgrounds');
+                if (!ensureDirectory(backgroundDir)) {
                     continue;
                 }
-                const backgroundBaseName = `${characterFolder}_${asset.baseName}`;
                 // Delete existing background with same base name
-                deleteExistingByBaseName(directories.backgrounds, backgroundBaseName);
-                const fileName = `${backgroundBaseName}.${asset.ext || 'png'}`;
-                const filePath = path.join(directories.backgrounds, fileName);
+                deleteExistingByBaseName(backgroundDir, asset.baseName);
+                const fileName = `${asset.baseName}.${asset.ext || 'png'}`;
+                const filePath = path.join(backgroundDir, fileName);
                 writeFileAtomicSync(filePath, buffer);
-                invalidateThumbnail(directories, 'bg', fileName);
                 console.debug(`CharX: Saved background "${asset.name}" as ${fileName}`);
                 summary.backgrounds += 1;
                 continue;

--- a/src/charx.js
+++ b/src/charx.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import _ from 'lodash';
 import sanitize from 'sanitize-filename';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
-import { extractFileFromZipBuffer, extractFilesFromZipBuffer, normalizeZipEntryPath } from './util.js';
+import { extractFileFromZipBuffer, extractFilesFromZipBuffer, normalizeZipEntryPath, ensureDirectory } from './util.js';
 import { DEFAULT_AVATAR_PATH } from './constants.js';
 import { invalidateThumbnail } from './endpoints/thumbnails.js';
 
@@ -30,6 +30,25 @@ function findZipStart(buffer) {
     return buf;
 }
 
+/**
+ * @typedef {Object} CharXAsset
+ * @property {string} type - Asset type (emotion, expression, background, etc.)
+ * @property {string} name - Asset name from metadata
+ * @property {string} ext - File extension (lowercase, no dot)
+ * @property {string} zipPath - Normalized path within the ZIP archive
+ * @property {number} order - Original index in assets array
+ * @property {string} [storageCategory] - 'sprite' | 'background' | 'misc' (set by mapCharXAssetsForStorage)
+ * @property {string} [baseName] - Normalized filename base (set by mapCharXAssetsForStorage)
+ */
+
+/**
+ * @typedef {Object} CharXParseResult
+ * @property {Object} card - Parsed card.json (CCv2 or CCv3 spec)
+ * @property {string|Buffer} avatar - Avatar image buffer or DEFAULT_AVATAR_PATH
+ * @property {CharXAsset[]} auxiliaryAssets - Assets mapped for storage
+ * @property {Map<string, Buffer>} extractedBuffers - Map of zipPath to extracted buffer
+ */
+
 export class CharXParser {
     #data;
 
@@ -41,6 +60,10 @@ export class CharXParser {
         this.#data = findZipStart(Buffer.isBuffer(data) ? data : Buffer.from(data));
     }
 
+    /**
+     * Parse the CharX archive and extract card data and assets.
+     * @returns {Promise<CharXParseResult>}
+     */
     async parse() {
         console.info('Importing from CharX');
         const cardBuffer = await extractFileFromZipBuffer(this.#data, 'card.json');
@@ -243,21 +266,14 @@ export class CharXParser {
     }
 }
 
-function ensureFolder(dirPath) {
-    try {
-        if (!fs.existsSync(dirPath)) {
-            fs.mkdirSync(dirPath, { recursive: true });
-        } else if (!fs.statSync(dirPath).isDirectory()) {
-            console.warn(`CharX: Path ${dirPath} exists and is not a directory.`);
-            return false;
-        }
-        return true;
-    } catch (error) {
-        console.error(`CharX: Failed to prepare directory ${dirPath}`, error);
-        return false;
-    }
-}
-
+/**
+ * Gets a unique file path by appending a numeric suffix if needed.
+ * Uses underscore separator for compatibility with ST's sprite naming.
+ * @param {string} dirPath - Directory path
+ * @param {string} baseName - Base filename without extension
+ * @param {string} ext - File extension without dot
+ * @returns {string} Full unique file path
+ */
 function getUniqueAssetPath(dirPath, baseName, ext) {
     const safeExt = ext || 'png';
     let suffix = 0;
@@ -295,7 +311,7 @@ export function persistCharXAssets(assets, bufferMap, directories, characterFold
             return spritesPath;
         }
         const candidate = path.join(directories.characters, characterFolder);
-        if (!ensureFolder(candidate)) {
+        if (!ensureDirectory(candidate)) {
             return null;
         }
         spritesPath = candidate;
@@ -308,7 +324,7 @@ export function persistCharXAssets(assets, bufferMap, directories, characterFold
         }
         // Use the image gallery path: user/images/{characterName}/
         const candidate = path.join(directories.userImages, characterFolder);
-        if (!ensureFolder(candidate)) {
+        if (!ensureDirectory(candidate)) {
             return null;
         }
         miscPath = candidate;
@@ -338,7 +354,7 @@ export function persistCharXAssets(assets, bufferMap, directories, characterFold
         }
 
         if (asset.storageCategory === 'background') {
-            if (!ensureFolder(directories.backgrounds)) {
+            if (!ensureDirectory(directories.backgrounds)) {
                 continue;
             }
             const backgroundBaseName = `${characterFolder}_${asset.baseName}`;

--- a/src/charx.js
+++ b/src/charx.js
@@ -298,7 +298,7 @@ export class CharXParser {
  */
 function deleteExistingByBaseName(dirPath, baseName) {
     try {
-        const files = fs.readdirSync(dirPath);
+        const files = fs.readdirSync(dirPath, { withFileTypes: true }).filter(f => f.isFile()).map(f => f.name);
         for (const file of files) {
             if (path.parse(file).name === baseName) {
                 fs.unlinkSync(path.join(dirPath, file));

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -779,7 +779,7 @@ async function importFromCharX(uploadPath, { request }, preservedFileName) {
     // Apply standard character transformations
     let processedCard = readFromV2(card);
     unsetPrivateFields(processedCard);
-    processedCard['create_date'] = humanizedDateTime();
+    processedCard['create_date'] = new Date().toISOString();
     processedCard.name = sanitize(processedCard.name);
 
     const fileName = preservedFileName || getPngName(processedCard.name, request.user.directories);

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -14,7 +14,7 @@ import storage from 'node-persist';
 
 import { AVATAR_WIDTH, AVATAR_HEIGHT, DEFAULT_AVATAR_PATH } from '../constants.js';
 import { default as validateAvatarUrlMiddleware, getFileNameValidationFunction } from '../middleware/validateFileName.js';
-import { deepMerge, humanizedDateTime, tryParse, extractFileFromZipBuffer, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements } from '../util.js';
+import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements } from '../util.js';
 import { TavernCardValidator } from '../validator/TavernCardValidator.js';
 import { parse, read, write } from '../character-card-parser.js';
 import { readWorldInfoFile } from './worldinfo.js';
@@ -23,6 +23,7 @@ import { importRisuSprites } from './sprites.js';
 import { getUserDirectories } from '../users.js';
 import { getChatInfo } from './chats.js';
 import { ByafParser } from '../byaf.js';
+import { CharXParser, persistCharXAssets } from '../charx.js';
 import cacheBuster from '../middleware/cacheBuster.js';
 
 // With 100 MB limit it would take roughly 3000 characters to reach this limit
@@ -767,40 +768,38 @@ async function importFromYaml(uploadPath, context, preservedFileName) {
  * @returns {Promise<string>} Internal name of the character
  */
 async function importFromCharX(uploadPath, { request }, preservedFileName) {
-    const data = fs.readFileSync(uploadPath).buffer;
+    const fileBuffer = fs.readFileSync(uploadPath);
+    // Create a properly-sized ArrayBuffer (Node's buffer pool can cause oversized .buffer)
+    const data = fileBuffer.buffer.slice(fileBuffer.byteOffset, fileBuffer.byteOffset + fileBuffer.byteLength);
     fs.unlinkSync(uploadPath);
-    console.info('Importing from CharX');
-    const cardBuffer = await extractFileFromZipBuffer(data, 'card.json');
 
-    if (!cardBuffer) {
-        throw new Error('Failed to extract card.json from CharX file');
-    }
+    const parser = new CharXParser(data);
+    const { card, avatar, auxiliaryAssets, extractedBuffers } = await parser.parse();
 
-    const card = readFromV2(JSON.parse(cardBuffer.toString()));
+    // Apply standard character transformations
+    let processedCard = readFromV2(card);
+    unsetPrivateFields(processedCard);
+    processedCard['create_date'] = humanizedDateTime();
+    processedCard.name = sanitize(processedCard.name);
 
-    if (card.spec === undefined) {
-        throw new Error('Invalid CharX card file: missing spec field');
-    }
+    const fileName = preservedFileName || getPngName(processedCard.name, request.user.directories);
+    console.debug(`CharX: Saving character as ${fileName}.png`);
 
-    /** @type {string|Buffer} */
-    let avatar = DEFAULT_AVATAR_PATH;
-    const assets = _.get(card, 'data.assets');
-    if (Array.isArray(assets) && assets.length) {
-        for (const asset of assets.filter(x => x.type === 'icon' && typeof x.uri === 'string')) {
-            const pathNoProtocol = String(asset.uri.replace(/^(?:\/\/|[^/]+)*\//, ''));
-            const buffer = await extractFileFromZipBuffer(data, pathNoProtocol);
-            if (buffer) {
-                avatar = buffer;
-                break;
+    if (auxiliaryAssets.length > 0) {
+        try {
+            const summary = persistCharXAssets(auxiliaryAssets, extractedBuffers, request.user.directories, fileName);
+            if (summary.sprites || summary.backgrounds || summary.misc) {
+                console.info(`CharX: Imported ${summary.sprites} sprite(s), ${summary.backgrounds} background(s), ${summary.misc} misc asset(s) for ${fileName}`);
+                console.info(`CharX: Sprites → characters/${fileName}/, Backgrounds → backgrounds/${fileName}_*, Gallery → user/images/${fileName}/`);
             }
+        } catch (error) {
+            console.warn(`CharX: Failed to persist auxiliary assets for ${fileName}`, error);
         }
     }
 
-    unsetPrivateFields(card);
-    card['create_date'] = new Date().toISOString();
-    card.name = sanitize(card.name);
-    const fileName = preservedFileName || getPngName(card.name, request.user.directories);
-    const result = await writeCharacterData(avatar, JSON.stringify(card), fileName, request);
+    console.debug('CharX: Writing character data to PNG');
+    const result = await writeCharacterData(avatar, JSON.stringify(processedCard), fileName, request);
+    console.debug(`CharX: Import ${result ? 'successful' : 'failed'} for ${fileName}`);
     return result ? fileName : '';
 }
 

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -786,23 +786,19 @@ async function importFromCharX(uploadPath, { request }, preservedFileName) {
     // Use the actual character name for asset folders, not the unique filename
     // ST's sprite system looks up by character name, not PNG filename
     const characterFolder = processedCard.name;
-    console.debug(`CharX: Saving character as ${fileName}.png`);
 
     if (auxiliaryAssets.length > 0) {
         try {
             const summary = persistCharXAssets(auxiliaryAssets, extractedBuffers, request.user.directories, characterFolder);
             if (summary.sprites || summary.backgrounds || summary.misc) {
-                console.info(`CharX: Imported ${summary.sprites} sprite(s), ${summary.backgrounds} background(s), ${summary.misc} misc asset(s) for ${characterFolder}`);
-                console.info(`CharX: Sprites → characters/${characterFolder}/, Backgrounds → characters/${characterFolder}/backgrounds/, Gallery → user/images/${characterFolder}/`);
+                console.log(`CharX: Imported ${summary.sprites} sprite(s), ${summary.backgrounds} background(s), ${summary.misc} misc asset(s) for ${characterFolder}`);
             }
         } catch (error) {
             console.warn(`CharX: Failed to persist auxiliary assets for ${characterFolder}`, error);
         }
     }
 
-    console.debug('CharX: Writing character data to PNG');
     const result = await writeCharacterData(avatar, JSON.stringify(processedCard), fileName, request);
-    console.debug(`CharX: Import ${result ? 'successful' : 'failed'} for ${fileName}`);
     return result ? fileName : '';
 }
 

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -783,17 +783,20 @@ async function importFromCharX(uploadPath, { request }, preservedFileName) {
     processedCard.name = sanitize(processedCard.name);
 
     const fileName = preservedFileName || getPngName(processedCard.name, request.user.directories);
+    // Use the actual character name for asset folders, not the unique filename
+    // ST's sprite system looks up by character name, not PNG filename
+    const characterFolder = processedCard.name;
     console.debug(`CharX: Saving character as ${fileName}.png`);
 
     if (auxiliaryAssets.length > 0) {
         try {
-            const summary = persistCharXAssets(auxiliaryAssets, extractedBuffers, request.user.directories, fileName);
+            const summary = persistCharXAssets(auxiliaryAssets, extractedBuffers, request.user.directories, characterFolder);
             if (summary.sprites || summary.backgrounds || summary.misc) {
-                console.info(`CharX: Imported ${summary.sprites} sprite(s), ${summary.backgrounds} background(s), ${summary.misc} misc asset(s) for ${fileName}`);
-                console.info(`CharX: Sprites → characters/${fileName}/, Backgrounds → backgrounds/${fileName}_*, Gallery → user/images/${fileName}/`);
+                console.info(`CharX: Imported ${summary.sprites} sprite(s), ${summary.backgrounds} background(s), ${summary.misc} misc asset(s) for ${characterFolder}`);
+                console.info(`CharX: Sprites → characters/${characterFolder}/, Backgrounds → backgrounds/${characterFolder}_*, Gallery → user/images/${characterFolder}/`);
             }
         } catch (error) {
-            console.warn(`CharX: Failed to persist auxiliary assets for ${fileName}`, error);
+            console.warn(`CharX: Failed to persist auxiliary assets for ${characterFolder}`, error);
         }
     }
 

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -793,7 +793,7 @@ async function importFromCharX(uploadPath, { request }, preservedFileName) {
             const summary = persistCharXAssets(auxiliaryAssets, extractedBuffers, request.user.directories, characterFolder);
             if (summary.sprites || summary.backgrounds || summary.misc) {
                 console.info(`CharX: Imported ${summary.sprites} sprite(s), ${summary.backgrounds} background(s), ${summary.misc} misc asset(s) for ${characterFolder}`);
-                console.info(`CharX: Sprites → characters/${characterFolder}/, Backgrounds → backgrounds/${characterFolder}_*, Gallery → user/images/${characterFolder}/`);
+                console.info(`CharX: Sprites → characters/${characterFolder}/, Backgrounds → characters/${characterFolder}/backgrounds/, Gallery → user/images/${characterFolder}/`);
             }
         } catch (error) {
             console.warn(`CharX: Failed to persist auxiliary assets for ${characterFolder}`, error);

--- a/src/util.js
+++ b/src/util.js
@@ -264,6 +264,146 @@ export async function extractFileFromZipBuffer(archiveBuffer, fileExtension) {
 }
 
 /**
+ * Normalizes a ZIP entry path for safe extraction.
+ * @param {string} entryName The entry name from the ZIP archive
+ * @returns {string|null} Normalized path or null if invalid
+ */
+export function normalizeZipEntryPath(entryName) {
+    if (typeof entryName !== 'string') {
+        return null;
+    }
+
+    let normalized = entryName.replace(/\\/g, '/').trim();
+
+    if (!normalized) {
+        return null;
+    }
+
+    normalized = normalized.replace(/^\.\/+/g, '');
+    normalized = path.posix.normalize(normalized);
+
+    if (!normalized || normalized === '.' || normalized.startsWith('..')) {
+        return null;
+    }
+
+    if (normalized.startsWith('/')) {
+        normalized = normalized.slice(1);
+    }
+
+    return normalized;
+}
+
+/**
+ * Extracts multiple files from an ArrayBuffer containing a ZIP archive.
+ * @param {ArrayBufferLike} archiveBuffer Buffer containing a ZIP archive
+ * @param {string[]} fileNames Array of file paths to extract
+ * @returns {Promise<Map<string, Buffer>>} Map of normalized paths to their extracted buffers
+ */
+export async function extractFilesFromZipBuffer(archiveBuffer, fileNames) {
+    const targets = new Map();
+
+    if (Array.isArray(fileNames)) {
+        for (const fileName of fileNames) {
+            const normalized = normalizeZipEntryPath(fileName);
+            if (normalized && !targets.has(normalized)) {
+                targets.set(normalized, true);
+            }
+        }
+    }
+
+    if (targets.size === 0) {
+        console.debug('extractFilesFromZipBuffer: No targets to extract');
+        return new Map();
+    }
+
+    console.debug(`extractFilesFromZipBuffer: Extracting ${targets.size} files:`, [...targets.keys()]);
+
+    return await new Promise((resolve) => {
+        const results = new Map();
+
+        try {
+            yauzl.fromBuffer(Buffer.from(archiveBuffer), { lazyEntries: true }, (err, zipfile) => {
+                if (err) {
+                    console.warn(`Error opening ZIP file: ${err.message}`);
+                    return resolve(results);
+                }
+
+                let finished = false;
+                const finalize = () => {
+                    if (finished) {
+                        return;
+                    }
+                    finished = true;
+                    resolve(results);
+                };
+
+                zipfile.readEntry();
+
+                zipfile.on('entry', (entry) => {
+                    const normalizedEntry = normalizeZipEntryPath(entry.fileName);
+                    if (!normalizedEntry || !targets.has(normalizedEntry)) {
+                        return zipfile.readEntry();
+                    }
+
+                    console.debug(`extractFilesFromZipBuffer: Found target ${normalizedEntry}`);
+
+                    zipfile.openReadStream(entry, (streamErr, readStream) => {
+                        if (streamErr) {
+                            console.warn(`Error opening read stream: ${streamErr.message}`);
+                            return zipfile.readEntry();
+                        }
+
+                        const chunks = [];
+                        readStream.on('data', (chunk) => {
+                            chunks.push(chunk);
+                        });
+
+                        readStream.on('end', () => {
+                            results.set(normalizedEntry, Buffer.concat(chunks));
+                            targets.delete(normalizedEntry);
+                            console.debug(`extractFilesFromZipBuffer: Extracted ${normalizedEntry}, ${targets.size} remaining`);
+
+                            if (targets.size === 0) {
+                                console.debug('extractFilesFromZipBuffer: All targets found, finalizing');
+                                finalize();
+                            } else {
+                                zipfile.readEntry();
+                            }
+                        });
+
+                        readStream.on('error', (streamError) => {
+                            console.warn(`Error reading stream: ${streamError.message}`);
+                            zipfile.readEntry();
+                        });
+                    });
+                });
+
+                zipfile.on('error', (zipError) => {
+                    console.warn('ZIP processing error', zipError);
+                    finalize();
+                });
+
+                zipfile.on('close', () => {
+                    console.debug('extractFilesFromZipBuffer: ZIP closed');
+                    finalize();
+                });
+
+                zipfile.on('end', () => {
+                    console.debug('extractFilesFromZipBuffer: ZIP end reached');
+                    if (targets.size > 0) {
+                        console.warn(`extractFilesFromZipBuffer: ZIP ended but ${targets.size} targets not found:`, [...targets.keys()]);
+                    }
+                    finalize();
+                });
+            });
+        } catch (error) {
+            console.warn('Failed to process ZIP buffer', error);
+            resolve(results);
+        }
+    });
+}
+
+/**
  * Extracts all images from a ZIP archive.
  * @param {string} zipFilePath Path to the ZIP archive
  * @returns {Promise<[string, Buffer][]>} Array of image buffers

--- a/src/util.js
+++ b/src/util.js
@@ -221,7 +221,6 @@ export async function extractFileFromZipBuffer(archiveBuffer, fileExtension) {
 
                 zipfile.on('entry', (entry) => {
                     if (entry.fileName.endsWith(fileExtension) && !entry.fileName.startsWith('__MACOSX')) {
-                        console.info(`Extracting ${entry.fileName}`);
                         zipfile.openReadStream(entry, (err, readStream) => {
                             if (err) {
                                 console.warn(`Error opening read stream: ${err.message}`);
@@ -312,11 +311,8 @@ export async function extractFilesFromZipBuffer(archiveBuffer, fileNames) {
     }
 
     if (targets.size === 0) {
-        console.debug('extractFilesFromZipBuffer: No targets to extract');
         return new Map();
     }
-
-    console.debug(`extractFilesFromZipBuffer: Extracting ${targets.size} files:`, [...targets.keys()]);
 
     return await new Promise((resolve) => {
         const results = new Map();
@@ -345,8 +341,6 @@ export async function extractFilesFromZipBuffer(archiveBuffer, fileNames) {
                         return zipfile.readEntry();
                     }
 
-                    console.debug(`extractFilesFromZipBuffer: Found target ${normalizedEntry}`);
-
                     zipfile.openReadStream(entry, (streamErr, readStream) => {
                         if (streamErr) {
                             console.warn(`Error opening read stream: ${streamErr.message}`);
@@ -361,10 +355,8 @@ export async function extractFilesFromZipBuffer(archiveBuffer, fileNames) {
                         readStream.on('end', () => {
                             results.set(normalizedEntry, Buffer.concat(chunks));
                             targets.delete(normalizedEntry);
-                            console.debug(`extractFilesFromZipBuffer: Extracted ${normalizedEntry}, ${targets.size} remaining`);
 
                             if (targets.size === 0) {
-                                console.debug('extractFilesFromZipBuffer: All targets found, finalizing');
                                 finalize();
                             } else {
                                 zipfile.readEntry();
@@ -384,15 +376,10 @@ export async function extractFilesFromZipBuffer(archiveBuffer, fileNames) {
                 });
 
                 zipfile.on('close', () => {
-                    console.debug('extractFilesFromZipBuffer: ZIP closed');
                     finalize();
                 });
 
                 zipfile.on('end', () => {
-                    console.debug('extractFilesFromZipBuffer: ZIP end reached');
-                    if (targets.size > 0) {
-                        console.warn(`extractFilesFromZipBuffer: ZIP ended but ${targets.size} targets not found:`, [...targets.keys()]);
-                    }
                     finalize();
                 });
             });
@@ -446,7 +433,6 @@ export async function getImageBuffers(zipFilePath) {
                 zipfile.on('entry', (entry) => {
                     const mimeType = mime.lookup(entry.fileName);
                     if (mimeType && mimeType.startsWith('image/') && !entry.fileName.startsWith('__MACOSX')) {
-                        console.info(`Extracting ${entry.fileName}`);
                         zipfile.openReadStream(entry, (err, readStream) => {
                             if (err) {
                                 reject(err);

--- a/src/util.js
+++ b/src/util.js
@@ -404,6 +404,26 @@ export async function extractFilesFromZipBuffer(archiveBuffer, fileNames) {
 }
 
 /**
+ * Ensures a directory exists, creating it if necessary.
+ * @param {string} dirPath Path to the directory
+ * @returns {boolean} True if the directory exists or was created, false on error
+ */
+export function ensureDirectory(dirPath) {
+    try {
+        if (!fs.existsSync(dirPath)) {
+            fs.mkdirSync(dirPath, { recursive: true });
+        } else if (!fs.statSync(dirPath).isDirectory()) {
+            console.warn(`ensureDirectory: Path ${dirPath} exists and is not a directory.`);
+            return false;
+        }
+        return true;
+    } catch (error) {
+        console.error(`ensureDirectory: Failed to prepare directory ${dirPath}`, error);
+        return false;
+    }
+}
+
+/**
  * Extracts all images from a ZIP archive.
  * @param {string} zipFilePath Path to the ZIP archive
  * @returns {Promise<[string, Buffer][]>} Array of image buffers


### PR DESCRIPTION
# PR: Enhanced CharX Import with Asset Extraction

## Summary
- Extract and store embedded CharX assets (sprites, backgrounds, gallery images) to accessible locations
- Add ZIP utility functions for efficient multi-file extraction
- Refactor CharX parsing logic into dedicated `src/charx.js` module
- Support SFX (self-extracting) ZIP archives
- Overwrite existing assets on re-import (matches ST's sprite upload behavior)

## Reason for Change
Currently, CharX imports only extract the character card data and avatar. Embedded assets (expressions, backgrounds, etc.) packaged within the `.charx` archive are discarded. This PR enables richer character experiences by making all packaged assets accessible through existing SillyTavern endpoints.

Inspired by [Add Full Support for BYAF Archives #4701](https://github.com/SillyTavern/SillyTavern/pull/4701)

## What Changed

### New File: `src/charx.js` (~415 lines)
- `CharXParser` class handling card.json parsing and asset collection
- `persistCharXAssets()` function to save extracted assets to appropriate directories
- `findZipStart()` to handle SFX (self-extracting) ZIP archives
- `stripTrailingImageExtension()` to handle metadata names containing extensions
- `deleteExistingByBaseName()` for overwrite behavior matching sprites.js
- Asset categorization logic based on CCv3 asset types
- Per-file error handling (one bad file won't abort entire import)

### Modified: `src/util.js` (+160 lines)
- `normalizeZipEntryPath()` - Safely normalize ZIP entry paths
- `extractFilesFromZipBuffer()` - Extract multiple files from ZIP in single pass
- `ensureDirectory()` - Shared helper for directory creation

### Modified: `src/endpoints/characters.js` (~+25/-25 lines)
- Updated `importFromCharX()` to use new CharXParser
- Fixed ArrayBuffer slicing for proper ZIP handling (Node.js buffer pool issue)
- Removed now-unused direct ZIP extraction code

## Asset Storage Mapping

| CharX Type | ST Category | Target Directory | Naming |
|:-----------|:------------|:-----------------|:-------|
| `icon` (name="main") | Avatar | `characters/` | `{charName}.png` |
| `emotion`, `expression` | Sprite | `characters/{charName}/` | `{assetName}.{ext}` (hyphens) |
| `background` | Background | `characters/{charName}/backgrounds/` | `{assetName}.{ext}` |
| `user_icon` | N/A | **Skipped** | Ignored to prevent conflicts |
| `x-risu-asset`, other | Gallery | `user/images/{charName}/` | `{assetName}.{ext}` |

## Technical Notes

### Overwrite Behavior
Assets are overwritten on re-import, matching ST's existing sprite upload behavior (`sprites.js`). This ensures character updates work correctly - importing "Maidbot v2.charx" will replace v1's sprites with new art.

### SFX Archive Support
Some CharX files are SFX (self-extracting) ZIPs with an executable header. The parser scans for the ZIP signature (`PK\x03\x04`) and extracts from that offset.

### Sprite Naming Convention
Sprite filenames use hyphens instead of underscores (e.g., `joy-happy.png` not `joy_happy.png`). This ensures ST's expression label extraction works correctly, as `sprites.js` splits on `-` or `.` to derive the expression label. Underscores are NOT delimiters in ST's sprite system.

### Extension Stripping
Asset metadata sometimes includes the extension in the name (e.g., `"name": "image.png", "ext": "png"`). The parser strips trailing extensions to avoid `image.png.png` filenames.

### RisuAI Compatibility
- The `embeded://` URI scheme typo is intentional - it's how RisuAI exports CharX files
- RisuAI exports most assets as `x-risu-asset` type regardless of their actual purpose. These are stored in the gallery folder (`user/images/{charName}/`). Proper categorization requires creators to use CCv3 standard types (`emotion`, `expression`, `background`).

### Error Resilience
Per-file error handling ensures one problematic asset doesn't abort the entire import. Failed assets are logged and skipped; import continues with remaining files.

## Note on PR Size
This PR exceeds the 200-line soft limit (~600 lines). The changes are tightly coupled:
- CharXParser depends on the new utility functions
- The endpoint changes depend on CharXParser
- Splitting would leave intermediate commits non-functional

The code is logically organized into three distinct areas (utilities, parser, endpoint integration) which should aid review.

---

## Test Plan

### Prerequisites
- CharX files with various asset types (test files available at [charx-test-files-v1](https://github.com/axAilotl/SillyTavern/releases/tag/charx-test-files-v1))
- Real-world CharX exports from RisuAI (tested with 34 files, 200-300MB each)

### Test Cases

#### TC1: Basic CharX Import (Regression)
**File:** `test_basic.charx`
1. Import a simple CharX file (avatar only, no extras)
2. **Expected:** Character imports successfully with correct name and avatar
3. **Verify:** No errors in console, character appears in list

#### TC2: All 28 ST Expressions
**File:** `test_all_expressions.charx`
1. Import CharX with all 28 standard expression sprites
2. **Expected:** All sprites saved to `characters/{charName}/`
3. **Verify:** Expression selector shows all 28 expressions populated

#### TC3: Backgrounds
**File:** `test_backgrounds.charx`
1. Import CharX containing `background` type assets
2. **Expected:** Backgrounds saved to `characters/{charName}/backgrounds/{assetName}.{ext}`
3. **Verify:** Backgrounds appear in character folder

#### TC4: Mixed Assets (Including x-risu-asset)
**File:** `test_mixed.charx`
1. Import CharX with sprites, backgrounds, gallery, AND x-risu-asset types
2. **Expected:**
   - Sprites → `characters/{name}/`
   - Backgrounds → `characters/{name}/backgrounds/`
   - x-risu-asset & gallery → `user/images/{name}/`
3. **Verify:** Console shows correct counts for each category

#### TC5: user_icon Skipping
**File:** `test_user_icon.charx`
1. Import CharX containing `user_icon` type assets
2. **Expected:** user_icon assets are NOT imported (by design)
3. **Verify:** Only sprite imported, no user avatar files created

#### TC6: Edge Cases (Special Characters, Underscores)
**File:** `test_edge_cases.charx`
1. Import CharX with:
   - Underscores in sprite names (should become hyphens)
   - Special characters in names
   - Missing assets (referenced but not in ZIP)
2. **Expected:**
   - `joy_happy_face` → `joy-happy-face.png`
   - Special chars normalized
   - Missing assets skipped with warning
3. **Verify:** Console warnings for missing assets, files named correctly

#### TC7: x-risu-asset Only
**File:** `test_x_risu_only.charx`
1. Import CharX with only `x-risu-asset` type (common in RisuAI exports)
2. **Expected:** All assets go to `user/images/{charName}/`
3. **Verify:** Console shows `X misc asset(s)`, files in gallery folder

#### TC8: Large Files / Stress Test
**Files:** Real RisuAI exports (20-200MB, 1000+ assets)
1. Import large CharX files
2. **Expected:** All assets extracted without memory issues
3. **Verify:** Console shows progress, import completes successfully

#### TC9: SFX (Self-Extracting) Archives
**Files:** CharX files that WinRAR identifies as "SFX ZIP"
1. Import SFX CharX archives
2. **Expected:** Parser finds ZIP signature and extracts successfully
3. **Verify:** Console shows `CharX: Found ZIP signature at offset X (SFX archive)`

#### TC10: Re-import / Overwrite
1. Import a CharX file with sprites
2. Modify one of the imported sprite files manually
3. Re-import the same CharX file
4. **Expected:** Modified sprite is overwritten with original from CharX
5. **Verify:** File content matches CharX version, not manual edit

### Automated Checks
- [x] `npm run lint` passes with no errors
- [x] Server starts without errors after changes
- [x] Test generator creates valid CharX files

---

## Testing Completed
- ✅ All 7 generated test files import correctly
- ✅ 34 real-world RisuAI CharX files (20-200MB each) imported successfully
- ✅ SFX archive support verified
- ✅ Thousands of assets per file handled without issues
- ✅ Overwrite behavior verified
- ✅ Lint passes

Additionally tested adding 300+ Chub, Wyvern, Character Tavern PNG and JSON files, and CharX with CCv3 standard types. To ensure no impact to other card types.

## Known Limitations
- **PNG-embedded CharX:** Some tools embed CharX data as base64 in PNG files. These are not supported (would require different parsing approach).
- **RisuAI asset typing:** RisuAI exports most assets as `x-risu-asset` regardless of purpose. These go to gallery; proper sprite categorization requires creators to use CCv3 standard types.

## Reviewer Notes
- The `embeded://` URI scheme typo is intentional - it's how RisuAI exports CharX files (comment added in code)
- Asset name normalization converts to lowercase with hyphens (sprites) or underscores (others)
- `user_icon` assets are explicitly skipped to avoid overwriting user's persona avatars
- Trailing extensions are stripped from asset names to avoid `file.png.png`
- Overwrite behavior matches `sprites.js` upload-zip endpoint

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

