### PR TITLE
Macros 2.0 (v0.5.2) - Onboarding for new Macro Engine

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -282,6 +282,7 @@ import { AudioPlayer } from './scripts/audio-player.js';
 import { MacroEnvBuilder } from './scripts/macros/engine/MacroEnvBuilder.js';
 import { MacroEngine } from './scripts/macros/engine/MacroEngine.js';
 import { addChatBackupsBrowser } from './scripts/chat-backups.js';
+import { onbordingExperimentalMacroEngine } from './scripts/macros/engine/MacroDiagnostics.js';
 
 // API OBJECT FOR EXTERNAL WIRING
 globalThis.SillyTavern = {
@@ -2709,6 +2710,20 @@ export function substituteParamsLegacy(content, _name1, _name2, _original, _grou
             dynamicMacros: additionalMacro ?? {},
             postProcessFn: postProcessFn ?? ((x) => x),
         });
+    }
+
+    // Try to roughly detect experimental macro features to show the onboarding if needed.
+    // This does not have to be 100% accurate, only best effort what we can quickly check.
+    // Only do this if the warning wasn't shown yet, to prevent needless regex checks.
+    if (accountStorage.getItem('slash_command_experimental_engine_warning_shown') !== 'true') {
+        let feature = /** @type {string} */ (null);
+        if (/{{\s*if/.test(content)) feature = '{{if}} macro';
+        else if (/{{\s*\//.test(content)) feature = 'scoped macro';
+        else if (/{{\s*[!?~#/]/.test(content)) feature = 'macro flags';
+        else if (/{{\s*[.$]/.test(content)) feature = 'variable shorthands';
+        else if (/\{\{(?:(?!\}\}).)*\{\{(?=[\s\S]*?\}\}[\s\S]*?\}\})/.test(content)) feature = 'nested macro';
+
+        if (feature) onbordingExperimentalMacroEngine(feature);
     }
 
     const environment = {};

--- a/public/script.js
+++ b/public/script.js
@@ -2723,7 +2723,7 @@ export function substituteParamsLegacy(content, _name1, _name2, _original, _grou
         else if (/{{\s*[.$]/.test(content)) feature = 'variable shorthands';
         else if (/\{\{(?:(?!\}\}).)*\{\{(?=[\s\S]*?\}\}[\s\S]*?\}\})/.test(content)) feature = 'nested macro';
 
-        if (feature) onboardingExperimentalMacroEngine(feature);
+        if (feature) void onboardingExperimentalMacroEngine(feature);
     }
 
     const environment = {};

--- a/public/script.js
+++ b/public/script.js
@@ -282,7 +282,7 @@ import { AudioPlayer } from './scripts/audio-player.js';
 import { MacroEnvBuilder } from './scripts/macros/engine/MacroEnvBuilder.js';
 import { MacroEngine } from './scripts/macros/engine/MacroEngine.js';
 import { addChatBackupsBrowser } from './scripts/chat-backups.js';
-import { onbordingExperimentalMacroEngine } from './scripts/macros/engine/MacroDiagnostics.js';
+import { onboardingExperimentalMacroEngine } from './scripts/macros/engine/MacroDiagnostics.js';
 
 // API OBJECT FOR EXTERNAL WIRING
 globalThis.SillyTavern = {
@@ -2716,14 +2716,14 @@ export function substituteParamsLegacy(content, _name1, _name2, _original, _grou
     // This does not have to be 100% accurate, only best effort what we can quickly check.
     // Only do this if the warning wasn't shown yet, to prevent needless regex checks.
     if (accountStorage.getItem('slash_command_experimental_engine_warning_shown') !== 'true') {
-        let feature = /** @type {string} */ (null);
+        let feature = /** @type {string|null} */ (null);
         if (/{{\s*if/.test(content)) feature = '{{if}} macro';
         else if (/{{\s*\//.test(content)) feature = 'scoped macro';
         else if (/{{\s*[!?~#/]/.test(content)) feature = 'macro flags';
         else if (/{{\s*[.$]/.test(content)) feature = 'variable shorthands';
         else if (/\{\{(?:(?!\}\}).)*\{\{(?=[\s\S]*?\}\}[\s\S]*?\}\})/.test(content)) feature = 'nested macro';
 
-        if (feature) onbordingExperimentalMacroEngine(feature);
+        if (feature) onboardingExperimentalMacroEngine(feature);
     }
 
     const environment = {};

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -13,6 +13,7 @@ import {
 import { enumIcons } from '../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { ValidFlagSymbols } from '../macros/engine/MacroFlags.js';
 import { MACRO_VARIABLE_SHORTHAND_PATTERN } from '../macros/engine/MacroLexer.js';
+import { onbordingExperimentalMacroEngine } from '../macros/engine/MacroDiagnostics.js';
 
 /** @typedef {import('../macros/engine/MacroRegistry.js').MacroDefinition} MacroDefinition */
 
@@ -1063,6 +1064,10 @@ export function parseMacroContext(macroText, cursorOffset) {
         }
     }
 
+    if (flags.length > 0) {
+        onbordingExperimentalMacroEngine('macro flags');
+    }
+
     // Check for variable shorthand prefix (. or $)
     // These trigger variable expression mode instead of regular macro parsing
     /** @type {'.'|'$'|null} */
@@ -1152,6 +1157,8 @@ export function parseMacroContext(macroText, cursorOffset) {
         // For ++ and --, the operator is complete (no value needed)
         // For invalid trailing chars, none of the typing flags will be true
         const isOperatorComplete = (variableOperator === '++' || variableOperator === '--');
+
+        onbordingExperimentalMacroEngine('variable shorthands');
 
         // Return early for variable shorthand - different structure than regular macros
         return {
@@ -1277,6 +1284,10 @@ export function parseMacroContext(macroText, cursorOffset) {
     }
 
     const leftPadding = macroText.match(/^\s+/)?.[0] ?? '';
+
+    if (leftPadding) {
+        onbordingExperimentalMacroEngine('leading whitespace');
+    }
 
     // Clean identifier: strip trailing colons (for partial :: typing)
     let cleanIdentifier = identifierOnly.replace(/:+$/, '');

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -1065,7 +1065,7 @@ export function parseMacroContext(macroText, cursorOffset) {
     }
 
     if (flags.length > 0) {
-        onboardingExperimentalMacroEngine('macro flags');
+        void onboardingExperimentalMacroEngine('macro flags');
     }
 
     // Check for variable shorthand prefix (. or $)
@@ -1158,7 +1158,7 @@ export function parseMacroContext(macroText, cursorOffset) {
         // For invalid trailing chars, none of the typing flags will be true
         const isOperatorComplete = (variableOperator === '++' || variableOperator === '--');
 
-        onboardingExperimentalMacroEngine('variable shorthands');
+        void onboardingExperimentalMacroEngine('variable shorthands');
 
         // Return early for variable shorthand - different structure than regular macros
         return {
@@ -1286,7 +1286,7 @@ export function parseMacroContext(macroText, cursorOffset) {
     const leftPadding = macroText.match(/^\s+/)?.[0] ?? '';
 
     if (leftPadding) {
-        onboardingExperimentalMacroEngine('leading whitespace');
+        void onboardingExperimentalMacroEngine('leading whitespace');
     }
 
     // Clean identifier: strip trailing colons (for partial :: typing)

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -13,7 +13,7 @@ import {
 import { enumIcons } from '../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { ValidFlagSymbols } from '../macros/engine/MacroFlags.js';
 import { MACRO_VARIABLE_SHORTHAND_PATTERN } from '../macros/engine/MacroLexer.js';
-import { onbordingExperimentalMacroEngine } from '../macros/engine/MacroDiagnostics.js';
+import { onboardingExperimentalMacroEngine } from '../macros/engine/MacroDiagnostics.js';
 
 /** @typedef {import('../macros/engine/MacroRegistry.js').MacroDefinition} MacroDefinition */
 
@@ -1065,7 +1065,7 @@ export function parseMacroContext(macroText, cursorOffset) {
     }
 
     if (flags.length > 0) {
-        onbordingExperimentalMacroEngine('macro flags');
+        onboardingExperimentalMacroEngine('macro flags');
     }
 
     // Check for variable shorthand prefix (. or $)
@@ -1158,7 +1158,7 @@ export function parseMacroContext(macroText, cursorOffset) {
         // For invalid trailing chars, none of the typing flags will be true
         const isOperatorComplete = (variableOperator === '++' || variableOperator === '--');
 
-        onbordingExperimentalMacroEngine('variable shorthands');
+        onboardingExperimentalMacroEngine('variable shorthands');
 
         // Return early for variable shorthand - different structure than regular macros
         return {
@@ -1286,7 +1286,7 @@ export function parseMacroContext(macroText, cursorOffset) {
     const leftPadding = macroText.match(/^\s+/)?.[0] ?? '';
 
     if (leftPadding) {
-        onbordingExperimentalMacroEngine('leading whitespace');
+        onboardingExperimentalMacroEngine('leading whitespace');
     }
 
     // Clean identifier: strip trailing colons (for partial :: typing)

--- a/public/scripts/macros/engine/MacroDiagnostics.js
+++ b/public/scripts/macros/engine/MacroDiagnostics.js
@@ -57,7 +57,7 @@ async function onboardingExperimentalMacroEngineUnsafe(feature = null) {
                 <span>${t`Recognized Feature: `}<strong>${feature}</strong></span>
             </div>` : ''}
         <p>${t`For more information on the new macro engine, visit the <br />${`<a href="https://docs.sillytavern.app/usage/core-concepts/macros/">${t`Macro Documentation`}</a>`}.`}</p>
-        <p>${t`You can enable the engine anytime time under:<br />${t`User Settings`} → ${t`Experimental Macro Engine`}`}</p>
+        <p>${t`You can enable the engine any time under:<br />${t`User Settings`} → ${t`Experimental Macro Engine`}`}</p>
         <p>${t`Would you like to enable it now?`}</p>`);
     if (result == POPUP_RESULT.AFFIRMATIVE) {
         power_user.experimental_macro_engine = true;

--- a/public/scripts/macros/engine/MacroDiagnostics.js
+++ b/public/scripts/macros/engine/MacroDiagnostics.js
@@ -31,7 +31,7 @@ import { SimpleMutex } from '/scripts/util/SimpleMutex.js';
 
 
 // Use mutex here so even on parallel usage without awaiting the popup, this will only show up once.
-export const onbordingExperimentalMacroEngineMutext = new SimpleMutex(onbordingExperimentalMacroEngineUnsafe);
+export const onboardingExperimentalMacroEngineMutex = new SimpleMutex(onboardingExperimentalMacroEngineUnsafe);
 
 /**
  * Onboards the user to use the experimental macro engine.
@@ -40,9 +40,9 @@ export const onbordingExperimentalMacroEngineMutext = new SimpleMutex(onbordingE
  * @param {string|null} feature - The feature that requires the experimental macro engine, or null if not applicable or unknown.
  * @returns {Promise<void>} - A promise that resolves when the user has been onboarded.
  */
-export const onbordingExperimentalMacroEngine = onbordingExperimentalMacroEngineMutext.update.bind(onbordingExperimentalMacroEngineMutext);
+export const onboardingExperimentalMacroEngine = onboardingExperimentalMacroEngineMutex.update.bind(onboardingExperimentalMacroEngineMutex);
 
-async function onbordingExperimentalMacroEngineUnsafe(feature = null) {
+async function onboardingExperimentalMacroEngineUnsafe(feature = null) {
     // Show a popup once telling a user that they are using experimental features hat only work with the new engine.
     // Ask them if they want to turn the experimental engine on.
     if (power_user.experimental_macro_engine) return;

--- a/public/scripts/macros/engine/MacroDiagnostics.js
+++ b/public/scripts/macros/engine/MacroDiagnostics.js
@@ -3,6 +3,13 @@
 /** @typedef {import('chevrotain').ILexingError} ILexingError */
 /** @typedef {import('chevrotain').IRecognitionException} IRecognitionException */
 
+import { saveSettingsDebounced } from '/script.js';
+import { t } from '/scripts/i18n.js';
+import { Popup, POPUP_RESULT } from '/scripts/popup.js';
+import { power_user } from '/scripts/power-user.js';
+import { accountStorage } from '/scripts/util/AccountStorage.js';
+import { SimpleMutex } from '/scripts/util/SimpleMutex.js';
+
 /**
  * @typedef {Object} MacroErrorContext
  * @property {string} [macroName]
@@ -21,6 +28,46 @@
  *
  * @typedef {MacroErrorContext & { message: string, error?: any }} MacroLogOptions
  */
+
+
+// Use mutex here so even on parallel usage without awaiting the popup, this will only show up once.
+export const onbordingExperimentalMacroEngineMutext = new SimpleMutex(onbordingExperimentalMacroEngineUnsafe);
+
+/**
+ * Onboards the user to use the experimental macro engine.
+ * Asks the user to enable it if they haven't already.
+ *
+ * @param {string|null} feature - The feature that requires the experimental macro engine, or null if not applicable or unknown.
+ * @returns {Promise<void>} - A promise that resolves when the user has been onboarded.
+ */
+export const onbordingExperimentalMacroEngine = onbordingExperimentalMacroEngineMutext.update.bind(onbordingExperimentalMacroEngineMutext);
+
+async function onbordingExperimentalMacroEngineUnsafe(feature = null) {
+    // Show a popup once telling a user that they are using experimental features hat only work with the new engine.
+    // Ask them if they want to turn the experimental engine on.
+    if (power_user.experimental_macro_engine) return;
+
+    // If already shown, do not show again
+    const shown = accountStorage.getItem('slash_command_experimental_engine_warning_shown');
+    if (shown === 'true') return;
+
+    const result = await Popup.show.confirm(t`Experimental Macro Engine`, `
+        <p>${t`You are using experimental macro features that require the new macro engine.`}</p>
+        ${feature ? `<div class="info-block hint">
+                <span>${t`Recognized Feature: `}<strong>${feature}</strong></span>
+            </div>` : ''}
+        <p>${t`For more information on the new macro engine, visit the <br />${`<a href="https://docs.sillytavern.app/usage/core-concepts/macros/">${t`Macro Documentation`}</a>`}.`}</p>
+        <p>${t`You can enable the engine anytime time under:<br />${t`User Settings`} → ${t`Experimental Macro Engine`}`}</p>
+        <p>${t`Would you like to enable it now?`}</p>`);
+    if (result == POPUP_RESULT.AFFIRMATIVE) {
+        power_user.experimental_macro_engine = true;
+        $('#experimental_macro_engine').prop('checked', power_user.experimental_macro_engine);
+        saveSettingsDebounced();
+    }
+
+    // Only show this once
+    accountStorage.setItem('slash_command_experimental_engine_warning_shown', 'true');
+}
 
 /**
  * Creates an error representing a runtime macro invocation problem (such as

--- a/public/scripts/macros/engine/MacroDiagnostics.js
+++ b/public/scripts/macros/engine/MacroDiagnostics.js
@@ -43,7 +43,7 @@ export const onboardingExperimentalMacroEngineMutex = new SimpleMutex(onboarding
 export const onboardingExperimentalMacroEngine = onboardingExperimentalMacroEngineMutex.update.bind(onboardingExperimentalMacroEngineMutex);
 
 async function onboardingExperimentalMacroEngineUnsafe(feature = null) {
-    // Show a popup once telling a user that they are using experimental features hat only work with the new engine.
+    // Show a popup once telling a user that they are using experimental features that only work with the new engine.
     // Ask them if they want to turn the experimental engine on.
     if (power_user.experimental_macro_engine) return;
 

--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -39,7 +39,7 @@ import { macros as macroSystem } from '../macros/macro-system.js';
 import { AutoCompleteOption } from '../autocomplete/AutoCompleteOption.js';
 import { chat_metadata } from '/script.js';
 import { extension_settings } from '../extensions.js';
-import { onbordingExperimentalMacroEngine } from '../macros/engine/MacroDiagnostics.js';
+import { onboardingExperimentalMacroEngine } from '../macros/engine/MacroDiagnostics.js';
 
 /** @typedef {import('./SlashCommand.js').NamedArgumentsCapture} NamedArgumentsCapture */
 /** @typedef {import('./SlashCommand.js').NamedArguments} NamedArguments */
@@ -619,7 +619,7 @@ export class SlashCommandParser {
                         resultStart = conditionStartInText + macroNameStart;
                     }
 
-                    await onbordingExperimentalMacroEngine('{{if}} macro');
+                    await onboardingExperimentalMacroEngine('{{if}} macro');
 
                     const result = new AutoCompleteNameResult(
                         resultIdentifier,
@@ -739,7 +739,7 @@ export class SlashCommandParser {
                         scopedMacroName: scopedMacro.name,
                     };
 
-                    await onbordingExperimentalMacroEngine('scoped macros');
+                    await onboardingExperimentalMacroEngine('scoped macros');
 
                     // Only show the scoped macro's details - no list of other macros
                     // This creates a "details only" view showing the scoped arg being typed

--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -39,6 +39,7 @@ import { macros as macroSystem } from '../macros/macro-system.js';
 import { AutoCompleteOption } from '../autocomplete/AutoCompleteOption.js';
 import { chat_metadata } from '/script.js';
 import { extension_settings } from '../extensions.js';
+import { onbordingExperimentalMacroEngine } from '../macros/engine/MacroDiagnostics.js';
 
 /** @typedef {import('./SlashCommand.js').NamedArgumentsCapture} NamedArgumentsCapture */
 /** @typedef {import('./SlashCommand.js').NamedArguments} NamedArguments */
@@ -618,6 +619,8 @@ export class SlashCommandParser {
                         resultStart = conditionStartInText + macroNameStart;
                     }
 
+                    await onbordingExperimentalMacroEngine('{{if}} macro');
+
                     const result = new AutoCompleteNameResult(
                         resultIdentifier,
                         resultStart,
@@ -735,6 +738,8 @@ export class SlashCommandParser {
                         isInScopedContent: true,
                         scopedMacroName: scopedMacro.name,
                     };
+
+                    await onbordingExperimentalMacroEngine('scoped macros');
 
                     // Only show the scoped macro's details - no list of other macros
                     // This creates a "details only" view showing the scoped arg being typed


### PR DESCRIPTION
## Summary
Adds a one-time onboarding popup that detects when a user is trying to use **experimental macro syntax** while the **Experimental Macro Engine** is still disabled, and offers to enable it immediately (with a link to the docs).

> [!IMPORTANT]
> The intention is to **remove** this onboarding once the experimental engine is replacing the old macro parsing completely and the setting is removed too. 

### What’s included
- **Central onboarding helper** (`onbordingExperimentalMacroEngine`) that:
  - Shows a confirm popup (once per account)
  - Optionally enables the experimental engine + saves settings
  - Uses a mutex to prevent duplicate popups when multiple triggers happen at once
- **Best-effort detection in legacy substitution** to catch common experimental syntax early, including:
  - `{{if}}` macros
  - scoped macros
  - macro flags
  - variable shorthands
  - nested macros
- **Autocomplete integration** so users get nudged while typing:
  - flags detection
  - variable shorthand detection
  - leading whitespace detection
- **Slash command parser integration** to onboard when `{{if}}` / scoped macros are encountered during parsing/autocomplete.

### Why
This reduces “why doesn’t this work?” confusion by proactively explaining that certain syntax requires the new engine, while keeping the UX low-noise (shown once, no nagging).

### Notes / behavior
- Detection is intentionally heuristic (good-enough, not perfect).
- Popup is only evaluated until it has been shown once.
- If the user declines, they can still enable it later via **User Settings → Experimental Macro Engine**.

## Copilot Summary
This pull request introduces a user onboarding flow for experimental macro engine features. The main goal is to detect when users are attempting to use advanced or experimental macro syntax and prompt them to enable the experimental macro engine if it is not already active. This is achieved through a combination of detection logic and a mutex-protected popup, ensuring the user is only prompted once.

Key changes include:

**Experimental Macro Engine Onboarding**

- Added a new `onbordingExperimentalMacroEngine` function in `MacroDiagnostics.js` that detects usage of experimental macro features and prompts the user to enable the experimental macro engine, using a mutex to prevent multiple popups. The popup provides context about the detected feature and links to documentation. The user's choice is persisted to avoid repeated prompts. [[1]](diffhunk://#diff-8c91fe459266faa3ee1cd8d25680cdce715cf568e546c47b1bc8d3140d7fd378R6-R12) [[2]](diffhunk://#diff-8c91fe459266faa3ee1cd8d25680cdce715cf568e546c47b1bc8d3140d7fd378R32-R71)

**Integration with Macro Parsing and Autocomplete**

- Integrated onboarding prompts into macro parsing and autocomplete logic:
  - In `EnhancedMacroAutoCompleteOption.js`, calls to `onbordingExperimentalMacroEngine` are added when macro flags, variable shorthands, or leading whitespace are detected, prompting the user as needed. [[1]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1067-R1070) [[2]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1161-R1162) [[3]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1288-R1291)
  - In `SlashCommandParser.js`, onboarding is triggered when advanced macro features like `{{if}}` macros or scoped macros are encountered during slash command parsing. [[1]](diffhunk://#diff-004fd3f4997ea17f0f372b35c41232f56ef680770e9e8fc9e0a70e439a4dd220R622-R623) [[2]](diffhunk://#diff-004fd3f4997ea17f0f372b35c41232f56ef680770e9e8fc9e0a70e439a4dd220R742-R743)

**Heuristic Detection in Macro Substitution**

- Added heuristic detection for experimental macro features in `substituteParamsLegacy` in `script.js`, triggering onboarding if advanced syntax patterns are found and the warning has not been shown yet.

**Imports and Wiring**

- Updated import statements in relevant files to include the new onboarding function, ensuring it is available where needed. [[1]](diffhunk://#diff-4a4ec86e4c05b413e9b128d0f702c797e4a2afd8be513301c019824560d0c8e6R285) [[2]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR16) [[3]](diffhunk://#diff-004fd3f4997ea17f0f372b35c41232f56ef680770e9e8fc9e0a70e439a4dd220R42)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).