### PR TITLE
Vertexaisearch

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -427,12 +427,8 @@ async function sendMakerSuiteRequest(request, response) {
                         delete tool.function.parameters;
                     }
                     functionDeclarations.push(tool.function);
-                } else if (tool.type === 'retrieval') {
-                    if (authType === 'full') {
-                        tools.push({ retrieval: tool.retrieval });
-                    } else {
-                        console.warn('Skipping Vertex AI Search: grounding is only supported in Full (Service Account) authentication mode.');
-                    }
+                } else if (tool[tool.type]) {
+                    tools.push({ [tool.type]: tool[tool.type] });
                 }
             }
             if (functionDeclarations.length > 0) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -427,9 +427,17 @@ async function sendMakerSuiteRequest(request, response) {
                         delete tool.function.parameters;
                     }
                     functionDeclarations.push(tool.function);
+                } else if (tool.type === 'retrieval') {
+                    if (authType === 'full') {
+                        tools.push({ retrieval: tool.retrieval });
+                    } else {
+                        console.warn('Skipping Vertex AI Search: grounding is only supported in Full (Service Account) authentication mode.');
+                    }
                 }
             }
-            tools.push({ function_declarations: functionDeclarations });
+            if (functionDeclarations.length > 0) {
+                tools.push({ function_declarations: functionDeclarations });
+            }
         }
 
         if (isThinkingConfigModel(model)) {


### PR DESCRIPTION
What this does:
It exposes a tool of type 'retrieval' for appropriate Gemini models, so an extension can enable the vertexAiSearch tool. This lets you use your own datastores as grounding sources when using Gemini 2.5+ and a full service account.

The end result looks like this:
```
  tools: [
    {
      retrieval: {
        vertexAiSearch: {
          datastore: 'projects/my-project-id/locations/global/collections/default_collection/dataStores/test_123456789'
        }
      }
    }
  ]
```

Testing:
I have a basic extension here: https://github.com/mightytribble/vertex-ai-search but it requires setup in VertexAI to work. You need to create a datastore, assign IAM permissions, etc. It does work for me, though - Gemini successfully calls the retrieval tool, queries my sample datastore to find answers then uses the results in its reply. It's pretty neat!

## Checklist:

- [X ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
