### PR TITLE
Correct error message in evalBoolean

### DIFF
--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -575,7 +575,7 @@ export function evalBoolean(rule, a, b) {
         case 'neq':
             return aString !== bString;
         default:
-            throw new Error(`Unknown boolean comparison rule for type number. Accepted: in, nin, eq, neq. Provided: ${rule}`);
+            throw new Error(`Unknown boolean comparison rule for type string. Accepted: in, nin, eq, neq. Provided: ${rule}`);
     }
 }
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

The error message for unsupported boolean comparison for strings incorrectly states number instead.

