### PR TITLE
Add docker data directories to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,6 @@ access.log
 /colab
 .gemini
 /docker/config
-/docker/user
 /docker/extensions
 /docker/data
 /docker/plugins

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,8 @@ access.log
 /public/scripts/extensions/third-party
 /colab
 .gemini
+/docker/config
+/docker/user
+/docker/extensions
+/docker/data
+/docker/plugins


### PR DESCRIPTION
Added directories which are generated when using SillyTavern with docker-compose.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
