### PR TITLE
Macros 2.0 [Fix] - Macro display override uses alias name if relevant + preserve whitespaces for autocomplete closing tag

### DIFF
--- a/public/scripts/autocomplete/AutoComplete.js
+++ b/public/scripts/autocomplete/AutoComplete.js
@@ -692,8 +692,10 @@ export class AutoComplete {
      */
     async select() {
         if (this.isReplaceable && this.selectedItem.value !== null) {
-            this.textarea.value = `${this.text.slice(0, this.effectiveParserResult.start)}${this.selectedItem.replacer}${this.text.slice(this.effectiveParserResult.start + this.effectiveParserResult.name.length + (this.startQuote ? 1 : 0) + (this.endQuote ? 1 : 0))}`;
-            this.textarea.selectionStart = this.effectiveParserResult.start + this.selectedItem.replacer.length;
+            // Apply per-option replacement offset (e.g., for closing tags that need to replace leading whitespace)
+            const effectiveStart = this.effectiveParserResult.start + (this.selectedItem.replacementStartOffset ?? 0);
+            this.textarea.value = `${this.text.slice(0, effectiveStart)}${this.selectedItem.replacer}${this.text.slice(this.effectiveParserResult.start + this.effectiveParserResult.name.length + (this.startQuote ? 1 : 0) + (this.endQuote ? 1 : 0))}`;
+            this.textarea.selectionStart = effectiveStart + this.selectedItem.replacer.length;
             this.textarea.selectionEnd = this.textarea.selectionStart;
             this.show(false, false, true);
         } else {

--- a/public/scripts/autocomplete/AutoCompleteOption.js
+++ b/public/scripts/autocomplete/AutoCompleteOption.js
@@ -13,6 +13,15 @@ export class AutoCompleteOption {
     /** @type {(input:string)=>boolean} */ matchProvider;
     /** @type {(input:string)=>string} */ valueProvider;
     /** @type {boolean} */ makeSelectable = false;
+
+    /**
+     * Offset to adjust the replacement start position.
+     * Negative values start replacement earlier (e.g., -2 to include 2 chars before normal start).
+     * Used by closing tag autocomplete to replace leading whitespace.
+     * @type {number}
+     */
+    replacementStartOffset = 0;
+
     /**
      * Priority for sorting. Lower values = higher priority (sorted first).
      * Default is 100 (normal priority). Use lower values for items that should appear at the top.

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -1051,7 +1051,7 @@ export function parseMacroContext(macroText, cursorOffset) {
     while (i < macroText.length) {
         const char = macroText[i];
         // Check if this looks like a closing tag: `/` followed by an identifier character
-        if (char === '/' && i + 1 < macroText.length && /[a-zA-Z_]/.test(macroText[i + 1])) {
+        if (char === '/' && i + 1 < macroText.length && /[a-zA-Z/]/.test(macroText[i + 1])) {
             // This is a closing tag identifier, not a flag - stop parsing flags
             break;
         }

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -907,20 +907,33 @@ export class MacroClosingTagAutoCompleteOption extends AutoCompleteOption {
     /** @type {string} */
     #macroName;
 
+    /** @type {string} */
+    #paddingBefore;
+
+    /** @type {string} */
+    #paddingAfter;
+
     /**
      * @param {string} macroName - The name of the macro to close.
+     * @param {Object} [options] - Optional configuration.
+     * @param {string} [options.paddingBefore=''] - Whitespace to add after {{ (matching opening tag style).
+     * @param {string} [options.paddingAfter=''] - Whitespace to add before }} (matching opening tag style).
      */
-    constructor(macroName) {
+    constructor(macroName, options = {}) {
         // The closing tag is what we're suggesting - use /macroName as the name for matching
         const closingTag = `/${macroName}`;
         super(closingTag, '{/');
         this.#macroName = macroName;
+        this.#paddingBefore = options.paddingBefore ?? '';
+        this.#paddingAfter = options.paddingAfter ?? '';
 
         // Custom valueProvider to return the correct replacement text
         // Autocomplete REPLACES the typed identifier entirely, so return the full closing tag
+        // Include the same whitespace padding as the opening tag
         this.valueProvider = () => {
             // Return full closing tag content (without {{ since that's before the identifier)
-            return `/${macroName}}}`;
+            // Format: paddingBefore + /macroName + paddingAfter + }}
+            return `${this.#paddingBefore}/${macroName}${this.#paddingAfter}}}`;
         };
 
         // Make selectable so TAB completion works (valueProvider alone makes it non-selectable)

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -916,8 +916,9 @@ export class MacroClosingTagAutoCompleteOption extends AutoCompleteOption {
     /**
      * @param {string} macroName - The name of the macro to close.
      * @param {Object} [options] - Optional configuration.
-     * @param {string} [options.paddingBefore=''] - Whitespace to add after {{ (matching opening tag style).
-     * @param {string} [options.paddingAfter=''] - Whitespace to add before }} (matching opening tag style).
+     * @param {string} [options.paddingBefore=''] - Whitespace after {{ in opening tag (target padding).
+     * @param {string} [options.paddingAfter=''] - Whitespace before }} in opening tag (target padding).
+     * @param {string} [options.currentPadding=''] - Whitespace the user has already typed after {{.
      */
     constructor(macroName, options = {}) {
         // The closing tag is what we're suggesting - use /macroName as the name for matching
@@ -927,12 +928,16 @@ export class MacroClosingTagAutoCompleteOption extends AutoCompleteOption {
         this.#paddingBefore = options.paddingBefore ?? '';
         this.#paddingAfter = options.paddingAfter ?? '';
 
+        // Calculate the replacement offset to replace any existing whitespace the user typed
+        // This allows us to normalize the whitespace to match the opening tag's style
+        const currentPadding = options.currentPadding ?? '';
+        // Negative offset to start replacement earlier (eating the user's whitespace)
+        this.replacementStartOffset = -currentPadding.length;
+
         // Custom valueProvider to return the correct replacement text
-        // Autocomplete REPLACES the typed identifier entirely, so return the full closing tag
-        // Include the same whitespace padding as the opening tag
+        // Includes the target paddingBefore from the opening tag, replacing any user-typed whitespace
         this.valueProvider = () => {
-            // Return full closing tag content (without {{ since that's before the identifier)
-            // Format: paddingBefore + /macroName + paddingAfter + }}
+            // Return: paddingBefore + /macroName + paddingAfter + }}
             return `${this.#paddingBefore}/${macroName}${this.#paddingAfter}}}`;
         };
 

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -54,6 +54,9 @@ import { MACRO_VARIABLE_SHORTHAND_PATTERN } from '../macros/engine/MacroLexer.js
  * @property {boolean} [noBraces=false] - If true, display without {{ }} braces (for use as values, e.g., in {{if}} conditions).
  * @property {string} [paddingAfter=''] - Whitespace to add before closing }} (for matching opening whitespace style).
  * @property {boolean} [closeWithBraces=false] - If true, the completion will add }} to close the macro.
+ * @property {string[]} [flags=[]] - The currently already written flags for this autocomplete.
+ * @property {string} [currentFlag] - The current flag that is present, if any.
+ * @property {string} [fullText] - The currently written full text.
  */
 
 export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
@@ -62,6 +65,9 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
 
     /** @type {MacroAutoCompleteContext|null} */
     #context = null;
+
+    /** @type {EnhancedMacroAutoCompleteOptions|null} */
+    #options = null;
 
     /** @type {boolean} */
     #noBraces = false;
@@ -83,12 +89,12 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
         if (contextOrOptions && typeof contextOrOptions === 'object') {
             if ('noBraces' in contextOrOptions || 'paddingAfter' in contextOrOptions || 'closeWithBraces' in contextOrOptions) {
                 // It's an options object
-                const options = /** @type {EnhancedMacroAutoCompleteOptions} */ (contextOrOptions);
-                this.#noBraces = options.noBraces ?? false;
-                this.#paddingAfter = options.paddingAfter ?? '';
+                this.#options = /** @type {EnhancedMacroAutoCompleteOptions} */ (contextOrOptions);
+                this.#noBraces = this.#options.noBraces ?? false;
+                this.#paddingAfter = this.#options.paddingAfter ?? '';
 
                 // If noBraces mode with closeWithBraces, complete with name + padding + }}
-                if (options.closeWithBraces) {
+                if (this.#options.closeWithBraces) {
                     this.valueProvider = () => `${macro.name}${this.#paddingAfter}}}`;
                     this.makeSelectable = true;
                 }
@@ -109,6 +115,12 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
                 this.valueProvider = () => `${macro.name}${this.#paddingAfter}}}`;
                 this.makeSelectable = true; // Required when using valueProvider
             }
+        }
+
+        // {{//}} needs special handling. If we autocomplete right after **one** slash is already typed, we need to replace that, as it's treated as a flag otherwise.
+        const fullText = this.#options?.fullText ?? this.#context?.fullText ?? '';
+        if (macro.name === '//' && fullText.endsWith('/')) {
+            this.replacementStartOffset = (this.replacementStartOffset ?? 0) - 1; // Cut the leading slash
         }
     }
 

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -9,7 +9,7 @@ import {
     createSourceIndicator,
     createAliasIndicator,
     renderMacroDetails,
-} from '../macros/MacroBrowser.js';
+} from '../macros/engine/MacroBrowser.js';
 import { enumIcons } from '../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { ValidFlagSymbols } from '../macros/engine/MacroFlags.js';
 import { MACRO_VARIABLE_SHORTHAND_PATTERN } from '../macros/engine/MacroLexer.js';

--- a/public/scripts/macros/definitions/core-macros.js
+++ b/public/scripts/macros/definitions/core-macros.js
@@ -261,6 +261,13 @@ export function registerCoreMacros() {
     MacroRegistry.registerMacro('//', {
         aliases: [{ alias: 'comment', visible: false }],
         category: MacroCategory.UTILITY,
+        unnamedArgs: [
+            {
+                name: 'comment',
+                type: MacroValueType.STRING,
+                description: 'Any kind of text as comment. If you want multiline comments, consider using a scoped macro like {{//}}First\nSecond{{///}}.',
+            },
+        ],
         list: true,         // We consume any arguments as if this is a list, but we'll ignore them in the handler anyway
         strictArgs: false,  // and we also always remove it, even if the parsing might say it's invalid
         description: 'Comment macro that produces an empty string. Can be used for writing into prompt definitions, without being passed to the context.',

--- a/public/scripts/macros/engine/MacroBrowser.js
+++ b/public/scripts/macros/engine/MacroBrowser.js
@@ -3,11 +3,11 @@
  * Similar to SlashCommandBrowser but for the macro system.
  */
 
-import { MacroRegistry, MacroCategory } from './engine/MacroRegistry.js';
-import { performFuzzySearch } from '../power-user.js';
+import { MacroRegistry, MacroCategory } from './MacroRegistry.js';
+import { performFuzzySearch } from '../../power-user.js';
 
-/** @typedef {import('./engine/MacroRegistry.js').MacroDefinition} MacroDefinition */
-/** @typedef {import('./engine/MacroRegistry.js').MacroValueType} MacroValueType */
+/** @typedef {import('./MacroRegistry.js').MacroDefinition} MacroDefinition */
+/** @typedef {import('./MacroRegistry.js').MacroValueType} MacroValueType */
 
 /**
  * Category display names and order for documentation.

--- a/public/scripts/macros/engine/MacroBrowser.js
+++ b/public/scripts/macros/engine/MacroBrowser.js
@@ -5,6 +5,7 @@
 
 import { MacroRegistry, MacroCategory } from './MacroRegistry.js';
 import { performFuzzySearch } from '../../power-user.js';
+import { escapeRegex } from '/scripts/utils.js';
 
 /** @typedef {import('./MacroRegistry.js').MacroDefinition} MacroDefinition */
 /** @typedef {import('./MacroRegistry.js').MacroValueType} MacroValueType */
@@ -328,6 +329,11 @@ function getCategoryConfig(category) {
 export function formatMacroSignature(macro) {
     // Use displayOverride if provided
     if (macro.displayOverride) {
+        if (macro.aliasOf) {
+            // Replace all occurrences of the macro name with the alias for this list
+            const escapedMainName = escapeRegex(macro.aliasOf);
+            return macro.displayOverride.replace(new RegExp(`(?<=[\\b{\\s])${escapedMainName}(?=[\\b}:\\s])`, 'g'), `${macro.name}`);
+        }
         return macro.displayOverride;
     }
 

--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -897,6 +897,9 @@ export class SlashCommandParser {
             if (!macroContext) {
                 macroContext = /** @type {EnhancedMacroAutoCompleteOptions} */ ({
                     paddingAfter: context.paddingBefore, // Match whitespace before the macro - will only be used if the macro gets auto-closed
+                    flags: context.flags,
+                    currentFlag: context.currentFlag,
+                    fullText: context.fullText,
                 });
             }
 

--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -808,7 +808,11 @@ export class SlashCommandParser {
         if (unclosedScopes.length > 0) {
             // Suggest closing the innermost (last) unclosed scope first
             const innermostScope = unclosedScopes[unclosedScopes.length - 1];
-            const closingOption = new MacroClosingTagAutoCompleteOption(innermostScope.name);
+            // Preserve the same whitespace padding as the opening tag
+            const closingOption = new MacroClosingTagAutoCompleteOption(innermostScope.name, {
+                paddingBefore: innermostScope.paddingBefore,
+                paddingAfter: innermostScope.paddingAfter,
+            });
             options.push(closingOption);
 
             // If inside a scoped {{if}}, also suggest {{else}}
@@ -1216,7 +1220,7 @@ export class SlashCommandParser {
      * Uses the MacroParser and MacroCstWalker for accurate analysis.
      *
      * @param {string} textUpToCursor - The document text up to the cursor position.
-     * @returns {Array<{ name: string, startOffset: number, endOffset: number }>}
+     * @returns {Array<{ name: string, startOffset: number, endOffset: number, paddingBefore: string, paddingAfter: string }>}
      */
     #findUnclosedScopes(textUpToCursor) {
         if (!textUpToCursor) return [];
@@ -1239,32 +1243,43 @@ export class SlashCommandParser {
      * Used when the parser fails on incomplete input.
      *
      * @param {string} text - The text to analyze.
-     * @returns {Array<{ name: string, startOffset: number, endOffset: number }>}
+     * @returns {Array<{ name: string, startOffset: number, endOffset: number, paddingBefore: string, paddingAfter: string }>}
      */
     #findUnclosedScopesRegex(text) {
-        // Simple regex to find macro openings and closings
-        // This is a fallback - less accurate but works on partial input
-        const macroPattern = /\{\{(\/?)([\w-]+)/g;
+        // Regex to find macro openings and closings, capturing whitespace padding
+        // Group 1: padding after {{, Group 2: optional /, Group 3: macro name
+        const macroPattern = /\{\{(\s*)(\/?)([\w-]+)/g;
         const stack = [];
 
         let match;
         while ((match = macroPattern.exec(text)) !== null) {
-            const isClosing = match[1] === '/';
-            const name = match[2];
+            const paddingBefore = match[1];
+            const isClosing = match[2] === '/';
+            const name = match[3];
 
             if (isClosing) {
-                // Pop matching opener
-                if (stack.length > 0 && stack[stack.length - 1].name === name) {
+                // Pop matching opener (case-insensitive)
+                if (stack.length > 0 && stack[stack.length - 1].name.toLowerCase() === name.toLowerCase()) {
                     stack.pop();
                 }
             } else {
                 // Check if macro can accept scoped content
                 const macroDef = macroSystem.registry.getPrimaryMacro(name);
                 if (macroDef && macroDef.maxArgs > 0) {
+                    // Try to find closing }} to extract trailing whitespace
+                    let paddingAfter = '';
+                    const afterMatch = text.slice(match.index + match[0].length);
+                    const closingMatch = afterMatch.match(/^[^}]*?(\s*)\}\}/);
+                    if (closingMatch) {
+                        paddingAfter = closingMatch[1];
+                    }
+
                     stack.push({
                         name,
                         startOffset: match.index,
                         endOffset: match.index + match[0].length,
+                        paddingBefore,
+                        paddingAfter,
                     });
                 }
             }

--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -808,10 +808,12 @@ export class SlashCommandParser {
         if (unclosedScopes.length > 0) {
             // Suggest closing the innermost (last) unclosed scope first
             const innermostScope = unclosedScopes[unclosedScopes.length - 1];
-            // Preserve the same whitespace padding as the opening tag
+            // Preserve whitespace padding from the opening tag
+            // Pass currentPadding so the closing tag can replace user-typed whitespace with the target padding
             const closingOption = new MacroClosingTagAutoCompleteOption(innermostScope.name, {
                 paddingBefore: innermostScope.paddingBefore,
                 paddingAfter: innermostScope.paddingAfter,
+                currentPadding: context.paddingBefore,
             });
             options.push(closingOption);
 

--- a/public/scripts/system-messages.js
+++ b/public/scripts/system-messages.js
@@ -4,7 +4,7 @@ import { t } from './i18n.js';
 import { getMessageTimeStamp } from './RossAscends-mods.js';
 import { getSlashCommandsHelp } from './slash-commands.js';
 import { SlashCommandBrowser } from './slash-commands/SlashCommandBrowser.js';
-import { MacroBrowser, getMacrosHelp } from './macros/MacroBrowser.js';
+import { MacroBrowser, getMacrosHelp } from './macros/engine/MacroBrowser.js';
 import { renderTemplateAsync } from './templates.js';
 
 /** @type {Record<string, ChatMessage>} */


### PR DESCRIPTION
This PR fixes a display bug, adds some UX to macro autocomplete and moves the MacroBrowser module-like class to its correct place.

Changes:

- **`displayOverride` now utilizes alias name when displaying alias**
  On macro registration, one can set a `displayOverride` field to make a custom display of how the macro should show up in the macro browser (help) and the autocomplete, for example to use a different syntax where it makes sense.
  Up until now, when adding aliases to that macro too, they used the displayOverride as is, so macros were listed duplicated. Now, the aliases will replace the appearance of the main macro name inside the displayOverride with the alias to improve readability.  
  No current core macro uses both, but I discovered it when `{{comment}}` syntax was not a deprecated syntax yet.
  
- **Autocomplete for closing tags on scoped macros respects whitespaces**
  Up until now, autocompleting a macro without arguments wrote closing brackets respecting the whitespaces automatically. Writing `{{ us` and autocompleting made it `{{ user }}`. The closing tags suggested as autocomplete options did not yet.  
  Now when typing `{{  setvar myvar  }}Something` the autocomplete closing tag will insert `{{  /setvar  }}`, as one would expect.
  
- **Move `MacroBrowser.js` to `/macros/engine` subfolder**
  This was always planned, just missed in an oversight. Only root level file will the the export file `macro-system.js`. 

- **Fixed autocomplete of `{{//}}` comment macro**
  When the comment macro was already half-typed, like `{{ /` it autocompleted it by thinking it was a closing flag to `{{ ///`, which is not intended. Fixed that.

- **Update `{{ //` comment macro to have an unnamed arg**
  This improves the documentation in the autocomplete and macro browser explaining how this macro works, without being confusing.

## Copilot Summary
This pull request improves the macro autocomplete and parsing system by ensuring that whitespace padding around macro tags is preserved when suggesting closing tags. It also refactors the macro browser file structure and updates related imports. The most important changes are grouped below.

**Whitespace Preservation in Macro Autocomplete:**

* The `MacroClosingTagAutoCompleteOption` class now accepts and applies `paddingBefore` and `paddingAfter` options, ensuring that suggested closing macro tags match the whitespace style of their corresponding opening tags.
* The macro CST walker (`MacroCstWalker`) and regex fallback in the slash command parser have been updated to extract and propagate whitespace padding details for unclosed macro scopes, so that suggestions remain stylistically consistent. [[1]](diffhunk://#diff-763175bd6b061dc9c59c051ed4afe698540540a12279a2d11730e9323017b248L193-R193) [[2]](diffhunk://#diff-763175bd6b061dc9c59c051ed4afe698540540a12279a2d11730e9323017b248L206-R206) [[3]](diffhunk://#diff-763175bd6b061dc9c59c051ed4afe698540540a12279a2d11730e9323017b248R225-R233) [[4]](diffhunk://#diff-763175bd6b061dc9c59c051ed4afe698540540a12279a2d11730e9323017b248R242-R274) [[5]](diffhunk://#diff-004fd3f4997ea17f0f372b35c41232f56ef680770e9e8fc9e0a70e439a4dd220L811-R815) [[6]](diffhunk://#diff-004fd3f4997ea17f0f372b35c41232f56ef680770e9e8fc9e0a70e439a4dd220L1219-R1223) [[7]](diffhunk://#diff-004fd3f4997ea17f0f372b35c41232f56ef680770e9e8fc9e0a70e439a4dd220L1242-R1282)

**File Structure and Import Refactoring:**

* The `MacroBrowser.js` file has been moved to `macros/engine/`, and all relevant imports throughout the codebase have been updated to reflect this new location. [[1]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bL12-R12) [[2]](diffhunk://#diff-452c7cdf9e89c72f3fd781d32612b3d6d8f2f03a29e0947e05614bd9c67f7a0dL6-R11) [[3]](diffhunk://#diff-3eb25c411950473a00a6f9e428b8c3b439cb884cbb3d9dfcffe0da7463fd0f3eL7-R7)

**Macro Signature Display Enhancement:**

* When displaying macro signatures, if a macro is an alias, the display override now replaces the main macro name with the alias, ensuring that documentation and suggestions are accurate for aliases.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).