### PR TITLE
Replace Google Translate library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
                 "express": "^4.21.0",
                 "form-data": "^4.0.4",
                 "fuse.js": "^7.1.0",
-                "google-translate-api-browser": "^3.0.1",
                 "google-translate-api-x": "^10.7.2",
                 "handlebars": "^4.7.8",
                 "helmet": "^8.1.0",
@@ -5389,12 +5388,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/google-translate-api-browser": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/google-translate-api-browser/-/google-translate-api-browser-3.0.1.tgz",
-            "integrity": "sha512-KTLodkyGBWMK9IW6QIeJ2zCuju4Z0CLpbkADKo+yLhbSTD4l+CXXpQ/xaynGVAzeBezzJG6qn8MLeqOq3SmW0A==",
-            "license": "MIT"
         },
         "node_modules/google-translate-api-x": {
             "version": "10.7.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
         "express": "^4.21.0",
         "form-data": "^4.0.4",
         "fuse.js": "^7.1.0",
-        "google-translate-api-browser": "^3.0.1",
         "google-translate-api-x": "^10.7.2",
         "handlebars": "^4.7.8",
         "helmet": "^8.1.0",

--- a/src/endpoints/translate.js
+++ b/src/endpoints/translate.js
@@ -1,10 +1,8 @@
-import { createRequire } from 'node:module';
-
 import fetch from 'node-fetch';
 import express from 'express';
 import { translate as bingTranslate } from 'bing-translate-api';
-import iconv from 'iconv-lite';
 import urlJoin from 'url-join';
+import { Translator } from 'google-translate-api-x';
 
 import { readSecret, SECRET_KEYS } from './secrets.js';
 import { getConfigValue, uuidv4 } from '../util.js';
@@ -14,30 +12,6 @@ const ONERING_URL_DEFAULT = 'http://127.0.0.1:4990/translate';
 const LINGVA_DEFAULT = 'https://lingva.ml/api/v1';
 
 export const router = express.Router();
-
-/**
- * Get the Google Translate API client.
- * @returns {import('google-translate-api-browser')} Google Translate API client
- */
-function getGoogleTranslateClient() {
-    const require = createRequire(import.meta.url);
-    const googleTranslateApi = require('google-translate-api-browser');
-    return googleTranslateApi;
-}
-
-/**
- * Tries to decode an ArrayBuffer to a string using iconv-lite for UTF-8.
- * @param {ArrayBuffer} buffer ArrayBuffer
- * @returns {string} Decoded string
- */
-function decodeBuffer(buffer) {
-    try {
-        return iconv.decode(Buffer.from(buffer), 'utf-8');
-    } catch (error) {
-        console.error('Failed to decode buffer:', error);
-        return Buffer.from(buffer).toString('utf-8');
-    }
-}
 
 router.post('/libre', async (request, response) => {
     try {
@@ -101,8 +75,8 @@ router.post('/libre', async (request, response) => {
 
 router.post('/google', async (request, response) => {
     try {
-        const text = request.body.text;
-        const lang = request.body.lang;
+        const text = String(request.body.text ?? '');
+        const lang = String(request.body.lang ?? '');
 
         if (!text || !lang) {
             return response.sendStatus(400);
@@ -110,18 +84,8 @@ router.post('/google', async (request, response) => {
 
         console.debug('Input text: ' + text);
 
-        const { generateRequestUrl, normaliseResponse } = getGoogleTranslateClient();
-        const requestUrl = generateRequestUrl(text, { to: lang });
-        const result = await fetch(requestUrl);
-
-        if (!result.ok) {
-            console.warn('Google Translate error: ', result.statusText);
-            return response.sendStatus(500);
-        }
-
-        const buffer = await result.arrayBuffer();
-        const translateResponse = normaliseResponse(JSON.parse(decodeBuffer(buffer)));
-        const translatedText = translateResponse.text;
+        const translator = new Translator({ to: lang });
+        const translatedText = await translator.translate(text).then(result => result.text);
 
         response.setHeader('Content-Type', 'text/plain; charset=utf-8');
         console.debug('Translated text: ' + translatedText);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

They provide identical translations. Confirmed that with a unit test which I'm not committing since the library is removed. So I don't see a reason to keep the library that constantly annoys with an audit log.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
