### PR TITLE
Fix: don't call append media twice on swipe

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2138,6 +2138,9 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
         }
         const newChatHeight = chatElement.prop('scrollHeight');
         const diff = newChatHeight - chatHeight;
+        if (Math.abs(diff) < 1) {
+            return;
+        }
         chatElement.scrollTop(scrollPosition + diff);
     };
 
@@ -10018,7 +10021,9 @@ export async function swipe(event, direction, { source, repeated, message = chat
         thisMesDiv.css('height', thisMesDivHeight);
         expandNewMessage(thisMesDiv);
 
-        appendMediaToMessage(chat[mesId], thisMesDiv);
+        if (run_generate) {
+            appendMediaToMessage(chat[mesId], thisMesDiv);
+        }
 
         await eventSource.emit(event_types.MESSAGE_SWIPED, (mesId));
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Something I've noticed while testing #4981:

1. `appendMediaToMessage` is called twice on regular swipes. As far as I understand, it's needed to clear-out the media from the last swipe when swiping right to generate, otherwise it will be handled by `addOneMessage`, so this call is redundant in all cases but when `run_generate`.
2. Sometimes the scroll position after attaching media was not correctly adjusted when there's no difference between old and new chat scroll height. So we'd just skip scroll adjust when the difference is less than one pixel.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
