### PR TITLE
Enhance world duplication to use current world name as base

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2531,7 +2531,12 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
     });
 
     $('#world_duplicate').off('click').on('click', async () => {
-        const tempName = getFreeWorldName();
+        // Find current name for the world selected
+        const selectedIndex = String($('#world_editor_select').find(':selected').val());
+        const worldName = world_names[selectedIndex] || null;
+
+        // Use the current name as default input, then ask user for the name
+        const tempName = getFreeWorldName(worldName);
         const finalName = await Popup.show.input('Create a new World Info?', 'Enter a name for the new file:', tempName);
 
         if (finalName) {
@@ -4180,10 +4185,25 @@ export function getFreeWorldEntryUid(data) {
     return null;
 }
 
-export function getFreeWorldName() {
+
+/**
+ * Generates a free world name based on the given input name.
+ * If the input name is null, a default name is used.
+ * If the input name already exists, a numbered suffix is added.
+ *
+ * @param {string|null} worldName - The name to base the new world name on. If null, a default name is used.
+ * @param {Object} [options={}] - Optional parameters.
+ * @param {boolean} [options.stripIndex=true] - Whether to strip any numbered suffix from the input name before generating the new name.
+ * @return {string|undefined} The generated free world name, or undefined if no free name could be found after trying 100,000 times.
+ */
+export function getFreeWorldName(worldName = null, { stripIndex = true } = {}) {
+    worldName ??= t`New World`;
+    if (stripIndex) {
+        worldName = worldName.replace(/\s*\(\d+\)$/, '');
+    }
     const MAX_FREE_NAME = 100_000;
     for (let index = 1; index < MAX_FREE_NAME; index++) {
-        const newName = `New World (${index})`;
+        const newName = `${worldName} (${index})`;
         if (world_names.includes(newName)) {
             continue;
         }


### PR DESCRIPTION
Based on a suggestion from Misaki on Discord.

Simple change to use the world name of the world you are duplicating, instead of defaulting to "New World (1)".

### Changes
- Copy world name on duplicate as the default suggestion
- JSDocs for `getFreeWorldName`
- Strip by default any index suffix (e.g. " (2)") from the world name, before finding free name

## Copilot Summary
This pull request enhances the logic for generating new world names when duplicating a world entry, making the process more intuitive and user-friendly. The changes ensure that the duplicated world's name is based on the currently selected world, with improved handling to avoid name collisions and unnecessary suffixes.

**Improvements to world name generation:**

* The `getFreeWorldName` function now accepts an optional base name and strips any existing numbered suffix before generating a new unique name. This results in cleaner and more predictable names when duplicating worlds.
* When duplicating a world entry, the current world's name is used as the default for the new entry, making the duplication process more intuitive for users.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).