### PR TITLE
Added regex filter option to TTS extension

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -1,6 +1,6 @@
 import { cancelTtsPlay, eventSource, event_types, getCurrentChatId, isStreamingEnabled, name2, saveSettingsDebounced, substituteParams } from '../../../script.js';
 import { ModuleWorkerWrapper, extension_settings, getContext, renderExtensionTemplateAsync } from '../../extensions.js';
-import { delay, escapeRegex, getBase64Async, getStringHash, onlyUnique } from '../../utils.js';
+import { delay, escapeRegex, getBase64Async, getStringHash, onlyUnique, regexFromString } from '../../utils.js';
 import { EdgeTtsProvider } from './edge.js';
 import { ElevenLabsTtsProvider } from './elevenlabs.js';
 import { SileroTtsProvider } from './silerotts.js';
@@ -639,12 +639,16 @@ async function processTtsQueue() {
     }
 
     if (extension_settings.tts.apply_regex) {
-        const regexPattern = extension_settings.tts.regex_pattern || '[^a-zA-Z0-9\\s.,!?;:\'"()-]+';
+        const regexPattern = extension_settings.tts.regex_pattern || '/[^a-zA-Z0-9\\s.,!?;:\'"()-]+/g';
         try {
-            const regex = new RegExp(regexPattern, 'g');
-            text = text.replace(regex, '').trim();
-            // Clean up extra spaces that might be left after removal
-            text = text.replace(/\s+/g, ' ').trim();
+            const regex = regexFromString(regexPattern);
+            if (!regex) {
+                console.error('Invalid regex pattern:', regexPattern);
+            } else {
+                text = text.replace(regex, '').trim();
+                // Clean up extra spaces that might be left after removal
+                text = text.replace(/\s+/g, ' ').trim();
+            }
         } catch (error) {
             console.error('Invalid regex pattern:', error);
         }
@@ -840,6 +844,7 @@ function loadSettings() {
     $('#tts_apply_regex').prop('checked', extension_settings.tts.apply_regex);
     $('#tts_regex_pattern').val(extension_settings.tts.regex_pattern);
     $('#tts_regex_block').toggle(extension_settings.tts.apply_regex);
+    updateRegexPatternWarning();
     $('#playback_rate').val(extension_settings.tts.playback_rate);
     $('#playback_rate_counter').val(Number(extension_settings.tts.playback_rate).toFixed(2));
     $('#playback_rate_block').toggle(extension_settings.tts.currentProvider !== 'System');
@@ -856,7 +861,7 @@ const defaultSettings = {
     playback_rate: 1,
     multi_voice_enabled: false,
     apply_regex: false,
-    regex_pattern: '[^a-zA-Z0-9\\s.,!?;:\'"()-]+',
+    regex_pattern: '[^a-zA-Z0-9\\s.,!?;:\'"()—–~@#$%&*+=/\\\\<>\\[\\]{}]+',
 };
 
 function setTtsStatus(status, success) {
@@ -957,15 +962,33 @@ function onMultiVoiceClick() {
     initVoiceMap();
 }
 
-function onApplyRegexClick() {
+function onApplyRegexChange() {
     extension_settings.tts.apply_regex = !!$('#tts_apply_regex').prop('checked');
     saveSettingsDebounced();
     $('#tts_regex_block').toggle(extension_settings.tts.apply_regex);
+    updateRegexPatternWarning();
 }
 
 function onRegexPatternChange() {
     extension_settings.tts.regex_pattern = $('#tts_regex_pattern').val();
     saveSettingsDebounced();
+    updateRegexPatternWarning();
+}
+
+function updateRegexPatternWarning() {
+    if (!extension_settings.tts.apply_regex) {
+        $('#tts_regex_warning').addClass('display-none');
+        return;
+    }
+
+    const pattern = $('#tts_regex_pattern').val();
+    if (!pattern) {
+        $('#tts_regex_warning').addClass('display-none');
+        return;
+    }
+
+    const regex = regexFromString(pattern);
+    $('#tts_regex_warning').toggleClass('display-none', !!regex);
 }
 
 //##############//
@@ -1477,7 +1500,7 @@ jQuery(async function () {
         $('#tts_narrate_by_paragraphs').on('click', onNarrateByParagraphsClick);
         $('#tts_narrate_user').on('click', onNarrateUserClick);
         $('#tts_multi_voice_enabled').on('click', onMultiVoiceClick);
-        $('#tts_apply_regex').on('click', onApplyRegexClick);
+        $('#tts_apply_regex').on('input', onApplyRegexChange);
         $('#tts_regex_pattern').on('input', onRegexPatternChange);
 
         $('#playback_rate').on('input', function () {

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -638,19 +638,13 @@ async function processTtsQueue() {
             : text.replaceAll('*', '').trim(); // remove just the asterisks
     }
 
-    if (extension_settings.tts.apply_regex) {
-        const regexPattern = extension_settings.tts.regex_pattern || '/[^a-zA-Z0-9\\s.,!?;:\'"()-]+/g';
-        try {
-            const regex = regexFromString(regexPattern);
-            if (!regex) {
-                console.error('Invalid regex pattern:', regexPattern);
-            } else {
-                text = text.replace(regex, '').trim();
-                // Clean up extra spaces that might be left after removal
-                text = text.replace(/\s+/g, ' ').trim();
-            }
-        } catch (error) {
-            console.error('Invalid regex pattern:', error);
+    if (extension_settings.tts.apply_regex && extension_settings.tts.regex_pattern) {
+        const regex = regexFromString(extension_settings.tts.regex_pattern);
+        if (regex) {
+            // Clean up extra spaces that might be left after removal
+            text = text.replace(regex, '').replace(/\s+/g, ' ').trim();
+        } else {
+            console.warn('Invalid regex pattern:', extension_settings.tts.regex_pattern);
         }
     }
 
@@ -861,7 +855,7 @@ const defaultSettings = {
     playback_rate: 1,
     multi_voice_enabled: false,
     apply_regex: false,
-    regex_pattern: '/[^a-zA-Z0-9\\s.,!?;:\'"()—–@#$%&*+=/\\\\<>\\[\\]{}]+/g',
+    regex_pattern: '',
 };
 
 function setTtsStatus(status, success) {
@@ -970,7 +964,7 @@ function onApplyRegexChange() {
 }
 
 function onRegexPatternChange() {
-    extension_settings.tts.regex_pattern = $('#tts_regex_pattern').val();
+    extension_settings.tts.regex_pattern = $('#tts_regex_pattern').val().toString();
     saveSettingsDebounced();
     updateRegexPatternWarning();
 }
@@ -982,7 +976,7 @@ function updateRegexPatternWarning() {
         return;
     }
 
-    const pattern = $('#tts_regex_pattern').val();
+    const pattern = extension_settings.tts.regex_pattern;
     if (!pattern) {
         warning.hide();
         return;

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -638,6 +638,18 @@ async function processTtsQueue() {
             : text.replaceAll('*', '').trim(); // remove just the asterisks
     }
 
+    if (extension_settings.tts.apply_regex) {
+        const regexPattern = extension_settings.tts.regex_pattern || '[^a-zA-Z0-9\\s.,!?;:\'"()-]+';
+        try {
+            const regex = new RegExp(regexPattern, 'g');
+            text = text.replace(regex, '').trim();
+            // Clean up extra spaces that might be left after removal
+            text = text.replace(/\s+/g, ' ').trim();
+        } catch (error) {
+            console.error('Invalid regex pattern:', error);
+        }
+    }
+
     if (extension_settings.tts.narrate_quoted_only) {
         const partJoiner = (ttsProvider?.separator || ' ... ');
         text = joinQuotedBlocks(text, { separator: partJoiner, includeQuotes: true });
@@ -825,6 +837,9 @@ function loadSettings() {
     $('#tts_skip_codeblocks').prop('checked', extension_settings.tts.skip_codeblocks);
     $('#tts_skip_tags').prop('checked', extension_settings.tts.skip_tags);
     $('#tts_multi_voice_enabled').prop('checked', extension_settings.tts.multi_voice_enabled);
+    $('#tts_apply_regex').prop('checked', extension_settings.tts.apply_regex);
+    $('#tts_regex_pattern').val(extension_settings.tts.regex_pattern);
+    $('#tts_regex_block').toggle(extension_settings.tts.apply_regex);
     $('#playback_rate').val(extension_settings.tts.playback_rate);
     $('#playback_rate_counter').val(Number(extension_settings.tts.playback_rate).toFixed(2));
     $('#playback_rate_block').toggle(extension_settings.tts.currentProvider !== 'System');
@@ -840,6 +855,8 @@ const defaultSettings = {
     narrate_user: false,
     playback_rate: 1,
     multi_voice_enabled: false,
+    apply_regex: false,
+    regex_pattern: '[^a-zA-Z0-9\\s.,!?;:\'"()-]+',
 };
 
 function setTtsStatus(status, success) {
@@ -938,6 +955,17 @@ function onMultiVoiceClick() {
     saveSettingsDebounced();
     // Reinitialize voice map to show/hide voices
     initVoiceMap();
+}
+
+function onApplyRegexClick() {
+    extension_settings.tts.apply_regex = !!$('#tts_apply_regex').prop('checked');
+    saveSettingsDebounced();
+    $('#tts_regex_block').toggle(extension_settings.tts.apply_regex);
+}
+
+function onRegexPatternChange() {
+    extension_settings.tts.regex_pattern = $('#tts_regex_pattern').val();
+    saveSettingsDebounced();
 }
 
 //##############//
@@ -1449,6 +1477,8 @@ jQuery(async function () {
         $('#tts_narrate_by_paragraphs').on('click', onNarrateByParagraphsClick);
         $('#tts_narrate_user').on('click', onNarrateUserClick);
         $('#tts_multi_voice_enabled').on('click', onMultiVoiceClick);
+        $('#tts_apply_regex').on('click', onApplyRegexClick);
+        $('#tts_regex_pattern').on('input', onRegexPatternChange);
 
         $('#playback_rate').on('input', function () {
             const value = $(this).val();

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -976,19 +976,20 @@ function onRegexPatternChange() {
 }
 
 function updateRegexPatternWarning() {
+    const warning = $('#tts_regex_warning');
     if (!extension_settings.tts.apply_regex) {
-        $('#tts_regex_warning').addClass('display-none');
+        warning.hide();
         return;
     }
 
     const pattern = $('#tts_regex_pattern').val();
     if (!pattern) {
-        $('#tts_regex_warning').addClass('display-none');
+        warning.hide();
         return;
     }
 
     const regex = regexFromString(pattern);
-    $('#tts_regex_warning').toggleClass('display-none', !!regex);
+    warning.toggle(!regex);
 }
 
 //##############//

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -861,7 +861,7 @@ const defaultSettings = {
     playback_rate: 1,
     multi_voice_enabled: false,
     apply_regex: false,
-    regex_pattern: '[^a-zA-Z0-9\\s.,!?;:\'"()—–~@#$%&*+=/\\\\<>\\[\\]{}]+',
+    regex_pattern: '/[^a-zA-Z0-9\\s.,!?;:\'"()—–@#$%&*+=/\\\\<>\\[\\]{}]+/g',
 };
 
 function setTtsStatus(status, success) {
@@ -1501,7 +1501,7 @@ jQuery(async function () {
         $('#tts_narrate_by_paragraphs').on('click', onNarrateByParagraphsClick);
         $('#tts_narrate_user').on('click', onNarrateUserClick);
         $('#tts_multi_voice_enabled').on('click', onMultiVoiceClick);
-        $('#tts_apply_regex').on('input', onApplyRegexChange);
+        $('#tts_apply_regex').on('change', onApplyRegexChange);
         $('#tts_regex_pattern').on('input', onRegexPatternChange);
 
         $('#playback_rate').on('input', function () {

--- a/public/scripts/extensions/tts/settings.html
+++ b/public/scripts/extensions/tts/settings.html
@@ -68,6 +68,7 @@
                         <small data-i18n="Regex Pattern">Regex Pattern (removes matching text)</small>
                     </div>
                     <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Default: [^a-zA-Z0-9\s.,!?;:'\"()—–~@#$%&*+=/\\\\<>\[\]{}]+" />
+                    <small id="tts_regex_warning" class="warning display-none" data-i18n="Invalid regex pattern.">Invalid regex pattern.</small>
                     <small data-i18n="Regex Description">Applies the regex pattern to filter text before TTS. You can change this to keep or remove characters as needed.</small>
                 </div>
                 <label class="checkbox_label" for="tts_multi_voice_enabled"

--- a/public/scripts/extensions/tts/settings.html
+++ b/public/scripts/extensions/tts/settings.html
@@ -53,12 +53,23 @@
                 </label>
                 <label class="checkbox_label" for="tts_skip_tags">
                     <input type="checkbox" id="tts_skip_tags">
-                    <small data-i18n="Skip tagged blocks">Skip &lt;tagged&gt; blocks</small>
+                    <small data-i18n="Skip tagged blocks">Skip <tagged> blocks</small>
                 </label>
                 <label class="checkbox_label" for="tts_pass_asterisks">
                     <input type="checkbox" id="tts_pass_asterisks">
                     <small data-i18n="Pass Asterisks to TTS Engine">Pass Asterisks to TTS Engine</small>
                 </label>
+                <label class="checkbox_label" for="tts_apply_regex">
+                    <input type="checkbox" id="tts_apply_regex">
+                    <small data-i18n="Apply regex filter">Apply regex filter to text</small>
+                </label>
+                <div id="tts_regex_block" class="margin-top5 display-none">
+                    <div class="range-block-title justifyLeft">
+                        <small data-i18n="Regex Pattern">Regex Pattern (removes matching text)</small>
+                    </div>
+                    <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Default: [^a-zA-Z0-9\s.,!?;:'\"()-]+" />
+                    <small data-i18n="Regex Description">Removes emojis and non-English text. Keeps letters, numbers, and punctuation.</small>
+                </div>
                 <label class="checkbox_label" for="tts_multi_voice_enabled"
                 data-i18n="[title]Works best when: Pass Asterisks to TTS Engine is enabled, and both Only narrate quotes and Ignore *text, even 'quotes', inside asterisks* are disabled."
                 title="Works best when: Pass Asterisks to TTS Engine is enabled, and both Only narrate quotes and Ignore *text, even 'quotes', inside asterisks* are disabled.">

--- a/public/scripts/extensions/tts/settings.html
+++ b/public/scripts/extensions/tts/settings.html
@@ -53,7 +53,7 @@
                 </label>
                 <label class="checkbox_label" for="tts_skip_tags">
                     <input type="checkbox" id="tts_skip_tags">
-                    <small data-i18n="Skip tagged blocks">Skip <tagged> blocks</small>
+                    <small data-i18n="Skip tagged blocks">Skip &lt;tagged&gt; blocks</small>
                 </label>
                 <label class="checkbox_label" for="tts_pass_asterisks">
                     <input type="checkbox" id="tts_pass_asterisks">
@@ -67,8 +67,8 @@
                     <div class="range-block-title justifyLeft">
                         <small data-i18n="Regex Pattern">Regex Pattern (removes matching text)</small>
                     </div>
-                    <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Default: [^a-zA-Z0-9\s.,!?;:'\"()-]+" />
-                    <small data-i18n="Regex Description">Removes emojis and non-English text. Keeps letters, numbers, and punctuation.</small>
+                    <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Default: [^a-zA-Z0-9\s.,!?;:'\"()—–~@#$%&*+=/\\\\<>\[\]{}]+" />
+                    <small data-i18n="Regex Description">Applies the regex pattern to filter text before TTS. You can change this to keep or remove characters as needed.</small>
                 </div>
                 <label class="checkbox_label" for="tts_multi_voice_enabled"
                 data-i18n="[title]Works best when: Pass Asterisks to TTS Engine is enabled, and both Only narrate quotes and Ignore *text, even 'quotes', inside asterisks* are disabled."

--- a/public/scripts/extensions/tts/settings.html
+++ b/public/scripts/extensions/tts/settings.html
@@ -67,7 +67,7 @@
                     <div class="range-block-title justifyLeft">
                         <small data-i18n="Regex Pattern">Regex Pattern (removes matching text)</small>
                     </div>
-                    <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Default: [^a-zA-Z0-9\s.,!?;:'\"()—–~@#$%&*+=/\\\\<>\[\]{}]+" />
+                    <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Default: [^a-zA-Z0-9\s.,!?;:'&quot;()]+" />
                     <small id="tts_regex_warning" class="warning display-none" data-i18n="Invalid regex pattern.">Invalid regex pattern.</small>
                     <small data-i18n="Regex Description">Applies the regex pattern to filter text before TTS. You can change this to keep or remove characters as needed.</small>
                 </div>

--- a/public/scripts/extensions/tts/settings.html
+++ b/public/scripts/extensions/tts/settings.html
@@ -59,18 +59,6 @@
                     <input type="checkbox" id="tts_pass_asterisks">
                     <small data-i18n="Pass Asterisks to TTS Engine">Pass Asterisks to TTS Engine</small>
                 </label>
-                <label class="checkbox_label" for="tts_apply_regex">
-                    <input type="checkbox" id="tts_apply_regex">
-                    <small data-i18n="Apply regex filter">Apply regex filter to text</small>
-                </label>
-                <div id="tts_regex_block" class="margin-top5 display-none">
-                    <div class="range-block-title justifyLeft">
-                        <small data-i18n="Regex Pattern">Regex Pattern (removes matching text)</small>
-                    </div>
-                    <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Default: [^a-zA-Z0-9\s.,!?;:'&quot;()]+" />
-                    <small id="tts_regex_warning" class="warning" style="display: none;" data-i18n="Invalid regex pattern.">Invalid regex pattern.</small>
-                    <small data-i18n="Regex Description">Applies the regex pattern to filter text before TTS. You can change this to keep or remove characters as needed.</small>
-                </div>
                 <label class="checkbox_label" for="tts_multi_voice_enabled"
                 data-i18n="[title]Works best when: Pass Asterisks to TTS Engine is enabled, and both Only narrate quotes and Ignore *text, even 'quotes', inside asterisks* are disabled."
                 title="Works best when: Pass Asterisks to TTS Engine is enabled, and both Only narrate quotes and Ignore *text, even 'quotes', inside asterisks* are disabled.">
@@ -79,6 +67,17 @@
                         Different voices for "quotes", *text inside asterisks* and other text
                     </small>
                 </label>
+                <label class="checkbox_label" for="tts_apply_regex" title="Applies the regex pattern to filter text before TTS.">
+                    <input type="checkbox" id="tts_apply_regex">
+                    <small data-i18n="Apply regex filter">Apply regex filter to text</small>
+                </label>
+                <div id="tts_regex_block" class="marginTop5" style="display: none;">
+                    <div class="range-block-title justifyLeft">
+                        <small data-i18n="Regex Pattern">Regex Pattern (removes matching text)</small>
+                    </div>
+                    <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Example: /[^a-zA-Z0-9\s.,!?;:'&quot;()]+/g" />
+                    <small id="tts_regex_warning" class="warning" style="display: none;" data-i18n="Invalid regex pattern.">Invalid regex pattern.</small   >
+                </div>
             </div>
             <div id="playback_rate_block" class="range-block">
                 <hr>

--- a/public/scripts/extensions/tts/settings.html
+++ b/public/scripts/extensions/tts/settings.html
@@ -68,7 +68,7 @@
                         <small data-i18n="Regex Pattern">Regex Pattern (removes matching text)</small>
                     </div>
                     <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Default: [^a-zA-Z0-9\s.,!?;:'&quot;()]+" />
-                    <small id="tts_regex_warning" class="warning display-none" data-i18n="Invalid regex pattern.">Invalid regex pattern.</small>
+                    <small id="tts_regex_warning" class="warning" style="display: none;" data-i18n="Invalid regex pattern.">Invalid regex pattern.</small>
                     <small data-i18n="Regex Description">Applies the regex pattern to filter text before TTS. You can change this to keep or remove characters as needed.</small>
                 </div>
                 <label class="checkbox_label" for="tts_multi_voice_enabled"

--- a/public/scripts/extensions/tts/settings.html
+++ b/public/scripts/extensions/tts/settings.html
@@ -71,12 +71,12 @@
                     <input type="checkbox" id="tts_apply_regex">
                     <small data-i18n="Apply regex filter">Apply regex filter to text</small>
                 </label>
-                <div id="tts_regex_block" class="marginTop5" style="display: none;">
+                <div id="tts_regex_block" class="marginTop5">
                     <div class="range-block-title justifyLeft">
                         <small data-i18n="Regex Pattern">Regex Pattern (removes matching text)</small>
                     </div>
                     <input type="text" id="tts_regex_pattern" class="text_pole width100p" placeholder="Example: /[^a-zA-Z0-9\s.,!?;:'&quot;()]+/g" />
-                    <small id="tts_regex_warning" class="warning" style="display: none;" data-i18n="Invalid regex pattern.">Invalid regex pattern.</small   >
+                    <small id="tts_regex_warning" class="warning" data-i18n="Invalid regex pattern.">Invalid regex pattern.</small>
                 </div>
             </div>
             <div id="playback_rate_block" class="range-block">


### PR DESCRIPTION
I've added an option to apply regex to the text before it is sent to the TTS API. My initial reasoning was that the TTS I use doesn't work well with emojis and non-english text.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
