### PR TITLE
perf(regex): optimize script caching and regex processing performance

### DIFF
--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -41,7 +41,9 @@ export class RegexProvider {
     /** @type {Map<string, RegExp>} */
     #cache = new Map();
     /** @type {number} */
-    #maxSize = 500;
+    // Increased capacity to improve cache hit rate in large rule sets.
+    // Memory vs speed trade-off: fewer recompilations under heavy usage.
+    #maxSize = 1000;
 
     static instance = new RegexProvider();
 
@@ -51,7 +53,8 @@ export class RegexProvider {
      * @returns {RegExp?} Compiled regex or null if invalid
      */
     get(regexString) {
-        const regex = this.#cache.has(regexString)
+        const existed = this.#cache.has(regexString);
+        const regex = existed
             ? this.#cache.get(regexString)
             : regexFromString(regexString);
 
@@ -59,14 +62,20 @@ export class RegexProvider {
             return null;
         }
 
-        // LRU: Move to end by re-inserting
-        this.#cache.delete(regexString);
-        this.#cache.set(regexString, regex);
-
-        // Evict oldest if at capacity
-        if (this.#cache.size >= this.#maxSize) {
-            const firstKey = this.#cache.keys().next().value;
-            this.#cache.delete(firstKey);
+        // LRU policy details:
+        // - Hit: re-insert to mark as most-recently-used without changing size
+        // - Miss: evict the oldest BEFORE inserting when at capacity
+        // This keeps effective capacity equal to #maxSize
+        if (existed) {
+            this.#cache.delete(regexString);
+            this.#cache.set(regexString, regex);
+        } else {
+            // Evict oldest BEFORE adding to keep size at max capacity
+            if (this.#cache.size >= this.#maxSize) {
+                const firstKey = this.#cache.keys().next().value;
+                this.#cache.delete(firstKey);
+            }
+            this.#cache.set(regexString, regex);
         }
 
         // Reset lastIndex for global/sticky regexes
@@ -85,14 +94,89 @@ export class RegexProvider {
     }
 }
 
+// Detect capture group references inside replacement templates:
+// - "$1", "$2", ... numbered references
+// - "$<name>" named references
+const groupRefRegex = /(\$(\d+))|\$<([^>]+)>/g;
+// Cache execution plans per script and override context
+// Key: script id (or content hash) + characterOverride
+// Value: precomputed structures (tokens, trim regex, flags) to minimize per-match work
+const scriptExecCache = new Map();
+
 /**
  * Retrieves the list of regex scripts by combining the scripts from the extension settings and the character data
  *
  * @param {GetRegexScriptsOptions} options Options for retrieving the regex scripts
  * @returns {RegexScript[]} An array of regex scripts, where each script is an object containing the necessary information.
  */
-export function getRegexScripts(options = DEFAULT_GET_REGEX_SCRIPTS_OPTIONS) {
-    return [...Object.values(SCRIPT_TYPES).flatMap(type => getScriptsByType(type, options))];
+// Scripts cache and context tracking to reduce recomposition overhead
+// These caches store the composed script arrays for the current UI context.
+// Context keys include: selected character (chid), character reference, preset API, and preset name.
+// When any of these change, caches are invalidated to ensure fresh script lists.
+let scriptsCacheAll = null;
+let scriptsCacheAllowed = null;
+let lastContext = {
+    chid: undefined,
+    characterRef: undefined,
+    presetApi: null,
+    presetName: null,
+};
+
+export function invalidateScriptsCache() {
+    // Clear both caches so subsequent calls rebuild script arrays for the new context
+    scriptsCacheAll = null;
+    scriptsCacheAllowed = null;
+}
+
+export function getRegexScripts(options = DEFAULT_GET_REGEX_SCRIPTS_OPTIONS, characterOverride = null) {
+    let currentChid = this_chid;
+
+    if (characterOverride) {
+        // Map avatar override to a temporary chid for script selection
+        // This allows running scripts in the context of another character without switching UI state
+        const overrideId = characters.findIndex(c => c.avatar === characterOverride);
+        if (overrideId !== -1) {
+            currentChid = String(overrideId);
+        }
+    }
+
+    const currentCharacterRef = characters?.[currentChid];
+    const currentPresetApi = getCurrentPresetAPI();
+    const currentPresetName = getCurrentPresetName();
+
+    // If not using override and context changed, invalidate caches to rebuild script arrays
+    if (
+        !characterOverride && (
+            currentChid !== lastContext.chid ||
+            currentCharacterRef !== lastContext.characterRef ||
+            currentPresetApi !== lastContext.presetApi ||
+            currentPresetName !== lastContext.presetName
+        )
+    ) {
+        invalidateScriptsCache();
+        lastContext = {
+            chid: currentChid,
+            characterRef: currentCharacterRef,
+            presetApi: currentPresetApi,
+            presetName: currentPresetName,
+        };
+    }
+
+    if (characterOverride) {
+        return [...Object.values(SCRIPT_TYPES).flatMap(type => getScriptsByType(type, options, currentChid))];
+    }
+
+    if (options.allowedOnly) {
+        if (!scriptsCacheAllowed) {
+            scriptsCacheAllowed = [...Object.values(SCRIPT_TYPES).flatMap(type => getScriptsByType(type, options, currentChid))];
+        }
+        return scriptsCacheAllowed;
+    }
+
+    if (!scriptsCacheAll) {
+        scriptsCacheAll = [...Object.values(SCRIPT_TYPES).flatMap(type => getScriptsByType(type, options, currentChid))];
+    }
+    return scriptsCacheAll;
 }
 
 /**
@@ -101,20 +185,23 @@ export function getRegexScripts(options = DEFAULT_GET_REGEX_SCRIPTS_OPTIONS) {
  * @param {GetRegexScriptsOptions} options Options for retrieving the regex scripts
  * @returns {RegexScript[]} An array of regex scripts for the specified type.
  */
-export function getScriptsByType(scriptType, { allowedOnly } = DEFAULT_GET_REGEX_SCRIPTS_OPTIONS) {
+// `targetChid` allows selecting scripts for a specific character (used by overrides)
+export function getScriptsByType(scriptType, { allowedOnly } = DEFAULT_GET_REGEX_SCRIPTS_OPTIONS, targetChid = this_chid) {
     switch (scriptType) {
         case SCRIPT_TYPE_UNKNOWN:
             return [];
         case SCRIPT_TYPES.GLOBAL:
             return extension_settings.regex ?? [];
         case SCRIPT_TYPES.SCOPED: {
-            if (allowedOnly && !extension_settings?.character_allowed_regex?.includes(characters?.[this_chid]?.avatar)) {
+            // Respect per-character allow-list when returning scoped scripts
+            if (allowedOnly && !extension_settings?.character_allowed_regex?.includes(characters?.[targetChid]?.avatar)) {
                 return [];
             }
-            const scopedScripts = characters[this_chid]?.data?.extensions?.regex_scripts;
+            const scopedScripts = characters[targetChid]?.data?.extensions?.regex_scripts;
             return Array.isArray(scopedScripts) ? scopedScripts : [];
         }
         case SCRIPT_TYPES.PRESET: {
+            // Respect per-preset allow-list when returning preset scripts
             if (allowedOnly && !extension_settings?.preset_allowed_regex?.[getCurrentPresetAPI()]?.includes(getCurrentPresetName())) {
                 return [];
             }
@@ -138,14 +225,20 @@ export async function saveScriptsByType(scripts, scriptType) {
     switch (scriptType) {
         case SCRIPT_TYPES.GLOBAL:
             extension_settings.regex = scripts;
+            // Global scripts are stored in extension_settings; invalidate caches so UI sees updated lists
+            invalidateScriptsCache();
             saveSettingsDebounced();
             break;
         case SCRIPT_TYPES.SCOPED:
             await writeExtensionField(this_chid, 'regex_scripts', scripts);
+            // Scoped scripts changed; invalidate caches for correct per-character lists
+            invalidateScriptsCache();
             break;
         case SCRIPT_TYPES.PRESET: {
             const presetManager = getPresetManager();
             await presetManager.writePresetExtensionField({ path: 'regex_scripts', value: scripts });
+            // Preset scripts changed; invalidate caches for correct per-preset lists
+            invalidateScriptsCache();
             break;
         }
         default:
@@ -178,6 +271,8 @@ export function allowScopedScripts(character) {
     }
     if (!extension_settings.character_allowed_regex.includes(avatar)) {
         extension_settings.character_allowed_regex.push(avatar);
+        // Allow-list updated; invalidate caches so scoped scripts become visible
+        invalidateScriptsCache();
         saveSettingsDebounced();
     }
 }
@@ -198,6 +293,8 @@ export function disallowScopedScripts(character) {
     const index = extension_settings.character_allowed_regex.indexOf(avatar);
     if (index !== -1) {
         extension_settings.character_allowed_regex.splice(index, 1);
+        // Allow-list updated; invalidate caches so scoped scripts are hidden
+        invalidateScriptsCache();
         saveSettingsDebounced();
     }
 }
@@ -230,6 +327,8 @@ export function allowPresetScripts(apiId, presetName) {
     }
     if (!extension_settings.preset_allowed_regex[apiId].includes(presetName)) {
         extension_settings.preset_allowed_regex[apiId].push(presetName);
+        // Allow-list updated; invalidate caches so preset scripts become visible
+        invalidateScriptsCache();
         saveSettingsDebounced();
     }
 }
@@ -250,6 +349,8 @@ export function disallowPresetScripts(apiId, presetName) {
     const index = extension_settings.preset_allowed_regex[apiId].indexOf(presetName);
     if (index !== -1) {
         extension_settings.preset_allowed_regex[apiId].splice(index, 1);
+        // Allow-list updated; invalidate caches so preset scripts are hidden
+        invalidateScriptsCache();
         saveSettingsDebounced();
     }
 }
@@ -339,41 +440,98 @@ export function getRegexedString(rawString, placement, { characterOverride, isMa
         return finalString;
     }
 
-    const allRegex = getRegexScripts({ allowedOnly: true });
-    allRegex.forEach((script) => {
-        if (
-            // Script applies to Markdown and input is Markdown
+    // Iterate with early exits to reduce overhead:
+    // 1) Early filter by placement
+    // 2) Short-circuit scenario flags (markdown/prompt)
+    // 3) Skip non-editable on edit, and depth out of range
+    const allRegex = getRegexScripts({ allowedOnly: true }, characterOverride);
+    for (let i = 0; i < allRegex.length; i++) {
+        const script = allRegex[i];
+
+        if (!Array.isArray(script?.placement) || !script.placement.includes(placement)) {
+            continue;
+        }
+
+        const applies =
             (script.markdownOnly && isMarkdown) ||
-            // Script applies to Generate and input is Generate
             (script.promptOnly && isPrompt) ||
-            // Script applies to all cases when neither "only"s are true, but there's no need to do it when `isMarkdown`, the as source (chat history) should already be changed beforehand
-            (!script.markdownOnly && !script.promptOnly && !isMarkdown && !isPrompt)
-        ) {
-            if (isEdit && !script.runOnEdit) {
-                console.debug(`getRegexedString: Skipping script ${script.scriptName} because it does not run on edit`);
-                return;
+            (!script.markdownOnly && !script.promptOnly && !isMarkdown && !isPrompt);
+
+        if (!applies) {
+            continue;
+        }
+
+        if (isEdit && !script.runOnEdit) {
+            continue;
+        }
+
+        if (typeof depth === 'number') {
+            if (!isNaN(script.minDepth) && script.minDepth !== null && script.minDepth >= -1 && depth < script.minDepth) {
+                continue;
             }
 
-            // Check if the depth is within the min/max depth
-            if (typeof depth === 'number') {
-                if (!isNaN(script.minDepth) && script.minDepth !== null && script.minDepth >= -1 && depth < script.minDepth) {
-                    console.debug(`getRegexedString: Skipping script ${script.scriptName} because depth ${depth} is less than minDepth ${script.minDepth}`);
-                    return;
-                }
-
-                if (!isNaN(script.maxDepth) && script.maxDepth !== null && script.maxDepth >= 0 && depth > script.maxDepth) {
-                    console.debug(`getRegexedString: Skipping script ${script.scriptName} because depth ${depth} is greater than maxDepth ${script.maxDepth}`);
-                    return;
-                }
-            }
-
-            if (script.placement.includes(placement)) {
-                finalString = runRegexScript(script, finalString, { characterOverride });
+            if (!isNaN(script.maxDepth) && script.maxDepth !== null && script.maxDepth >= 0 && depth > script.maxDepth) {
+                continue;
             }
         }
-    });
+
+        // Apply this script; output becomes input for the next script to preserve ordering
+        finalString = runRegexScript(script, finalString, { characterOverride });
+    }
 
     return finalString;
+}
+
+function getExecPlan(regexScript, characterOverride) {
+    // Build a stable cache key; prefer script id when available
+    const key = (regexScript.id ? String(regexScript.id) : JSON.stringify({ fr: regexScript.findRegex, rs: regexScript.replaceString, ts: regexScript.trimStrings, sr: regexScript.substituteRegex })) + '|' + (characterOverride || '');
+    const cached = scriptExecCache.get(key);
+    if (cached) return cached;
+    // Normalize match macro to "$0" so downstream handling is uniform
+    const preparedReplaceString = regexScript.replaceString ? regexScript.replaceString.replace(/\{\{match\}\}/gi, '$0') : '';
+    const preparedTrimStrings = Array.isArray(regexScript.trimStrings)
+        ? regexScript.trimStrings.map((trimString) => substituteParams(trimString, undefined, characterOverride))
+        : [];
+    // Feature flags guiding fast paths
+    const hasGroupRefs = /(\$\d+)|\$<[^>]+>/.test(preparedReplaceString);
+    const needsSubstitution = /\{\{[^}]+\}\}/.test(preparedReplaceString);
+    // Compile a single alternation for trimming, reducing multiple replaceAll calls
+    const trimAlternation = preparedTrimStrings.filter(Boolean).map(s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+    const trimRegex = trimAlternation ? new RegExp(trimAlternation, 'g') : null;
+    const isNoOp = !needsSubstitution && !hasGroupRefs && preparedTrimStrings.length === 0 && preparedReplaceString === '$0';
+    // Tokenize template once: literals + numbered/named references
+    let tokens = null;
+    if (hasGroupRefs) {
+        const re = new RegExp(groupRefRegex.source, groupRefRegex.flags);
+        tokens = [];
+        let last = 0;
+        let m;
+        while ((m = re.exec(preparedReplaceString)) !== null) {
+            const idx = m.index;
+            if (idx > last) {
+                tokens.push({ t: 'lit', v: preparedReplaceString.slice(last, idx) });
+            }
+            if (m[2]) {
+                tokens.push({ t: 'num', i: Number(m[2]) });
+            } else if (m[3]) {
+                tokens.push({ t: 'name', n: m[3] });
+            }
+            last = idx + m[0].length;
+        }
+        if (last < preparedReplaceString.length) {
+            tokens.push({ t: 'lit', v: preparedReplaceString.slice(last) });
+        }
+    }
+    // Execution plan summary:
+    // - preparedReplaceString: normalized template
+    // - preparedTrimStrings: expanded per override
+    // - hasGroupRefs / needsSubstitution: decide fast paths
+    // - trimRegex: one-pass trimming regex
+    // - isNoOp: skip entirely if template equals original
+    // - tokens: pre-parsed segments for fast emission
+    const plan = { preparedReplaceString, preparedTrimStrings, hasGroupRefs, needsSubstitution, trimRegex, isNoOp, tokens };
+    scriptExecCache.set(key, plan);
+    return plan;
 }
 
 /**
@@ -406,38 +564,48 @@ export function runRegexScript(regexScript, rawString, { characterOverride } = {
     const regexString = getRegexString();
     const findRegex = RegexProvider.instance.get(regexString);
 
+    // Retrieve precomputed execution plan for this script/context
+    const { preparedReplaceString, hasGroupRefs, needsSubstitution, trimRegex, isNoOp, tokens } = getExecPlan(regexScript, characterOverride);
+
     // The user skill issued. Return with nothing.
     if (!findRegex) {
         return newString;
     }
 
-    // Run replacement. Currently does not support the Overlay strategy
-    newString = rawString.replace(findRegex, function (match) {
-        const args = [...arguments];
-        const replaceString = regexScript.replaceString.replace(/{{match}}/gi, '$0');
-        const replaceWithGroups = replaceString.replaceAll(/\$(\d+)|\$<([^>]+)>/g, (_, num, groupName) => {
-            if (num) {
-                // Handle numbered capture groups ($1, $2, etc.)
-                match = args[Number(num)];
-            } else if (groupName) {
-                // Handle named capture groups ($<name>)
-                const groups = args[args.length - 1];
-                match = groups && typeof groups === 'object' && groups[groupName];
+    // Fast path: no-op rule ("$0" without macros or trimming)
+    if (isNoOp) {
+        return newString;
+    }
+
+    // Fast path: constant replacement without callback
+    if (!hasGroupRefs && !needsSubstitution && !trimRegex) {
+        return rawString.replace(findRegex, preparedReplaceString);
+    }
+    // General path: emit via tokens, trim once per captured value, conditionally apply macros
+    newString = rawString.replace(findRegex, function (...args) {
+        const lastArg = args[args.length - 1];
+        let out = preparedReplaceString;
+        if (tokens) {
+            let buf = '';
+            for (let i = 0; i < tokens.length; i++) {
+                const tk = tokens[i];
+                if (tk.t === 'lit') {
+                    buf += tk.v;
+                } else if (tk.t === 'num') {
+                    let m = args[tk.i] || '';
+                    if (m && trimRegex) m = m.replace(trimRegex, '');
+                    buf += m;
+                } else {
+                    const groups = lastArg && typeof lastArg === 'object' ? lastArg : null;
+                    let m = (groups && groups[tk.n]) || '';
+                    if (m && trimRegex) m = m.replace(trimRegex, '');
+                    buf += m;
+                }
             }
-
-            // No match found - return the empty string
-            if (!match) {
-                return '';
-            }
-
-            // Remove trim strings from the match
-            const filteredMatch = filterString(match, regexScript.trimStrings, { characterOverride });
-
-            return filteredMatch;
-        });
-
-        // Substitute at the end
-        return substituteParams(replaceWithGroups);
+            out = buf;
+        }
+        // Macro substitution only when present to avoid unnecessary work
+        return needsSubstitution ? substituteParams(out) : out;
     });
 
     return newString;
@@ -450,12 +618,5 @@ export function runRegexScript(regexScript, rawString, { characterOverride } = {
  * @param {RegexScriptParams} params The parameters to use for the regex filter
  * @returns {string} The filtered string
  */
-function filterString(rawString, trimStrings, { characterOverride } = {}) {
-    let finalString = rawString;
-    trimStrings.forEach((trimString) => {
-        const subTrimString = substituteParams(trimString, undefined, characterOverride);
-        finalString = finalString.replaceAll(subTrimString, '');
-    });
-
-    return finalString;
-}
+// Legacy filterString removed: trimming now uses a compiled alternation (trimRegex)
+// inside the replacement callback, minimizing repeated passes.

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -8,7 +8,8 @@ import { commonEnumProviders, enumIcons } from '../../slash-commands/SlashComman
 import { SlashCommandEnumValue, enumTypes } from '../../slash-commands/SlashCommandEnumValue.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
 import { download, equalsIgnoreCaseAndAccents, escapeHtml, getFileText, getSortableDelay, isFalseBoolean, isTrueBoolean, regexFromString, setInfoBlock, uuidv4 } from '../../utils.js';
-import { allowPresetScripts, allowScopedScripts, disallowPresetScripts, disallowScopedScripts, getCurrentPresetAPI, getCurrentPresetName, getRegexScripts, getScriptsByType, isPresetScriptsAllowed, isScopedScriptsAllowed, regex_placement, RegexProvider, runRegexScript, saveScriptsByType, SCRIPT_TYPE_UNKNOWN, SCRIPT_TYPES, substitute_find_regex } from './engine.js';
+// Import `invalidateScriptsCache` to refresh script list caches after UI-level modifications
+import { allowPresetScripts, allowScopedScripts, disallowPresetScripts, disallowScopedScripts, getCurrentPresetAPI, getCurrentPresetName, getRegexScripts, getScriptsByType, invalidateScriptsCache, isPresetScriptsAllowed, isScopedScriptsAllowed, regex_placement, RegexProvider, runRegexScript, saveScriptsByType, SCRIPT_TYPE_UNKNOWN, SCRIPT_TYPES, substitute_find_regex } from './engine.js';
 import { t } from '../../i18n.js';
 import { accountStorage } from '../../util/AccountStorage.js';
 import { getPresetManager } from '../../preset-manager.js';
@@ -540,6 +541,12 @@ async function saveRegexScript(regexScript, existingScriptIndex, scriptType, sav
         array.push(regexScript);
     }
 
+    // Global scripts use `extension_settings.regex` and are persisted via `saveSettingsDebounced`.
+    // Invalidate caches here so subsequent UI requests read the latest global script list.
+    if (scriptType === SCRIPT_TYPES.GLOBAL) {
+        invalidateScriptsCache();
+    }
+
     if (scriptType === SCRIPT_TYPES.SCOPED) {
         await saveScriptsByType(array, SCRIPT_TYPES.SCOPED);
         allowScopedScripts(characters?.[this_chid]);
@@ -583,7 +590,8 @@ async function deleteRegexScript(id, scriptType, saveSettings = true) {
 
         switch (scriptType) {
             case SCRIPT_TYPES.GLOBAL:
-                // will be handled by saveSettingsDebounced
+                // Global list is saved by `saveSettingsDebounced`; invalidate caches to reflect deletions
+                invalidateScriptsCache();
                 break;
             case SCRIPT_TYPES.SCOPED:
                 await saveScriptsByType(array, SCRIPT_TYPES.SCOPED);
@@ -744,9 +752,14 @@ async function loadRegexScripts() {
         $(container).append(scriptHtml);
     }
 
-    getScriptsByType(SCRIPT_TYPES.GLOBAL).forEach((script, index) => renderScript('#saved_regex_scripts', script, SCRIPT_TYPES.GLOBAL, index));
-    getScriptsByType(SCRIPT_TYPES.SCOPED).forEach((script, index) => renderScript('#saved_scoped_scripts', script, SCRIPT_TYPES.SCOPED, index));
-    getScriptsByType(SCRIPT_TYPES.PRESET).forEach((script, index) => renderScript('#saved_preset_scripts', script, SCRIPT_TYPES.PRESET, index));
+    // Prefetch arrays once to avoid repeated calls and ensure consistent ordering
+    const globals = getScriptsByType(SCRIPT_TYPES.GLOBAL);
+    const scoped = getScriptsByType(SCRIPT_TYPES.SCOPED);
+    const preset = getScriptsByType(SCRIPT_TYPES.PRESET);
+
+    globals.forEach((script, index) => renderScript('#saved_regex_scripts', script, SCRIPT_TYPES.GLOBAL, index));
+    scoped.forEach((script, index) => renderScript('#saved_scoped_scripts', script, SCRIPT_TYPES.SCOPED, index));
+    preset.forEach((script, index) => renderScript('#saved_preset_scripts', script, SCRIPT_TYPES.PRESET, index));
 
     $('#regex_scoped_toggle').prop('checked', isScopedScriptsAllowed(characters?.[this_chid]));
     $('#regex_preset_toggle').prop('checked', isPresetScriptsAllowed(getCurrentPresetAPI(), getCurrentPresetName()));
@@ -1064,15 +1077,21 @@ function populateDebuggerRuleList(container) {
         return;
     }
 
+    // Build membership sets per type to categorize without relying on transient `_type` fields.
+    // Rationale: engine no longer annotates scripts; this avoids extra object copies
+    // and keeps categorization consistent with source-of-truth lists.
     const globalScriptIds = new Set(getScriptsByType(SCRIPT_TYPES.GLOBAL).map(s => s.id));
     const scopedScriptIds = new Set(getScriptsByType(SCRIPT_TYPES.SCOPED).map(s => s.id));
     const presetScriptIds = new Set(getScriptsByType(SCRIPT_TYPES.PRESET).map(s => s.id));
+
     const globalScripts = [];
     const scopedScripts = [];
     const presetScripts = [];
 
+    // Categorize scripts by membership in each list (GLOBAL/SCOPED/PRESET)
+    // Deep copy each script for UI editing and attach a stable `type` derived from membership.
     allScripts.forEach(script => {
-        const scriptCopy = structuredClone(script); // Use structuredClone for deep copy
+        const scriptCopy = structuredClone(script); // deep copy for UI editing
         if (globalScriptIds.has(script.id)) {
             // @ts-ignore
             scriptCopy.type = SCRIPT_TYPES.GLOBAL;


### PR DESCRIPTION
perf(regex): optimize script caching and regex processing performance

Introduce script caching to reduce redundant computation and improve match/replace efficiency:

1. Increase regex cache capacity to 1,000 entries
2. Implement LRU eviction strategy
3. Add script list cache to reduce UI re-render overhead
4. Refactor replacement logic to use a precomputed execution plan
5. Consolidate trim operations into a single regex replace Fix cache not updating after global/preset script changes

<!-- Put X in the box below to confirm -->

## Checklist:

- [ ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
