### PR TITLE
Macros 2.0 [Fix] - Fix `{{pick}}` macro seeding inside delayed-resolution macros like `{{if}}`

### DIFF
--- a/public/scripts/macros/engine/MacroEngine.js
+++ b/public/scripts/macros/engine/MacroEngine.js
@@ -108,9 +108,13 @@ class MacroEngine {
      *
      * @param {string} input - The input string to evaluate.
      * @param {MacroEnv} env - The environment to pass to the macro handler.
+     * @param {Object} [options={}] - Optional evaluation settings.
+     * @param {number} [options.contextOffset=0] - Base offset from the original top-level document.
+     *        Used when evaluating nested content (via resolve() in handlers) to preserve global
+     *        positioning for macros like {{pick}} that seed on position.
      * @returns {string} The resolved string.
      */
-    evaluate(input, env) {
+    evaluate(input, env, { contextOffset = 0 } = {}) {
         if (!input) {
             return '';
         }
@@ -138,7 +142,7 @@ class MacroEngine {
         try {
             evaluated = MacroCstWalker.evaluateDocument({
                 text: preProcessed,
-                contextOffset: 0,
+                contextOffset,
                 cst,
                 env: safeEnv,
                 resolveMacro: this.#resolveMacro.bind(this),


### PR DESCRIPTION
Continuation of #4977.
Based on the OpenAI Codex feedback [here](https://github.com/SillyTavern/SillyTavern/pull/4977#discussion_r2674535387).

### Summary

Fixes a bug where deterministic macros like `{{pick}}` would produce identical results when nested inside other macros with `delayArgResolution` (e.g., `{{if}}` blocks).

### The Problem

The macro engine uses global document offsets to seed deterministic macros like `{{pick}}`, ensuring that identical macros at different positions can produce different results. However, when these macros were nested inside handlers that use `delayArgResolution` (like `{{if}}`), the [resolve()](cci:1://file:///d:/code/SillyTavern/public/scripts/macros/engine/MacroRegistry.js:374:12-374:67) function would reset the offset to 0, causing all nested `{{pick}}` macros to use the same seed and produce identical results.

Example of the bug:
```javascript
// Both picks would return the same value
{{if true}}{{pick::A::B::C}}{{/if}}...{{if true}}{{pick::A::B::C}}{{/if}}
```

### The Solution

1. **Enhanced [MacroEngine.evaluate()](cci:1://file:///d:/code/SillyTavern/public/scripts/macros/engine/MacroEngine.js:105:4-158:5)** to accept an optional `contextOffset` parameter that preserves the original document position when evaluating nested content.

2. **Updated the [resolve()](cci:1://file:///d:/code/SillyTavern/public/scripts/macros/engine/MacroRegistry.js:374:12-374:67) function** in macro execution context to automatically pass the caller's `globalOffset` as the `contextOffset`. This ensures that any macros resolved via [resolve()](cci:1://file:///d:/code/SillyTavern/public/scripts/macros/engine/MacroRegistry.js:374:12-374:67) maintain their correct position in the original document.

3. **Added optional `offsetDelta` parameter** to [resolve()](cci:1://file:///d:/code/SillyTavern/public/scripts/macros/engine/MacroRegistry.js:374:12-374:67) for handlers that need to add additional uniqueness between multiple resolve calls.

The fix is transparent to existing macro handlers - any handler using [resolve()](cci:1://file:///d:/code/SillyTavern/public/scripts/macros/engine/MacroRegistry.js:374:12-374:67) now automatically gets the correct offset behavior. The `{{if}}` handler specifically benefits from this without requiring any code changes.

### Testing

Added comprehensive tests for `{{pick}}` macros inside `{{if}}` blocks to verify:
- Different seeds are generated for identical picks at different positions
- Deterministic behavior is maintained across multiple evaluations
- The fix works for both scoped and inline argument syntax

## Copilot Summary
This pull request improves how macro evaluation handles context offsets to ensure deterministic and unique behavior for position-based macros, especially when macros are nested or invoked through `resolve()`. It also updates the API for macro resolution and adds new end-to-end tests to verify correct seeding and stability.

**Macro engine context handling improvements:**

* The `evaluate` method in `MacroEngine` now accepts an `options` parameter with a `contextOffset`, allowing nested macro evaluations to preserve the correct global position. This ensures that macros like `{{pick}}` behave deterministically based on their position, even when evaluated inside other macros. [[1]](diffhunk://#diff-3a92ff2db12b05f99bec8f28978d514e0389505e770cacbd85764adefcf6aba1R111-R117) [[2]](diffhunk://#diff-3a92ff2db12b05f99bec8f28978d514e0389505e770cacbd85764adefcf6aba1L141-R145)
* The `resolve` function in the macro execution context now passes the caller's `globalOffset` (plus an optional `offsetDelta`) to `evaluate`, preserving unique and deterministic seeding for nested macros.

**Macro API and documentation updates:**

* The `MacroValueType` documentation and type signature for `resolve` are updated to reflect the new `options` parameter and explain its effect on position-based seeding.

**Testing and regression coverage:**

* Adds new end-to-end tests to verify that identical macros inside different blocks use different seeds (i.e., are positionally unique), and that deterministic output is maintained for macros like `{{pick}}` across repeated evaluations.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).