### PR TITLE
Improve chat branch naming to include original name

### DIFF
--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -172,7 +172,7 @@ export async function createBranch(mesId) {
     const lastMes = chat[mesId];
     const mainChat = selected_group ? groups?.find(x => x.id == selected_group)?.chat_id : characters[this_chid].chat;
     const newMetadata = { main_chat: mainChat };
-    let name = `Branch #${mesId} - ${humanizedDateTime()}`;
+    let name = `${mainChat} - Branch #${mesId} ${humanizedDateTime()}`;
 
     if (selected_group) {
         await saveGroupBookmarkChat(selected_group, name, newMetadata, mesId);


### PR DESCRIPTION
@underscorex86 asked for this.

Example for both a named chat, and a default name chat, both branched.
<img width="1010" height="367" alt="image" src="https://github.com/user-attachments/assets/c17cb6f7-8ce8-455d-bf00-a13943ca462a" />

## Copilot Summary
This pull request makes a small update to the branch naming convention in the `createBranch` function within `bookmarks.js`. The new branch name now includes the main chat identifier at the beginning, making it easier to identify the source chat for each branch. 

- Changed the branch name format in `createBranch` to start with the `mainChat` identifier, followed by the branch number and timestamp.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
