### PR TITLE
Updated `jest-puppeteer` to be compatible with `puppeteer` v23+

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -10,7 +10,7 @@
                 "@types/jest": "^29.5.12",
                 "eslint": "^8.57.0",
                 "jest": "^29.7.0",
-                "jest-puppeteer": "^10.0.1"
+                "jest-puppeteer": "^11.0.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -54,7 +54,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
             "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
@@ -601,19 +600,52 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-        "node_modules/@hapi/hoek": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-            "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@hapi/topo": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-            "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+        "node_modules/@hapi/address": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+            "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@hapi/hoek": "^9.0.0"
+                "@hapi/hoek": "^11.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@hapi/formula": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+            "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@hapi/hoek": {
+            "version": "11.0.7",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+            "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@hapi/pinpoint": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+            "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@hapi/tlds": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.4.tgz",
+            "integrity": "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@hapi/topo": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+            "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@hapi/hoek": "^11.0.2"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -1042,6 +1074,7 @@
             "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.2.tgz",
             "integrity": "sha512-i4Ez+s9oRWQbNjtI/3+jxr7OH508mjAKvza0ekPJem0ZtmsYHP3B5dq62+IaBHKaGCOuqJxXzvFLUhJvQ6jtsQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "debug": "^4.4.0",
                 "extract-zip": "^2.0.1",
@@ -1063,33 +1096,13 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
             "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/@sideway/address": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-            "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@hapi/hoek": "^9.0.0"
-            }
-        },
-        "node_modules/@sideway/formula": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-            "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@sideway/pinpoint": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-            "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-            "license": "BSD-3-Clause"
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
@@ -1115,11 +1128,18 @@
                 "@sinonjs/commons": "^3.0.0"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+            "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+            "license": "MIT"
+        },
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -1241,6 +1261,7 @@
             "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -1256,7 +1277,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
             "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1278,6 +1298,7 @@
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
             "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -1364,6 +1385,7 @@
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.0.1"
             },
@@ -1378,9 +1400,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+            "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
@@ -1392,7 +1414,8 @@
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
             "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
@@ -1512,7 +1535,8 @@
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
             "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
             "license": "Apache-2.0",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/bare-fs": {
             "version": "4.1.3",
@@ -1520,6 +1544,7 @@
             "integrity": "sha512-OeEZYIg+2qepaWLyphaOXHAHKo3xkM8y3BeGAvHdMN8GNWvEAU1Yw6rYpGzu/wDDbKxgEjVeVDpgGhDzaeMpjg==",
             "license": "Apache-2.0",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "bare-events": "^2.5.4",
                 "bare-path": "^3.0.0",
@@ -1543,6 +1568,7 @@
             "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
             "license": "Apache-2.0",
             "optional": true,
+            "peer": true,
             "engines": {
                 "bare": ">=1.14.0"
             }
@@ -1553,6 +1579,7 @@
             "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
             "license": "Apache-2.0",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "bare-os": "^3.0.1"
             }
@@ -1563,6 +1590,7 @@
             "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
             "license": "Apache-2.0",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "streamx": "^2.21.0"
             },
@@ -1584,6 +1612,7 @@
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
             "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -1629,7 +1658,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001629",
                 "electron-to-chromium": "^1.4.796",
@@ -1657,6 +1685,7 @@
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -1748,6 +1777,7 @@
             "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-4.1.1.tgz",
             "integrity": "sha512-biR7t4vF3YluE6RlMSk9IWk+b9U+WWyzHp+N2pL9vRTk+UXHYRTVp7jTK58ZNzMLBgoLMHY4QyJMbeuw3eKxqg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "mitt": "^3.0.1",
                 "zod": "^3.24.1"
@@ -1838,12 +1868,12 @@
             }
         },
         "node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "license": "MIT",
             "engines": {
-                "node": ">= 6"
+                "node": ">=18"
             }
         },
         "node_modules/concat-map": {
@@ -1955,6 +1985,7 @@
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
             "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -2010,6 +2041,7 @@
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
             "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ast-types": "^0.13.4",
                 "escodegen": "^2.1.0",
@@ -2108,6 +2140,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -2117,6 +2150,7 @@
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2198,6 +2232,7 @@
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
             "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -2219,7 +2254,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -2533,11 +2567,12 @@
             }
         },
         "node_modules/expect-puppeteer": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.0.0.tgz",
-            "integrity": "sha512-E7sE6nVdEbrnpDOBMmcLgyqLJKt876AlBg1A+gsu5R8cWx+SLafreOgJAgzXg5Qko7Tk0cW5oZdRbHQLU738dg==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-11.0.0.tgz",
+            "integrity": "sha512-fgxsbOD+HqwOCMitYqEDzRoJM2fxKbCKPYfUoukK+qdZm/nC+cTOI74Au2MfmMZmF/5CgQGO4+1Ywq2GgD8zCQ==",
+            "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/extract-zip": {
@@ -2545,6 +2580,7 @@
             "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
             "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "debug": "^4.1.1",
                 "get-stream": "^5.1.0",
@@ -2565,6 +2601,7 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
             "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pump": "^3.0.0"
             },
@@ -2585,7 +2622,8 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
             "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -2622,6 +2660,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pend": "~1.2.0"
             }
@@ -2676,14 +2715,14 @@
             }
         },
         "node_modules/find-process": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
-            "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
+            "version": "1.4.11",
+            "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.11.tgz",
+            "integrity": "sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA==",
             "license": "MIT",
             "dependencies": {
-                "chalk": "^4.0.0",
-                "commander": "^5.1.0",
-                "debug": "^4.1.1"
+                "chalk": "~4.1.2",
+                "commander": "^12.1.0",
+                "loglevel": "^1.9.2"
             },
             "bin": {
                 "find-process": "bin/find-process.js"
@@ -2723,9 +2762,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -2743,9 +2782,9 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -2877,6 +2916,7 @@
             "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
             "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^6.0.2",
@@ -3063,6 +3103,7 @@
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -3076,6 +3117,7 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -3183,6 +3225,7 @@
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
             "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jsbn": "1.1.0",
                 "sprintf-js": "^1.1.3"
@@ -3195,7 +3238,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
             "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
@@ -3530,20 +3574,21 @@
             }
         },
         "node_modules/jest-dev-server": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.0.0.tgz",
-            "integrity": "sha512-FtyBBDxrAIfTX3hyKSOwj5KU6Z7fFLew5pQYOFpwyf+qpPpULL8aYxtsFkbkAwcs+Mb7qhcNbVLeiWsLOd7CKw==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-11.0.0.tgz",
+            "integrity": "sha512-a54rw3uEzsPckyiXo2rPji9R/5z0d0qhXtru+NwCP8cDxOFk/BIP9PNgmcLh0DU8UTl8s6Lg1u+ri5uQsTJTmw==",
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",
                 "cwd": "^0.10.0",
                 "find-process": "^1.4.7",
                 "prompts": "^2.4.2",
-                "spawnd": "^10.0.0",
+                "spawnd": "^11.0.0",
                 "tree-kill": "^1.2.2",
-                "wait-on": "^7.2.0"
+                "wait-on": "^8.0.1"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/jest-diff": {
@@ -3607,18 +3652,19 @@
             }
         },
         "node_modules/jest-environment-puppeteer": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.0.1.tgz",
-            "integrity": "sha512-FxMzVRyqieQqSy5CPWiwdK5t9dkRHid5eoRTVa8RtYeXLlpW6lU0dAmxEfPkdnDVCiPUhC2APeKOXq0J72bgag==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-11.0.0.tgz",
+            "integrity": "sha512-BJR+k19/awJmXVc5IJ3VY+tho0888PvHAp16D+DP/ezRL84bgg4ggc1Q3mfa85DI+Nw9hgTme3pt0X5F7CWxmg==",
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",
                 "cosmiconfig": "^8.3.6",
                 "deepmerge": "^4.3.1",
-                "jest-dev-server": "^10.0.0",
+                "jest-dev-server": "^11.0.0",
                 "jest-environment-node": "^29.7.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/jest-get-type": {
@@ -3735,15 +3781,16 @@
             }
         },
         "node_modules/jest-puppeteer": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.0.1.tgz",
-            "integrity": "sha512-FzC35XbqeuQEt1smXh1EOqhJaRkWqJkyWDMfGkcZ8C59QHXeJ7F/iOmiNqYi6l/OsycUuOPCk+IkjfGfS9YbrQ==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-11.0.0.tgz",
+            "integrity": "sha512-kixkUTNcXikldQ+TusIEvqtTO/et/MiXGkoUBQViPSdSN6JOPvTjDN/mo6Jh4EJzay8qFg/Sd4v4gPS0y9b+zw==",
+            "license": "MIT",
             "dependencies": {
-                "expect-puppeteer": "^10.0.0",
-                "jest-environment-puppeteer": "^10.0.1"
+                "expect-puppeteer": "^11.0.0",
+                "jest-environment-puppeteer": "^11.0.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "peerDependencies": {
                 "puppeteer": ">=19"
@@ -3995,16 +4042,21 @@
             }
         },
         "node_modules/joi": {
-            "version": "17.13.3",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-            "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+            "version": "18.0.2",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
+            "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@hapi/hoek": "^9.3.0",
-                "@hapi/topo": "^5.1.0",
-                "@sideway/address": "^4.1.5",
-                "@sideway/formula": "^3.0.1",
-                "@sideway/pinpoint": "^2.0.0"
+                "@hapi/address": "^5.1.1",
+                "@hapi/formula": "^3.0.2",
+                "@hapi/hoek": "^11.0.7",
+                "@hapi/pinpoint": "^2.0.1",
+                "@hapi/tlds": "^1.1.1",
+                "@hapi/topo": "^6.0.2",
+                "@standard-schema/spec": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
             }
         },
         "node_modules/js-tokens": {
@@ -4030,7 +4082,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
             "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jsesc": {
             "version": "2.5.2",
@@ -4149,6 +4202,19 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "license": "MIT"
+        },
+        "node_modules/loglevel": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+            "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            },
+            "funding": {
+                "type": "tidelift",
+                "url": "https://tidelift.com/funding/github/npm/loglevel"
+            }
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -4277,7 +4343,8 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -4296,6 +4363,7 @@
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -4439,6 +4507,7 @@
             "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
             "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
                 "agent-base": "^7.1.2",
@@ -4458,6 +4527,7 @@
             "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
             "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "degenerator": "^5.0.0",
                 "netmask": "^2.0.2"
@@ -4551,7 +4621,8 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/picocolors": {
             "version": "1.0.1",
@@ -4632,6 +4703,7 @@
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -4654,6 +4726,7 @@
             "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
             "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -4673,6 +4746,7 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
             "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -4688,6 +4762,7 @@
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
             "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -4708,6 +4783,7 @@
             "integrity": "sha512-ifYqoY6wGs0yZeFuFPn8BE9FhuveXkarF+eO18I2e/axdoCh4Qh1AE+qXdJBhdaeoPt6eRNTY4Dih29Jbq8wow==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@puppeteer/browsers": "2.10.2",
                 "chromium-bidi": "4.1.1",
@@ -4728,6 +4804,7 @@
             "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.7.2.tgz",
             "integrity": "sha512-P9pZyTmJqKODFCnkZgemCpoFA4LbAa8+NumHVQKyP5X9IgdNS1ZnAnIh1sMAwhF8/xEUGf7jt+qmNLlKieFw1Q==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@puppeteer/browsers": "2.10.2",
                 "chromium-bidi": "4.1.1",
@@ -4744,13 +4821,15 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "license": "Python-2.0"
+            "license": "Python-2.0",
+            "peer": true
         },
         "node_modules/puppeteer/node_modules/cosmiconfig": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
             "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
@@ -4777,6 +4856,7 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
             "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -4945,9 +5025,9 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
@@ -5009,6 +5089,7 @@
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
@@ -5019,6 +5100,7 @@
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
             "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
@@ -5033,6 +5115,7 @@
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -5062,15 +5145,16 @@
             }
         },
         "node_modules/spawnd": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.0.0.tgz",
-            "integrity": "sha512-6GKcakMTryb5b1SWCvdubCDHEsR2k+5VZUD5G19umZRarkvj1RyCGyizcqhjewI7cqZo8fTVD8HpnDZbVOLMtg==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-11.0.0.tgz",
+            "integrity": "sha512-brBHv9HYi8lwNvbI7X52NDZe4yAdsQwvr81b/r98LaN82LzeEnQ0L6YXBvG25zhgWRadTwB+4GsUu9NrNQcVzw==",
+            "license": "MIT",
             "dependencies": {
                 "signal-exit": "^4.1.0",
                 "tree-kill": "^1.2.2"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/spawnd/node_modules/signal-exit": {
@@ -5108,6 +5192,7 @@
             "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
             "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-fifo": "^1.3.2",
                 "text-decoder": "^1.1.0"
@@ -5214,6 +5299,7 @@
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
             "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
@@ -5228,6 +5314,7 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
             "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
@@ -5253,6 +5340,7 @@
             "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
             "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "b4a": "^1.6.4"
             }
@@ -5333,7 +5421,8 @@
             "version": "2.12.0",
             "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
             "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/undici-types": {
             "version": "5.26.5",
@@ -5395,16 +5484,16 @@
             }
         },
         "node_modules/wait-on": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-            "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
+            "integrity": "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==",
             "license": "MIT",
             "dependencies": {
-                "axios": "^1.6.1",
-                "joi": "^17.11.0",
+                "axios": "^1.12.1",
+                "joi": "^18.0.1",
                 "lodash": "^4.17.21",
                 "minimist": "^1.2.8",
-                "rxjs": "^7.8.1"
+                "rxjs": "^7.8.2"
             },
             "bin": {
                 "wait-on": "bin/wait-on"
@@ -5487,6 +5576,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
             "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -5550,6 +5640,7 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
@@ -5572,6 +5663,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
             "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,6 +11,6 @@
         "@types/jest": "^29.5.12",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
-        "jest-puppeteer": "^10.0.1"
+        "jest-puppeteer": "^11.0.0"
     }
 }


### PR DESCRIPTION
Fixes jest-puppeteer crash.
https://github.com/argos-ci/jest-puppeteer/pull/588

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
