### PR TITLE
`refactor/perf-printMessages` #0: Refactored `printMessages` into `redisplayChat`.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1449,8 +1449,6 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     const messages = targetChat.slice(startIndex);
 
     if (messages.length > 0) {
-        const lastMessage = messages.pop();
-
         const newMessageElements = messages.map( (message, offset) => {
             const i = startIndex + offset;
             const messageElement = addOneMessage(message, { scroll: false, forceId: i, showSwipes: false, insert: false });
@@ -1458,12 +1456,8 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
             return messageElement[0];
         });
 
-        const lastMessageId = targetChat.length - 1;
-        const lastMessageElement = addOneMessage(lastMessage, { scroll: false, forceId: lastMessageId, showSwipes: false, insert: false });
-
         //The last_mes has been removed, add it to the new last message.
-        lastMessageElement.addClass('last_mes');
-        newMessageElements.push(lastMessageElement[0]);
+        newMessageElements.at(-1).classList.add('last_mes');
 
         //Append to chat in one DOM update.
         chatElement.append(newMessageElements);

--- a/public/script.js
+++ b/public/script.js
@@ -1424,23 +1424,59 @@ export async function printMessages() {
         chatElement.append('<div id="show_more_messages">Show more messages</div>');
     }
 
-    const newMessageElements = [];
+    await redisplayChat({ startIndex, fade: false });
 
-    for (let i = startIndex; i < chat.length; i++) {
-        const item = chat[i];
-        const messageElement = addOneMessage(item, { scroll: false, forceId: i, showSwipes: false, insert: false });
-        newMessageElements.push(messageElement);
-    }
-
-    chatElement.append(newMessageElements);
-    chatElement.find('.mes').removeClass('last_mes');
-    chatElement.find('.mes').last().addClass('last_mes');
-    refreshSwipeButtons(false, false);
-    applyStylePins();
-    updateEditArrowClasses();
-    applyCharacterTagsToMessageDivs({ mesIds: lodash.range(startIndex, chat.length,  1) });
     scrollChatToBottom({ waitForFrame: true });
     delay(debounce_timeout.short).then(() => scrollOnMediaLoad());
+}
+
+/**
+ * Visually updates all chat messages including and after index by removing them, then adding them.
+ * @param {object} [options] Options
+ * @param {ChatMessage[]} [options.targetChat=chat] All messages in chat before startIndex will remain unchanged.
+ * @param {Number} [options.startIndex=0] Everything including and after startIndex will be replaced.
+ * @param {Boolean} [options.fade=true] When false, the swipe chevrons will not fade in.
+ */
+export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = true } = {}) {
+    //.find is faster than .children.
+    const messageElements = chatElement.find('.mes');
+    messageElements.removeClass('last_mes');
+
+    //Remove messages after index.
+    messageElements.filter(`.mes[mesid="${startIndex}"]`).nextAll('.mes').addBack().remove();
+
+    let t1 = performance.now();
+
+    const messages = targetChat.slice(startIndex);
+
+    if (messages.length > 0) {
+        const lastMessage = messages.pop();
+
+        const newMessageElements = messages.map( (message, offset) => {
+            let i = startIndex + offset;
+            const messageElement = addOneMessage(message, { scroll: false, forceId: i, showSwipes: false, insert: false });
+
+            return messageElement[0];
+        });
+
+        const lastMessageId = targetChat.length - 1;
+        const lastMessageElement = addOneMessage(lastMessage, { scroll: false, forceId: lastMessageId, showSwipes: false, insert: false });
+
+        //The last_mes has been removed, add it to the new last message.
+        lastMessageElement.addClass('last_mes');
+        newMessageElements.push(lastMessageElement[0]);
+
+        //Append to chat in one DOM update.
+        chatElement.append(newMessageElements);
+
+        applyCharacterTagsToMessageDivs({ mesIds: lodash.range(startIndex, targetChat.length,  1) });
+    }
+
+    refreshSwipeButtons(false, fade);
+    applyStylePins();
+    updateEditArrowClasses();
+
+    console.info(`Rendered ${targetChat.length - startIndex} messages in ${(performance.now() - t1) / 1000} seconds.`);
 }
 
 export function scrollOnMediaLoad() {
@@ -9627,23 +9663,6 @@ export async function createOrEditCharacter(e) {
 }
 
 /**
- * Visually updates all chat messages including andd after index by removing them, then adding them.
- * @param {ChatMessage[]} chat All messages in chat before index will remain unchanged.
- * @param {Number} index The last unchanged messageId.
- */
-export async function redisplayChat(chat, index) {
-    //Remove messages after index.
-    chatElement.children(`.mes[mesid="${index}"]`).nextAll('.mes').addBack().remove();
-
-    //Skip to index, then add extra messages.
-    for (let i = index; i <= chat.length - 1; i++) {
-        //addOneMessage will update last_mes.
-        addOneMessage(chat[i], { scroll: false, showSwipes: false, forceId: i });
-    }
-    refreshSwipeButtons();
-}
-
-/**
  * Formats a counter for a swipe view.
  * @param {number} current The current number of items.
  * @param {number} total The total number of items.
@@ -9797,7 +9816,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
 
                 //Update the chat.
                 await loadFromSwipeId(mesId, chat[mesId].swipe_id);
-                await redisplayChat(chat, mesId);
+                await redisplayChat({ startIndex: mesId });
             }
             else {
                 await Popup.show.confirm(

--- a/public/script.js
+++ b/public/script.js
@@ -1438,7 +1438,6 @@ export async function printMessages() {
  * @param {Boolean} [options.fade=true] When false, the swipe chevrons will not fade in.
  */
 export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = true } = {}) {
-    //.find is faster than .children.
     const messageElements = chatElement.find('.mes');
     messageElements.removeClass('last_mes');
 

--- a/public/script.js
+++ b/public/script.js
@@ -1476,7 +1476,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     applyStylePins();
     updateEditArrowClasses();
 
-    console.info(`Rendered ${targetChat.length - startIndex} messages in ${(performance.now() - t1) / 1000} seconds.`);
+    console.info(`Rendered ${targetChat.length - startIndex} messages in ${((performance.now() - t1) / 1000).toFixed(3)} seconds.`);
 }
 
 export function scrollOnMediaLoad() {

--- a/public/script.js
+++ b/public/script.js
@@ -1445,7 +1445,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     //Remove messages after index.
     messageElements.filter(`.mes[mesid="${startIndex}"]`).nextAll('.mes').addBack().remove();
 
-    let t1 = performance.now();
+    const t1 = performance.now();
 
     const messages = targetChat.slice(startIndex);
 
@@ -1453,7 +1453,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
         const lastMessage = messages.pop();
 
         const newMessageElements = messages.map( (message, offset) => {
-            let i = startIndex + offset;
+            const i = startIndex + offset;
             const messageElement = addOneMessage(message, { scroll: false, forceId: i, showSwipes: false, insert: false });
 
             return messageElement[0];


### PR DESCRIPTION
See https://github.com/SillyTavern/SillyTavern/pull/4947#issuecomment-3726566838 for context.

Refactor `printMessages` into `redisplayChat`.
This prevents redundant code.

The extra complexity with `lastMessageElement` is to save a DOM query.
From `chatElement.find('.mes').last().addClass('last_mes');`
To `lastMessageElement.addClass('last_mes');`


## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
