### PR TITLE
Macros 2.0 [➕Macros] - Add `{{hasExtension}}` macro, and refactor extension lookup logic

### DIFF
--- a/public/scripts/extensions-slashcommands.js
+++ b/public/scripts/extensions-slashcommands.js
@@ -22,30 +22,28 @@ function getExtensionActionCallback(action) {
         }
 
         const reload = !isFalseBoolean(args?.reload?.toString());
-        const { name: internalExtensionName } = findExtension(extensionName);
-        if (!internalExtensionName) {
+        const extension = findExtension(extensionName);
+        if (!extension) {
             toastr.warning(`Extension ${extensionName} does not exist.`);
             return '';
         }
 
-        const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
-
-        if (action === 'enable' && isEnabled) {
-            toastr.info(`Extension ${extensionName} is already enabled.`);
-            return internalExtensionName;
+        if (action === 'enable' && extension.enabled) {
+            toastr.info(`Extension ${extension.name} is already enabled.`);
+            return extension.name;
         }
 
-        if (action === 'disable' && !isEnabled) {
-            toastr.info(`Extension ${extensionName} is already disabled.`);
-            return internalExtensionName;
+        if (action === 'disable' && !extension.enabled) {
+            toastr.info(`Extension ${extension.name} is already disabled.`);
+            return extension.name;
         }
 
         if (action === 'toggle') {
-            action = isEnabled ? 'disable' : 'enable';
+            action = extension.enabled ? 'disable' : 'enable';
         }
 
         if (reload) {
-            toastr.info(`${action.charAt(0).toUpperCase() + action.slice(1)}ing extension ${extensionName} and reloading...`);
+            toastr.info(`${action.charAt(0).toUpperCase() + action.slice(1)}ing extension ${extension.name} and reloading...`);
 
             // Clear input, so it doesn't stay because the command didn't "finish",
             // and wait for a bit to both show the toast and let the clear bubble through.
@@ -54,20 +52,20 @@ function getExtensionActionCallback(action) {
         }
 
         if (action === 'enable') {
-            await enableExtension(internalExtensionName, reload);
+            await enableExtension(extension.name, reload);
         } else {
-            await disableExtension(internalExtensionName, reload);
+            await disableExtension(extension.name, reload);
         }
 
-        toastr.success(`Extension ${extensionName} ${action}d.`);
+        toastr.success(`Extension ${extension.name} ${action}d.`);
 
 
-        console.info(`Extension ${action}ed: ${extensionName}`);
+        console.info(`Extension ${action}ed: ${extension.name}`);
         if (!reload) {
             console.info('Reload not requested, so page needs to be reloaded manually for changes to take effect.');
         }
 
-        return internalExtensionName;
+        return extension.name;
     };
 }
 

--- a/public/scripts/extensions-slashcommands.js
+++ b/public/scripts/extensions-slashcommands.js
@@ -1,11 +1,11 @@
-import { disableExtension, enableExtension, extension_settings, extensionNames } from './extensions.js';
+import { disableExtension, enableExtension, extension_settings, extensionNames, findExtension } from './extensions.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { SlashCommandClosure } from './slash-commands/SlashCommandClosure.js';
 import { commonEnumProviders } from './slash-commands/SlashCommandCommonEnumsProvider.js';
 import { enumTypes, SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
-import { equalsIgnoreCaseAndAccents, isFalseBoolean, isTrueBoolean } from './utils.js';
+import { isFalseBoolean, isTrueBoolean } from './utils.js';
 
 /**
  * @param {'enable' | 'disable' | 'toggle'} action - The action to perform on the extension
@@ -22,7 +22,7 @@ function getExtensionActionCallback(action) {
         }
 
         const reload = !isFalseBoolean(args?.reload?.toString());
-        const internalExtensionName = findExtension(extensionName);
+        const { name: internalExtensionName } = findExtension(extensionName);
         if (!internalExtensionName) {
             toastr.warning(`Extension ${extensionName} does not exist.`);
             return '';
@@ -69,18 +69,6 @@ function getExtensionActionCallback(action) {
 
         return internalExtensionName;
     };
-}
-
-/**
- * Finds an extension by name, allowing omission of the "third-party/" prefix.
- *
- * @param {string} name - The name of the extension to find
- * @returns {string?} - The matched extension name or undefined if not found
- */
-function findExtension(name) {
-    return extensionNames.find(extName => {
-        return equalsIgnoreCaseAndAccents(extName, name) || equalsIgnoreCaseAndAccents(extName, `third-party/${name}`);
-    });
 }
 
 /**
@@ -244,14 +232,13 @@ export function registerExtensionSlashCommands() {
         name: 'extension-state',
         callback: async (_, extensionName) => {
             if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
-            const internalExtensionName = findExtension(extensionName);
-            if (!internalExtensionName) {
+            const extension = findExtension(extensionName);
+            if (!extension) {
                 toastr.warning(`Extension ${extensionName} does not exist.`);
                 return '';
             }
 
-            const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
-            return String(isEnabled);
+            return String(extension.enabled);
         },
         returns: 'The state of the extension, whether it is enabled.',
         unnamedArgumentList: [
@@ -282,8 +269,8 @@ export function registerExtensionSlashCommands() {
         aliases: ['extension-installed'],
         callback: async (_, extensionName) => {
             if (typeof extensionName !== 'string') throw new Error('Extension name must be a string. Closures or arrays are not allowed.');
-            const exists = findExtension(extensionName) !== undefined;
-            return exists ? 'true' : 'false';
+            const extension = findExtension(extensionName);
+            return extension !== null ? 'true' : 'false';
         },
         returns: 'Whether the extension exists and is installed.',
         unnamedArgumentList: [

--- a/public/scripts/extensions-slashcommands.js
+++ b/public/scripts/extensions-slashcommands.js
@@ -1,4 +1,4 @@
-import { disableExtension, enableExtension, extension_settings, extensionNames, findExtension } from './extensions.js';
+import { disableExtension, enableExtension, extensionNames, findExtension } from './extensions.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { SlashCommandClosure } from './slash-commands/SlashCommandClosure.js';

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -4,7 +4,7 @@ import { eventSource, event_types, saveSettings, saveSettingsDebounced, getReque
 import { showLoader } from './loader.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
-import { delay, isSubsetOf, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';
+import { delay, equalsIgnoreCaseAndAccents, isSubsetOf, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';
 import { getContext } from './st-context.js';
 import { isAdmin } from './user.js';
 import { addLocaleData, getCurrentLocale, t } from './i18n.js';
@@ -329,6 +329,21 @@ export async function disableExtension(name, reload = true) {
     } else {
         requiresReload = true;
     }
+}
+
+/**
+ * Finds an extension by name, allowing omission of the "third-party/" prefix.
+ *
+ * @param {string} name - The name of the extension to find
+ * @returns {{name: string, enabled: boolean}|null} Object with name and enabled properties, or null if not found
+ */
+export function findExtension(name) {
+    const internalExtensionName = extensionNames.find(extName => {
+        return equalsIgnoreCaseAndAccents(extName, name) || equalsIgnoreCaseAndAccents(extName, `third-party/${name}`);
+    });
+    if (!internalExtensionName) return null;
+    const isEnabled = !extension_settings.disabledExtensions.includes(internalExtensionName);
+    return { name: internalExtensionName, enabled: isEnabled };
 }
 
 /**

--- a/public/scripts/macros/definitions/state-macros.js
+++ b/public/scripts/macros/definitions/state-macros.js
@@ -1,5 +1,6 @@
 import { MacroRegistry, MacroCategory } from '../engine/MacroRegistry.js';
 import { eventSource, event_types } from '../../events.js';
+import { findExtension } from '/scripts/extensions.js';
 
 let lastGenerationTypeValue = '';
 let lastGenerationTypeTrackingInitialized = false;
@@ -36,5 +37,21 @@ export function registerStateMacros() {
         description: 'Type of the last queued generation request (e.g. "normal", "impersonate", "regenerate", "quiet", "swipe", "continue"). Empty if none yet or chat was switched.',
         returns: 'Type of the last queued generation request.',
         handler: () => lastGenerationTypeValue,
+    });
+
+    // Macro that checks if an extension is enabled
+    MacroRegistry.registerMacro('hasExtension', {
+        category: MacroCategory.STATE,
+        unnamedArgs: [{
+            name: 'extensionName',
+            type: 'string',
+            description: 'The name of the extension to check',
+        }],
+        description: 'Checks if a specific extension is enabled. If the extension does not exist, returns false.',
+        returns: 'true if the extension is enabled, false otherwise.',
+        handler: ({ unnamedArgs: [extensionName] }) => {
+            const extension = findExtension(extensionName);
+            return String(extension?.enabled ?? false);
+        },
     });
 }


### PR DESCRIPTION
This PR intends to allow presets, world info and char definitions to utilize optional blocks or macro content that only applies/resolves, if a specific extension is enabled.

This bases on the implementation of the new Macro Engine (#4820). It benefits from utilizing scoped macros (#4913) - especially the `{{if}}` macro.
It works even better with #4934 where scoped macros will not be resolved unless the `{{if}}` macro itself resolves to truthy.
This allows any prompt to define scoped blocks wrapped in an "if extension exists" to use extension-custom macros that are only implemented by them, and simply ignoring them if the extension is not enabled.

### Example:

```
Hello, {{user}}!

{{ if {{hasExtension SillyTavern-MyCustomMacros}} }}
  The current state is: {{myCustomMacroState}}
  I can use scoped and args too, like {{ myCustomScoped context }}
    Blah blah
  {{ /myCustomScoped }}
{{ /if }}
```

## Copilot Summary
This pull request refactors how extensions are looked up and introduces a new macro for checking if an extension is enabled. The main improvement is the centralization and enhancement of the `findExtension` function, which now returns both the extension's internal name and its enabled state. This change simplifies and standardizes extension checks across the codebase. Additionally, a new macro is added to allow macros to check if an extension is enabled.

Key changes include:

### Extension Lookup Refactor

* Moved and enhanced the `findExtension` function to `extensions.js` so it now returns an object with the extension's internal name and enabled state, or `null` if not found. This replaces the previous implementation that only returned the name or undefined.
* Updated all usages of `findExtension` in `extensions-slashcommands.js` to use the new return type, simplifying logic for checking if an extension exists or is enabled. [[1]](diffhunk://#diff-9d52c320d516f8161dc2869be8561d6fc701e9c94318b7d4456dc3eae0729039L25-R25) [[2]](diffhunk://#diff-9d52c320d516f8161dc2869be8561d6fc701e9c94318b7d4456dc3eae0729039L247-R241) [[3]](diffhunk://#diff-9d52c320d516f8161dc2869be8561d6fc701e9c94318b7d4456dc3eae0729039L285-R273)
* Removed the old `findExtension` implementation from `extensions-slashcommands.js` and updated imports accordingly. [[1]](diffhunk://#diff-9d52c320d516f8161dc2869be8561d6fc701e9c94318b7d4456dc3eae0729039L1-R8) [[2]](diffhunk://#diff-9d52c320d516f8161dc2869be8561d6fc701e9c94318b7d4456dc3eae0729039L74-L85)

### Macro System Enhancement

* Added a new `hasExtension` macro in `state-macros.js` that checks if a specific extension is enabled, returning `'true'` or `'false'`. This macro uses the new `findExtension` function for consistency. [[1]](diffhunk://#diff-e6187332b2da86516665c1b113bb6dcfed32d39e2f3cee6b1fd0ba832a12086bR3) [[2]](diffhunk://#diff-e6187332b2da86516665c1b113bb6dcfed32d39e2f3cee6b1fd0ba832a12086bR41-R56)

### Utility Imports

* Ensured `equalsIgnoreCaseAndAccents` is imported in `extensions.js` to support the improved `findExtension` logic.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).