### PR TITLE
update new siliconflow api address

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -83,7 +83,7 @@ const API_FIREWORKS = 'https://api.fireworks.ai/inference/v1';
 const API_COMETAPI = 'https://api.cometapi.com/v1';
 const API_ZAI_COMMON = 'https://api.z.ai/api/paas/v4';
 const API_ZAI_CODING = 'https://api.z.ai/api/coding/paas/v4';
-const API_SILICONFLOW = 'https://api.siliconflow.com/v1';
+const API_SILICONFLOW = 'https://api.siliconflow.cn/v1';
 const API_OPENROUTER = 'https://openrouter.ai/api/v1';
 
 /**


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [ x ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Reason: 
The siliconflow api address has changed from https://api.siliconflow.com/v1 to https://api.siliconflow.cn/v1. The silicon setting in the current version can not link to the server anymore. 

## Solution: 
Modifying the corresponding address in "src\endpoints\backends\chat-completions.js". 

## Test Method: 
I have tested the connection, model list retrieval and sent a test message in the api setting, all of them works fine now. 