### PR TITLE
Fix: init macros before extensions

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7754,6 +7754,7 @@ export async function getSettings() {
         selected_button = settings.selected_button;
 
         // TODO: Move me into firstLoadInit when experimental toggle is removed
+        // power_user.experimental_macro_engine
         initMacros();
 
         if (data.enable_extensions) {

--- a/public/script.js
+++ b/public/script.js
@@ -702,7 +702,6 @@ async function firstLoadInit() {
     initDynamicStyles();
     initTags();
     initBookmarks();
-    initMacros();
     await getUserAvatars(true, user_avatar);
     await getCharacters();
     await getBackgrounds();
@@ -7753,6 +7752,9 @@ export async function getSettings() {
         setWorldInfoSettings(settings.world_info_settings ?? settings, data);
 
         selected_button = settings.selected_button;
+
+        // TODO: Move me into firstLoadInit when experimental toggle is removed
+        initMacros();
 
         if (data.enable_extensions) {
             const enableAutoUpdate = Boolean(data.enable_extensions_auto_update);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Register macros before initializing extensions. Why in `getSettings`, you may ask? That's cause `initMacros` depends on `power_user` that should be initialized, but getSettings also activates extensions, so that was the only fitting place where it could work. That TODO certainly has to become WASDONE one day...

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
