### PR TITLE
Chevrons can overlap with other elements.

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1333,9 +1333,7 @@ body.hideAllSwipeButtons :is(.swipe_left, .swipe_right),
     /* With display:none, the swipes-counter div wil collapse, shifting the chevron. */
     visibility: hidden;
     /* Interactivity has limited availability https://caniuse.com/?search=interactivity */
-    @supports (interactivity: inert) {
-        interactivity: inert;
-    }
+    interactivity: inert;
     pointer-events: none;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -1333,6 +1333,10 @@ body.hideAllSwipeButtons :is(.swipe_left, .swipe_right),
     /* With display:none, the swipes-counter div wil collapse, shifting the chevron. */
     visibility: hidden;
     /* Interactivity has limited availability https://caniuse.com/?search=interactivity */
+    @supports (interactivity: inert) {
+        interactivity: inert;
+    }
+    pointer-events: none;
 }
 
 .ui-settings {

--- a/public/style.css
+++ b/public/style.css
@@ -1246,6 +1246,7 @@ body .panelControlBar {
     font-size: 20px;
     cursor: pointer;
     align-self: center;
+    pointer-events: all;
 }
 
 .swipe_left {
@@ -1258,6 +1259,7 @@ body .panelControlBar {
     position: absolute;
     right: 0;
     bottom: 0;
+    pointer-events: none;
 }
 
 .swipes-counter {

--- a/public/style.css
+++ b/public/style.css
@@ -1246,7 +1246,7 @@ body .panelControlBar {
     font-size: 20px;
     cursor: pointer;
     align-self: center;
-    pointer-events: all;
+    pointer-events: auto;
 }
 
 .swipe_left {
@@ -1275,6 +1275,7 @@ body .panelControlBar {
     justify-content: center;
     margin-bottom: var(--swipeCounterMargin);
     height: var(--swipeCounterHeight);
+    pointer-events: auto;
 }
 
 


### PR DESCRIPTION
https://github.com/SillyTavern/SillyTavern/pull/4712#issuecomment-3639322664
> There is a problem that was introduced here that I found accidentally: swipe blocks that are hidden with `visibility: hidden` are not click inert and will steal a click from the content they overlap, even if they're invisible. Most notable with the swipeRightBlock element that can steal this entire 40x45 block.
> 
> The simplest and very incomplete fix for that specific case would be (though it doesn't cover all the cases and "show swipe # on all messages" toggle):

Although I was unable to replicate the issue, this may fix it.
```css
/* Interactivity has limited availability https://caniuse.com/?search=interactivity */
@supports (interactivity: inert) {
    interactivity: inert;
}
pointer-events: none;
```
I would prefer to avoid the [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert) HTML attribute because I believe it would be far less efficient than the current global CSS class when toggling messages.

If the issue remains, may I also lower the chevron's `z-index: 9999`?

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
