### PR TITLE
`refactor/perf-printMessages` #2: Removed `getMessageFromTemplate`

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2481,7 +2481,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
     timerValue && newMessage.find('.mes_timer').attr('title', timerTitle).text(timerValue);
     bookmarkLink && updateBookmarkDisplay(newMessage);
 
-    if (mes.extra?.bias) {
+    if (mes.extra?.bias !== '') {
         const bias = messageFormatting(mes.extra?.bias, '', false, false, -1, {}, false);
         newMessage.find('.mes_bias').html(bias);
     }

--- a/public/script.js
+++ b/public/script.js
@@ -1856,8 +1856,6 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
  *
  * @param {JQuery<HTMLElement>} mes - The message element containing the timestamp where the icon should be inserted or replaced.
  * @param {ChatMessageExtra} extra - Contains the API and model details.
- * param {string} extra.api - The name of the API, used to determine which SVG to fetch.
- * param {string} extra.model - The model name, used to check for the substring "claude".
  */
 function insertSVGIcon(mes, extra) {
     // Determine the SVG filename
@@ -2458,8 +2456,8 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
     }
 
     const { timerValue, timerTitle } = formatGenerationTimer(mes.gen_started, mes.gen_finished, mes.extra?.token_count, mes.extra?.reasoning_duration, mes.extra?.time_to_first_token);
-    const tokenCount = mes.extra?.token_count ?? 0;
-    const bookmarkLink = mes?.extra?.bookmark_link ?? '';
+    const tokenCount = mes.extra?.token_count;
+    const bookmarkLink = mes?.extra?.bookmark_link;
 
     newMessage.attr({
         'mesid': newMessageId,
@@ -2478,12 +2476,12 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
     newMessage.find('.ch_name .name_text').text(mes.name);
     newMessage.find('.timestamp').text(timestamp).attr('title', `${mes.extra?.api ? mes.extra.api + ' - ' : ''}${mes.extra?.model ?? ''}`);
     newMessage.find('.mesIDDisplay').text(`#${newMessageId}`);
-    tokenCount ?? newMessage.find('.tokenCounterDisplay').text(`${tokenCount}t`);
-    mes.title ?? newMessage.attr('title', mes.title);
-    timerValue ?? newMessage.find('.mes_timer').attr('title', timerTitle).text(timerValue);
+    tokenCount && newMessage.find('.tokenCounterDisplay').text(`${tokenCount}t`);
+    mes.title && newMessage.attr('title', mes.title);
+    timerValue && newMessage.find('.mes_timer').attr('title', timerTitle).text(timerValue);
     bookmarkLink && updateBookmarkDisplay(newMessage);
 
-    if (typeof(mes.extra?.bias) === 'string') {
+    if (mes.extra?.bias) {
         const bias = messageFormatting(mes.extra?.bias, '', false, false, -1, {}, false);
         newMessage.find('.mes_bias').html(bias);
     }
@@ -2519,7 +2517,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
     }
 
     //if we have itemized messages, and the array isn't null..
-    if (mes.is_user === false && Array.isArray(itemizedPrompts) && itemizedPrompts.length > 0) {
+    if (!mes.is_user && Array.isArray(itemizedPrompts) && itemizedPrompts.length > 0) {
         const itemizedPrompt = itemizedPrompts.find(x => Number(x.mesId) === Number(newMessageId));
         if (itemizedPrompt) {
             newMessage.find('.mes_prompt').show();

--- a/public/script.js
+++ b/public/script.js
@@ -2446,19 +2446,15 @@ export function addCopyToCodeBlocks(messageElement) {
  * @returns {JQuery<HTMLElement>} The newly added message element
  */
 export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true, insertBefore = null, forceId = null, showSwipes = true, insert = true } = {}) {
+    // Callers push the new message to chat before calling addOneMessage
+    const newMessageId = typeof forceId == 'number' ? forceId : chat.length - 1;
+
     let messageText = mes.mes;
     const momentDate = timestampToMoment(mes.send_date);
     const timestamp = momentDate.isValid() ? momentDate.format('LL LT') : '';
 
     if (mes?.extra?.display_text) {
         messageText = mes.extra.display_text;
-    }
-
-    // Forbidden black magic
-    // This allows to use "continue" on user messages
-    if (type === 'swipe' && mes.swipe_id === undefined) {
-        mes.swipe_id = 0;
-        mes.swipes = [mes.mes];
     }
 
     let avatarImg = getThumbnailUrl('persona', user_avatar);
@@ -2479,7 +2475,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
             }
         }
         //old processing:
-        //if messge is from sytem, use the name provided in the message JSONL to proceed,
+        //if message is from system, use the name provided in the message JSONL to proceed,
         //if not system message, use name2 (char's name) to proceed
         //characterName = mes.is_system || mes.force_avatar ? mes.name : name2;
     } else if (mes.is_user && mes.force_avatar) {
@@ -2521,6 +2517,18 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
     };
 
     const renderedMessage = getMessageFromTemplate(params);
+    let newMessage;
+
+    if (type === 'swipe') {
+        // Forbidden black magic
+        // This allows to use "continue" on user messages
+        mes.swipe_id ??= 0;
+        mes.swipes ??= [mes.mes];
+        //This keeps listeners intact.
+        newMessage = chatElement.find(`[mesid="${newMessageId}"]`);
+    } else {
+        newMessage = insert ? chatElement.find(`[mesid="${newMessageId}"]`) : renderedMessage;
+    }
 
     if (type !== 'swipe' && insert) {
         if (!insertAfter && !insertBefore) {
@@ -2535,10 +2543,6 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         }
     }
 
-    // Callers push the new message to chat before calling addOneMessage
-    const newMessageId = typeof forceId == 'number' ? forceId : chat.length - 1;
-
-    const newMessage = insert ? chatElement.find(`[mesid="${newMessageId}"]`) : renderedMessage;
     const isSmallSys = mes?.extra?.isSmallSys;
 
     if (isSmallSys === true) {
@@ -2549,12 +2553,9 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         newMessage.addClass('toolCall');
     }
 
-    //shows or hides the Prompt display button
-    let mesIdToFind = type === 'swipe' ? params.mesId - 1 : params.mesId;  //Number(newMessage.attr('mesId'));
-
     //if we have itemized messages, and the array isn't null..
     if (params.isUser === false && Array.isArray(itemizedPrompts) && itemizedPrompts.length > 0) {
-        const itemizedPrompt = itemizedPrompts.find(x => Number(x.mesId) === Number(mesIdToFind));
+        const itemizedPrompt = itemizedPrompts.find(x => Number(x.mesId) === Number(newMessageId));
         if (itemizedPrompt) {
             newMessage.find('.mes_prompt').show();
         }
@@ -2565,32 +2566,13 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         $(this).parent().html('<div class="missing-avatar fa-solid fa-user-slash"></div>');
     });
 
-    if (type === 'swipe') {
-        newMessage.attr('swipeid', params.swipeId);
-        newMessage.find('.mes_text').html(messageText).attr('title', title);
-        newMessage.find('.timestamp').text(timestamp).attr('title', `${params.extra.api} - ${params.extra.model}`);
-        updateReasoningUI(newMessage);
-        appendMediaToMessage(mes, newMessage, scroll ? SCROLL_BEHAVIOR.ADJUST : SCROLL_BEHAVIOR.NONE);
-        if (power_user.timestamp_model_icon && params.extra?.api) {
-            insertSVGIcon(newMessage, params.extra);
-        }
-
-        if (mes.swipe_id == mes.swipes.length - 1) {
-            newMessage.find('.mes_timer').text(params.timerValue).attr('title', params.timerTitle);
-            newMessage.find('.tokenCounterDisplay').text(`${params.tokenCount}t`);
-        } else {
-            newMessage.find('.mes_timer').empty();
-            newMessage.find('.tokenCounterDisplay').empty();
-        }
-    } else {
-        newMessage.find('.mes_text').append(messageText);
-        appendMediaToMessage(mes, newMessage, scroll ? SCROLL_BEHAVIOR.ADJUST : SCROLL_BEHAVIOR.NONE);
-    }
+    newMessage.find('.mes_text').html(messageText);
+    appendMediaToMessage(mes, newMessage, scroll ? SCROLL_BEHAVIOR.ADJUST : SCROLL_BEHAVIOR.NONE);
 
     addCopyToCodeBlocks(newMessage);
 
     // Set the swipes counter for all non-user messages.
-    if (!params.isUser) {
+    if (!mes.is_user) {
         updateSwipeCounter(newMessageId, { messageElement: newMessage });
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -2454,7 +2454,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         //This keeps listeners intact.
         newMessage = chatElement.find(`[mesid="${newMessageId}"]`);
     } else {
-        newMessage = insert ? chatElement.find(`[mesid="${newMessageId}"]`) : messageTemplate.clone();
+        newMessage = messageTemplate.clone();
     }
 
     const { timerValue, timerTitle } = formatGenerationTimer(mes.gen_started, mes.gen_finished, mes.extra?.token_count, mes.extra?.reasoning_duration, mes.extra?.time_to_first_token);

--- a/public/script.js
+++ b/public/script.js
@@ -2120,10 +2120,6 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
             chatElement.scrollTop(scrollPosition);
             return;
         }
-        const newScrollPosition = chatElement.scrollTop();
-        if (newScrollPosition > scrollPosition) {
-            return;
-        }
         const newChatHeight = chatElement.prop('scrollHeight');
         const diff = newChatHeight - chatHeight;
         chatElement.scrollTop(scrollPosition + diff);

--- a/public/script.js
+++ b/public/script.js
@@ -2525,8 +2525,8 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         $(this).parent().html('<div class="missing-avatar fa-solid fa-user-slash"></div>');
     });
 
-    newMessage.find('.mes_text').html(messageText);
     appendMediaToMessage(mes, newMessage, scroll ? SCROLL_BEHAVIOR.ADJUST : SCROLL_BEHAVIOR.NONE);
+    newMessage.find('.mes_text').html(messageText);
 
     addCopyToCodeBlocks(newMessage);
 

--- a/public/script.js
+++ b/public/script.js
@@ -1855,9 +1855,9 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
  * the value in `extra.api`.
  *
  * @param {JQuery<HTMLElement>} mes - The message element containing the timestamp where the icon should be inserted or replaced.
- * @param {Object} extra - Contains the API and model details.
- * @param {string} extra.api - The name of the API, used to determine which SVG to fetch.
- * @param {string} extra.model - The model name, used to check for the substring "claude".
+ * @param {ChatMessageExtra} extra - Contains the API and model details.
+ * param {string} extra.api - The name of the API, used to determine which SVG to fetch.
+ * param {string} extra.model - The model name, used to check for the substring "claude".
  */
 function insertSVGIcon(mes, extra) {
     // Determine the SVG filename
@@ -1903,56 +1903,6 @@ function insertSVGIcon(mes, extra) {
 
     createModelImage('timestamp-icon', '.timestamp');
     createModelImage('thinking-icon', '.mes_reasoning_header_title', true);
-}
-
-
-function getMessageFromTemplate({
-    mesId,
-    swipeId,
-    characterName,
-    isUser,
-    avatarImg,
-    bias,
-    isSystem,
-    title,
-    timerValue,
-    timerTitle,
-    bookmarkLink,
-    forceAvatar,
-    timestamp,
-    tokenCount,
-    extra,
-    type,
-}) {
-    const mes = messageTemplate.clone();
-    mes.attr({
-        'mesid': mesId,
-        'swipeid': swipeId,
-        'ch_name': characterName,
-        'is_user': isUser,
-        'is_system': !!isSystem,
-        'bookmark_link': bookmarkLink,
-        'force_avatar': !!forceAvatar,
-        'timestamp': timestamp,
-        ...(type ? { type } : {}),
-    });
-    mes.find('.avatar img').attr('src', avatarImg);
-    mes.find('.ch_name .name_text').text(characterName);
-    mes.find('.mes_bias').html(bias);
-    mes.find('.timestamp').text(timestamp).attr('title', `${extra?.api ? extra.api + ' - ' : ''}${extra?.model ?? ''}`);
-    mes.find('.mesIDDisplay').text(`#${mesId}`);
-    tokenCount && mes.find('.tokenCounterDisplay').text(`${tokenCount}t`);
-    title && mes.attr('title', title);
-    timerValue && mes.find('.mes_timer').attr('title', timerTitle).text(timerValue);
-    bookmarkLink && updateBookmarkDisplay(mes);
-
-    updateReasoningUI(mes);
-
-    if (power_user.timestamp_model_icon && extra?.api) {
-        insertSVGIcon(mes, extra);
-    }
-
-    return mes;
 }
 
 /**
@@ -2459,7 +2409,6 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
 
     let avatarImg = getThumbnailUrl('persona', user_avatar);
     const isSystem = mes.is_system;
-    const title = mes.title;
 
     //for non-user messages
     if (!mes.is_user) {
@@ -2495,28 +2444,6 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         sanitizerOverrides,
         false,
     );
-    const bias = messageFormatting(mes.extra?.bias ?? '', '', false, false, -1, {}, false);
-    let bookmarkLink = mes?.extra?.bookmark_link ?? '';
-
-    let params = {
-        mesId: forceId ?? chat.length - 1,
-        swipeId: mes.swipe_id ?? 0,
-        characterName: mes.name,
-        isUser: mes.is_user,
-        avatarImg: avatarImg,
-        bias: bias,
-        isSystem: isSystem,
-        title: title,
-        bookmarkLink: bookmarkLink,
-        forceAvatar: mes.force_avatar,
-        timestamp: timestamp,
-        extra: mes.extra,
-        tokenCount: mes.extra?.token_count ?? 0,
-        type: mes.extra?.type ?? '',
-        ...formatGenerationTimer(mes.gen_started, mes.gen_finished, mes.extra?.token_count, mes.extra?.reasoning_duration, mes.extra?.time_to_first_token),
-    };
-
-    const renderedMessage = getMessageFromTemplate(params);
     let newMessage;
 
     if (type === 'swipe') {
@@ -2527,19 +2454,57 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         //This keeps listeners intact.
         newMessage = chatElement.find(`[mesid="${newMessageId}"]`);
     } else {
-        newMessage = insert ? chatElement.find(`[mesid="${newMessageId}"]`) : renderedMessage;
+        newMessage = insert ? chatElement.find(`[mesid="${newMessageId}"]`) : messageTemplate.clone();
     }
+
+    const { timerValue, timerTitle } = formatGenerationTimer(mes.gen_started, mes.gen_finished, mes.extra?.token_count, mes.extra?.reasoning_duration, mes.extra?.time_to_first_token);
+    const tokenCount = mes.extra?.token_count ?? 0;
+    const bookmarkLink = mes?.extra?.bookmark_link ?? '';
+
+    newMessage.attr({
+        'mesid': newMessageId,
+        'swipeid': mes.swipe_id ?? 0,
+        'ch_name': mes.name,
+        'is_user': mes.is_user,
+        'is_system': !!mes.is_system,
+        'bookmark_link': bookmarkLink,
+        'force_avatar': !!mes.force_avatar,
+        'timestamp': timestamp,
+        // ...(type ?? { type }),
+        'type': mes.extra?.type ?? '',
+    });
+
+    newMessage.find('.avatar img').attr('src', avatarImg);
+    newMessage.find('.ch_name .name_text').text(mes.name);
+    newMessage.find('.timestamp').text(timestamp).attr('title', `${mes.extra?.api ? mes.extra.api + ' - ' : ''}${mes.extra?.model ?? ''}`);
+    newMessage.find('.mesIDDisplay').text(`#${newMessageId}`);
+    tokenCount ?? newMessage.find('.tokenCounterDisplay').text(`${tokenCount}t`);
+    mes.title ?? newMessage.attr('title', mes.title);
+    timerValue ?? newMessage.find('.mes_timer').attr('title', timerTitle).text(timerValue);
+    bookmarkLink && updateBookmarkDisplay(newMessage);
+
+    if (typeof(mes.extra?.bias) === 'string') {
+        const bias = messageFormatting(mes.extra?.bias, '', false, false, -1, {}, false);
+        newMessage.find('.mes_bias').html(bias);
+    }
+
+    updateReasoningUI(newMessage);
+
+    if (power_user.timestamp_model_icon && mes.extra?.api) {
+        insertSVGIcon(newMessage, mes.extra);
+    }
+
 
     if (type !== 'swipe' && insert) {
         if (!insertAfter && !insertBefore) {
-            chatElement.append(renderedMessage);
+            chatElement.append(newMessage);
         }
         else if (insertAfter) {
             const target = chatElement.find(`.mes[mesid="${insertAfter}"]`);
-            $(renderedMessage).insertAfter(target);
+            $(newMessage).insertAfter(target);
         } else {
             const target = chatElement.find(`.mes[mesid="${insertBefore}"]`);
-            $(renderedMessage).insertBefore(target);
+            $(newMessage).insertBefore(target);
         }
     }
 
@@ -2554,7 +2519,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
     }
 
     //if we have itemized messages, and the array isn't null..
-    if (params.isUser === false && Array.isArray(itemizedPrompts) && itemizedPrompts.length > 0) {
+    if (mes.is_user === false && Array.isArray(itemizedPrompts) && itemizedPrompts.length > 0) {
         const itemizedPrompt = itemizedPrompts.find(x => Number(x.mesId) === Number(newMessageId));
         if (itemizedPrompt) {
             newMessage.find('.mes_prompt').show();


### PR DESCRIPTION
`getMessageFromTemplate` is an inconvenient function that requires more lines than it saves.
It cannot be used in any other function, therefore it should not exist.
This change also prevents an unnecessary call of `messageTemplate.clone` in `addOneMessage` when `type = 'swipe'`.

This PR is based on https://github.com/SillyTavern/SillyTavern/pull/4982, please review it first.
See https://github.com/SillyTavern/SillyTavern/pull/4947#issuecomment-3726566838 for context.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
