### PR TITLE
prevent invalid name error

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9514,6 +9514,14 @@ export async function createOrEditCharacter(e) {
             toastr.error(t`Failed to create character`);
         }
     } else {
+        // Guard clause: Ensure we're in a valid edit state before proceeding
+        // This prevents spurious saves when the form is in an indeterminate state (e.g., on fresh page loads)
+        const actiontype = $('#form_create').attr('actiontype');
+        if (actiontype !== 'editcharacter' || this_chid === undefined || !formData.get('ch_name')) {
+            console.debug('Skipping character edit: form is not in a valid edit state', { actiontype, this_chid, ch_name: formData.get('ch_name') });
+            return;
+        }
+
         try {
             let url = '/api/characters/edit';
 


### PR DESCRIPTION
Every time I open SillyTavern on a new tab, I get this notification:

> Something went wrong while saving the character, or the image file provided was in an invalid format. Double check that the image is not a webp.

and the following error in the log: `Error: invalid name.`

I then tried cloning sillytavern in a completely different place and not touching anything (default all, no characters) and I still get the error. So I tried asking Opus 4.5 about it, and it came up with this solution that seems to work. I don't know how I'm the only one with this error, maybe because I'm using Zen Browser?


## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
