### PR TITLE
Macros 2.0 [Fix] - Make macro name matching case-insensitive throughout the macro system

### DIFF
--- a/public/scripts/macros/engine/MacroCstWalker.js
+++ b/public/scripts/macros/engine/MacroCstWalker.js
@@ -157,8 +157,8 @@ class MacroCstWalker {
             if (!info) continue;
 
             if (info.isClosing) {
-                // Closing tag - pop matching opener from stack
-                if (unclosedStack.length > 0 && unclosedStack[unclosedStack.length - 1].name === info.name) {
+                // Closing tag - pop matching opener from stack (case-insensitive match)
+                if (unclosedStack.length > 0 && unclosedStack[unclosedStack.length - 1].name.toLowerCase() === info.name.toLowerCase()) {
                     unclosedStack.pop();
                 }
                 // If no matching opener, ignore (orphan closing tag)
@@ -1015,8 +1015,8 @@ class MacroCstWalker {
         for (let i = openingIdx + 1; i < macroInfos.length; i++) {
             const info = macroInfos[i];
 
-            // Only consider macros with the same name
-            if (info.name !== targetName) continue;
+            // Only consider macros with the same name (case-insensitive)
+            if (info.name.toLowerCase() !== targetName.toLowerCase()) continue;
 
             // Skip already matched macros
             if (info.matched) continue;

--- a/public/scripts/macros/engine/MacroEngine.js
+++ b/public/scripts/macros/engine/MacroEngine.js
@@ -165,10 +165,12 @@ class MacroEngine {
         if (!name) return raw;
 
         // First check if this is a dynamic macro to use. If so, we will create a temporary macro definition for it and use that over any registered macro.
+        // Dynamic macro keys are normalized to lowercase for case-insensitive matching.
         /** @type {MacroDefinition?} */
         let defOverride = null;
-        if (Object.hasOwn(env.dynamicMacros, name)) {
-            const impl = env.dynamicMacros[name];
+        const nameLower = name.toLowerCase();
+        if (Object.hasOwn(env.dynamicMacros, nameLower)) {
+            const impl = env.dynamicMacros[nameLower];
             defOverride = {
                 name,
                 aliases: [],

--- a/public/scripts/macros/engine/MacroEnvBuilder.js
+++ b/public/scripts/macros/engine/MacroEnvBuilder.js
@@ -143,8 +143,11 @@ class MacroEnvBuilder {
         env.functions.postProcess = typeof ctx.postProcessFn === 'function' ? ctx.postProcessFn : (x) => x;
 
         // Dynamic, per-call macros that should be visible only for this evaluation run.
+        // Keys are normalized to lowercase for case-insensitive matching.
         if (ctx.dynamicMacros && typeof ctx.dynamicMacros === 'object') {
-            env.dynamicMacros = { ...ctx.dynamicMacros };
+            for (const [key, value] of Object.entries(ctx.dynamicMacros)) {
+                env.dynamicMacros[key.toLowerCase()] = value;
+            }
         }
 
         // Let providers augment the env, if any are registered. Apply them in order,

--- a/public/scripts/macros/engine/MacroRegistry.js
+++ b/public/scripts/macros/engine/MacroRegistry.js
@@ -217,7 +217,7 @@ class MacroRegistry {
                     if (typeof aliasDef.alias !== 'string' || !aliasDef.alias.trim()) throw new Error(`Macro "${name}" options.aliases[${i}].alias must be a non-empty string.`);
                     const aliasName = aliasDef.alias.trim();
                     if (!isIdentifierValid(aliasName)) throw new Error(`Macro "${name}" options.aliases[${i}].alias "${aliasName}" is invalid. Must start with a letter, followed by word chars or hyphens.`);
-                    if (aliasName === name) throw new Error(`Macro "${name}" options.aliases[${i}].alias cannot be the same as the macro name.`);
+                    if (aliasName.toLowerCase() === name.toLowerCase()) throw new Error(`Macro "${name}" options.aliases[${i}].alias cannot be the same as the macro name (insensitive).`);
                     const visible = aliasDef.visible !== false; // Default to true
                     aliases.push({ alias: aliasName, visible });
                 }

--- a/public/scripts/macros/engine/MacroRegistry.js
+++ b/public/scripts/macros/engine/MacroRegistry.js
@@ -358,7 +358,8 @@ class MacroRegistry {
                 }
             }
 
-            if (this.#macros.has(name)) {
+            const nameKey = name.toLowerCase();
+            if (this.#macros.has(nameKey)) {
                 logMacroRegisterWarning({ macroName: name, message: `Macro "${name}" is already registered and will be overwritten.` });
             }
 
@@ -390,21 +391,22 @@ class MacroRegistry {
                 aliasVisible: null,
             };
 
-            this.#macros.set(name, definition);
+            this.#macros.set(nameKey, definition);
 
             // Register alias entries pointing to the same definition
             for (const { alias, visible } of aliases) {
-                if (this.#macros.has(alias)) {
+                const aliasKey = alias.toLowerCase();
+                if (this.#macros.has(aliasKey)) {
                     logMacroRegisterWarning({ macroName: name, message: `Alias "${alias}" for macro "${name}" overwrites an existing macro.` });
                 }
                 /** @type {MacroDefinition} */
                 const aliasEntry = {
                     ...definition,
-                    name: alias, // The lookup name is the alias
+                    name: alias, // The lookup name is the alias (preserves original casing for display)
                     aliasOf: name,
                     aliasVisible: visible,
                 };
-                this.#macros.set(alias, aliasEntry);
+                this.#macros.set(aliasKey, aliasEntry);
             }
 
             return definition;
@@ -427,7 +429,7 @@ class MacroRegistry {
     unregisterMacro(name) {
         if (typeof name !== 'string' || !name.trim()) throw new Error('Macro name must be a non-empty string');
         name = name.trim();
-        return this.#macros.delete(name);
+        return this.#macros.delete(name.toLowerCase());
     }
 
     /**
@@ -439,7 +441,7 @@ class MacroRegistry {
     hasMacro(name) {
         if (typeof name !== 'string' || !name.trim()) return false;
         name = name.trim();
-        return this.#macros.has(name);
+        return this.#macros.has(name.toLowerCase());
     }
 
     /**
@@ -451,7 +453,7 @@ class MacroRegistry {
     getMacro(name) {
         if (typeof name !== 'string' || !name.trim()) return undefined;
         name = name.trim();
-        return this.#macros.get(name);
+        return this.#macros.get(name.toLowerCase());
     }
 
     /**


### PR DESCRIPTION
Fixes the issue someone mentioned in Discord help chat that macros in the new engine do not support insensitive matching anymore.

All these should match the same Macro: `{{user}}`, `{{User}}`, `{{USER}}`

Now all matching is done insensitive, while still being performance-optimized. (Storying match keys and searching via lowercase-d versions of the macro name)  
Still, any display (Macro Browser / Help, Autocomplete, etc) will use the casing for display and information that was used on macro registration.

## Copilot Summary
This pull request standardizes macro name handling to be case-insensitive throughout the macro engine. The main changes ensure that macro registration, lookup, aliasing, dynamic macro usage, and tag matching all normalize names to lowercase for consistent behavior, regardless of input casing.

**Macro name normalization and case-insensitive handling:**

* All macro names and aliases are now stored and looked up using lowercase keys in `MacroRegistry`, affecting registration, aliasing, unregistration, existence checks, and retrieval (`registerMacro`, `unregisterMacro`, `hasMacro`, `getMacro`). [[1]](diffhunk://#diff-a333ffa33ac4df78ae65e3bdf5fc33dc4fdfd5364714943ca009faa98997e29cL361-R362) [[2]](diffhunk://#diff-a333ffa33ac4df78ae65e3bdf5fc33dc4fdfd5364714943ca009faa98997e29cL393-R409) [[3]](diffhunk://#diff-a333ffa33ac4df78ae65e3bdf5fc33dc4fdfd5364714943ca009faa98997e29cL430-R432) [[4]](diffhunk://#diff-a333ffa33ac4df78ae65e3bdf5fc33dc4fdfd5364714943ca009faa98997e29cL442-R444) [[5]](diffhunk://#diff-a333ffa33ac4df78ae65e3bdf5fc33dc4fdfd5364714943ca009faa98997e29cL454-R456)
* Dynamic macro keys are normalized to lowercase both when building the environment and when accessed, ensuring case-insensitive matching for dynamic macros. [[1]](diffhunk://#diff-01b97f3e518ab5b1e640d3f2aa64fd4521578fe57dc95685f864f3919974c688R146-R150) [[2]](diffhunk://#diff-3a92ff2db12b05f99bec8f28978d514e0389505e770cacbd85764adefcf6aba1R168-R173)

**Macro tag and matching logic:**

* Matching of macro opening and closing tags in `MacroCstWalker` is now case-insensitive, preventing issues with mismatched tag casing. [[1]](diffhunk://#diff-763175bd6b061dc9c59c051ed4afe698540540a12279a2d11730e9323017b248L160-R161) [[2]](diffhunk://#diff-763175bd6b061dc9c59c051ed4afe698540540a12279a2d11730e9323017b248L1018-R1019)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
