### PR TITLE
fix: prevent duplicate messages from concurrent reloadCurrentChat calls

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1569,26 +1569,56 @@ export async function deleteMessage(id, swipeDeletionIndex = undefined, askConfi
     await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
 }
 
+// Lock to prevent concurrent reloadCurrentChat calls causing duplicate messages
+let isReloadingChat = false;
+let pendingReloadPromise = null;
+
+/**
+ * Reloads the current chat, clearing and re-fetching all messages.
+ * Uses a lock mechanism to prevent concurrent calls from causing duplicate messages.
+ * @returns {Promise<void>}
+ */
 export async function reloadCurrentChat() {
-    preserveNeutralChat();
-    await clearChat();
-    chat.length = 0;
-
-    if (selected_group) {
-        await getGroupChat(selected_group, true);
-    }
-    else if (this_chid !== undefined) {
-        await getChat();
-    }
-    else {
-        resetChatState();
-        restoreNeutralChat();
-        await getCharacters();
-        await printMessages();
-        await eventSource.emit(event_types.CHAT_CHANGED, getCurrentChatId());
+    // If already reloading, return the pending promise to avoid concurrent execution
+    if (isReloadingChat) {
+        if (!pendingReloadPromise) {
+            pendingReloadPromise = new Promise(resolve => {
+                const checkInterval = setInterval(() => {
+                    if (!isReloadingChat) {
+                        clearInterval(checkInterval);
+                        pendingReloadPromise = null;
+                        resolve();
+                    }
+                }, 50);
+            });
+        }
+        return pendingReloadPromise;
     }
 
-    refreshSwipeButtons();
+    isReloadingChat = true;
+    try {
+        preserveNeutralChat();
+        await clearChat();
+        chat.length = 0;
+
+        if (selected_group) {
+            await getGroupChat(selected_group, true);
+        }
+        else if (this_chid !== undefined) {
+            await getChat();
+        }
+        else {
+            resetChatState();
+            restoreNeutralChat();
+            await getCharacters();
+            await printMessages();
+            await eventSource.emit(event_types.CHAT_CHANGED, getCurrentChatId());
+        }
+
+        refreshSwipeButtons();
+    } finally {
+        isReloadingChat = false;
+    }
 }
 
 /**


### PR DESCRIPTION
## Problem
When rapidly toggling settings that trigger `reloadCurrentChat()` (e.g., regex script enable/disable), duplicate first messages can appear in the chat. This is more noticeable on remote servers with higher network latency.

## Root Cause
`reloadCurrentChat()` has no protection against concurrent execution. When called multiple times in quick succession, multiple instances run in parallel, each calling `getChat()` → `printMessages()`, resulting in duplicate messages being added to the DOM.

## Solution
Add a simple lock mechanism to prevent concurrent `reloadCurrentChat()` calls:
- If already reloading, subsequent calls wait for the current operation to complete
- Uses `try/finally` to ensure the lock is always released

## Testing
1. Open a character chat on a remote server (higher latency makes it easier to reproduce)
2. Go to Regex extension settings
3. Rapidly click the enable/disable toggle multiple times
4. Before fix: duplicate first messages appear
5. After fix: only one first message is displayed

