### PR TITLE
Convert OAI tool_choice to Gemini functionCallingConfig for Gemini requests

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -483,8 +483,32 @@ async function sendMakerSuiteRequest(request, response) {
         if (tools.length) {
             body.tools = tools;
 
-            if (request.body.tool_config) {
-                body.toolConfig = request.body.tool_config;
+            const toolChoice = request.body.tool_choice;
+            let functionCallingConfig;
+
+            // Translate OpenAI's `tool_choice` to Gemini's `functionCallingConfig`
+            if (typeof toolChoice === 'string') {
+                switch (toolChoice) {
+                    case 'none':
+                        functionCallingConfig = { mode: 'NONE' };
+                        break;
+                    case 'required':
+                        functionCallingConfig = { mode: 'ANY' };
+                        break;
+                    case 'auto':
+                        functionCallingConfig = { mode: 'AUTO' };
+                        break;
+                }
+            } else if (typeof toolChoice === 'object' && toolChoice?.function?.name) {
+                // Force a specific function call
+                functionCallingConfig = {
+                    mode: 'ANY',
+                    allowedFunctionNames: [toolChoice.function.name],
+                };
+            }
+
+            if (functionCallingConfig) {
+                body.toolConfig = { functionCallingConfig };
             }
 
         }

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -482,6 +482,11 @@ async function sendMakerSuiteRequest(request, response) {
 
         if (tools.length) {
             body.tools = tools;
+
+            if (request.body.tool_config) {
+                body.toolConfig = request.body.tool_config;
+            }
+
         }
 
         return body;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -510,7 +510,6 @@ async function sendMakerSuiteRequest(request, response) {
             if (functionCallingConfig) {
                 body.toolConfig = { functionCallingConfig };
             }
-
         }
 
         return body;


### PR DESCRIPTION
Enables toolConfig blocks to be passed to Gemini endpoints, if tools are set. See: https://ai.google.dev/api/generate-content#request-body 

This enables you to force the request to use the provided tools, rather than letting the model decide whether or not to use them, by setting:
```
    toolConfig: {
        functionCallingConfig: {
            mode: 'any'
        }
    }
```

Limitations apply, but if you're only using the one tool it's the way to guarantee the model actually makes a RAG search rather than making something up.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
