### PR TITLE
Fix user handle naming logic

### DIFF
--- a/src/endpoints/users-admin.js
+++ b/src/endpoints/users-admin.js
@@ -163,7 +163,7 @@ router.post('/create', requireAdminMiddleware, async (request, response) => {
         }
 
         const handles = await getAllUserHandles();
-        const handle = lodash.kebabCase(String(request.body.handle).toLowerCase().trim());
+        const handle = lodash.deburr(String(request.body.handle).toLowerCase().trim()).replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 
         if (!handle) {
             console.warn('Create user failed: Invalid handle');
@@ -241,7 +241,7 @@ router.post('/slugify', requireAdminMiddleware, async (request, response) => {
             return response.status(400).json({ error: 'Missing required fields' });
         }
 
-        const text = lodash.kebabCase(String(request.body.text).toLowerCase().trim());
+        const text = lodash.deburr(String(request.body.text).toLowerCase().trim()).replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 
         return response.send(text);
     } catch (error) {

--- a/src/endpoints/users-admin.js
+++ b/src/endpoints/users-admin.js
@@ -19,6 +19,20 @@ import { DEFAULT_USER } from '../constants.js';
 
 export const router = express.Router();
 
+/**
+ * Slugifies a given text string.
+ * - Converts to lowercase
+ * - Trims whitespace
+ * - Replaces spaces and special characters with hyphens
+ * - Removes leading and trailing hyphens
+ * - Uses lodash.deburr to remove diacritical marks
+ * @param {string} text Text to slugify
+ * @returns {string} Slugified text
+ */
+function slugify(text) {
+    return lodash.deburr(String(text ?? '').toLowerCase().trim()).replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
 router.post('/get', requireAdminMiddleware, async (_request, response) => {
     try {
         /** @type {import('../users.js').User[]} */
@@ -163,7 +177,7 @@ router.post('/create', requireAdminMiddleware, async (request, response) => {
         }
 
         const handles = await getAllUserHandles();
-        const handle = lodash.deburr(String(request.body.handle).toLowerCase().trim()).replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+        const handle = slugify(request.body.handle);
 
         if (!handle) {
             console.warn('Create user failed: Invalid handle');
@@ -241,7 +255,7 @@ router.post('/slugify', requireAdminMiddleware, async (request, response) => {
             return response.status(400).json({ error: 'Missing required fields' });
         }
 
-        const text = lodash.deburr(String(request.body.text).toLowerCase().trim()).replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+        const text = slugify(request.body.text);
 
         return response.send(text);
     } catch (error) {


### PR DESCRIPTION
Currently, user handles are forced to be kebab-cased, which inserts dashes between letters and numbers (e.g. "abc123" becomes "abc-123"). This prevents users from having alphanumeric handles without separators. (It annoying me a lot while log in)

So I replaced the `lodash.kebabCase` usage in `src/endpoints/users-admin.js` with a custom slugification logic. This new logic still sanitizes the input (converts to lowercase, removes accents, replaces non-alphanumeric characters with dashes) but allows alphanumeric sequences to remain intact (e.g. "abc123" stays "abc123").

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
