### PR TITLE
Empty `swipes` are not handled by `ensureSwipes`.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6404,13 +6404,12 @@ export function ensureSwipes(message) {
         updated = true;
     }
 
-    message.swipes = message.swipes.map((mes) => {
+    message.swipes.forEach((mes, index, swipes) => {
         if (typeof mes !== 'string') {
             updated = true;
             console.warn('The message had a swipe that is not a string. It has has been set to \'\'.', message);
-            return '';
+            swipes[index] = '';
         }
-        return mes;
     });
 
     if (typeof message.swipe_id !== 'number') {

--- a/public/script.js
+++ b/public/script.js
@@ -6404,6 +6404,14 @@ export function ensureSwipes(message) {
         updated = true;
     }
 
+    message.swipes = message.swipes.map((mes) => {
+        if (typeof mes !== 'string') {
+            updated = true;
+            return '';
+        }
+        return mes;
+    });
+
     if (typeof message.swipe_id !== 'number') {
         message.swipe_id = 0;
         updated = true;

--- a/public/script.js
+++ b/public/script.js
@@ -6407,6 +6407,7 @@ export function ensureSwipes(message) {
     message.swipes = message.swipes.map((mes) => {
         if (typeof mes !== 'string') {
             updated = true;
+            console.warn('The message had a swipe that is not a string. It has has been set to \'\'.', message);
             return '';
         }
         return mes;

--- a/public/script.js
+++ b/public/script.js
@@ -6404,13 +6404,13 @@ export function ensureSwipes(message) {
         updated = true;
     }
 
-    message.swipes.forEach((mes, index, swipes) => {
-        if (typeof mes !== 'string') {
+    for (let i = 0; i < message.swipes.length; i++) {
+        if (typeof message.swipes[i] !== 'string') {
             updated = true;
             console.warn('The message had a swipe that is not a string. It has has been set to \'\'.', message);
-            swipes[index] = '';
+            message.swipes[i] = '';
         }
-    });
+    }
 
     if (typeof message.swipe_id !== 'number') {
         message.swipe_id = 0;


### PR DESCRIPTION
Empty swipes are not handled by `ensureSwipes`.

This may solve [u/Fenix-hama's issue](https://old.reddit.com/r/SillyTavernAI/comments/1p7vlt1/i_found_a_bug_and_now_i_cant_swipe_left_only_right/).

```javascript
message.swipes = message.swipes.map((mes) => {
    if (typeof mes !== 'string') {
        updated = true;
        console.warn('The message had a swipe that is not a string. It has has been set to \'\'.', message);
        return '';
    }
    return mes;
});
```

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
