### PR TITLE
Macros 2.0 (v0.6.6) - STscript compatibility

### DIFF
--- a/public/global.d.ts
+++ b/public/global.d.ts
@@ -21,6 +21,7 @@ declare global {
     type MessageTimestamp = string | number | Date;
     type Character = import('./scripts/char-data').v1CharData;
     type ChatMessageExtra = BaseMessageExtra & Partial<ReasoningMessageExtra> & Record<string, any>;
+    type MacroHandler = import('./scripts/macros/macro-system').MacroHandler;
 
     interface Group {
         id: string;

--- a/public/global.d.ts
+++ b/public/global.d.ts
@@ -21,7 +21,6 @@ declare global {
     type MessageTimestamp = string | number | Date;
     type Character = import('./scripts/char-data').v1CharData;
     type ChatMessageExtra = BaseMessageExtra & Partial<ReasoningMessageExtra> & Record<string, any>;
-    type MacroHandler = import('./scripts/macros/macro-system').MacroHandler;
 
     interface Group {
         id: string;

--- a/public/script.js
+++ b/public/script.js
@@ -2839,7 +2839,7 @@ export function substituteParamsLegacy(content, _name1, _name2, _original, _grou
  * @param {string} [options.original] - The original message for {{original}} substitution.
  * @param {string} [options.groupOverride] - The group members list for {{group}} substitution.
  * @param {boolean} [options.replaceCharacterCard=true] - Whether to replace character card macros.
- * @param {Record<string,string|MacroHandler>} [options.dynamicMacros={}] - Additional environment variables as dynamic macros for substitution. Registered as macro functions.
+ * @param {Record<string, import('./scripts/macros/engine/MacroEnv.types.js').DynamicMacroValue>} [options.dynamicMacros={}] - Additional environment variables as dynamic macros for substitution. Registered as macro functions.
  * @param {(x: string) => string} [options.postProcessFn=(x) => x] - Post-processing function for each substituted macro.
  * @returns {string} The string with substituted parameters.
  */

--- a/public/scripts/macros/engine/MacroEngine.js
+++ b/public/scripts/macros/engine/MacroEngine.js
@@ -1,16 +1,17 @@
 import { MacroParser } from './MacroParser.js';
 import { MacroCstWalker } from './MacroCstWalker.js';
-import { MacroRegistry } from './MacroRegistry.js';
+import { MacroRegistry, MacroValueType } from './MacroRegistry.js';
 import { logMacroGeneralError, logMacroInternalError, logMacroRuntimeWarning, logMacroSyntaxWarning } from './MacroDiagnostics.js';
 import { ELSE_MARKER } from '../definitions/core-macros.js';
 
 /** @typedef {import('./MacroCstWalker.js').MacroCall} MacroCall */
 /** @typedef {import('./MacroEnv.types.js').MacroEnv} MacroEnv */
+/** @typedef {import('./MacroRegistry.js').MacroDefinitionOptions} MacroDefinitionOptions */
 /** @typedef {import('./MacroRegistry.js').MacroDefinition} MacroDefinition */
 
 /**
  * A processor function that transforms text before or after macro evaluation.
- *
+*
  * @callback MacroProcessor
  * @param {string} text - The text to process.
  * @param {MacroEnv} env - The macro environment.
@@ -166,31 +167,44 @@ class MacroEngine {
 
         // First check if this is a dynamic macro to use. If so, we will create a temporary macro definition for it and use that over any registered macro.
         // Dynamic macro keys are normalized to lowercase for case-insensitive matching.
-        /** @type {MacroDefinition?} */
+        /** @type {MacroDefinition|null} */
         let defOverride = null;
         const nameLower = name.toLowerCase();
         if (Object.hasOwn(env.dynamicMacros, nameLower)) {
             const impl = env.dynamicMacros[nameLower];
-            defOverride = {
-                name,
-                aliases: [],
-                category: 'dynamic',
-                description: 'Dynamic macro',
-                minArgs: 0,
-                maxArgs: 0,
-                unnamedArgDefs: [],
-                list: null,
-                strictArgs: true, // Fail dynamic macros if they are called with arguments
-                returns: null,
-                returnType: 'string',
-                displayOverride: null,
-                exampleUsage: [],
-                source: { name: 'dynamic', isExtension: false, isThirdParty: false },
-                aliasOf: null,
-                aliasVisible: null,
-                delayArgResolution: false,
-                handler: typeof impl === 'function' ? impl : () => impl,
-            };
+
+            // Dynamic macros support three formats:
+            // 1. string - direct value, no args allowed
+            // 2. function - handler function, no args allowed (legacy behavior)
+            // 3. MacroDefinitionOptions object - full definition with handler, args, type validation, etc.
+
+            // Check if this looks like a MacroDefinitionOptions object (has handler property)
+            const looksLikeOptions = impl && typeof impl === 'object' &&
+                'handler' in impl && typeof impl.handler === 'function';
+
+            if (looksLikeOptions) {
+                // Case 3: MacroDefinitionOptions - use the full definition builder
+                try {
+                    const options = /** @type {MacroDefinitionOptions} */ (impl);
+                    defOverride = MacroRegistry.buildMacroDefFromOptions(name, options);
+                } catch (error) {
+                    // If building fails, log warning and fall through to check registered macros
+                    logMacroRuntimeWarning({ message: `Dynamic macro "${name}" has invalid options: ${error.message}`, call });
+                }
+            } else if (['string', 'number', 'boolean', 'function'].includes((typeof impl))) {
+                // Case 1: string or handler function
+                if (['number', 'boolean'].includes(typeof impl)) {
+                    logMacroRuntimeWarning({ message: `Dynamic macro "${name}" uses unsupported number/boolean format.`, call });
+                }
+                defOverride = MacroRegistry.buildMacroDefFromOptions(name, {
+                    handler: typeof impl === 'function' ? impl : () => String(impl ?? ''),
+                    category: 'dynamic',
+                    description: 'Dynamic macro',
+                    returnType: MacroValueType.STRING,
+                });
+            } else {
+                logMacroRuntimeWarning({ message: `Dynamic macro "${name}" is not defined correctly (must be string, a handler function, or a macro def options object with handler property).`, call });
+            }
         }
 
         // If not, check if the macro exists and is registered

--- a/public/scripts/macros/engine/MacroEngine.js
+++ b/public/scripts/macros/engine/MacroEngine.js
@@ -11,7 +11,7 @@ import { ELSE_MARKER } from '../definitions/core-macros.js';
 
 /**
  * A processor function that transforms text before or after macro evaluation.
-*
+ *
  * @callback MacroProcessor
  * @param {string} text - The text to process.
  * @param {MacroEnv} env - The macro environment.

--- a/public/scripts/macros/engine/MacroEngine.js
+++ b/public/scripts/macros/engine/MacroEngine.js
@@ -192,7 +192,7 @@ class MacroEngine {
                     logMacroRuntimeWarning({ message: `Dynamic macro "${name}" has invalid options: ${error.message}`, call });
                 }
             } else if (['string', 'number', 'boolean', 'function'].includes((typeof impl))) {
-                // Case 1: string or handler function
+                // Case 1 & 2: string or handler function
                 if (['number', 'boolean'].includes(typeof impl)) {
                     logMacroRuntimeWarning({ message: `Dynamic macro "${name}" uses unsupported number/boolean format.`, call });
                 }

--- a/public/scripts/macros/engine/MacroEnv.types.js
+++ b/public/scripts/macros/engine/MacroEnv.types.js
@@ -7,6 +7,15 @@
  */
 
 /** @typedef {import('./MacroRegistry.js').MacroHandler} MacroHandler */
+/** @typedef {import('./MacroRegistry.js').MacroDefinitionOptions} MacroDefinitionOptions */
+
+/**
+ * A dynamic macro value can be:
+ * - A string (direct value)
+ * - A MacroHandler function (resolved at runtime)
+ * - A MacroDefinitionOptions object (full macro definition with handler, args, etc.)
+ * @typedef {string | MacroHandler | MacroDefinitionOptions} DynamicMacroValue
+ */
 
 /**
  * @typedef {Object} MacroEnvNames
@@ -50,7 +59,7 @@
  * @property {MacroEnvCharacter} character
  * @property {MacroEnvSystem} system
  * @property {MacroEnvFunctions} functions
- * @property {Object<string, string|MacroHandler>} dynamicMacros
+ * @property {Object<string, DynamicMacroValue>} dynamicMacros
  * @property {Record<string, unknown>} extra
  */
 

--- a/public/scripts/macros/engine/MacroEnvBuilder.js
+++ b/public/scripts/macros/engine/MacroEnvBuilder.js
@@ -22,7 +22,7 @@ import { getStringHash } from '/scripts/utils.js';
  * @property {string|null} [original]
  * @property {string|null} [groupOverride]
  * @property {boolean} [replaceCharacterCard]
- * @property {Record<string, any>|null} [dynamicMacros]
+ * @property {Record<string, import('./MacroEnv.types.js').DynamicMacroValue>|null} [dynamicMacros]
  * @property {(value: string) => string} [postProcessFn]
  */
 

--- a/public/scripts/slash-commands/SlashCommandClosure.js
+++ b/public/scripts/slash-commands/SlashCommandClosure.js
@@ -49,6 +49,102 @@ export class SlashCommandClosure {
     }
 
     /**
+     * Performs parameter substitution using the macro engine.
+     * @param {string} text Text to substitute
+     * @param {SlashCommandScope} scope Script scope
+     * @param {{key:string, value:string|SlashCommandClosure}[]} macroList Custom scope macros
+     * @returns {string|SlashCommandClosure|(string|SlashCommandClosure)[]} Substituted text or list of strings/closures
+     */
+    substituteWithMacroEngine(text, scope, macroList) {
+        /** @type {Record<string, import('./../macros/engine/MacroEnv.types.js').DynamicMacroValue>} */
+        const dynamicMacros = {
+            'pipe': () => scope.pipe,
+            'var': {
+                strictArgs: false,
+                list: { min: 1, max: 2 },
+                handler: (context) => {
+                    try {
+                        // NB: Legacy replacer halted the script execution on unknown variables
+                        return scope.getVariable(context.list[0], context.list[1]);
+                    } catch (error) {
+                        console.warn('{{var}} dynamic macro execution error:', error);
+                        return '';
+                    }
+                },
+            },
+        };
+
+        /** @type {Map<string, SlashCommandClosure>} */
+        const closures = new Map();
+        /** @type {Record<string, { args: string[], value: string|SlashCommandClosure }[]>} */
+        const customMacros = {};
+
+        for (const macro of macroList) {
+            const [name, ...rest] = macro.key.split('::');
+            if (!Object.hasOwn(customMacros, name)) {
+                customMacros[name] = [];
+            }
+            customMacros[name].push({ args: rest, value: macro.value });
+        }
+
+        for (const [macroName, macroArguments] of Object.entries(customMacros)) {
+            dynamicMacros[macroName] = {
+                strictArgs: false,
+                list: { min: 0, max: Number.MAX_SAFE_INTEGER },
+                handler: (context) => {
+                    // Sort to prefer exact matches over wildcard matches
+                    const sortedMacroArgs = macroArguments.toSorted((a, b) => {
+                        const aHasWildcard = a.args.includes('*');
+                        const bHasWildcard = b.args.includes('*');
+                        if (aHasWildcard && !bHasWildcard) return 1;
+                        if (!aHasWildcard && bHasWildcard) return -1;
+                        return 0;
+                    });
+
+                    const findMacroMatch = (/** @type {{args: string[]}} */ i) => {
+                        // Exact match
+                        if (i.args.toString() === context.list.toString()) {
+                            return true;
+                        }
+                        // Wildcard match - if any definition arg is '*', it matches any value at that position
+                        if (i.args.length === context.list.length) {
+                            return i.args.every((arg, index) => arg === '*' || arg === context.list[index]);
+                        }
+                        return false;
+                    };
+
+                    const replacer = sortedMacroArgs.find(findMacroMatch)?.value;
+                    if (replacer instanceof SlashCommandClosure) {
+                        replacer.abortController = this.abortController;
+                        replacer.breakController = this.breakController;
+                        replacer.scope.parent = this.scope;
+                        if (this.debugController && !replacer.debugController) {
+                            replacer.debugController = this.debugController;
+                        }
+
+                        const closureKey = `__closure_${uuidv4()}__`;
+                        closures.set(closureKey, replacer);
+                        return `\n${closureKey}\n`;
+                    }
+
+                    return String(replacer ?? '');
+                },
+            };
+        }
+
+        const substitutedText = substituteParams(text, { dynamicMacros });
+
+        // If any closures were inserted, split the text accordingly
+        if (closures.size > 0) {
+            const parts = substitutedText.split('\n').map(part => closures.has(part) ? closures.get(part) : part);
+            return parts.length === 1 ? parts[0] : parts;
+        }
+
+        // No closures, return substituted text as-is
+        return substitutedText;
+    }
+
+    /**
      *
      * @param {string} text
      * @param {SlashCommandScope} scope
@@ -74,48 +170,7 @@ export class SlashCommandClosure {
             return 0;
         });
         if (power_user.experimental_macro_engine) {
-            /** @type {Map<string, SlashCommandClosure>} */
-            const closures = new Map();
-            /** @type {Record<string,string|MacroHandler>} */
-            const dynamicMacros = {
-                'pipe': () => scope.pipe,
-                'var': (context) => scope.getVariable(context.unnamedArgs[0], context.unnamedArgs[1]),
-                'arg': (context) => {
-                    const argName = context.unnamedArgs[0];
-                    if (!argName) {
-                        return '';
-                    }
-
-                    const replacer = macroList.find(it => it.key == `arg::${argName}`)?.value;
-                    if (replacer instanceof SlashCommandClosure) {
-                        replacer.abortController = this.abortController;
-                        replacer.breakController = this.breakController;
-                        replacer.scope.parent = this.scope;
-                        if (this.debugController && !replacer.debugController) {
-                            replacer.debugController = this.debugController;
-                        }
-
-                        const closureKey = `__closure_${uuidv4()}__`;
-                        closures.set(closureKey, replacer);
-                        return `\n${closureKey}\n`;
-                    }
-
-                    return replacer;
-                },
-            };
-            for (const macro of macroList) {
-                if (!/(?:arg)::/.test(macro.key) && typeof macro.value === 'string') {
-                    dynamicMacros[macro.key] = macro.value;
-                } else {
-                    console.warn(`Macro ${macro.key} is not eligible for dynamic substitution. Consider using dynamicMacros directly.`);
-                }
-            }
-            const substitutedText = substituteParams(text, { dynamicMacros });
-            if (closures.size > 0) {
-                const parts = substitutedText.split('\n').map(part => closures.has(part) ? closures.get(part) : part);
-                return parts.length === 1 ? parts[0] : parts;
-            }
-            return substitutedText;
+            return this.substituteWithMacroEngine(text, scope, macroList);
         }
         const macros = macroList.map(it=>escapeMacro(it)).join('|');
         const re = new RegExp(`(?<pipe>{{pipe}})|(?:{{var::(?<var>[^\\s]+?)(?:::(?<varIndex>(?!}}).+))?}})|(?:{{(?<macro>${macros})}})`);

--- a/public/scripts/slash-commands/SlashCommandClosure.js
+++ b/public/scripts/slash-commands/SlashCommandClosure.js
@@ -74,6 +74,8 @@ export class SlashCommandClosure {
             },
         };
 
+        // Special marker to denote closures in the substituted text
+        const CLOSURE_BOUNDARY = '\uFFF0~CLOSURE~\uFFF0';
         /** @type {Map<string, SlashCommandClosure>} */
         const closures = new Map();
         /** @type {Record<string, { args: string[], value: string|SlashCommandClosure }[]>} */
@@ -122,9 +124,9 @@ export class SlashCommandClosure {
                             replacer.debugController = this.debugController;
                         }
 
-                        const closureKey = `__closure_${uuidv4()}__`;
+                        const closureKey = uuidv4();
                         closures.set(closureKey, replacer);
-                        return `\n${closureKey}\n`;
+                        return `${CLOSURE_BOUNDARY}${closureKey}${CLOSURE_BOUNDARY}`;
                     }
 
                     return String(replacer ?? '');
@@ -136,7 +138,7 @@ export class SlashCommandClosure {
 
         // If any closures were inserted, split the text accordingly
         if (closures.size > 0) {
-            const parts = substitutedText.split('\n').map(part => closures.has(part) ? closures.get(part) : part);
+            const parts = substitutedText.split(CLOSURE_BOUNDARY).map(part => closures.has(part) ? closures.get(part) : part).filter(Boolean);
             return parts.length === 1 ? parts[0] : parts;
         }
 

--- a/public/scripts/slash-commands/SlashCommandClosure.js
+++ b/public/scripts/slash-commands/SlashCommandClosure.js
@@ -1,4 +1,5 @@
 import { substituteParams } from '../../script.js';
+import { power_user } from '../power-user.js';
 import { delay, escapeRegex, uuidv4 } from '../utils.js';
 import { SlashCommand } from './SlashCommand.js';
 import { SlashCommandAbortController } from './SlashCommandAbortController.js';
@@ -72,6 +73,50 @@ export class SlashCommandClosure {
             if (a.key.includes('*') && b.key.includes('*')) return b.key.indexOf('*') - a.key.indexOf('*');
             return 0;
         });
+        if (power_user.experimental_macro_engine) {
+            /** @type {Map<string, SlashCommandClosure>} */
+            const closures = new Map();
+            /** @type {Record<string,string|MacroHandler>} */
+            const dynamicMacros = {
+                'pipe': () => scope.pipe,
+                'var': (context) => scope.getVariable(context.unnamedArgs[0], context.unnamedArgs[1]),
+                'arg': (context) => {
+                    const argName = context.unnamedArgs[0];
+                    if (!argName) {
+                        return '';
+                    }
+
+                    const replacer = macroList.find(it => it.key == `arg::${argName}`)?.value;
+                    if (replacer instanceof SlashCommandClosure) {
+                        replacer.abortController = this.abortController;
+                        replacer.breakController = this.breakController;
+                        replacer.scope.parent = this.scope;
+                        if (this.debugController && !replacer.debugController) {
+                            replacer.debugController = this.debugController;
+                        }
+
+                        const closureKey = `__closure_${uuidv4()}__`;
+                        closures.set(closureKey, replacer);
+                        return `\n${closureKey}\n`;
+                    }
+
+                    return replacer;
+                },
+            };
+            for (const macro of macroList) {
+                if (!/(?:arg)::/.test(macro.key) && typeof macro.value === 'string') {
+                    dynamicMacros[macro.key] = macro.value;
+                } else {
+                    console.warn(`Macro ${macro.key} is not eligible for dynamic substitution. Consider using dynamicMacros directly.`);
+                }
+            }
+            const substitutedText = substituteParams(text, { dynamicMacros });
+            if (closures.size > 0) {
+                const parts = substitutedText.split('\n').map(part => closures.has(part) ? closures.get(part) : part);
+                return parts.length === 1 ? parts[0] : parts;
+            }
+            return substitutedText;
+        }
         const macros = macroList.map(it=>escapeMacro(it)).join('|');
         const re = new RegExp(`(?<pipe>{{pipe}})|(?:{{var::(?<var>[^\\s]+?)(?:::(?<varIndex>(?!}}).+))?}})|(?:{{(?<macro>${macros})}})`);
         let done = '';

--- a/public/scripts/slash-commands/SlashCommandClosure.js
+++ b/public/scripts/slash-commands/SlashCommandClosure.js
@@ -105,7 +105,7 @@ export class SlashCommandClosure {
 
                     const findMacroMatch = (/** @type {{args: string[]}} */ i) => {
                         // Exact match
-                        if (i.args.toString() === context.list.toString()) {
+                        if (i.args.length === context.list.length && i.args.every((arg, index) => arg === context.list[index])) {
                             return true;
                         }
                         // Wildcard match - if any definition arg is '*', it matches any value at that position

--- a/public/scripts/slash-commands/SlashCommandParser.js
+++ b/public/scripts/slash-commands/SlashCommandParser.js
@@ -1367,6 +1367,10 @@ export class SlashCommandParser {
     }
 
     replaceGetvar(value) {
+        // Not needed with the new parser.
+        if (power_user.experimental_macro_engine) {
+            return value;
+        }
         return value.replace(/{{(get(?:global)?var)::([^}]+)}}/gi, (match, cmd, name, idx) => {
             name = name.trim();
             cmd = cmd.toLowerCase();

--- a/tests/frontend/MacroSlashCommands.e2e.js
+++ b/tests/frontend/MacroSlashCommands.e2e.js
@@ -1,0 +1,178 @@
+
+import { test, expect } from '@playwright/test';
+import { testSetup } from './frontent-test-utils.js';
+
+test.describe('MacroSlashCommands', () => {
+    test.beforeEach(testSetup.awaitST);
+
+    test.describe('Parser Flags', () => {
+        test('should bypass REPLACE_GETVAR', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/parser-flag REPLACE_GETVAR || /setvar key=x \\{\\{lastMessageId}} || /pass {{getvar::x}}')).pipe;
+            });
+
+            expect(output).toBe('{{lastMessageId}}');
+        });
+    });
+
+    test.describe('{{pipe}} Macro', () => {
+        test('should support {{pipe}} macro', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/pass Hello World || /pass {{pipe}}')).pipe;
+            });
+
+            expect(output).toBe('Hello World');
+        });
+    });
+
+    test.describe('{{var}} Macro', () => {
+        test('should support {{var::key}} macro', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/let key=greeting Hello || /pass {{var::greeting}}')).pipe;
+            });
+
+            expect(output).toBe('Hello');
+        });
+
+        test('should support {{var::key::index}} macro', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/let key=list ["item1","item2","item3"] || /pass {{var::list::1}}')).pipe;
+            });
+
+            expect(output).toBe('item2');
+        });
+
+        test('should not fail on unknown variable keys', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+                return (await executeSlashCommandsWithOptions('/pass {{var::unknownKey}}')).pipe;
+            });
+
+            expect(output).toBe('');
+        });
+
+        test('should not fail on out-of-bounds variable index', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/let key=test {"key":"value"} || /pass {{var::test::error}}')).pipe;
+            });
+
+            expect(output).toBe('');
+        });
+    });
+
+    test.describe('{{arg}} Macro', () => {
+        test('should support {{arg}} macro with plain value', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/qr-arg hello world || /pass {{arg::hello}}')).pipe;
+            });
+
+            expect(output).toBe('world');
+        });
+
+        test('should support {{arg}} macro with closure value', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/qr-arg x {: /echo test :} || /echo {{arg::x}}')).pipe;
+            });
+
+            expect(output).toBe('[Closure]');
+        });
+
+        test('should support mixed type {{arg}} macro values', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/qr-arg a simple || /qr-arg b {: /echo closure :} || /echo {{arg::a}} and {{arg::b}}')).pipe;
+            });
+
+            expect(output).toBe('simple and ,[Closure]');
+        });
+
+        test('should support wildcard {{arg}} macro', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/qr-arg * wildcard || /pass {{arg::any}}')).pipe;
+            });
+
+            expect(output).toBe('wildcard');
+        });
+    });
+
+    test.describe('Custom Scope Macros', () => {
+        test('should support {{timesIndex}} in /times command', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                return (await executeSlashCommandsWithOptions('/times 1 {: /pass {{timesIndex}} :}')).pipe;
+            });
+
+            expect(output).toBe('0');
+        });
+
+        test('should support custom SlashCommandScope macros', async ({ page }) => {
+            const output = await page.evaluate(async () => {
+                const { executeSlashCommandsWithOptions } = await import('./scripts/slash-commands.js');
+                const { SlashCommandScope } = await import('./scripts/slash-commands/SlashCommandScope.js');
+                const { power_user } = await import('./scripts/power-user.js');
+
+                power_user.experimental_macro_engine = true;
+
+                // Create a custom scope with a macro
+                const customScope = new SlashCommandScope(null);
+                customScope.setMacro('uno::dos::tres', 'CUSTOM_VALUE');
+                customScope.setMacro('uno::dos::quatro', 'SHOULD_NOT_BE_USED');
+                customScope.setMacro('uno::dos::*', 'WILDCARD_VALUE');
+                return (await executeSlashCommandsWithOptions('/pass {{uno::dos::tres}}', { scope: customScope })).pipe;
+            });
+
+            expect(output).toBe('CUSTOM_VALUE');
+        });
+    });
+});

--- a/tests/frontend/MacroSlashCommands.e2e.js
+++ b/tests/frontend/MacroSlashCommands.e2e.js
@@ -1,4 +1,3 @@
-
 import { test, expect } from '@playwright/test';
 import { testSetup } from './frontent-test-utils.js';
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Replaces legacy macros shims in STscript parser.

1. Bypass `REPLACE_GETVAR` parser flag when experimental engine is enabled. Tested using [this example from docs](https://docs.sillytavern.app/usage/st-script/#replace-variable-macros).
2. [Add support for MacroDefinitionOptions format in dynamic macros](https://github.com/SillyTavern/SillyTavern/commit/aeba5e82281964531108c8c9a1587df46d31b5f9)
3. Replace STscript-specific macros (`{{pipe}}`, `{{var}}`, `{{arg}}`) with the engine if enabled.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
