### PR TITLE
Add model selection support for llama.cpp router mode

### DIFF
--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -16,6 +16,11 @@
     user-select: none;
 }
 
+.select2-container .select2-selection.select2-selection--single.select2-selection--clearable .select2-selection__clear {
+    top: 0;
+    right: 25px;
+}
+
 .select2-container .select2-selection .select2-selection__clear {
     color: var(--SmartThemeBodyColor);
     font-size: 20px;

--- a/public/index.html
+++ b/public/index.html
@@ -2681,7 +2681,7 @@
                                 </div>
                                 <div>
                                     <h4>
-                                        <span data-i18n="LlamaCpp Model">LlamaCpp Model</span>
+                                        <span data-i18n="llama.cpp Model">llama.cpp Model</span>
                                     </h4>
                                     <select id="llamacpp_model">
                                         <option value="" data-i18n="-- Connect to the API --">

--- a/public/index.html
+++ b/public/index.html
@@ -2679,6 +2679,16 @@
                                     <small data-i18n="Example: http://127.0.0.1:8080">Example: http://127.0.0.1:8080</small>
                                     <input id="llamacpp_api_url_text" class="text_pole wide100p" value="" autocomplete="off" data-server-history="llamacpp">
                                 </div>
+                                <div>
+                                    <h4>
+                                        <span data-i18n="LlamaCpp Model">LlamaCpp Model</span>
+                                    </h4>
+                                    <select id="llamacpp_model">
+                                        <option value="" data-i18n="-- Connect to the API --">
+                                            -- Connect to the API --
+                                        </option>
+                                    </select>
+                                </div>
                             </div>
                             <div data-tg-type="ollama">
                                 <div class="flex-container flexFlowColumn">

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -701,6 +701,7 @@ class PresetManager {
             'ollama_model',
             'vllm_model',
             'aphrodite_model',
+            'llamacpp_model',
             'server_urls',
             'type',
             'custom_model',

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -4834,6 +4834,7 @@ function getModelOptions(quiet) {
         { id: 'aphrodite_model', api: 'textgenerationwebui', type: textgen_types.APHRODITE },
         { id: 'ollama_model', api: 'textgenerationwebui', type: textgen_types.OLLAMA },
         { id: 'tabby_model', api: 'textgenerationwebui', type: textgen_types.TABBY },
+        { id: 'llamacpp_model', api: 'textgenerationwebui', type: textgen_types.LLAMACPP },
         { id: 'featherless_model', api: 'textgenerationwebui', type: textgen_types.FEATHERLESS },
         { id: 'model_openai_select', api: 'openai', type: chat_completion_sources.OPENAI },
         { id: 'model_claude_select', api: 'openai', type: chat_completion_sources.CLAUDE },

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -17,6 +17,7 @@ let vllmModels = [];
 let aphroditeModels = [];
 let featherlessModels = [];
 let tabbyModels = [];
+let llamacppModels = [];
 export let openRouterModels = [];
 
 /**
@@ -136,6 +137,30 @@ export async function loadTabbyModels(data) {
         option.text = model.id;
         option.selected = model.id === textgen_settings.tabby_model;
         $('#tabby_model').append(option);
+    }
+}
+
+export async function loadLlamaCppModels(data) {
+    if (!Array.isArray(data)) {
+        console.error('Invalid LlamaCpp models data', data);
+        return;
+    }
+
+    llamacppModels = data;
+    llamacppModels.sort((a, b) => a.id.localeCompare(b.id));
+    llamacppModels.unshift({ id: '' });
+
+    if (!llamacppModels.find(x => x.id === textgen_settings.llamacpp_model)) {
+        textgen_settings.llamacpp_model = llamacppModels[0]?.id || '';
+    }
+
+    $('#llamacpp_model').empty();
+    for (const model of llamacppModels) {
+        const option = document.createElement('option');
+        option.value = model.id;
+        option.text = model.id;
+        option.selected = model.id === textgen_settings.llamacpp_model;
+        $('#llamacpp_model').append(option);
     }
 }
 
@@ -637,6 +662,12 @@ function onTabbyModelSelect() {
     $('#api_button_textgenerationwebui').trigger('click');
 }
 
+function onLlamaCppModelSelect() {
+    const modelId = String($('#llamacpp_model').val());
+    textgen_settings.llamacpp_model = modelId;
+    $('#api_button_textgenerationwebui').trigger('click');
+}
+
 function onOpenRouterModelSelect() {
     const modelId = String($('#openrouter_model').val());
     textgen_settings.openrouter_model = modelId;
@@ -952,6 +983,7 @@ export function initTextGenModels() {
     $('#aphrodite_model').on('change', onAphroditeModelSelect);
     $('#tabby_download_model').on('click', downloadTabbyModel);
     $('#tabby_model').on('change', onTabbyModelSelect);
+    $('#llamacpp_model').on('change', onLlamaCppModelSelect);
     $('#featherless_model').on('change', () => onFeatherlessModelSelect(String($('#featherless_model').val())));
 
     const providersSelect = $('.openrouter_providers');
@@ -984,6 +1016,13 @@ export function initTextGenModels() {
             width: '100%',
         });
         $('#tabby_model').select2({
+            placeholder: t`[Currently loaded]`,
+            searchInputPlaceholder: t`Search models...`,
+            searchInputCssClass: 'text_pole',
+            width: '100%',
+            allowClear: true,
+        });
+        $('#llamacpp_model').select2({
             placeholder: t`[Currently loaded]`,
             searchInputPlaceholder: t`Search models...`,
             searchInputCssClass: 'text_pole',

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -142,7 +142,7 @@ export async function loadTabbyModels(data) {
 
 export async function loadLlamaCppModels(data) {
     if (!Array.isArray(data)) {
-        console.error('Invalid LlamaCpp models data', data);
+        console.error('Invalid llama.cpp models data', data);
         return;
     }
 

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -23,7 +23,7 @@ import { power_user, registerDebugFunction } from './power-user.js';
 import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
-import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels } from './textgen-models.js';
+import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels } from './textgen-models.js';
 import { ENCODE_TOKENIZERS, TEXTGEN_TOKENIZERS, TOKENIZER_SUPPORTED_KEY, getTextTokens, tokenizers } from './tokenizers.js';
 import { AbortReason } from './util/AbortReason.js';
 import { getSortableDelay, onlyUnique, arraysEqual, isObject } from './utils.js';
@@ -214,6 +214,7 @@ export const textgenerationwebui_settings = {
     aphrodite_model: '',
     dreamgen_model: 'lucid-v1-extra-large/text',
     tabby_model: '',
+    llamacpp_model: '',
     sampler_order: KOBOLDCPP_ORDER,
     logit_bias: [],
     n: 1,
@@ -701,6 +702,9 @@ async function getStatusTextgen() {
         } else if (textgenerationwebui_settings.type === textgen_types.TABBY) {
             loadTabbyModels(data?.data);
             setOnlineStatus(textgenerationwebui_settings.tabby_model || data?.result);
+        } else if (textgenerationwebui_settings.type === textgen_types.LLAMACPP) {
+            loadLlamaCppModels(data?.data);
+            setOnlineStatus(textgenerationwebui_settings.llamacpp_model || data?.result || t`Connected`);
         } else if (textgenerationwebui_settings.type === textgen_types.GENERIC) {
             loadGenericModels(data?.data);
             setOnlineStatus(textgenerationwebui_settings.generic_model || data?.result || t`Connected`);
@@ -1460,6 +1464,11 @@ export function getTextGenModel(settings = null) {
         case TABBY:
             if (settings.tabby_model) {
                 return settings.tabby_model;
+            }
+            break;
+        case LLAMACPP:
+            if (settings.llamacpp_model) {
+                return settings.llamacpp_model;
             }
             break;
         default:


### PR DESCRIPTION
## Add model selection support for llama.cpp router mode

## Context
llama.cpp has just introduced a new router mode, allowing selection between multiple models without restarting the server.
However, in text complete mode in SillyTavern the first model is automatically chosen, and there is no option to choose the loaded model.

https://huggingface.co/blog/ggml-org/model-management-in-llamacpp

This PR implements model selection for llama.cpp router mode, allowing users to select from multiple models without restarting the server.

## Changes

- Added llamacpp_model setting to store selected model
- Implemented loadLlamaCppModels() to fetch available models from /v1/models endpoint
- Added model dropdown UI in the llama.cpp settings section
- Integrated model selection with preset manager and slash commands
- Follows the same pattern as Ollama, Tabby, and vLLM implementations

Technical Details

- Uses existing /v1/models endpoint (already implemented in backend)
- Model parameter is included in /completion requests via getTextGenModel()
- Backward compatible (works with or without router mode)
- No breaking changes

## Test script

Router mode
1. Start llama.cpp server in router mode with multiple models loaded
2. Connect to the server in SillyTavern
3. Verify models appear in the dropdown
4. Select a model and verify it's used in API requests
5. Test model selection persists across page reloads and ST restarts

Single model mode
1. Start llama.cpp server in normal mode with single model
2. Connect to the server in SillyTavern
3. Verify single model appears in connection (No need to select a model from dropdown)
4. Run model and verify it's being used.
5. Test model selection persists across page reloads and ST restarts

This implements model selection for llama.cpp router mode, allowing users to select from multiple models without restarting the server. Follows the same pattern as Ollama, Tabby, and vLLM implementations.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
