### PR TITLE
`refactor/perf-printMessages` #3: Extracted `updateMessageItemizedPromptButton` and `getMessageHTML` from `addOneMessage` to improve readability.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2375,6 +2375,43 @@ export function addCopyToCodeBlocks(messageElement) {
     }
 }
 
+/**
+ * Shows or hides the Prompt display button
+ * @param {ChatMessage} message
+ * @param {*} options
+ */
+function updateMessageItemizedPromptButton(message, { messageId = chat.indexOf(message), messageElement = chatElement.find(`.mes[mesid="${messageId}"]`) }) {
+
+    //if we have itemized messages, and the array isn't null..
+    if (!message.is_user && Array.isArray(itemizedPrompts) && itemizedPrompts.length > 0) {
+        const itemizedPrompt = itemizedPrompts.find(x => Number(x.mesId) === Number(messageId));
+        if (itemizedPrompt) {
+            messageElement.find('.mes_prompt').show();
+        }
+    }
+}
+
+/**
+ * Gets messageFormatting for a ChatMessage object.
+ * @param {ChatMessage} message
+ * @param {*} options
+ * @returns
+ */
+function getMessageTextHTML(message, { messageId = chat.indexOf(message) }) {
+
+    // if mes.extra.uses_system_ui is true, set an override on the sanitizer options
+    const sanitizerOverrides = message.extra?.uses_system_ui ? { MESSAGE_ALLOW_SYSTEM_UI: true } : {};
+
+    return messageFormatting(
+        message.extra.display_text ?? message.mes,
+        message.name,
+        message.is_system,
+        message.is_user,
+        messageId,
+        sanitizerOverrides,
+        false,
+    );
+}
 
 /**
  * Adds a single message to the chat.
@@ -2393,16 +2430,10 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
     // Callers push the new message to chat before calling addOneMessage
     const newMessageId = typeof forceId == 'number' ? forceId : chat.length - 1;
 
-    let messageText = mes.mes;
     const momentDate = timestampToMoment(mes.send_date);
     const timestamp = momentDate.isValid() ? momentDate.format('LL LT') : '';
 
-    if (mes?.extra?.display_text) {
-        messageText = mes.extra.display_text;
-    }
-
     let avatarImg = getThumbnailUrl('persona', user_avatar);
-    const isSystem = mes.is_system;
 
     //for non-user messages
     if (!mes.is_user) {
@@ -2426,18 +2457,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         avatarImg = mes.force_avatar;
     }
 
-    // if mes.extra.uses_system_ui is true, set an override on the sanitizer options
-    const sanitizerOverrides = mes.extra?.uses_system_ui ? { MESSAGE_ALLOW_SYSTEM_UI: true } : {};
-
-    messageText = messageFormatting(
-        messageText,
-        mes.name,
-        isSystem,
-        mes.is_user,
-        chat.indexOf(mes),
-        sanitizerOverrides,
-        false,
-    );
+    const messageHTML = getMessageTextHTML(mes, { newMessageId });
     let newMessage;
 
     if (type === 'swipe') {
@@ -2512,13 +2532,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         newMessage.addClass('toolCall');
     }
 
-    //if we have itemized messages, and the array isn't null..
-    if (!mes.is_user && Array.isArray(itemizedPrompts) && itemizedPrompts.length > 0) {
-        const itemizedPrompt = itemizedPrompts.find(x => Number(x.mesId) === Number(newMessageId));
-        if (itemizedPrompt) {
-            newMessage.find('.mes_prompt').show();
-        }
-    }
+    updateMessageItemizedPromptButton(mes, { messageId: newMessageId, newMessage });
 
     newMessage.find('.avatar img').on('error', function () {
         $(this).hide();
@@ -2526,8 +2540,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
     });
 
     appendMediaToMessage(mes, newMessage, scroll ? SCROLL_BEHAVIOR.ADJUST : SCROLL_BEHAVIOR.NONE);
-    newMessage.find('.mes_text').html(messageText);
-
+    newMessage.find('.mes_text').html(messageHTML);
     addCopyToCodeBlocks(newMessage);
 
     // Set the swipes counter for all non-user messages.

--- a/public/script.js
+++ b/public/script.js
@@ -1682,7 +1682,7 @@ export async function sendTextareaMessage() {
  * @param {boolean} isSystem If the message was sent by the system
  * @param {boolean} isUser If the message was sent by the user
  * @param {number} messageId Message index in chat array
- * @param {object} [sanitizerOverrides] DOMPurify sanitizer option overrides
+ * @param {Partial<DOMPurify.Config>} [sanitizerOverrides] DOMPurify sanitizer option overrides
  * @param {boolean} [isReasoning] If the message is reasoning output
  * @returns {string} HTML string
  */
@@ -1831,7 +1831,7 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         mes = mes.replace(new RegExp(`(^|\n)${escapeRegex(ch_name)}:`, 'g'), '$1');
     }
 
-    /** @type {import('dompurify').Config & { RETURN_DOM_FRAGMENT: false; RETURN_DOM: false }} */
+    /** @type {DOMPurify.Config} */
     const config = {
         RETURN_DOM: false,
         RETURN_DOM_FRAGMENT: false,
@@ -2377,11 +2377,13 @@ export function addCopyToCodeBlocks(messageElement) {
 
 /**
  * Shows or hides the Prompt display button
- * @param {ChatMessage} message
- * @param {*} options
+ * @param {ChatMessage} message Message object
+ * @param {object} options Options
+ * @param {number} [options.messageId] Message ID
+ * @param {JQuery<HTMLElement>} [options.messageElement] Message element
+ * @return {void}
  */
 function updateMessageItemizedPromptButton(message, { messageId = chat.indexOf(message), messageElement = chatElement.find(`.mes[mesid="${messageId}"]`) }) {
-
     //if we have itemized messages, and the array isn't null..
     if (!message.is_user && Array.isArray(itemizedPrompts) && itemizedPrompts.length > 0) {
         const itemizedPrompt = itemizedPrompts.find(x => Number(x.mesId) === Number(messageId));
@@ -2394,12 +2396,13 @@ function updateMessageItemizedPromptButton(message, { messageId = chat.indexOf(m
 /**
  * Gets messageFormatting for a ChatMessage object.
  * @param {ChatMessage} message
- * @param {*} options
- * @returns
+ * @param {object} options Options
+ * @param {number} [options.messageId] Message ID
+ * @returns {string} Formatted message HTML
  */
 function getMessageTextHTML(message, { messageId = chat.indexOf(message) }) {
-
     // if mes.extra.uses_system_ui is true, set an override on the sanitizer options
+    /** @type {Partial<DOMPurify.Config>} */
     const sanitizerOverrides = message.extra?.uses_system_ui ? { MESSAGE_ALLOW_SYSTEM_UI: true } : {};
 
     return messageFormatting(
@@ -2457,7 +2460,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         avatarImg = mes.force_avatar;
     }
 
-    const messageHTML = getMessageTextHTML(mes, { newMessageId });
+    const messageHTML = getMessageTextHTML(mes, { messageId: newMessageId });
     let newMessage;
 
     if (type === 'swipe') {
@@ -2532,7 +2535,7 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll
         newMessage.addClass('toolCall');
     }
 
-    updateMessageItemizedPromptButton(mes, { messageId: newMessageId, newMessage });
+    updateMessageItemizedPromptButton(mes, { messageId: newMessageId, messageElement: newMessage });
 
     newMessage.find('.avatar img').on('error', function () {
         $(this).hide();

--- a/public/script.js
+++ b/public/script.js
@@ -2430,12 +2430,19 @@ function getMessageTextHTML(message, { messageId = chat.indexOf(message) }) {
  * @returns {JQuery<HTMLElement>} The newly added message element
  */
 export function addOneMessage(mes, { type = 'normal', insertAfter = undefined, scroll = true, insertBefore = undefined, forceId = null, showSwipes = true, insert = true } = {}) {
-    let newMessageId = chat.length - 1;
+    let newMessageId;
     // Callers push the new message to chat before calling addOneMessage
 
     if (typeof(forceId) === 'number') newMessageId = forceId;
     else if (typeof(insertBefore) === 'number') newMessageId = insertBefore - 1;
     else if (typeof(insertAfter) === 'number') newMessageId = insertAfter + 1;
+    else {
+        const index = chat.indexOf(mes);
+        if (index !== -1) {
+            newMessageId = index;
+        }
+        else newMessageId = chat.length - 1;
+    }
 
     const momentDate = timestampToMoment(mes.send_date);
     const timestamp = momentDate.isValid() ? momentDate.format('LL LT') : '';

--- a/public/script.js
+++ b/public/script.js
@@ -2433,9 +2433,9 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = undefined, s
     let newMessageId = chat.length - 1;
     // Callers push the new message to chat before calling addOneMessage
 
-    if (typeof(forceId) == 'number') newMessageId = forceId;
-    else if (typeof(insertBefore) == 'number') newMessageId = insertBefore - 1;
-    else if (typeof(insertAfter) == 'number') newMessageId = insertAfter + 1;
+    if (typeof(forceId) === 'number') newMessageId = forceId;
+    else if (typeof(insertBefore) === 'number') newMessageId = insertBefore - 1;
+    else if (typeof(insertAfter) === 'number') newMessageId = insertAfter + 1;
 
     const momentDate = timestampToMoment(mes.send_date);
     const timestamp = momentDate.isValid() ? momentDate.format('LL LT') : '';
@@ -2514,7 +2514,6 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = undefined, s
     if (power_user.timestamp_model_icon && mes.extra?.api) {
         insertSVGIcon(newMessage, mes.extra);
     }
-
 
     if (type !== 'swipe' && insert) {
         if (!insertAfter && !insertBefore) {

--- a/public/script.js
+++ b/public/script.js
@@ -2406,7 +2406,7 @@ function getMessageTextHTML(message, { messageId = chat.indexOf(message) }) {
     const sanitizerOverrides = message.extra?.uses_system_ui ? { MESSAGE_ALLOW_SYSTEM_UI: true } : {};
 
     return messageFormatting(
-        message.extra.display_text ?? message.mes,
+        message.extra?.display_text ?? message.mes,
         message.name,
         message.is_system,
         message.is_user,
@@ -2421,17 +2421,21 @@ function getMessageTextHTML(message, { messageId = chat.indexOf(message) }) {
  * @param {ChatMessage} mes Message object
  * @param {object} [options] Options
  * @param {string} [options.type='normal'] Message type
- * @param {number} [options.insertAfter=null] Message ID to insert the new message after
+ * @param {number} [options.insertAfter=undefined] Message ID to insert the new message after
  * @param {boolean} [options.scroll=true] Whether to scroll to the new message
- * @param {number} [options.insertBefore=null] Message ID to insert the new message before
+ * @param {number} [options.insertBefore=undefined] Message ID to insert the new message before
  * @param {number} [options.forceId=null] Force the message ID
  * @param {boolean} [options.showSwipes=true] Whether to refresh the swipe buttons.
  * @param {boolean} [options.insert=true] Whether to insert the message into the DOM.
  * @returns {JQuery<HTMLElement>} The newly added message element
  */
-export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true, insertBefore = null, forceId = null, showSwipes = true, insert = true } = {}) {
+export function addOneMessage(mes, { type = 'normal', insertAfter = undefined, scroll = true, insertBefore = undefined, forceId = null, showSwipes = true, insert = true } = {}) {
+    let newMessageId = chat.length - 1;
     // Callers push the new message to chat before calling addOneMessage
-    const newMessageId = typeof forceId == 'number' ? forceId : chat.length - 1;
+
+    if (typeof(forceId) == 'number') newMessageId = forceId;
+    else if (typeof(insertBefore) == 'number') newMessageId = insertBefore - 1;
+    else if (typeof(insertAfter) == 'number') newMessageId = insertAfter + 1;
 
     const momentDate = timestampToMoment(mes.send_date);
     const timestamp = momentDate.isValid() ? momentDate.format('LL LT') : '';

--- a/public/script.js
+++ b/public/script.js
@@ -1394,16 +1394,18 @@ export async function showMoreMessages(messagesToLoad = null) {
     const showMoreButton = $('#show_more_messages');
     const isButtonInView = isElementInViewport(showMoreButton[0]);
 
-
     const firstId = clamp(messageId - count, 0, Infinity);
-    let messageElements = [];
-    chat.slice(firstId, messageId).forEach((message,id)=>{
+    const messageElements = [];
+    chat.slice(firstId, messageId).forEach((message, id) => {
         messageElements.push(addOneMessage(message, { scroll: false, forceId: firstId + id, showSwipes: false, insert: false }));
     });
     // This could be faster: https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentElement
     // Fallback to chatElement if the button isn't where it's expected to be.
-    if (showMoreButton[0]) showMoreButton.after(messageElements);
-    else chatElement.prepend(messageElements);
+    if (showMoreButton[0]) {
+        showMoreButton.after(messageElements);
+    } else {
+        chatElement.prepend(messageElements);
+    }
 
     refreshSwipeButtons();
 
@@ -1454,7 +1456,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     const messages = targetChat.slice(startIndex);
 
     if (messages.length > 0) {
-        const newMessageElements = messages.map( (message, offset) => {
+        const newMessageElements = messages.map((message, offset) => {
             const i = startIndex + offset;
             const messageElement = addOneMessage(message, { scroll: false, forceId: i, showSwipes: false, insert: false });
 
@@ -1467,7 +1469,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
         //Append to chat in one DOM update.
         chatElement.append(newMessageElements);
 
-        applyCharacterTagsToMessageDivs({ mesIds: lodash.range(startIndex, targetChat.length,  1) });
+        applyCharacterTagsToMessageDivs({ mesIds: lodash.range(startIndex, targetChat.length, 1) });
     }
 
     refreshSwipeButtons(false, fade);
@@ -2439,9 +2441,9 @@ export function addOneMessage(mes, { type = 'normal', insertAfter = undefined, s
     let newMessageId;
     // Callers push the new message to chat before calling addOneMessage
 
-    if (typeof(forceId) === 'number') newMessageId = forceId;
-    else if (typeof(insertBefore) === 'number') newMessageId = insertBefore - 1;
-    else if (typeof(insertAfter) === 'number') newMessageId = insertAfter + 1;
+    if (typeof (forceId) === 'number') newMessageId = forceId;
+    else if (typeof (insertBefore) === 'number') newMessageId = insertBefore - 1;
+    else if (typeof (insertAfter) === 'number') newMessageId = insertAfter + 1;
     else {
         const index = chat.indexOf(mes);
         if (index !== -1) {

--- a/public/script.js
+++ b/public/script.js
@@ -2429,28 +2429,32 @@ function getMessageTextHTML(message, { messageId = chat.indexOf(message) }) {
  * @param {ChatMessage} mes Message object
  * @param {object} [options] Options
  * @param {string} [options.type='normal'] Message type
- * @param {number} [options.insertAfter=undefined] Message ID to insert the new message after
+ * @param {number} [options.insertAfter=null] Message ID to insert the new message after
  * @param {boolean} [options.scroll=true] Whether to scroll to the new message
- * @param {number} [options.insertBefore=undefined] Message ID to insert the new message before
+ * @param {number} [options.insertBefore=null] Message ID to insert the new message before
  * @param {number} [options.forceId=null] Force the message ID
  * @param {boolean} [options.showSwipes=true] Whether to refresh the swipe buttons.
  * @param {boolean} [options.insert=true] Whether to insert the message into the DOM.
  * @returns {JQuery<HTMLElement>} The newly added message element
  */
-export function addOneMessage(mes, { type = 'normal', insertAfter = undefined, scroll = true, insertBefore = undefined, forceId = null, showSwipes = true, insert = true } = {}) {
-    let newMessageId;
+export function addOneMessage(mes, { type = 'normal', insertAfter = null, scroll = true, insertBefore = null, forceId = null, showSwipes = true, insert = true } = {}) {
     // Callers push the new message to chat before calling addOneMessage
-
-    if (typeof (forceId) === 'number') newMessageId = forceId;
-    else if (typeof (insertBefore) === 'number') newMessageId = insertBefore - 1;
-    else if (typeof (insertAfter) === 'number') newMessageId = insertAfter + 1;
-    else {
+    const newMessageId = (() => {
+        if (typeof forceId === 'number') {
+            return forceId;
+        }
+        if (typeof insertBefore === 'number') {
+            return insertBefore - 1;
+        }
+        if (typeof insertAfter === 'number') {
+            return insertAfter + 1;
+        }
         const index = chat.indexOf(mes);
         if (index !== -1) {
-            newMessageId = index;
+            return index;
         }
-        else newMessageId = chat.length - 1;
-    }
+        return chat.length - 1;
+    })();
 
     const momentDate = timestampToMoment(mes.send_date);
     const timestamp = momentDate.isValid() ? momentDate.format('LL LT') : '';

--- a/public/script.js
+++ b/public/script.js
@@ -1391,18 +1391,24 @@ export async function showMoreMessages(messagesToLoad = null) {
 
     console.debug('Inserting messages before', messageId, 'count', count, 'chat length', chat.length);
     const prevHeight = chatElement.prop('scrollHeight');
-    const isButtonInView = isElementInViewport($('#show_more_messages')[0]);
+    const showMoreButton = $('#show_more_messages');
+    const isButtonInView = isElementInViewport(showMoreButton[0]);
 
-    while (messageId > 0 && count > 0) {
-        let newMessageId = messageId - 1;
-        addOneMessage(chat[newMessageId], { insertBefore: messageId >= chat.length ? null : messageId, scroll: false, forceId: newMessageId, showSwipes: false });
-        count--;
-        messageId--;
-    }
+
+    const firstId = clamp(messageId - count, 0, Infinity);
+    let messageElements = [];
+    chat.slice(firstId, messageId).forEach((message,id)=>{
+        messageElements.push(addOneMessage(message, { scroll: false, forceId: firstId + id, showSwipes: false, insert: false }));
+    });
+    // This could be faster: https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentElement
+    // Fallback to chatElement if the button isn't where it's expected to be.
+    if (showMoreButton[0]) showMoreButton.after(messageElements);
+    else chatElement.prepend(messageElements);
+
     refreshSwipeButtons();
 
-    if (messageId == 0) {
-        $('#show_more_messages').remove();
+    if (firstId === 0) {
+        showMoreButton.remove();
     }
 
     if (isButtonInView) {

--- a/public/script.js
+++ b/public/script.js
@@ -2406,7 +2406,7 @@ function getMessageTextHTML(message, { messageId = chat.indexOf(message) }) {
     const sanitizerOverrides = message.extra?.uses_system_ui ? { MESSAGE_ALLOW_SYSTEM_UI: true } : {};
 
     return messageFormatting(
-        message.extra?.display_text ?? message.mes,
+        message.extra?.display_text || message.mes,
         message.name,
         message.is_system,
         message.is_user,

--- a/public/script.js
+++ b/public/script.js
@@ -11683,14 +11683,16 @@ jQuery(async function () {
         const oldScroll = chatElement[0].scrollTop;
         const clone = structuredClone(chat[this_edit_mes_id]);
         clone.send_date = Date.now();
-        clone.mes = $(this).closest('.mes').find('.edit_textarea').val().toString();
+        const this_edit_mes_element = $(this).closest('.mes');
+        clone.mes = this_edit_mes_element.find('.edit_textarea').val().toString();
 
         if (power_user.trim_spaces) {
             clone.mes = clone.mes.trim();
         }
 
         chat.splice(Number(this_edit_mes_id) + 1, 0, clone);
-        addOneMessage(clone, { insertAfter: this_edit_mes_id });
+        const newMessageElement = addOneMessage(clone, { insert: false });
+        this_edit_mes_element.after(newMessageElement);
 
         updateViewMessageIds();
         await saveChatConditional();

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -685,7 +685,7 @@ export function formatCreatorNotes(text, avatarId) {
     const preference = new StylesPreference(avatarId);
     const sanitizeStyles = !preference.get();
     const decodeStyleParam = { prefix: sanitizeStyles ? '#creator_notes_spoiler ' : '' };
-    /** @type {import('dompurify').Config} */
+    /** @type {DOMPurify.Config} */
     const config = {
         RETURN_DOM: false,
         RETURN_DOM_FRAGMENT: false,

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -4642,7 +4642,8 @@ async function messageRoleCallback(args, role) {
     await eventSource.emit(event_types.MESSAGE_EDITED, modifyAt);
     const existingMessage = chatElement.find(`.mes[mesid="${modifyAt}"]`);
     if (existingMessage.length) {
-        addOneMessage(message, { forceId: modifyAt, insertAfter: modifyAt, scroll: false });
+        const newMessageElement = addOneMessage(message, { forceId: modifyAt, insert: false, scroll: false });
+        existingMessage.after(newMessageElement);
         existingMessage.remove();
     }
     await eventSource.emit(event_types.MESSAGE_UPDATED, modifyAt);
@@ -4707,7 +4708,8 @@ async function messageNameCallback(args, name) {
     await eventSource.emit(event_types.MESSAGE_EDITED, modifyAt);
     const existingMessage = chatElement.find(`.mes[mesid="${modifyAt}"]`);
     if (existingMessage.length) {
-        addOneMessage(message, { forceId: modifyAt, insertAfter: modifyAt, scroll: false });
+        const newMessageElement = addOneMessage(message, { forceId: modifyAt, insert: false, scroll: false });
+        existingMessage.after(newMessageElement);
         existingMessage.remove();
     }
     await eventSource.emit(event_types.MESSAGE_UPDATED, modifyAt);


### PR DESCRIPTION
I extracted `updateMessageItemizedPromptButton` and `getMessageHTML` from `addOneMessage` to improve readability.

This PR is based on #4983, please review it first.
See https://github.com/SillyTavern/SillyTavern/pull/4947#issuecomment-3726566838 for context.

## Checklist:
- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
