### PR TITLE
Migrate substituteParams calls to new engine

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -1280,10 +1280,10 @@ class PromptManager {
         const preparedPrompt = new Prompt(prompt);
 
         if (typeof original === 'string') {
-            if (0 < groupMembers.length) preparedPrompt.content = substituteParams(prompt.content ?? '', null, null, original, groupMembers.join(', '));
-            else preparedPrompt.content = substituteParams(prompt.content, null, null, original);
+            if (0 < groupMembers.length) preparedPrompt.content = substituteParams(prompt.content ?? '', { original, groupOverride: groupMembers.join(', ') });
+            else preparedPrompt.content = substituteParams(prompt.content, { original });
         } else {
-            if (0 < groupMembers.length) preparedPrompt.content = substituteParams(prompt.content ?? '', null, null, null, groupMembers.join(', '));
+            if (0 < groupMembers.length) preparedPrompt.content = substituteParams(prompt.content ?? '', { groupOverride: groupMembers.join(', ') });
             else preparedPrompt.content = substituteParams(prompt.content);
         }
 

--- a/public/scripts/extensions/regex/engine.js
+++ b/public/scripts/extensions/regex/engine.js
@@ -457,7 +457,7 @@ export function runRegexScript(regexScript, rawString, { characterOverride } = {
 function filterString(rawString, trimStrings, { characterOverride } = {}) {
     let finalString = rawString;
     trimStrings.forEach((trimString) => {
-        const subTrimString = substituteParams(trimString, undefined, characterOverride);
+        const subTrimString = substituteParams(trimString, { name2Override: characterOverride });
         finalString = finalString.replaceAll(subTrimString, '');
     });
 

--- a/public/scripts/extensions/translate/index.js
+++ b/public/scripts/extensions/translate/index.js
@@ -210,7 +210,7 @@ async function translateIncomingMessage(messageId) {
         return;
     }
 
-    const textToTranslate = substituteParams(message.mes, context.name1, message.name);
+    const textToTranslate = substituteParams(message.mes, { name2Override: message.name });
     const translation = await translate(textToTranslate, extension_settings.translate.target_language);
     message.extra.display_text = translation;
 
@@ -238,7 +238,7 @@ async function translateIncomingMessageReasoning(messageId) {
         return false;
     }
 
-    const textToTranslate = substituteParams(message.extra.reasoning, context.name1, message.name);
+    const textToTranslate = substituteParams(message.extra.reasoning, { name2Override: message.name });
     const translation = await translate(textToTranslate, extension_settings.translate.target_language);
     message.extra.reasoning_display_text = translation;
 

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -39,8 +39,6 @@ import {
     setCharacterName,
     setEditedMessageId,
     is_send_press,
-    name1,
-    name2,
     resetChatState,
     setSendButtonState,
     getCharacters,
@@ -459,7 +457,7 @@ export function getGroupDepthPrompts(groupId, characterId) {
             continue;
         }
 
-        const depthPromptText = baseChatReplace(character.data?.extensions?.depth_prompt?.prompt?.trim(), name1, character.name) || '';
+        const depthPromptText = baseChatReplace(character.data?.extensions?.depth_prompt?.prompt?.trim(), null, character.name) || '';
         const depthPromptDepth = character.data?.extensions?.depth_prompt?.depth ?? depth_prompt_depth_default;
         const depthPromptRole = character.data?.extensions?.depth_prompt?.role ?? depth_prompt_role_default;
 
@@ -517,7 +515,7 @@ export function getGroupCharacterCardsLazy(groupId, characterId) {
         if (!value) return '';
         value = value.replace(/<FIELDNAME>/gi, fieldName);
         value = trim ? value.trim() : value;
-        return baseChatReplace(value, name1, characterName);
+        return baseChatReplace(value, null, characterName);
     }
 
     /**
@@ -543,7 +541,7 @@ export function getGroupCharacterCardsLazy(groupId, characterId) {
     /**
      * Collects and joins field values from all group members
      * @param {string} fieldName Display name of the field
-     * @param {function(import('../script.js').Character): string} getter Function to get field value from character
+     * @param {function(Character): string} getter Function to get field value from character
      * @param {function(string): string} [preprocess] Optional preprocess function
      * @returns {string} Combined field values
      */
@@ -567,8 +565,8 @@ export function getGroupCharacterCardsLazy(groupId, characterId) {
     return createLazyFields({
         description: () => collectField('Description', c => c.description),
         personality: () => collectField('Personality', c => c.personality),
-        scenario: () => baseChatReplace(scenarioOverride?.trim(), name1, name2) || collectField('Scenario', c => c.scenario),
-        mesExamples: () => baseChatReplace(mesExamplesOverride?.trim(), name1, name2) ||
+        scenario: () => baseChatReplace(scenarioOverride?.trim()) || collectField('Scenario', c => c.scenario),
+        mesExamples: () => baseChatReplace(mesExamplesOverride?.trim()) ||
             collectField('Example Messages', c => c.mes_example, x => !x.startsWith('<START>') ? `<START>\n${x}` : x),
     });
 }
@@ -602,7 +600,7 @@ async function getFirstCharacterMessage(character) {
     mes['original_avatar'] = character.avatar;
     mes['extra'] = { 'gen_id': Date.now() * Math.random() * 1000000 };
     mes['mes'] = messageText
-        ? substituteParams(messageText.trim(), name1, character.name)
+        ? substituteParams(messageText.trim(), { name2Override: character.name })
         : '';
     mes['force_avatar'] =
         character.avatar != 'none'

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -436,10 +436,10 @@ export function formatInstructModeChat(name, mes, isUser, isNarrator, forceAvata
     let suffix = getSuffix() || '';
 
     if (instruct.macro) {
-        prefix = substituteParams(prefix, name1, name2);
+        prefix = substituteParams(prefix, { name1Override: name1, name2Override: name2 });
         prefix = prefix.replace(/{{name}}/gi, name || 'System');
 
-        suffix = substituteParams(suffix, name1, name2);
+        suffix = substituteParams(suffix, { name1Override: name1, name2Override: name2 });
         suffix = suffix.replace(/{{name}}/gi, name || 'System');
     }
 
@@ -524,10 +524,10 @@ export function formatInstructModeExamples(mesExamplesArray, name1, name2) {
     let outputSuffix = power_user.instruct.output_suffix || '';
 
     if (power_user.instruct.macro) {
-        inputPrefix = substituteParams(inputPrefix, name1, name2);
-        outputPrefix = substituteParams(outputPrefix, name1, name2);
-        inputSuffix = substituteParams(inputSuffix, name1, name2);
-        outputSuffix = substituteParams(outputSuffix, name1, name2);
+        inputPrefix = substituteParams(inputPrefix, { name1Override: name1, name2Override: name2 });
+        outputPrefix = substituteParams(outputPrefix, { name1Override: name1, name2Override: name2 });
+        inputSuffix = substituteParams(inputSuffix, { name1Override: name1, name2Override: name2 });
+        outputSuffix = substituteParams(outputSuffix, { name1Override: name1, name2Override: name2 });
 
         inputPrefix = inputPrefix.replace(/{{name}}/gi, name1);
         outputPrefix = outputPrefix.replace(/{{name}}/gi, name2);
@@ -631,7 +631,7 @@ export function formatInstructModePrompt(name, isImpersonate, promptBias, name1,
     }
 
     if (instruct.macro) {
-        sequence = substituteParams(sequence, name1, name2);
+        sequence = substituteParams(sequence, { name1Override: name1, name2Override: name2 });
         sequence = sequence.replace(/{{name}}/gi, name || 'System');
     }
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Updated all calls in the codebase with more than 1 param to new object-based signature.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
