### PR TITLE
Adjust itemized prompts on message move/delete

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -272,7 +272,7 @@ import { extractReasoningFromData, extractReasoningSignatureFromData, initReason
 import { accountStorage } from './scripts/util/AccountStorage.js';
 import { initWelcomeScreen, openPermanentAssistantChat, openPermanentAssistantCard, getPermanentAssistantAvatar } from './scripts/welcome-screen.js';
 import { initDataMaid } from './scripts/data-maid.js';
-import { clearItemizedPrompts, deleteItemizedPrompts, findItemizedPromptSet, initItemizedPrompts, itemizedParams, itemizedPrompts, loadItemizedPrompts, promptItemize, replaceItemizedPromptText, saveItemizedPrompts } from './scripts/itemized-prompts.js';
+import { clearItemizedPrompts, deleteItemizedPromptForMessage, deleteItemizedPrompts, findItemizedPromptSet, initItemizedPrompts, itemizedParams, itemizedPrompts, loadItemizedPrompts, promptItemize, replaceItemizedPromptText, saveItemizedPrompts, swapItemizedPrompts } from './scripts/itemized-prompts.js';
 import { getSystemMessageByType, initSystemMessages, SAFETY_CHAT, sendSystemMessage, system_message_types, system_messages } from './scripts/system-messages.js';
 import { event_types, eventSource } from './scripts/events.js';
 import { initAccessibility } from './scripts/a11y.js';
@@ -1601,6 +1601,7 @@ export async function deleteMessage(id, swipeDeletionIndex = undefined, askConfi
     chat_metadata.tainted = true;
 
     const startIndex = [0, minId].includes(id) ? id : null;
+    deleteItemizedPromptForMessage(id);
     updateViewMessageIds(startIndex);
     saveChatDebounced();
 
@@ -8142,6 +8143,7 @@ async function messageEditMove(sourceId, targetId) {
         this_edit_mes_id = targetId;
     }
 
+    swapItemizedPrompts(sourceId, targetId);
     updateViewMessageIds();
     refreshSwipeButtons();
     await saveChatConditional();
@@ -11450,6 +11452,9 @@ jQuery(async function () {
         });
 
         if (this_del_mes >= 0) {
+            for (let i = (chat.length - 1); i >= this_del_mes; i--) {
+                deleteItemizedPromptForMessage(i);
+            }
             chatElement.find(`.mes[mesid="${this_del_mes}"]`).nextAll('div').remove();
             chatElement.find(`.mes[mesid="${this_del_mes}"]`).remove();
             chat.length = this_del_mes;

--- a/public/script.js
+++ b/public/script.js
@@ -1546,6 +1546,7 @@ export async function clearChat() {
 }
 
 export async function deleteLastMessage() {
+    deleteItemizedPromptForMessage(chat.length - 1);
     chat.length = chat.length - 1;
     chatElement.children('.mes').last().remove();
     await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
@@ -4231,6 +4232,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             //do nothing? why does this check exist?
         }
         else if (type !== 'quiet' && type !== 'swipe' && !isImpersonate && !dryRun && chat.length) {
+            deleteItemizedPromptForMessage(chat.length - 1);
             chat.length = chat.length - 1;
             await removeLastMessage();
             await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);

--- a/public/scripts/itemized-prompts.js
+++ b/public/scripts/itemized-prompts.js
@@ -222,6 +222,7 @@ export async function itemizedParams(itemizedPrompts, thisPromptSet, incomingMes
 
 export function findItemizedPromptSet(itemizedPrompts, incomingMesId) {
     let thisPromptSet = undefined;
+    priorPromptArrayItemForRawPromptDisplay = -1;
 
     for (let i = 0; i < itemizedPrompts.length; i++) {
         console.log(`looking for ${incomingMesId} vs ${itemizedPrompts[i].mesId}`);
@@ -262,7 +263,7 @@ export async function promptItemize(itemizedPrompts, requestedMesId) {
 
     /** @type {HTMLElement} */
     const diffPrevPrompt = popup.dlg.querySelector('#diffPrevPrompt');
-    if (priorPromptArrayItemForRawPromptDisplay) {
+    if (priorPromptArrayItemForRawPromptDisplay >= 0) {
         diffPrevPrompt.style.display = '';
         diffPrevPrompt.addEventListener('click', function () {
             const dmp = new DiffMatchPatch();
@@ -371,6 +372,8 @@ export function swapItemizedPrompts(sourceMessageId, targetMessageId) {
     targetPrompts.forEach(prompt => {
         prompt.mesId = sourceMessageId;
     });
+
+    itemizedPrompts.sort((a, b) => a.mesId - b.mesId);
 }
 
 /**

--- a/public/scripts/itemized-prompts.js
+++ b/public/scripts/itemized-prompts.js
@@ -350,3 +350,42 @@ export function initItemizedPrompts() {
         await deleteItemizedPrompts(name);
     });
 }
+
+/**
+ * Swaps the itemized prompts between two messages. Useful when moving messages around in the chat.
+ * @param {number} sourceMessageId Source message ID
+ * @param {number} targetMessageId Target message ID
+ */
+export function swapItemizedPrompts(sourceMessageId, targetMessageId) {
+    if (!Array.isArray(itemizedPrompts)) {
+        return;
+    }
+
+    const sourcePrompts = itemizedPrompts.filter(x => x.mesId === sourceMessageId);
+    const targetPrompts = itemizedPrompts.filter(x => x.mesId === targetMessageId);
+
+    sourcePrompts.forEach(prompt => {
+        prompt.mesId = targetMessageId;
+    });
+
+    targetPrompts.forEach(prompt => {
+        prompt.mesId = sourceMessageId;
+    });
+}
+
+/**
+ * Deletes the itemized prompt for a specific message.
+ * Shifts down other itemized prompts as necessary.
+ * @param {number} messageId Message ID to delete itemized prompt for
+ */
+export function deleteItemizedPromptForMessage(messageId) {
+    if (!Array.isArray(itemizedPrompts)) {
+        return;
+    }
+
+    itemizedPrompts = itemizedPrompts.filter(x => x.mesId !== messageId);
+
+    for (const prompt of itemizedPrompts.filter(x => x.mesId > messageId)) {
+        prompt.mesId -= 1;
+    }
+}


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Move itemized prompts when moving messages in chat.
2. Delete and shift itemized prompt message ids when deleting chat messages.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
