### PR TITLE
Allow editing of global Worldinfo settings

### DIFF
--- a/public/global.d.ts
+++ b/public/global.d.ts
@@ -8,6 +8,7 @@ import { FileAttachment } from './scripts/chats';
 import { ReasoningMessageExtra } from './scripts/reasoning';
 import { IGNORE_SYMBOL, OVERSWIPE_BEHAVIOR } from './scripts/constants';
 import { ToolInvocation } from './scripts/tool-calling';
+import { getWorldInfoSettings } from './scripts/world-info';
 
 declare global {
     // Custom types
@@ -16,6 +17,7 @@ declare global {
     type ReasoningSettings = typeof power_user.reasoning;
     type ChatCompletionSettings = typeof oai_settings;
     type TextCompletionSettings = typeof textgenerationwebui_settings;
+    type WorldInfoSettings = ReturnType<typeof getWorldInfoSettings>;
     type MessageTimestamp = string | number | Date;
     type Character = import('./scripts/char-data').v1CharData;
     type ChatMessageExtra = BaseMessageExtra & Partial<ReasoningMessageExtra> & Record<string, any>;

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -813,6 +813,48 @@ export function getWorldInfoSettings() {
     };
 }
 
+/**
+ *  Updates the world info settings.
+ * @param {object} settings - Settings object
+ * @param {string[]} [active_world_info] - Optional array of active world info names
+ */
+ export function updateWorldInfoSettings(settings, active_world_info) {
+    console.debug('[WI] Updating world info settings', settings, active_world_info);
+    if (settings.world_info_depth !== undefined)
+        world_info_depth = Number(settings.world_info_depth);
+    if (settings.world_info_min_activations !== undefined)
+        world_info_min_activations = Number(settings.world_info_min_activations);
+    if (settings.world_info_min_activations_depth_max !== undefined)
+        world_info_min_activations_depth_max = Number(settings.world_info_min_activations_depth_max);
+    if (settings.world_info_budget !== undefined)
+        world_info_budget = Number(settings.world_info_budget);
+    if (settings.world_info_include_names !== undefined)
+        world_info_include_names = Boolean(settings.world_info_include_names);
+    if (settings.world_info_recursive !== undefined)
+        world_info_recursive = Boolean(settings.world_info_recursive);
+    if (settings.world_info_overflow_alert !== undefined)
+        world_info_overflow_alert = Boolean(settings.world_info_overflow_alert);
+    if (settings.world_info_case_sensitive !== undefined)
+        world_info_case_sensitive = Boolean(settings.world_info_case_sensitive);
+    if (settings.world_info_match_whole_words !== undefined)
+        world_info_match_whole_words = Boolean(settings.world_info_match_whole_words);
+    if (settings.world_info_character_strategy !== undefined)
+        world_info_character_strategy = Number(settings.world_info_character_strategy);
+    if (settings.world_info_budget_cap !== undefined)
+        world_info_budget_cap = Number(settings.world_info_budget_cap);
+    if (settings.world_info_use_group_scoring !== undefined)
+        world_info_use_group_scoring = Boolean(settings.world_info_use_group_scoring);
+    if (settings.world_info_max_recursion_steps !== undefined)
+        world_info_max_recursion_steps = Number(settings.world_info_max_recursion_steps);
+
+    if (active_world_info && Array.isArray(active_world_info)) {
+        delete settings.world_info;
+        selected_world_info = active_world_info;
+    }
+
+    saveSettingsDebounced();
+};
+
 export const world_info_position = {
     before: 0,
     after: 1,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -814,46 +814,45 @@ export function getWorldInfoSettings() {
 }
 
 /**
- *  Updates the world info settings.
- * @param {object} settings - Settings object
- * @param {string[]} [active_world_info] - Optional array of active world info names
+ * Updates the world info settings.
+ * @param {WorldInfoSettings} settings - Settings object
+ * @param {string[]} [activeWorldInfo] - Optional array of active world info names
  */
- export function updateWorldInfoSettings(settings, active_world_info) {
-    console.debug('[WI] Updating world info settings', settings, active_world_info);
-    if (settings.world_info_depth !== undefined)
-        world_info_depth = Number(settings.world_info_depth);
-    if (settings.world_info_min_activations !== undefined)
-        world_info_min_activations = Number(settings.world_info_min_activations);
-    if (settings.world_info_min_activations_depth_max !== undefined)
-        world_info_min_activations_depth_max = Number(settings.world_info_min_activations_depth_max);
-    if (settings.world_info_budget !== undefined)
-        world_info_budget = Number(settings.world_info_budget);
-    if (settings.world_info_include_names !== undefined)
-        world_info_include_names = Boolean(settings.world_info_include_names);
-    if (settings.world_info_recursive !== undefined)
-        world_info_recursive = Boolean(settings.world_info_recursive);
-    if (settings.world_info_overflow_alert !== undefined)
-        world_info_overflow_alert = Boolean(settings.world_info_overflow_alert);
-    if (settings.world_info_case_sensitive !== undefined)
-        world_info_case_sensitive = Boolean(settings.world_info_case_sensitive);
-    if (settings.world_info_match_whole_words !== undefined)
-        world_info_match_whole_words = Boolean(settings.world_info_match_whole_words);
-    if (settings.world_info_character_strategy !== undefined)
-        world_info_character_strategy = Number(settings.world_info_character_strategy);
-    if (settings.world_info_budget_cap !== undefined)
-        world_info_budget_cap = Number(settings.world_info_budget_cap);
-    if (settings.world_info_use_group_scoring !== undefined)
-        world_info_use_group_scoring = Boolean(settings.world_info_use_group_scoring);
-    if (settings.world_info_max_recursion_steps !== undefined)
-        world_info_max_recursion_steps = Number(settings.world_info_max_recursion_steps);
+export function updateWorldInfoSettings(settings, activeWorldInfo) {
+    console.debug('[WI] Updating world info settings', settings, activeWorldInfo);
 
-    if (active_world_info && Array.isArray(active_world_info)) {
+    /** @type {Record<keyof WorldInfoSettings, (value: any) => void>} */
+    const fields = {
+        world_info_depth: (value) => world_info_depth = Number(value),
+        world_info_min_activations: (value) => world_info_min_activations = Number(value),
+        world_info_min_activations_depth_max: (value) => world_info_min_activations_depth_max = Number(value),
+        world_info_budget: (value) => world_info_budget = Number(value),
+        world_info_include_names: (value) => world_info_include_names = Boolean(value),
+        world_info_recursive: (value) => world_info_recursive = Boolean(value),
+        world_info_overflow_alert: (value) => world_info_overflow_alert = Boolean(value),
+        world_info_case_sensitive: (value) => world_info_case_sensitive = Boolean(value),
+        world_info_match_whole_words: (value) => world_info_match_whole_words = Boolean(value),
+        world_info_character_strategy: (value) => world_info_character_strategy = Number(value),
+        world_info_budget_cap: (value) => world_info_budget_cap = Number(value),
+        world_info_use_group_scoring: (value) => world_info_use_group_scoring = Boolean(value),
+        world_info_max_recursion_steps: (value) => world_info_max_recursion_steps = Number(value),
+        // Unused
+        world_info: (_value) => {},
+    };
+
+    for (const [key, setter] of Object.entries(fields)) {
+        if (Object.hasOwn(settings, key)) {
+            setter(settings[key]);
+        }
+    }
+
+    if (Array.isArray(activeWorldInfo)) {
         delete settings.world_info;
-        selected_world_info = active_world_info;
+        selected_world_info = activeWorldInfo;
     }
 
     saveSettingsDebounced();
-};
+}
 
 export const world_info_position = {
     before: 0,


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Yes Hi hello, i want to edit global world info settings. For that i created a function that does that.
It takes a a settings object for that and optionally a list of global worldinfos that are active.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
