### PR TITLE
PPP: Add config setting for single newline between system messages

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -233,8 +233,12 @@ extensions:
 # Disabling will fallback to another locally available tokenizer.
 enableDownloadableTokenizers: true
 # -- OPENAI CONFIGURATION --
-# A placeholder message to use in strict prompt post-processing mode when the prompt doesn't start with a user message
-promptPlaceholder: "[Start a new chat]"
+# Prompt Post-Processing tweaks
+promptPostProcessing:
+  # A placeholder message to use in strict prompt post-processing mode when the prompt doesn't start with a user message
+  placeholder: "[Start a new chat]"
+  # Use one newline (legacy "Squash system messages" option) between system messages instead of two (original PPP behavior)
+  systemMergeSingleNewLine: false
 openai:
   # Will send a random user ID to OpenAI completion API
   randomizeUserId: false

--- a/src/config-init.js
+++ b/src/config-init.js
@@ -134,6 +134,11 @@ const keyMigrationMap = [
         newKey: 'sso.authentikAuth',
         migrate: (value) => value,
     },
+    {
+        oldKey: 'promptPlaceholder',
+        newKey: 'promptPostProcessing.placeholder',
+        migrate: (value) => value,
+    },
 ];
 
 /**


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Follow-up to #4821 

"Squash system" was not fully compatible with PPP since it used a single newline for merging instead of two (and it appears to be a big deal).

---

Who would win: 
OUR MOST CAPABLE LARGE LANGUAGE MODEL 
vs
One newliney boi

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
