### PR TITLE
Show a page reload prompt on EME toggle

### DIFF
--- a/public/scripts/macros/engine/MacroDiagnostics.js
+++ b/public/scripts/macros/engine/MacroDiagnostics.js
@@ -61,8 +61,7 @@ async function onboardingExperimentalMacroEngineUnsafe(feature = null) {
         <p>${t`Would you like to enable it now?`}</p>`);
     if (result == POPUP_RESULT.AFFIRMATIVE) {
         power_user.experimental_macro_engine = true;
-        $('#experimental_macro_engine').prop('checked', power_user.experimental_macro_engine);
-        saveSettingsDebounced();
+        $('#experimental_macro_engine').prop('checked', power_user.experimental_macro_engine).trigger('input');
     }
 
     // Only show this once

--- a/public/scripts/macros/engine/MacroDiagnostics.js
+++ b/public/scripts/macros/engine/MacroDiagnostics.js
@@ -3,7 +3,6 @@
 /** @typedef {import('chevrotain').ILexingError} ILexingError */
 /** @typedef {import('chevrotain').IRecognitionException} IRecognitionException */
 
-import { saveSettingsDebounced } from '/script.js';
 import { t } from '/scripts/i18n.js';
 import { Popup, POPUP_RESULT } from '/scripts/popup.js';
 import { power_user } from '/scripts/power-user.js';

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -4015,6 +4015,18 @@ jQuery(() => {
     $('#experimental_macro_engine').on('input', function () {
         power_user.experimental_macro_engine = !!$(this).prop('checked');
         saveSettingsDebounced();
+
+        eventSource.once(event_types.SETTINGS_UPDATED, function() {
+            toastr.info(
+                t`Click here to reload.`,
+                t`Toggling the Experimental Macro Engine requires a reload.`,
+                {
+                    onclick: () => window.location.reload(),
+                    timeOut: 10000,
+                    preventDuplicates: true,
+                },
+            );
+        });
     });
 
     $('#disable_group_trimming').on('input', function () {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -4017,7 +4017,7 @@ jQuery(() => {
         saveSettingsDebounced();
 
         eventSource.once(event_types.SETTINGS_UPDATED, function() {
-            toastr.info(
+            toastr.warning(
                 t`Click here to reload.`,
                 t`Toggling the Experimental Macro Engine requires a reload.`,
                 {


### PR DESCRIPTION
Closes #4992

Displays a toast when toggling Macros 2.0 via auto-suggest or user settings menu. Clicking the toast will reload the page.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
