### PR TITLE
Feat/add bananabread as vector source

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -115,7 +115,7 @@ const settings = {
 const moduleWorker = new ModuleWorkerWrapper(synchronizeChat);
 const webllmProvider = new WebLlmVectorProvider();
 const cachedSummaries = new Map();
-const vectorApiRequiresUrl = ['llamacpp', 'vllm', 'ollama', 'koboldcpp'];
+const vectorApiRequiresUrl = ['bananabread', 'llamacpp', 'vllm', 'ollama', 'koboldcpp'];
 
 /**
  * Gets the Collection ID for a file embedded in the chat.
@@ -1137,6 +1137,7 @@ function toggleSettings() {
     $('#cohere_vectorsModel').toggle(settings.source === 'cohere');
     $('#ollama_vectorsModel').toggle(settings.source === 'ollama');
     $('#llamacpp_vectorsModel').toggle(settings.source === 'llamacpp');
+    $('#bananabread_vectorsModel').toggle(settings.source === 'bananabread');
     $('#vllm_vectorsModel').toggle(settings.source === 'vllm');
     $('#nomicai_apiKey').toggle(settings.source === 'nomicai');
     $('#webllm_vectorsModel').toggle(settings.source === 'webllm');

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -10,6 +10,7 @@
                     Vectorization Source
                 </label>
                 <select id="vectors_source" class="text_pole">
+                    <option value="bananabread">BananaBread</option>
                     <option value="chutes">Chutes</option>
                     <option value="cohere">Cohere</option>
                     <option value="electronhub">Electron Hub</option>
@@ -99,6 +100,14 @@
             <div class="flex-container flexFlowColumn" id="llamacpp_vectorsModel">
                 <span data-i18n="The server MUST be started with the --embedding flag to use this feature!">
                     The server MUST be started with the <code>--embedding</code> flag to use this feature!
+                </span>
+                <i data-i18n="Hint: Set the URL in the API connection settings.">
+                    Hint: Set the URL in the API connection settings.
+                </i>
+            </div>
+            <div class="flex-container flexFlowColumn" id="bananabread_vectorsModel">
+                <span>
+                    BananaBread is a custom embedding server compatible with llama.cpp.
                 </span>
                 <i data-i18n="Hint: Set the URL in the API connection settings.">
                     Hint: Set the URL in the API connection settings.

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -29,6 +29,7 @@ const SOURCES = [
     'nomicai',
     'cohere',
     'ollama',
+    'bananabread',
     'llamacpp',
     'vllm',
     'webllm',
@@ -70,6 +71,7 @@ async function getVector(source, sourceSettings, text, isQuery, directories) {
             return getVertexVector(text, sourceSettings.model, sourceSettings.request);
         case 'cohere':
             return getCohereVector(text, isQuery, directories, sourceSettings.model);
+        case 'bananabread':
         case 'llamacpp':
             return getLlamaCppVector(text, sourceSettings.apiUrl, directories);
         case 'vllm':
@@ -132,6 +134,7 @@ async function getBatchVector(source, sourceSettings, texts, isQuery, directorie
             case 'cohere':
                 results.push(...await getCohereBatchVector(batch, isQuery, directories, sourceSettings.model));
                 break;
+            case 'bananabread':
             case 'llamacpp':
                 results.push(...await getLlamaCppBatchVector(batch, sourceSettings.apiUrl, directories));
                 break;
@@ -186,6 +189,7 @@ function getSourceSettings(source, request) {
             return {
                 model: String(request.body.model),
             };
+        case 'bananabread':
         case 'llamacpp':
             return {
                 apiUrl: String(request.body.apiUrl),


### PR DESCRIPTION
Hello :)
this PR adds bananabread into the list of supported vectorization sources. [Bananabread](https://github.com/prolix-oc/BananaBread) is an embedding and reranking server supporting multiple models including MixedBread AI and Qwen3, with llama.cpp-compatible endpoints.

I've met some difficulties when using default vectra storage and bananabread as an embedding provider when developing the [VectHare plugin](https://github.com/Coneja-Chibi/VectHare), and i didn't find any workaround to make it work with vectra apart from changing the method to llamacpp api (not very ux to use one method and pretend to use another?)

I know bananabred is a very specific thing, and maybe it would be better to provide a way to integrate new vectorization sources from the plugin's end, but that would be a whole ass another PR 😄 anyway, let's discuss it? :)


<!-- Put X in the box below to confirm -->

## Checklist:

- [ X ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
