### PR TITLE
Optimize getGroupPastChats

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -18,7 +18,6 @@ import {
     paginationDropdownChangeHandler,
     waitUntilCondition,
     uuidv4,
-    humanFileSize,
 } from './utils.js';
 import { RA_CountCharTokens, humanizedDateTime, dragElement, favsToHotswap, getMessageTimeStamp } from './RossAscends-mods.js';
 import { power_user, loadMovingUIState, sortEntitiesList } from './power-user.js';
@@ -2137,24 +2136,15 @@ export async function getGroupPastChats(groupId) {
 
     try {
         for (const chatId of group.chats) {
-            const messages = await loadGroupChat(chatId);
-            if (!Array.isArray(messages)) {
-                continue;
-            }
-            const fileSize = humanFileSize(JSON.stringify(messages).length);
-            if (messages.length > 0 && Object.hasOwn(messages[0], 'chat_metadata')) {
-                messages.shift();
-            }
-            const chatItems = messages.length;
-            const lastMessage = messages.length ? messages[messages.length - 1].mes : '[The chat is empty]';
-            const lastMessageDate = messages.length ? (messages[messages.length - 1].send_date || Date.now()) : Date.now();
-            chats.push({
-                'file_name': chatId,
-                'mes': lastMessage,
-                'last_mes': lastMessageDate,
-                'file_size': fileSize,
-                'chat_items': chatItems,
+            const response = await fetch('/api/chats/group/info', {
+                method: 'POST',
+                headers: getRequestHeaders(),
+                body: JSON.stringify({ id: chatId }),
             });
+            if (response.ok) {
+                const data = await response.json();
+                chats.push(data);
+            }
         }
     } catch (err) {
         console.error(err);

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -2123,7 +2123,7 @@ export async function createNewGroupChat(groupId) {
 /**
  * Retrieves past chats for a specified group.
  * @param {string} groupId Group ID
- * @returns {Promise<Array>} Array of past chats
+ * @returns {Promise<Array<import('../../src/endpoints/chats.js').ChatInfo>>} Array of past chats
  */
 export async function getGroupPastChats(groupId) {
     const group = groups.find(x => x.id === groupId);

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -760,9 +760,26 @@ router.post('/group/get', (request, response) => {
     }
 
     const id = request.body.id;
-    const chatFilePath = path.join(request.user.directories.groupChats, `${id}.jsonl`);
+    const chatFilePath = path.join(request.user.directories.groupChats, sanitize(`${id}.jsonl`));
 
     return response.send(getChatData(chatFilePath));
+});
+
+router.post('/group/info', async (request, response) => {
+    try {
+        if (!request.body || !request.body.id) {
+            return response.sendStatus(400);
+        }
+
+        const id = request.body.id;
+        const chatFilePath = path.join(request.user.directories.groupChats, sanitize(`${id}.jsonl`));
+
+        const chatInfo = await getChatInfo(chatFilePath);
+        return response.send(chatInfo);
+    } catch (error) {
+        console.error(error);
+        return response.sendStatus(500);
+    }
 });
 
 router.post('/group/delete', (request, response) => {
@@ -772,13 +789,13 @@ router.post('/group/delete', (request, response) => {
         }
 
         const id = request.body.id;
-        const chatFilePath = path.join(request.user.directories.groupChats, `${id}.jsonl`);
+        const chatFilePath = path.join(request.user.directories.groupChats, sanitize(`${id}.jsonl`));
 
         //Return success if the file was deleted.
         if (tryDeleteFile(chatFilePath)) {
             return response.send({ ok: true });
         } else {
-            console.error('The group chat file was not deleted.\'');
+            console.error('The group chat file was not deleted.');
             return response.sendStatus(400);
         }
     } catch (error) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Will use server-side chat info gathering method instead of loading the entire chat into memory.

1. Add a new `/api/chats/group/info` endpoint
2. Uses that endpoint in `getGroupPastChats`

As it's not used in core code, [TopInfoBar](https://github.com/SillyTavern/Extension-TopInfoBar) extension might be needed to see the effect.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
