### PR TITLE
Add taxon filter controls to Group Chat member list

### DIFF
--- a/public/css/tags.css
+++ b/public/css/tags.css
@@ -67,6 +67,10 @@
     display: none;
 }
 
+.tag.tag-absent {
+    text-decoration: line-through;
+}
+
 .tag.actionable {
     border-radius: 50%;
     aspect-ratio: 1 / 1;

--- a/public/index.html
+++ b/public/index.html
@@ -6126,6 +6126,12 @@
                             </div>
                             <div class="inline-drawer-content">
                                 <div id="currentGroupMembers" name="Current Group Members" class="flex-container flexFlowColumn overflowYAuto flex1">
+                                    <div id="rm_group_members_header">
+                                        <input id="rm_group_members_filter" class="text_pole margin0" type="search" data-i18n="[placeholder]Search..." placeholder="Search..." />
+                                    </div>
+                                    <div class="rm_tag_controls">
+                                        <div class="tags rm_tag_filter"></div>
+                                    </div>
                                     <div id="rm_group_members_pagination" class="rm_group_members_pagination group_pagination"></div>
                                     <div id="rm_group_members" class="rm_group_members overflowYAuto flex-container" group_empty_text="Group is empty." data-i18n="[group_empty_text]Group is empty."></div>
                                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -6143,7 +6143,7 @@
                                 <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                             </div>
                             <div class="inline-drawer-content">
-                                <div name="Unadded Char List" class="flex-container flexFlowColumn overflowYAuto flex1">
+                                <div id="unaddedCharList" name="Unadded Char List" class="flex-container flexFlowColumn overflowYAuto flex1">
                                     <div id="rm_group_add_members_header">
                                         <input id="rm_group_filter" class="text_pole margin0" type="search" data-i18n="[placeholder]Search..." placeholder="Search..." />
                                     </div>

--- a/public/script.js
+++ b/public/script.js
@@ -953,7 +953,8 @@ export async function printCharacters(fullRefresh = false) {
 
     // We are actually always reprinting filters, as it "doesn't hurt", and this way they are always up to date
     printTagFilters(tag_filter_type.character);
-    printTagFilters(tag_filter_type.group_member);
+    printTagFilters(tag_filter_type.group_members_list);
+    printTagFilters(tag_filter_type.group_candidates_list);
 
     // We are also always reprinting the lists on character/group edit window, as these ones doesn't get updated otherwise
     applyTagsOnCharacterSelect();

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -134,6 +134,7 @@ export const group_generation_mode = {
 export const DEFAULT_AUTO_MODE_DELAY = 5;
 
 export const groupCandidatesFilter = new FilterHelper(debounce(printGroupCandidates, debounce_timeout.quick));
+export const groupMembersFilter = new FilterHelper(debounce(printGroupMembers, debounce_timeout.quick));
 let autoModeWorker = null;
 const saveGroupDebounced = debounce(async (group, reload) => await _save(group, reload), debounce_timeout.relaxed);
 /** @type {Map<string, number>} */
@@ -1574,13 +1575,20 @@ function getGroupCharacters({ doFilter = false, onlyMembers = false } = {}) {
     }
 
     if (onlyMembers) {
+        if (doFilter) {
+            candidates = groupMembersFilter.applyFilters(candidates);
+        }
         candidates.sort(sortMembersFn);
+        const useFilterOrder = doFilter && !!$('#rm_group_members_filter').val();
+        if (useFilterOrder) {
+            sortEntitiesList(candidates, useFilterOrder, groupMembersFilter);
+        }
+        groupMembersFilter.clearFuzzySearchCaches();
     } else {
         const useFilterOrder = doFilter && !!$('#rm_group_filter').val();
         sortEntitiesList(candidates, useFilterOrder, groupCandidatesFilter);
+        groupCandidatesFilter.clearFuzzySearchCaches();
     }
-
-    groupCandidatesFilter.clearFuzzySearchCaches();
     return candidates;
 }
 
@@ -1621,7 +1629,7 @@ function printGroupMembers() {
         const pageSize = Number(accountStorage.getItem(storageKey)) || 5;
         const sizeChangerOptions = [5, 10, 25, 50, 100, 200, 500, 1000];
         $(this).pagination({
-            dataSource: getGroupCharacters({ doFilter: false, onlyMembers: true }),
+            dataSource: getGroupCharacters({ doFilter: true, onlyMembers: true }),
             pageRange: 1,
             position: 'top',
             showPageNumbers: false,
@@ -1782,6 +1790,7 @@ function select_group_chats(groupId, skipAnimation) {
     $('#group_avatar_preview').empty().append(getGroupAvatar(group));
     $('#rm_group_restore_avatar').toggle(!!group && isValidImageUrl(group.avatar_url));
     $('#rm_group_filter').val('').trigger('input');
+    $('#rm_group_members_filter').val('').trigger('input');
     $('#rm_group_activation_strategy').val(replyStrategy);
     $(`#rm_group_activation_strategy option[value="${replyStrategy}"]`).prop('selected', true);
     $('#rm_group_generation_mode').val(generationMode);
@@ -2047,6 +2056,11 @@ async function openCharacterDefinition(characterSelect) {
 function filterGroupMembers() {
     const searchValue = String($(this).val()).toLowerCase();
     groupCandidatesFilter.setFilterData(FILTER_TYPES.SEARCH, searchValue);
+}
+
+function filterGroupMemberList() {
+    const searchValue = String($(this).val()).toLowerCase();
+    groupMembersFilter.setFilterData(FILTER_TYPES.SEARCH, searchValue);
 }
 
 async function createGroup() {
@@ -2424,6 +2438,7 @@ jQuery(() => {
         openGroupById(groupId);
     });
     $('#rm_group_filter').on('input', filterGroupMembers);
+    $('#rm_group_members_filter').on('input', filterGroupMemberList);
     $('#rm_group_submit').on('click', createGroup);
     $('#rm_group_scenario').on('click', setCharacterSettingsOverrides);
     $('#rm_group_automode').on('input', function () {

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1558,38 +1558,63 @@ function isGroupMember(group, avatarId) {
  * @returns {Array<{item: Character, id: number, type: string}>} Array of group character objects
  */
 function getGroupCharacters({ doFilter = false, onlyMembers = false } = {}) {
-    function sortMembersFn(a, b) {
+    function applyFilterAndSort(results, filter, filterSelector) {
+        let filtered = results;
+        if (doFilter) {
+            filtered = filter.applyFilters(filtered);
+        }
+        const useFilterOrder = doFilter && !!$(filterSelector).val();
+        sortEntitiesList(filtered, useFilterOrder, filter);
+        filter.clearFuzzySearchCaches();
+        return filtered;
+    }
+
+    function handleMembers(results, thisGroup) {
         const membersArray = thisGroup?.members ?? newGroupMembers;
-        const aIndex = membersArray.indexOf(a.item.avatar);
-        const bIndex = membersArray.indexOf(b.item.avatar);
-        return aIndex - bIndex;
+
+        // Create index map for O(1) lookups in member sort function
+        // (separate from characterIndexMap which maps character objects to their array indices)
+        const memberIndexMap = new Map(membersArray.map((avatar, index) => [avatar, index]));
+
+        function sortMembersFn(a, b) {
+            const aIndex = memberIndexMap.get(a.item.avatar) ?? -1;
+            const bIndex = memberIndexMap.get(b.item.avatar) ?? -1;
+            return aIndex - bIndex;
+        }
+
+        // Apply manual member sort before filter and sort
+        let filtered = results;
+        if (doFilter) {
+            filtered = groupMembersFilter.applyFilters(filtered);
+        }
+        filtered.sort(sortMembersFn);
+
+        // Apply conditional filter-based sort and cleanup
+        const useFilterOrder = doFilter && !!$('#rm_group_members_filter').val();
+        if (useFilterOrder) {
+            sortEntitiesList(filtered, useFilterOrder, groupMembersFilter);
+        }
+        groupMembersFilter.clearFuzzySearchCaches();
+        return filtered;
     }
 
     const thisGroup = openGroupId && groups.find((x) => x.id == openGroupId);
-    let candidates = characters
+
+    // Create index map for O(1) lookups when mapping characters to their array indices
+    // (separate from memberIndexMap used later for sorting members by their group order)
+    const characterIndexMap = new Map(characters.map((char, index) => [char, index]));
+
+    const results = characters
         .filter((x) => isGroupMember(thisGroup, x.avatar) == onlyMembers)
-        .map((x) => ({ item: x, id: characters.indexOf(x), type: 'character' }));
+        .map((x) => ({ item: x, id: characterIndexMap.get(x), type: 'character' }));
 
-    if (doFilter) {
-        candidates = groupCandidatesFilter.applyFilters(candidates);
+    // Early return for candidates (non-members)
+    if (!onlyMembers) {
+        return applyFilterAndSort(results, groupCandidatesFilter, '#rm_group_filter');
     }
 
-    if (onlyMembers) {
-        if (doFilter) {
-            candidates = groupMembersFilter.applyFilters(candidates);
-        }
-        candidates.sort(sortMembersFn);
-        const useFilterOrder = doFilter && !!$('#rm_group_members_filter').val();
-        if (useFilterOrder) {
-            sortEntitiesList(candidates, useFilterOrder, groupMembersFilter);
-        }
-        groupMembersFilter.clearFuzzySearchCaches();
-    } else {
-        const useFilterOrder = doFilter && !!$('#rm_group_filter').val();
-        sortEntitiesList(candidates, useFilterOrder, groupCandidatesFilter);
-        groupCandidatesFilter.clearFuzzySearchCaches();
-    }
-    return candidates;
+    // Handle members with manual sort capability
+    return handleMembers(results, thisGroup);
 }
 
 function printGroupCandidates() {

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1451,7 +1451,7 @@ async function modifyGroupMember(groupId, groupMember, isDelete) {
     printGroupMembers();
 
     // Refresh the tag filters for both lists to reflect any new tags
-    printTagFilters(tag_filter_type.group_member);
+    printTagFilters(tag_filter_type.group_candidates_list);
     printTagFilters(tag_filter_type.group_members_list);
 
     const groupHasMembers = getGroupCharacters({ doFilter: false, onlyMembers: true }).length > 0;

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -80,7 +80,7 @@ import {
     chatElement,
     ensureMessageMediaIsArray,
 } from '../script.js';
-import { printTagList, createTagMapFromList, applyTagsOnCharacterSelect, tag_map, applyTagsOnGroupSelect } from './tags.js';
+import { printTagList, createTagMapFromList, applyTagsOnCharacterSelect, tag_map, applyTagsOnGroupSelect, printTagFilters, tag_filter_type } from './tags.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
 import { isExternalMediaAllowed } from './chats.js';
 import { POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
@@ -1449,6 +1449,10 @@ async function modifyGroupMember(groupId, groupMember, isDelete) {
 
     printGroupCandidates();
     printGroupMembers();
+
+    // Refresh the tag filters for both lists to reflect any new tags
+    printTagFilters(tag_filter_type.group_member);
+    printTagFilters(tag_filter_type.group_members_list);
 
     const groupHasMembers = getGroupCharacters({ doFilter: false, onlyMembers: true }).length > 0;
     $('#rm_group_submit').prop('disabled', !groupHasMembers);

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -94,10 +94,20 @@ function getFilterContext(filterHelper) {
  * @returns {FilterHelper} The appropriate filter helper instance
  */
 function getFilterHelper(listSelector) {
-    if ($(listSelector).is(GROUP_MEMBERS_FILTER_SELECTOR)) {
+    const $element = $(listSelector);
+
+    // Check if this filter is in the group members section
+    if ($element.closest('.rm_tag_controls').prev().is('#rm_group_members_header')) {
         return groupMembersFilter;
     }
-    return $(listSelector).is(GROUP_FILTER_SELECTOR) ? groupCandidatesFilter : entitiesFilter;
+
+    // Check if this filter is in the group candidates (add members) section
+    if ($element.closest('.rm_tag_controls').prev().is('#rm_group_add_members_header')) {
+        return groupCandidatesFilter;
+    }
+
+    // Default to character list filter
+    return entitiesFilter;
 }
 
 /**
@@ -169,9 +179,23 @@ const TAG_ID_TO_FILTER_TYPE = new Map([
 ]);
 
 /**
+ * Gets the storage key prefix for a filter helper to enable persistence.
+ * @param {FilterHelper} filterHelper - The filter helper to check
+ * @returns {string|null} Storage key prefix or null if no persistence
+ */
+function getFilterStorageKey(filterHelper) {
+    if (filterHelper === entitiesFilter) {
+        return 'CharacterList';
+    } else if (filterHelper === groupCandidatesFilter) {
+        return 'GroupCandidates';
+    } else if (filterHelper === groupMembersFilter) {
+        return 'GroupMembers';
+    }
+    return null;
+}
+
+/**
  * Checks if the given filter helper is the main character list filter.
- * Filter states are only persisted to storage for the main character list.
- * Group contexts maintain independent, non-persistent filter states.
  * @param {FilterHelper} filterHelper - The filter helper to check
  * @returns {boolean} True if this is the main character list
  */
@@ -185,6 +209,45 @@ export const tag_filter_type = {
     group_member: 1,
     group_members_list: 2,
 };
+
+/**
+ * Gets the power_user setting key for tag filter visibility for a given context.
+ * @param {number} type - The tag_filter_type
+ * @returns {string} The power_user setting key
+ */
+function getTagFilterVisibilitySetting(type) {
+    switch (type) {
+        case tag_filter_type.character:
+            return 'show_tag_filters';
+        case tag_filter_type.group_member:
+            return 'show_tag_filters_group_candidates';
+        case tag_filter_type.group_members_list:
+            return 'show_tag_filters_group_members';
+        default:
+            return 'show_tag_filters';
+    }
+}
+
+/**
+ * Gets the tag filter visibility state for a given context.
+ * @param {number} type - The tag_filter_type
+ * @returns {boolean} Whether tag filters should be shown
+ */
+function getTagFilterVisibility(type) {
+    const settingKey = getTagFilterVisibilitySetting(type);
+    return power_user[settingKey] ?? false;
+}
+
+/**
+ * Sets the tag filter visibility state for a given context.
+ * @param {number} type - The tag_filter_type
+ * @param {boolean} visible - Whether tag filters should be shown
+ */
+function setTagFilterVisibility(type, visible) {
+    const settingKey = getTagFilterVisibilitySetting(type);
+    power_user[settingKey] = visible;
+    saveSettingsDebounced();
+}
 
 /** @enum {number} */
 export const tag_import_setting = {
@@ -202,15 +265,14 @@ export const tag_sort_mode = {
 };
 
 /**
- * @type {{ FAV: Tag, GROUP: Tag, FOLDER: Tag, VIEW: Tag, HINT: Tag, UNFILTER: Tag }}
  * A collection of global actionable tags for the filter panel.
  *
  * Tags with `filter_state` property (FAV, GROUP, FOLDER) maintain persistent state:
- * - In main character list: state is saved to storage and tag.filter_state
- * - In group contexts: state is ephemeral (stored only in filter helper)
+ * - Each context (character list, group candidates, group members) saves state independently
+ * - Main character list also maintains tag.filter_state for backward compatibility
  *
  * Tags without `filter_state` (VIEW, HINT, UNFILTER) are action buttons only.
- * */
+ */
 const ACTIONABLE_TAGS = {
     FAV: { id: '1', sort_order: 1, name: 'Show only favorites', color: 'rgba(255, 255, 0, 0.5)', filter_state: undefined, action: filterByFav, icon: 'fa-solid fa-star', class: 'filterByFavorites' },
     GROUP: { id: '0', sort_order: 2, name: 'Show only groups', color: 'rgba(100, 100, 100, 0.5)', filter_state: undefined, action: filterByGroups, icon: 'fa-solid fa-users', class: 'filterByGroups' },
@@ -461,19 +523,25 @@ function getTagBlock(tag, entities, hidden = 0, isUseless = false) {
 
 /**
  * Common logic for applying actionable tag filters (Favorites, Groups, Folders).
- * Persists state to storage only for the main character list.
+ * Persists state to storage for all filter contexts.
  * @param {FilterHelper} filterHelper - Instance of FilterHelper class
  * @param {object} tag - The actionable tag object
  * @param {string} filterType - The filter type constant
- * @param {string} storageKey - The storage key for persistence
+ * @param {string} storageKey - The storage key base for persistence
  */
 function applyActionableTagFilter(filterHelper, tag, filterType, storageKey) {
     const state = toggleTagThreeState($(this));
 
-    // Only persist to global state and storage for main character list
+    // Persist to storage for all contexts
+    const storagePrefix = getFilterStorageKey(filterHelper);
+    if (storagePrefix) {
+        const contextStorageKey = `${storagePrefix}_${storageKey}`;
+        accountStorage.setItem(contextStorageKey, state);
+    }
+
+    // Also update global state for main character list (backward compatibility)
     if (isMainCharacterList(filterHelper)) {
         tag.filter_state = state;
-        accountStorage.setItem(storageKey, state);
     }
 
     // Update the filter helper for the current context
@@ -482,35 +550,28 @@ function applyActionableTagFilter(filterHelper, tag, filterType, storageKey) {
 
 /**
  * Determines the filter state for a tag based on context.
- * For actionable tags: reads from persisted state (main list) or filter helper (group contexts).
+ * For actionable tags: reads from persisted state via filter helper.
  * For regular tags: reads from the filter helper's TAG filter data.
+ * @param {FilterHelper} filterHelper - The filter helper for the current context
  * @param {object} tag - The tag object
- * @param {FilterHelper} filterHelper - The filter helper instance
- * @param {boolean} isFilterActionable - Whether this is an actionable tag with filter_state
- * @returns {string} The filter state (SELECTED, EXCLUDED, or default)
+ * @param {boolean} isFilterActionable - Whether the tag is an actionable filter tag
+ * @returns {string} The filter state
  */
-function determineTagFilterState(tag, filterHelper, isFilterActionable) {
+function determineTagFilterState(filterHelper, tag, isFilterActionable) {
     if (isFilterActionable) {
-        // For actionable tags (Favorites, Groups, Folders):
-        // - In main list: read from tag.filter_state (persisted globally)
-        // - In group contexts: read from filter helper (independent, non-persistent)
-        if (isMainCharacterList(filterHelper)) {
-            return tag.filter_state || DEFAULT_FILTER_STATE;
-        } else {
-            // Read from filter helper for group contexts
-            const filterType = TAG_ID_TO_FILTER_TYPE.get(tag.id) || null;
-            if (filterType) {
-                return filterHelper.getFilterData(filterType) || DEFAULT_FILTER_STATE;
-            }
+        // For actionable tags: read from filter helper (which is loaded from storage)
+        const filterType = TAG_ID_TO_FILTER_TYPE.get(tag.id) || null;
+        if (filterType) {
+            return filterHelper.getFilterData(filterType) || DEFAULT_FILTER_STATE;
         }
     } else {
-        // For regular tag filters, read from the filter helper for this context
-        const filterData = filterHelper.getFilterData(FILTER_TYPES.TAG);
-
-        if (filterData?.selected?.includes(tag.id)) {
-            return 'SELECTED';
-        } else if (filterData?.excluded?.includes(tag.id)) {
+        // For regular tags: read from the filter helper's TAG filter data
+        const tagFilterData = filterHelper.getFilterData(FILTER_TYPES.TAG);
+        if (tagFilterData.excluded.includes(tag.id)) {
             return 'EXCLUDED';
+        }
+        if (tagFilterData.selected.includes(tag.id)) {
+            return 'SELECTED';
         }
     }
 
@@ -1270,7 +1331,7 @@ function appendTagToList(listElement, tag, { removable = false, isFilter = false
         const isFilterActionable = clickableAction && 'filter_state' in tag;
 
         if (isFilter || isFilterActionable) {
-            const filterState = determineTagFilterState(tag, filterHelper, isFilterActionable);
+            const filterState = determineTagFilterState(filterHelper, tag, isFilterActionable);
             toggleTagThreeState(tagElement, { stateOverride: filterState });
         }
     }
@@ -1298,18 +1359,73 @@ function onTagFilterClick(listElement) {
 
     const filterHelper = getFilterHelper($(listElement));
 
-    // Always update the tag's filter_state for the main character list (for persistence)
-    // For group contexts, we only update the filter helper state, not the global tag object
+    // Update the tag's filter_state for the main character list (backward compatibility)
     if (existingTag && isMainCharacterList(filterHelper)) {
         existingTag.filter_state = state;
         saveSettingsDebounced();
     }
 
-    // We don't print anything manually, updating the filter will automatically trigger a redraw of all relevant stuff
+    // Persist to storage for all contexts
+    const storagePrefix = getFilterStorageKey(filterHelper);
+    if (storagePrefix && existingTag) {
+        const storageKey = `${storagePrefix}_tag_${tagId}`;
+        accountStorage.setItem(storageKey, state);
+    }
+
+    // Apply all tag filters by reading from DOM state (this triggers the filter helper update)
     runTagFilters(listElement);
 
     // Focus the tag again we were at, if possible. To improve keyboard navigation
     setTimeout(() => parent.find(`.tag[id="${tagId}"]`).trigger('focus'), DEFAULT_PRINT_TIMEOUT + 1);
+}
+
+/**
+ * Loads persisted filter states for a given filter context.
+ * @param {FilterHelper} filterHelper - The filter helper instance
+ * @param {string} storagePrefix - The storage key prefix for this context
+ */
+function loadFilterStatesForContext(filterHelper, storagePrefix) {
+    const validStates = new Set(Object.keys(FILTER_STATES));
+    const readState = (/** @type {string} */ storageKey) => {
+        const v = accountStorage.getItem(storageKey);
+        return v && validStates.has(v) ? v : null;
+    };
+
+    // Load actionable tag states (Favorites, Groups, Folders)
+    const favState = readState(`${storagePrefix}_${ACTIONABLE_FILTER_STORAGE_KEYS.FAV}`);
+    if (favState) {
+        filterHelper.setFilterData(FILTER_TYPES.FAV, favState, true);
+    }
+
+    const groupState = readState(`${storagePrefix}_${ACTIONABLE_FILTER_STORAGE_KEYS.GROUP}`);
+    if (groupState) {
+        filterHelper.setFilterData(FILTER_TYPES.GROUP, groupState, true);
+    }
+
+    const folderState = readState(`${storagePrefix}_${ACTIONABLE_FILTER_STORAGE_KEYS.FOLDER}`);
+    if (folderState) {
+        filterHelper.setFilterData(FILTER_TYPES.FOLDER, folderState, true);
+    }
+
+    // Load regular tag filter states
+    const tagFilterData = filterHelper.getFilterData(FILTER_TYPES.TAG);
+    for (const tag of tags) {
+        const storageKey = `${storagePrefix}_tag_${tag.id}`;
+        const state = readState(storageKey);
+
+        if (state) {
+            if (state === 'SELECTED') {
+                if (!tagFilterData.selected.includes(tag.id)) {
+                    tagFilterData.selected.push(tag.id);
+                }
+            } else if (state === 'EXCLUDED') {
+                if (!tagFilterData.excluded.includes(tag.id)) {
+                    tagFilterData.excluded.push(tag.id);
+                }
+            }
+        }
+    }
+    filterHelper.setFilterData(FILTER_TYPES.TAG, tagFilterData, true);
 }
 
 /**
@@ -1442,11 +1558,21 @@ function printTagFilters(type = tag_filter_type.character) {
         printTagList(bogusDrilldown, { tags: navigatedTags, tagOptions: { removable: true } });
     }
 
-    runTagFilters(FILTER_SELECTOR);
+    // Don't call runTagFilters here - it would overwrite the loaded filter states with the DOM state.
+    // The visual state (CSS classes) already matches the filter helper state set by loadFilterStatesForContext.
+    // runTagFilters is only needed when user clicks a tag (handled in onTagFilterClick).
 
-    if (power_user.show_tag_filters) {
-        $(FILTER_SELECTOR).closest('.rm_tag_controls').find('.showTagList').addClass('selected');
+    // Initialize the tag list visibility based on saved settings for this context
+    const shouldShowTags = getTagFilterVisibility(type);
+    const showTagListButton = $(FILTER_SELECTOR).closest('.rm_tag_controls').find('.showTagList');
+
+    // Update button state to match the saved setting
+    showTagListButton.toggleClass('selected', shouldShowTags);
+
+    if (shouldShowTags) {
         $(FILTER_SELECTOR).find('.tag:not(.actionable)').show();
+    } else {
+        $(FILTER_SELECTOR).find('.tag:not(.actionable)').hide();
     }
 
     updateTagFilterIndicator(FILTER_SELECTOR);
@@ -1535,6 +1661,7 @@ export function applyTagsOnGroupSelect(groupId = null) {
 
     groupId = groupId ?? (selected_group ? Number(selected_group) : undefined);
     printTagList($('#groupTagList'), { forEntityOrKey: groupId, tagOptions: { removable: true } });
+    printTagFilters(tag_filter_type.group_member);
     printTagFilters(tag_filter_type.group_members_list);
 }
 
@@ -2061,9 +2188,21 @@ function onTagListHintClick() {
     }
 
     $(this).siblings('.innerActionable').toggleClass('hidden');
-    power_user.show_tag_filters = $(this).hasClass('selected');
-    saveSettingsDebounced();
-    console.debug('show_tag_filters', power_user.show_tag_filters);
+
+    // Determine which context this button belongs to and save the setting
+    let filterType = tag_filter_type.character;
+
+    // Check which section we're in by looking at the sibling header
+    const $tagControls = $(this).closest('.rm_tag_controls');
+    if ($tagControls.prev().is('#rm_group_add_members_header')) {
+        filterType = tag_filter_type.group_member;
+    } else if ($tagControls.prev().is('#rm_group_members_header')) {
+        filterType = tag_filter_type.group_members_list;
+    }
+
+    const isSelected = $(this).hasClass('selected');
+    setTagFilterVisibility(filterType, isSelected);
+    console.debug('show_tag_filters for type', filterType, ':', isSelected);
 }
 
 /**
@@ -2500,8 +2639,12 @@ function restoreSavedTagFilters() {
         if (favState) {
             ACTIONABLE_TAGS.FAV.filter_state = favState;
             entitiesFilter.setFilterData(FILTER_TYPES.FAV, favState, true);
-            // Group contexts start with default state, not persisted state
         }
+
+        // Load persisted filter states for all contexts (including character list)
+        loadFilterStatesForContext(entitiesFilter, 'CharacterList');
+        loadFilterStatesForContext(groupCandidatesFilter, 'GroupCandidates');
+        loadFilterStatesForContext(groupMembersFilter, 'GroupMembers');
         if (groupState) {
             ACTIONABLE_TAGS.GROUP.filter_state = groupState;
             entitiesFilter.setFilterData(FILTER_TYPES.GROUP, groupState, true);
@@ -2511,25 +2654,9 @@ function restoreSavedTagFilters() {
             entitiesFilter.setFilterData(FILTER_TYPES.FOLDER, folderState, true);
         }
 
-        // Restore regular tag filter states from tag objects to entitiesFilter
-        // This ensures that saved tag filters are properly loaded for the main character list
-        const selectedTagIds = [];
-        const excludedTagIds = [];
-
-        for (const tag of tags) {
-            if (tag.filter_state === FILTER_STATES.SELECTED) {
-                selectedTagIds.push(tag.id);
-            } else if (tag.filter_state === FILTER_STATES.EXCLUDED) {
-                excludedTagIds.push(tag.id);
-            }
-        }
-
-        if (selectedTagIds.length > 0 || excludedTagIds.length > 0) {
-            entitiesFilter.setFilterData(FILTER_TYPES.TAG, {
-                excluded: excludedTagIds,
-                selected: selectedTagIds,
-            }, true);
-        }
+        // Note: Regular tag filter states are now loaded from storage via loadFilterStatesForContext()
+        // The old tag.filter_state property is only maintained for backward compatibility with
+        // the main character list's actionable tags (Favorites, Groups, Folders)
     } catch (e) {
         console.warn('Failed to restore actionable filter states from account storage', e);
     }

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -2297,12 +2297,12 @@ function removeMissingTagFilters() {
 
 function registerTagsSlashCommands() {
     /**
-         * Gets a tag by its name. Optionally can create the tag if it does not exist.
-         * @param {string} tagName - The name of the tag
-         * @param {object} options - Optional arguments
-         * @param {boolean} [options.allowCreate=false] - Whether a new tag should be created if no tag with the name exists
-         * @returns {Tag?} The tag, or null if not found
-         */
+     * Gets a tag by its name. Optionally can create the tag if it does not exist.
+     * @param {string} tagName - The name of the tag
+     * @param {object} options - Optional arguments
+     * @param {boolean} [options.allowCreate=false] - Whether a new tag should be created if no tag with the name exists
+     * @returns {Tag?} The tag, or null if not found
+     */
     function paraGetTag(tagName, { allowCreate = false } = {}) {
         if (!tagName) {
             toastr.warning('Tag name must be provided.');
@@ -2495,13 +2495,13 @@ function registerTagsSlashCommands() {
 }
 
 /**
-     * Function to apply character tags to message divs when rendering the chat
-     * @param {object} options Options for applying character tags
-     * @param {number|number[]} [options.mesIds=[]] An id or array of message IDs to filter by.
-     * If empty, all messages will be processed.
-     * @returns {void}
-     * @description This function iterates through the chat messages and applies character tags
-     */
+ * Function to apply character tags to message divs when rendering the chat
+ * @param {object} options Options for applying character tags
+ * @param {number|number[]} [options.mesIds=[]] An id or array of message IDs to filter by.
+ * If empty, all messages will be processed.
+ * @returns {void}
+ * @description This function iterates through the chat messages and applies character tags
+ */
 export function applyCharacterTagsToMessageDivs({ mesIds = [] } = {}) {
     try {
         const messagesFilter = buildMessagesFilter(mesIds);
@@ -2602,12 +2602,12 @@ function buildMessagesFilter(mesIds) {
 }
 
 /**
-     * Helper function to apply all necessary data attributes to a DOM element.
-     * @param {JQuery<HTMLElement>} $element - The jQuery object for the message div.
-     * @param {object} tagData - An object containing tag information.
-     * @param {string[]} tagData.tagNames - An array of tag names.
-     * @param {string} tagData.joinedTagNames - A comma-separated string of tag names.
-     */
+ * Helper function to apply all necessary data attributes to a DOM element.
+ * @param {JQuery<HTMLElement>} $element - The jQuery object for the message div.
+ * @param {object} tagData - An object containing tag information.
+ * @param {string[]} tagData.tagNames - An array of tag names.
+ * @param {string} tagData.joinedTagNames - A comma-separated string of tag names.
+ */
 function applyTags($element, tagData) {
     $element.attr('data-char-tags', tagData.joinedTagNames);
     tagData.tagNames.forEach(tagName => {
@@ -2622,11 +2622,11 @@ function applyTags($element, tagData) {
 }
 
 /**
-     * Normalizes a tag name by trimming, converting spaces to hyphens, replacing accented characters,
-     * removing special characters, and converting to lowercase.
-     * @param {string} name The tag name to normalize.
-     * @returns {string} The normalized tag name.
-     */
+ * Normalizes a tag name by trimming, converting spaces to hyphens, replacing accented characters,
+ * removing special characters, and converting to lowercase.
+ * @param {string} name The tag name to normalize.
+ * @returns {string} The normalized tag name.
+ */
 function normalizeTagName(name) {
     if (!name?.trim()) {
         return '';
@@ -2641,10 +2641,11 @@ function normalizeTagName(name) {
         .toLowerCase();
 }
 
-/** Extracts the character avatar file name from the avatar source URL.
-     * @param {string} avatarSrc The source URL of the character avatar.
-     * @returns {string|null} The normalized avatar file name, or null if the input is falsy or doesn't contain a valid file name.
-     */
+/**
+ * Extracts the character avatar file name from the avatar source URL.
+ * @param {string} avatarSrc The source URL of the character avatar.
+ * @returns {string|null} The normalized avatar file name, or null if the input is falsy or doesn't contain a valid file name.
+ */
 function extractCharacterAvatar(avatarSrc) {
     if (!avatarSrc) {
         return null;

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -130,14 +130,16 @@ function getVisibleAvatarsForGroupContext(type, currentGroup) {
         return [];
     }
 
-    if (type === tag_filter_type.group_members_list) {
-        // For members list, return current group members
-        return currentGroup.members;
-    } else {
-        // For candidates list, return non-members
-        return characters
-            .filter(c => !currentGroup.members.includes(c.avatar))
-            .map(c => c.avatar);
+    switch (type) {
+        case tag_filter_type.group_members_list:
+            return currentGroup.members;
+        case tag_filter_type.group_member:
+            return characters
+                .filter(c => !currentGroup.members.includes(c.avatar))
+                .map(c => c.avatar);
+        default:
+            console.warn('getVisibleAvatarsForGroupContext got invalid type, expected 1 or 2, got ', type)
+            return []
     }
 }
 

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1541,6 +1541,7 @@ function printTagFilters(type = tag_filter_type.character) {
 
     if (isGroupContext(type)) {
         // For group contexts, show all tags but mark ones without presence in current context as inactive
+        // CAUTION: when called by openGroupById, the selected_group variable might not yet be updated
         const currentGroup = selected_group ? groups.find(x => x.id == selected_group) : null;
         const visibleAvatars = getVisibleAvatarsForGroupContext(type, currentGroup);
 

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -97,12 +97,12 @@ function getFilterHelper(listSelector) {
     const $element = $(listSelector);
 
     // Check if this filter is in the group members section
-    if ($element.closest('.rm_tag_controls').prev().is('#rm_group_members_header')) {
+    if ($element.closest('#currentGroupMembers').length > 0) {
         return groupMembersFilter;
     }
 
     // Check if this filter is in the group candidates (add members) section
-    if ($element.closest('.rm_tag_controls').prev().is('#rm_group_add_members_header')) {
+    if ($element.closest('#unaddedCharList').length > 0) {
         return groupCandidatesFilter;
     }
 

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1168,6 +1168,7 @@ function newTag(tagName) {
  * @property {boolean} [isGeneralList=false] - If true, indicates that this is the general list of tags.
  * @property {boolean} [skipExistsCheck=false] - If true, the tag gets added even if a tag with the same id already exists.
  * @property {boolean} [isCharacterList=false] - If true, indicates that this is the character's list of tags.
+ * @property {boolean} [isInactive=false] - If true, indicates that the tag is inactive (for styling purposes).
  */
 
 /**
@@ -1180,6 +1181,7 @@ function newTag(tagName) {
  * @property {function(object): function} [tagActionSelector=undefined] - An optional override for the action property that can be assigned to each tag via tagOptions.
  * If set, the selector is executed on each tag as input argument. This allows a list of tags to be provided and each tag can have it's action based on the tag object itself.
  * @property {TagOptions} [tagOptions={}] - Options for tag behavior. (Same object will be passed into "appendTagToList")
+ * @property {string[]} [inactiveTags=[]] - List of tag IDs that are considered inactive (for styling purposes).
  */
 
 /**

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -116,7 +116,7 @@ function getFilterHelper(listSelector) {
  * @returns {boolean} True if this is a group context
  */
 function isGroupContext(type) {
-    return type === tag_filter_type.group_member || type === tag_filter_type.group_members_list;
+    return [tag_filter_type.group_member, tag_filter_type.group_members_list].includes(type);
 }
 
 /**

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1386,6 +1386,8 @@ function onTagFilterClick(listElement) {
 
     // Focus the tag again we were at, if possible. To improve keyboard navigation
     setTimeout(() => parent.find(`.tag[id="${tagId}"]`).trigger('focus'), DEFAULT_PRINT_TIMEOUT + 1);
+
+    updateTagFilterIndicator(listElement);
 }
 
 /**
@@ -1598,13 +1600,16 @@ function printTagFilters(type = tag_filter_type.character) {
     updateTagFilterIndicator(FILTER_SELECTOR);
 }
 
+/**
+ * Updates the tag filter indicator based on the selected/excluded tags in the given filter selector
+ * @param {string|JQuery<HTMLElement>} filterSelector - The selector or jQuery element for the tag filter container
+ */
 function updateTagFilterIndicator(filterSelector) {
     const selector = filterSelector || CHARACTER_FILTER_SELECTOR;
-    if ($(selector).find('.tag:not(.actionable)').is('.selected, .excluded')) {
-        $(selector).closest('.rm_tag_controls').find('.showTagList').addClass('indicator');
-    } else {
-        $(selector).closest('.rm_tag_controls').find('.showTagList').removeClass('indicator');
-    }
+    const tagFilter = typeof selector === 'string' ? $(selector) : selector;
+    const showTagListButton = tagFilter.closest('.rm_tag_controls').find('.showTagList');
+    const hasActiveTags = tagFilter.find('.tag:not(.actionable)').is('.selected, .excluded');
+    showTagListButton.toggleClass('indicator', hasActiveTags);
 }
 
 function onTagRemoveClick(event) {
@@ -2590,14 +2595,14 @@ export function applyCharacterTagsToMessageDivs({ mesIds = [] } = {}) {
 }
 
 /**
-     * Builds a jQuery selector string to filter messages by their IDs.
-     * @param {number|number[]} mesIds - An id or array of message IDs to filter by.
-     * @returns {string} A jQuery selector string that matches messages with the specified IDs.
-     * If mesIds is empty, it returns '.mes' to select all messages.
-     * @example
-     * buildMessagesFilter([1, 5]); // Returns '.mes[mesid="1"],.mes[mesid="5"]'
-     * buildMessagesFilter([]); // Returns '.mes'
-     */
+ * Builds a jQuery selector string to filter messages by their IDs.
+ * @param {number|number[]} mesIds - An id or array of message IDs to filter by.
+ * @returns {string} A jQuery selector string that matches messages with the specified IDs.
+ * If mesIds is empty, it returns '.mes' to select all messages.
+ * @example
+ * buildMessagesFilter([1, 5]); // Returns '.mes[mesid="1"],.mes[mesid="5"]'
+ * buildMessagesFilter([]); // Returns '.mes'
+ */
 function buildMessagesFilter(mesIds) {
     const allMessages = '.mes';
 

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -53,8 +53,6 @@ export {
     removeTagFromMap,
 };
 
-/** @typedef {import('../script.js').Character} Character */
-
 const CHARACTER_FILTER_SELECTOR = '#rm_characters_block .rm_tag_filter';
 const GROUP_FILTER_SELECTOR = '#rm_group_add_members_header ~ .rm_tag_controls .rm_tag_filter';
 const GROUP_MEMBERS_FILTER_SELECTOR = '#rm_group_members_header ~ .rm_tag_controls .rm_tag_filter';
@@ -90,11 +88,11 @@ function getFilterContext(filterHelper) {
 
 /**
  * Get the filter helper for a given list selector.
- * @param {string} listSelector - jQuery selector for the list
+ * @param {string|JQuery<HTMLElement>} listSelector - jQuery selector for the list
  * @returns {FilterHelper} The appropriate filter helper instance
  */
 function getFilterHelper(listSelector) {
-    const $element = $(listSelector);
+    const $element = typeof listSelector === 'string' ? $(listSelector) : listSelector;
 
     // Check if this filter is in the group members section
     if ($element.closest('#currentGroupMembers').length > 0) {

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -15,7 +15,7 @@ import {
 } from '../script.js';
 import { FILTER_TYPES, FILTER_STATES, DEFAULT_FILTER_STATE, isFilterState, FilterHelper } from './filters.js';
 
-import { groupCandidatesFilter, groups, selected_group } from './group-chats.js';
+import { groupCandidatesFilter, groupMembersFilter, groups, selected_group } from './group-chats.js';
 import { download, onlyUnique, parseJsonFile, uuidv4, getSortableDelay, flashHighlight, equalsIgnoreCaseAndAccents, includesIgnoreCaseAndAccents, removeFromArray, getFreeName, debounce, findChar } from './utils.js';
 import { power_user } from './power-user.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
@@ -56,12 +56,16 @@ export {
 /** @typedef {import('../script.js').Character} Character */
 
 const CHARACTER_FILTER_SELECTOR = '#rm_characters_block .rm_tag_filter';
-const GROUP_FILTER_SELECTOR = '#rm_group_chats_block .rm_tag_filter';
+const GROUP_FILTER_SELECTOR = '#rm_group_add_members_header ~ .rm_tag_controls .rm_tag_filter';
+const GROUP_MEMBERS_FILTER_SELECTOR = '#rm_group_members_header ~ .rm_tag_controls .rm_tag_filter';
 const TAG_TEMPLATE = $('#tag_template .tag');
 const FOLDER_TEMPLATE = $('#bogus_folder_template .bogus_folder_select');
 const VIEW_TAG_TEMPLATE = $('#tag_view_template .tag_view_item');
 
 function getFilterHelper(listSelector) {
+    if ($(listSelector).is(GROUP_MEMBERS_FILTER_SELECTOR)) {
+        return groupMembersFilter;
+    }
     return $(listSelector).is(GROUP_FILTER_SELECTOR) ? groupCandidatesFilter : entitiesFilter;
 }
 
@@ -75,6 +79,7 @@ const ACTIONABLE_FILTER_STORAGE_KEYS = Object.freeze({
 export const tag_filter_type = {
     character: 0,
     group_member: 1,
+    group_members_list: 2,
 };
 
 /** @enum {number} */
@@ -354,6 +359,7 @@ function filterByFav(_filterHelper) {
     accountStorage.setItem(ACTIONABLE_FILTER_STORAGE_KEYS.FAV, state);
     entitiesFilter.setFilterData(FILTER_TYPES.FAV, state);
     groupCandidatesFilter.setFilterData(FILTER_TYPES.FAV, state);
+    groupMembersFilter.setFilterData(FILTER_TYPES.FAV, state);
 }
 
 /**
@@ -1103,7 +1109,18 @@ function appendTagToList(listElement, tag, { removable = false, isFilter = false
 
     // If this is a tag for a general list and its either a filter or actionable, lets mark its current state
     if ((isFilter || clickableAction) && isGeneralList) {
-        toggleTagThreeState(tagElement, { stateOverride: tag.filter_state ?? DEFAULT_FILTER_STATE });
+        // Get the filter state from the appropriate filter helper instead of the global tag object
+        const filterHelper = getFilterHelper($(listElement));
+        const filterData = filterHelper.getFilterData(FILTER_TYPES.TAG);
+        let filterState = DEFAULT_FILTER_STATE;
+
+        if (filterData && filterData.selected && filterData.selected.includes(tag.id)) {
+            filterState = 'SELECTED';
+        } else if (filterData && filterData.excluded && filterData.excluded.includes(tag.id)) {
+            filterState = 'EXCLUDED';
+        }
+
+        toggleTagThreeState(tagElement, { stateOverride: filterState });
     }
 
     if (isFilter) {
@@ -1127,7 +1144,9 @@ function onTagFilterClick(listElement) {
 
     let state = toggleTagThreeState($(this));
 
-    if (existingTag) {
+    // Only save to global tag state if we're in the character list (not group contexts)
+    const filterHelper = getFilterHelper($(listElement));
+    if (existingTag && filterHelper === entitiesFilter) {
         existingTag.filter_state = state;
         saveSettingsDebounced();
     }
@@ -1201,7 +1220,22 @@ function runTagFilters(listElement) {
 }
 
 function printTagFilters(type = tag_filter_type.character) {
-    const FILTER_SELECTOR = type === tag_filter_type.character ? CHARACTER_FILTER_SELECTOR : GROUP_FILTER_SELECTOR;
+    let FILTER_SELECTOR;
+    switch (type) {
+        case tag_filter_type.character:
+            FILTER_SELECTOR = CHARACTER_FILTER_SELECTOR;
+            break;
+        case tag_filter_type.group_member:
+            FILTER_SELECTOR = GROUP_FILTER_SELECTOR;
+            break;
+        case tag_filter_type.group_members_list:
+            FILTER_SELECTOR = GROUP_MEMBERS_FILTER_SELECTOR;
+            break;
+        default:
+            FILTER_SELECTOR = CHARACTER_FILTER_SELECTOR;
+            break;
+    }
+
     $(FILTER_SELECTOR).empty();
 
     // Print all action tags. (Rework 'Folder' button to some kind of onboarding if no folders are enabled yet)
@@ -1316,6 +1350,7 @@ export function applyTagsOnGroupSelect(groupId = null) {
 
     groupId = groupId ?? (selected_group ? Number(selected_group) : undefined);
     printTagList($('#groupTagList'), { forEntityOrKey: groupId, tagOptions: { removable: true } });
+    printTagFilters(tag_filter_type.group_members_list);
 }
 
 /**
@@ -2271,6 +2306,7 @@ function restoreSavedTagFilters() {
             ACTIONABLE_TAGS.FAV.filter_state = favState;
             entitiesFilter.setFilterData(FILTER_TYPES.FAV, favState, true);
             groupCandidatesFilter.setFilterData(FILTER_TYPES.FAV, favState, true);
+            groupMembersFilter.setFilterData(FILTER_TYPES.FAV, favState, true);
         }
         if (groupState) {
             ACTIONABLE_TAGS.GROUP.filter_state = groupState;

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -116,7 +116,7 @@ function getFilterHelper(listSelector) {
  * @returns {boolean} True if this is a group context
  */
 function isGroupContext(type) {
-    return [tag_filter_type.group_member, tag_filter_type.group_members_list].includes(type);
+    return [tag_filter_type.group_candidates_list, tag_filter_type.group_members_list].includes(type);
 }
 
 /**
@@ -133,7 +133,7 @@ function getVisibleAvatarsForGroupContext(type, currentGroup) {
     switch (type) {
         case tag_filter_type.group_members_list:
             return currentGroup.members;
-        case tag_filter_type.group_member:
+        case tag_filter_type.group_candidates_list:
             return characters
                 .filter(c => !currentGroup.members.includes(c.avatar))
                 .map(c => c.avatar);
@@ -198,7 +198,9 @@ function isMainCharacterList(filterHelper) {
 /** @enum {number} */
 export const tag_filter_type = {
     character: 0,
+    /** @deprecated use `group_candidates_list` instead */
     group_member: 1,
+    group_candidates_list: 1,
     group_members_list: 2,
 };
 
@@ -211,7 +213,7 @@ function getTagFilterVisibilitySetting(type) {
     switch (type) {
         case tag_filter_type.character:
             return 'show_tag_filters';
-        case tag_filter_type.group_member:
+        case tag_filter_type.group_candidates_list:
             return 'show_tag_filters_group_candidates';
         case tag_filter_type.group_members_list:
             return 'show_tag_filters_group_members';
@@ -1497,7 +1499,7 @@ function printTagFilters(type = tag_filter_type.character) {
         case tag_filter_type.character:
             FILTER_SELECTOR = CHARACTER_FILTER_SELECTOR;
             break;
-        case tag_filter_type.group_member:
+        case tag_filter_type.group_candidates_list:
             FILTER_SELECTOR = GROUP_FILTER_SELECTOR;
             break;
         case tag_filter_type.group_members_list:
@@ -1663,7 +1665,7 @@ export function applyTagsOnGroupSelect(groupId = null) {
 
     groupId = groupId ?? (selected_group ? Number(selected_group) : undefined);
     printTagList($('#groupTagList'), { forEntityOrKey: groupId, tagOptions: { removable: true } });
-    printTagFilters(tag_filter_type.group_member);
+    printTagFilters(tag_filter_type.group_candidates_list);
     printTagFilters(tag_filter_type.group_members_list);
 }
 
@@ -2197,7 +2199,7 @@ function onTagListHintClick() {
     // Check which section we're in by looking at the sibling header
     const $tagControls = $(this).closest('.rm_tag_controls');
     if ($tagControls.prev().is('#rm_group_add_members_header')) {
-        filterType = tag_filter_type.group_member;
+        filterType = tag_filter_type.group_candidates_list;
     } else if ($tagControls.prev().is('#rm_group_members_header')) {
         filterType = tag_filter_type.group_members_list;
     }

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1492,6 +1492,8 @@ function runTagFilters(listElement) {
 }
 
 function printTagFilters(type = tag_filter_type.character) {
+    removeMissingTagFilters();
+
     let FILTER_SELECTOR;
     switch (type) {
         case tag_filter_type.character:
@@ -2262,14 +2264,45 @@ function printViewTagList(tagContainer, empty = true) {
     }
 }
 
+function removeMissingTagFilters() {
+    const tagIds = new Set(tags.map(tag => tag.id));
+
+    for (const helper of [groupCandidatesFilter, groupMembersFilter, entitiesFilter]) {
+        const { selected, excluded } = helper.getFilterData(FILTER_TYPES.TAG);
+        let anyRemoved = false;
+
+        if (Array.isArray(selected)) {
+            for (let i = selected.length - 1; i >= 0; i--) {
+                if (!tagIds.has(selected[i])) {
+                    selected.splice(i, 1);
+                    anyRemoved = true;
+                }
+            }
+        }
+
+        if (Array.isArray(excluded)) {
+            for (let i = excluded.length - 1; i >= 0; i--) {
+                if (!tagIds.has(excluded[i])) {
+                    excluded.splice(i, 1);
+                    anyRemoved = true;
+                }
+            }
+        }
+
+        if (anyRemoved) {
+            helper.setFilterData(FILTER_TYPES.TAG, { selected, excluded });
+        }
+    }
+}
+
 function registerTagsSlashCommands() {
     /**
-     * Gets a tag by its name. Optionally can create the tag if it does not exist.
-     * @param {string} tagName - The name of the tag
-     * @param {object} options - Optional arguments
-     * @param {boolean} [options.allowCreate=false] - Whether a new tag should be created if no tag with the name exists
-     * @returns {Tag?} The tag, or null if not found
-     */
+         * Gets a tag by its name. Optionally can create the tag if it does not exist.
+         * @param {string} tagName - The name of the tag
+         * @param {object} options - Optional arguments
+         * @param {boolean} [options.allowCreate=false] - Whether a new tag should be created if no tag with the name exists
+         * @returns {Tag?} The tag, or null if not found
+         */
     function paraGetTag(tagName, { allowCreate = false } = {}) {
         if (!tagName) {
             toastr.warning('Tag name must be provided.');
@@ -2462,13 +2495,13 @@ function registerTagsSlashCommands() {
 }
 
 /**
- * Function to apply character tags to message divs when rendering the chat
- * @param {object} options Options for applying character tags
- * @param {number|number[]} [options.mesIds=[]] An id or array of message IDs to filter by.
- * If empty, all messages will be processed.
- * @returns {void}
- * @description This function iterates through the chat messages and applies character tags
- */
+     * Function to apply character tags to message divs when rendering the chat
+     * @param {object} options Options for applying character tags
+     * @param {number|number[]} [options.mesIds=[]] An id or array of message IDs to filter by.
+     * If empty, all messages will be processed.
+     * @returns {void}
+     * @description This function iterates through the chat messages and applies character tags
+     */
 export function applyCharacterTagsToMessageDivs({ mesIds = [] } = {}) {
     try {
         const messagesFilter = buildMessagesFilter(mesIds);
@@ -2541,14 +2574,14 @@ export function applyCharacterTagsToMessageDivs({ mesIds = [] } = {}) {
 }
 
 /**
- * Builds a jQuery selector string to filter messages by their IDs.
- * @param {number|number[]} mesIds - An id or array of message IDs to filter by.
- * @returns {string} A jQuery selector string that matches messages with the specified IDs.
- * If mesIds is empty, it returns '.mes' to select all messages.
- * @example
- * buildMessagesFilter([1, 5]); // Returns '.mes[mesid="1"],.mes[mesid="5"]'
- * buildMessagesFilter([]); // Returns '.mes'
- */
+     * Builds a jQuery selector string to filter messages by their IDs.
+     * @param {number|number[]} mesIds - An id or array of message IDs to filter by.
+     * @returns {string} A jQuery selector string that matches messages with the specified IDs.
+     * If mesIds is empty, it returns '.mes' to select all messages.
+     * @example
+     * buildMessagesFilter([1, 5]); // Returns '.mes[mesid="1"],.mes[mesid="5"]'
+     * buildMessagesFilter([]); // Returns '.mes'
+     */
 function buildMessagesFilter(mesIds) {
     const allMessages = '.mes';
 
@@ -2569,12 +2602,12 @@ function buildMessagesFilter(mesIds) {
 }
 
 /**
- * Helper function to apply all necessary data attributes to a DOM element.
- * @param {JQuery<HTMLElement>} $element - The jQuery object for the message div.
- * @param {object} tagData - An object containing tag information.
- * @param {string[]} tagData.tagNames - An array of tag names.
- * @param {string} tagData.joinedTagNames - A comma-separated string of tag names.
- */
+     * Helper function to apply all necessary data attributes to a DOM element.
+     * @param {JQuery<HTMLElement>} $element - The jQuery object for the message div.
+     * @param {object} tagData - An object containing tag information.
+     * @param {string[]} tagData.tagNames - An array of tag names.
+     * @param {string} tagData.joinedTagNames - A comma-separated string of tag names.
+     */
 function applyTags($element, tagData) {
     $element.attr('data-char-tags', tagData.joinedTagNames);
     tagData.tagNames.forEach(tagName => {
@@ -2589,11 +2622,11 @@ function applyTags($element, tagData) {
 }
 
 /**
- * Normalizes a tag name by trimming, converting spaces to hyphens, replacing accented characters,
- * removing special characters, and converting to lowercase.
- * @param {string} name The tag name to normalize.
- * @returns {string} The normalized tag name.
- */
+     * Normalizes a tag name by trimming, converting spaces to hyphens, replacing accented characters,
+     * removing special characters, and converting to lowercase.
+     * @param {string} name The tag name to normalize.
+     * @returns {string} The normalized tag name.
+     */
 function normalizeTagName(name) {
     if (!name?.trim()) {
         return '';
@@ -2609,9 +2642,9 @@ function normalizeTagName(name) {
 }
 
 /** Extracts the character avatar file name from the avatar source URL.
- * @param {string} avatarSrc The source URL of the character avatar.
- * @returns {string|null} The normalized avatar file name, or null if the input is falsy or doesn't contain a valid file name.
- */
+     * @param {string} avatarSrc The source URL of the character avatar.
+     * @returns {string|null} The normalized avatar file name, or null if the input is falsy or doesn't contain a valid file name.
+     */
 function extractCharacterAvatar(avatarSrc) {
     if (!avatarSrc) {
         return null;

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -62,11 +62,94 @@ const TAG_TEMPLATE = $('#tag_template .tag');
 const FOLDER_TEMPLATE = $('#bogus_folder_template .bogus_folder_select');
 const VIEW_TAG_TEMPLATE = $('#tag_view_template .tag_view_item');
 
+/**
+ * Gets the context information (selector and search input) for a filter helper.
+ * Used to reduce code duplication when working with different filter contexts.
+ * @param {FilterHelper} filterHelper - The filter helper instance
+ * @returns {{selector: string, searchInput: string}|null} Context info or null if unknown
+ */
+function getFilterContext(filterHelper) {
+    if (filterHelper === entitiesFilter) {
+        return {
+            selector: CHARACTER_FILTER_SELECTOR,
+            searchInput: '#character_search_bar',
+        };
+    } else if (filterHelper === groupCandidatesFilter) {
+        return {
+            selector: GROUP_FILTER_SELECTOR,
+            searchInput: '#rm_group_filter',
+        };
+    } else if (filterHelper === groupMembersFilter) {
+        return {
+            selector: GROUP_MEMBERS_FILTER_SELECTOR,
+            searchInput: '#rm_group_members_filter',
+        };
+    }
+    return null;
+}
+
+/**
+ * Get the filter helper for a given list selector.
+ * @param {string} listSelector - jQuery selector for the list
+ * @returns {FilterHelper} The appropriate filter helper instance
+ */
 function getFilterHelper(listSelector) {
     if ($(listSelector).is(GROUP_MEMBERS_FILTER_SELECTOR)) {
         return groupMembersFilter;
     }
     return $(listSelector).is(GROUP_FILTER_SELECTOR) ? groupCandidatesFilter : entitiesFilter;
+}
+
+/**
+ * Checks if the given type is a group context.
+ * @param {tag_filter_type} type - The filter type to check
+ * @returns {boolean} True if this is a group context
+ */
+function isGroupContext(type) {
+    return type === tag_filter_type.group_member || type === tag_filter_type.group_members_list;
+}
+
+/**
+ * Gets visible character avatars for a group context.
+ * @param {tag_filter_type} type - The filter type
+ * @param {object} currentGroup - The current group object
+ * @returns {string[]} Array of visible character avatars
+ */
+function getVisibleAvatarsForGroupContext(type, currentGroup) {
+    if (!currentGroup || !Array.isArray(currentGroup.members)) {
+        return [];
+    }
+
+    if (type === tag_filter_type.group_members_list) {
+        // For members list, return current group members
+        return currentGroup.members;
+    } else {
+        // For candidates list, return non-members
+        return characters
+            .filter(c => !currentGroup.members.includes(c.avatar))
+            .map(c => c.avatar);
+    }
+}
+
+/**
+ * Filters actionable tags for group contexts.
+ * In group contexts, hide GROUP and FOLDER filters but keep Favorites and utility buttons.
+ * @param {object[]} actionTags - Array of actionable tag objects
+ * @returns {object[]} Filtered array of actionable tags
+ */
+function filterActionableTagsForGroupContext(actionTags) {
+    return actionTags.filter(tag => {
+        // Always show Favorites
+        if (tag.id === ACTIONABLE_TAGS.FAV.id) {
+            return true;
+        }
+        // Hide GROUP and FOLDER filters in group contexts (not relevant)
+        if (tag.id === ACTIONABLE_TAGS.GROUP.id || tag.id === ACTIONABLE_TAGS.FOLDER.id) {
+            return false;
+        }
+        // Show utility buttons (VIEW, HINT, UNFILTER)
+        return true;
+    });
 }
 
 const ACTIONABLE_FILTER_STORAGE_KEYS = Object.freeze({
@@ -1310,15 +1393,45 @@ function printTagFilters(type = tag_filter_type.character) {
     $(FILTER_SELECTOR).empty();
 
     // Print all action tags. (Rework 'Folder' button to some kind of onboarding if no folders are enabled yet)
-    const actionTags = Object.values(ACTIONABLE_TAGS);
+    let actionTags = Object.values(ACTIONABLE_TAGS);
     actionTags.find(x => x == ACTIONABLE_TAGS.FOLDER).name = power_user.bogus_folders ? 'Show only folders' : 'Enable \'Tags as Folder\'\n\nAllows characters to be grouped in folders by their assigned tags.\nTags have to be explicitly chosen as folder to show up.\n\nClick here to start';
+
+    // For group contexts, filter actionable tags to only show relevant ones
+    if (isGroupContext(type)) {
+        actionTags = filterActionableTagsForGroupContext(actionTags);
+    }
+
     printTagList($(FILTER_SELECTOR), { empty: false, sort: false, tags: actionTags, tagActionSelector: tag => tag.action, tagOptions: { isGeneralList: true } });
 
     const inListActionTags = Object.values(InListActionable);
     printTagList($(FILTER_SELECTOR), { empty: false, sort: false, tags: inListActionTags, tagActionSelector: tag => tag.action, tagOptions: { isGeneralList: true } });
 
-    const characterTagIds = Object.values(tag_map).flat();
-    const tagsToDisplay = tags.filter(x => characterTagIds.includes(x.id)).sort(compareTagsForSort);
+    // Determine which character tags to display based on context
+    let tagsToDisplay;
+
+    if (isGroupContext(type)) {
+        // For group contexts, only show tags that have at least one visible member
+        const currentGroup = selected_group ? groups.find(x => x.id == selected_group) : null;
+        const visibleAvatars = getVisibleAvatarsForGroupContext(type, currentGroup);
+
+        if (visibleAvatars.length > 0) {
+            // Only include tags that are assigned to at least one visible character
+            const characterTagIds = visibleAvatars
+                .map(avatar => tag_map[avatar] || [])
+                .flat()
+                .filter(onlyUnique);
+
+            tagsToDisplay = tags.filter(x => characterTagIds.includes(x.id)).sort(compareTagsForSort);
+        } else {
+            // No group selected, show no tags
+            tagsToDisplay = [];
+        }
+    } else {
+        // For main character list, show all tags as before
+        const characterTagIds = Object.values(tag_map).flat();
+        tagsToDisplay = tags.filter(x => characterTagIds.includes(x.id)).sort(compareTagsForSort);
+    }
+
     printTagList($(FILTER_SELECTOR), { empty: false, tags: tagsToDisplay, tagOptions: { isFilter: true, isGeneralList: true } });
 
     // Print bogus folder navigation
@@ -1332,18 +1445,19 @@ function printTagFilters(type = tag_filter_type.character) {
     runTagFilters(FILTER_SELECTOR);
 
     if (power_user.show_tag_filters) {
-        $('.rm_tag_controls .showTagList').addClass('selected');
-        $('.rm_tag_controls').find('.tag:not(.actionable)').show();
+        $(FILTER_SELECTOR).closest('.rm_tag_controls').find('.showTagList').addClass('selected');
+        $(FILTER_SELECTOR).find('.tag:not(.actionable)').show();
     }
 
-    updateTagFilterIndicator();
+    updateTagFilterIndicator(FILTER_SELECTOR);
 }
 
-function updateTagFilterIndicator() {
-    if ($('.rm_tag_controls').find('.tag:not(.actionable)').is('.selected, .excluded')) {
-        $('.rm_tag_controls .showTagList').addClass('indicator');
+function updateTagFilterIndicator(filterSelector) {
+    const selector = filterSelector || CHARACTER_FILTER_SELECTOR;
+    if ($(selector).find('.tag:not(.actionable)').is('.selected, .excluded')) {
+        $(selector).closest('.rm_tag_controls').find('.showTagList').addClass('indicator');
     } else {
-        $('.rm_tag_controls .showTagList').removeClass('indicator');
+        $(selector).closest('.rm_tag_controls').find('.showTagList').removeClass('indicator');
     }
 }
 
@@ -1952,12 +2066,22 @@ function onTagListHintClick() {
     console.debug('show_tag_filters', power_user.show_tag_filters);
 }
 
-function onClearAllFiltersClick() {
+/**
+ * Clears all filters for the current list context.
+ * @param {FilterHelper} filterHelper - The filter helper for the current context
+ */
+function onClearAllFiltersClick(filterHelper) {
     console.debug('clear all filters clicked');
+
+    const context = getFilterContext(filterHelper);
+    if (!context) {
+        console.warn('Unknown filter helper in onClearAllFiltersClick');
+        return;
+    }
 
     // We have to manually go through the elements and unfilter by clicking...
     // Thankfully nearly all filter controls are three-state-toggles
-    const filterTags = $('.rm_tag_controls .rm_tag_filter').find('.tag');
+    const filterTags = $(context.selector).find('.tag');
     for (const tag of filterTags) {
         const toggleState = $(tag).attr('data-toggle-state');
         if (toggleState !== undefined && !isFilterState(toggleState ?? FILTER_STATES.UNDEFINED, FILTER_STATES.UNDEFINED)) {
@@ -1965,8 +2089,8 @@ function onClearAllFiltersClick() {
         }
     }
 
-    // Reset search too
-    $('#character_search_bar').val('').trigger('input');
+    // Reset search input for this context
+    $(context.searchInput).val('').trigger('input');
 }
 
 /**

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -138,8 +138,8 @@ function getVisibleAvatarsForGroupContext(type, currentGroup) {
                 .filter(c => !currentGroup.members.includes(c.avatar))
                 .map(c => c.avatar);
         default:
-            console.warn('getVisibleAvatarsForGroupContext got invalid type, expected 1 or 2, got ', type)
-            return []
+            console.warn('getVisibleAvatarsForGroupContext got invalid type, expected 1 or 2, got ', type);
+            return [];
     }
 }
 
@@ -169,16 +169,6 @@ const ACTIONABLE_FILTER_STORAGE_KEYS = Object.freeze({
     FAV: 'TagFilterState_FAV',
     FOLDER: 'TagFilterState_FOLDER',
 });
-
-/**
- * Map of tag IDs to their corresponding filter types.
- * Used for actionable tags (Favorites, Groups, Folders).
- */
-const TAG_ID_TO_FILTER_TYPE = new Map([
-    ['1', FILTER_TYPES.FAV],
-    ['0', FILTER_TYPES.GROUP],
-    ['4', FILTER_TYPES.FOLDER],
-]);
 
 /**
  * Gets the storage key prefix for a filter helper to enable persistence.
@@ -283,6 +273,16 @@ const ACTIONABLE_TAGS = {
     HINT: { id: '3', sort_order: 5, name: 'Show Tag List', color: 'rgba(150, 100, 100, 0.5)', action: onTagListHintClick, icon: 'fa-solid fa-tags', class: 'showTagList' },
     UNFILTER: { id: '5', sort_order: 6, name: 'Clear all filters', action: onClearAllFiltersClick, icon: 'fa-solid fa-filter-circle-xmark', class: 'clearAllFilters' },
 };
+
+/**
+ * Map of tag IDs to their corresponding filter types.
+ * Used for actionable tags (Favorites, Groups, Folders).
+ */
+const TAG_ID_TO_FILTER_TYPE = new Map([
+    [ACTIONABLE_TAGS.FAV.id, FILTER_TYPES.FAV],
+    [ACTIONABLE_TAGS.GROUP.id, FILTER_TYPES.GROUP],
+    [ACTIONABLE_TAGS.FOLDER.id, FILTER_TYPES.FOLDER],
+]);
 
 /** @type {{[key: string]: Tag}} An optional list of actionables that can be utilized by extensions */
 const InListActionable = {

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -1188,7 +1188,7 @@ function newTag(tagName) {
  * @param {JQuery<HTMLElement>|string} element - The container element where the tags are to be printed. (Optionally can also be a string selector for the element, which will then be resolved)
  * @param {PrintTagListOptions} [options] - Optional parameters for printing the tag list.
  */
-function printTagList(element, { tags = undefined, addTag = undefined, forEntityOrKey = undefined, empty = true, sort = true, tagActionSelector = undefined, tagOptions = {} } = {}) {
+function printTagList(element, { tags = undefined, addTag = undefined, forEntityOrKey = undefined, empty = true, sort = true, tagActionSelector = undefined, tagOptions = {}, inactiveTags = [] } = {}) {
     const $element = (typeof element === 'string') ? $(element) : element;
     const key = forEntityOrKey !== undefined ? getTagKeyForEntity(forEntityOrKey) : getTagKey();
     let printableTags = tags ? (typeof tags === 'function' ? tags() : tags) : getTagsList(key, sort);
@@ -1244,7 +1244,9 @@ function printTagList(element, { tags = undefined, addTag = undefined, forEntity
 
         // Check if we should print this tag
         if (shouldPrintTag(tag) || additionalTagsPrinted++ < availableSlotsForAdditionalTags) {
-            appendTagToList($element, tag, tagOptions);
+            // Check if this tag is in the inactive list
+            const isInactive = inactiveTags.includes(tag.id);
+            appendTagToList($element, tag, { ...tagOptions, isInactive });
         } else {
             tagsSkipped++;
         }
@@ -1266,7 +1268,7 @@ function printTagList(element, { tags = undefined, addTag = undefined, forEntity
 
             // Do not bubble further, we are just expanding
             event.stopPropagation();
-            printTagList($element, { tags: tags, addTag: addTag, forEntityOrKey: forEntityOrKey, empty: empty, tagActionSelector: tagActionSelector, tagOptions: tagOptions });
+            printTagList($element, { tags: tags, addTag: addTag, forEntityOrKey: forEntityOrKey, empty: empty, tagActionSelector: tagActionSelector, tagOptions: tagOptions, inactiveTags: inactiveTags });
         };
 
         // Print the placeholder object with its styling and action to show the remaining tags
@@ -1287,7 +1289,7 @@ function printTagList(element, { tags = undefined, addTag = undefined, forEntity
  * @param {TagOptions} [options={}] - Options for tag behavior
  * @returns {void}
  */
-function appendTagToList(listElement, tag, { removable = false, isFilter = false, action = undefined, removeAction = undefined, isGeneralList = false, skipExistsCheck = false } = {}) {
+function appendTagToList(listElement, tag, { removable = false, isFilter = false, action = undefined, removeAction = undefined, isGeneralList = false, skipExistsCheck = false, isInactive = false } = {}) {
     if (!listElement) {
         return;
     }
@@ -1322,6 +1324,9 @@ function appendTagToList(listElement, tag, { removable = false, isFilter = false
     if (tag.icon) {
         tagElement.find('.tag_name').text('').attr('title', `${translate(tag.name)} ${tag.title || ''}`.trim()).addClass(tag.icon);
         tagElement.addClass('actionable');
+    }
+    if (isInactive) {
+        tagElement.addClass('tag-absent');
     }
 
     // We could have multiple ways of actions passed in. The manual arguments have precendence in front of a specified tag action
@@ -1528,20 +1533,28 @@ function printTagFilters(type = tag_filter_type.character) {
 
     // Determine which character tags to display based on context
     let tagsToDisplay;
+    let inactiveTags = [];
 
     if (isGroupContext(type)) {
-        // For group contexts, only show tags that have at least one visible member
+        // For group contexts, show all tags but mark ones without presence in current context as inactive
         const currentGroup = selected_group ? groups.find(x => x.id == selected_group) : null;
         const visibleAvatars = getVisibleAvatarsForGroupContext(type, currentGroup);
 
         if (visibleAvatars.length > 0) {
-            // Only include tags that are assigned to at least one visible character
-            const characterTagIds = visibleAvatars
+            // Get tags that are assigned to at least one visible character
+            const activeCharacterTagIds = visibleAvatars
                 .map(avatar => tag_map[avatar] || [])
                 .flat()
                 .filter(onlyUnique);
 
-            tagsToDisplay = tags.filter(x => characterTagIds.includes(x.id)).sort(compareTagsForSort);
+            // Show all tags that exist in the tag_map
+            const allCharacterTagIds = Object.values(tag_map).flat().filter(onlyUnique);
+            tagsToDisplay = tags.filter(x => allCharacterTagIds.includes(x.id)).sort(compareTagsForSort);
+
+            // Mark tags that are not in the active set as inactive
+            inactiveTags = tagsToDisplay
+                .filter(x => !activeCharacterTagIds.includes(x.id))
+                .map(x => x.id);
         } else {
             // No group selected, show no tags
             tagsToDisplay = [];
@@ -1552,7 +1565,8 @@ function printTagFilters(type = tag_filter_type.character) {
         tagsToDisplay = tags.filter(x => characterTagIds.includes(x.id)).sort(compareTagsForSort);
     }
 
-    printTagList($(FILTER_SELECTOR), { empty: false, tags: tagsToDisplay, tagOptions: { isFilter: true, isGeneralList: true } });
+    printTagList($(FILTER_SELECTOR), { empty: false, tags: tagsToDisplay, tagOptions: { isFilter: true, isGeneralList: true }, inactiveTags: inactiveTags });
+
 
     // Print bogus folder navigation
     const bogusDrilldown = $(FILTER_SELECTOR).siblings('.rm_tag_bogus_drilldown');

--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -75,6 +75,27 @@ const ACTIONABLE_FILTER_STORAGE_KEYS = Object.freeze({
     FOLDER: 'TagFilterState_FOLDER',
 });
 
+/**
+ * Map of tag IDs to their corresponding filter types.
+ * Used for actionable tags (Favorites, Groups, Folders).
+ */
+const TAG_ID_TO_FILTER_TYPE = new Map([
+    ['1', FILTER_TYPES.FAV],
+    ['0', FILTER_TYPES.GROUP],
+    ['4', FILTER_TYPES.FOLDER],
+]);
+
+/**
+ * Checks if the given filter helper is the main character list filter.
+ * Filter states are only persisted to storage for the main character list.
+ * Group contexts maintain independent, non-persistent filter states.
+ * @param {FilterHelper} filterHelper - The filter helper to check
+ * @returns {boolean} True if this is the main character list
+ */
+function isMainCharacterList(filterHelper) {
+    return filterHelper === entitiesFilter;
+}
+
 /** @enum {number} */
 export const tag_filter_type = {
     character: 0,
@@ -99,12 +120,18 @@ export const tag_sort_mode = {
 
 /**
  * @type {{ FAV: Tag, GROUP: Tag, FOLDER: Tag, VIEW: Tag, HINT: Tag, UNFILTER: Tag }}
- * A collection of global actional tags for the filter panel
+ * A collection of global actionable tags for the filter panel.
+ *
+ * Tags with `filter_state` property (FAV, GROUP, FOLDER) maintain persistent state:
+ * - In main character list: state is saved to storage and tag.filter_state
+ * - In group contexts: state is ephemeral (stored only in filter helper)
+ *
+ * Tags without `filter_state` (VIEW, HINT, UNFILTER) are action buttons only.
  * */
 const ACTIONABLE_TAGS = {
-    FAV: { id: '1', sort_order: 1, name: 'Show only favorites', color: 'rgba(255, 255, 0, 0.5)', action: filterByFav, icon: 'fa-solid fa-star', class: 'filterByFavorites' },
-    GROUP: { id: '0', sort_order: 2, name: 'Show only groups', color: 'rgba(100, 100, 100, 0.5)', action: filterByGroups, icon: 'fa-solid fa-users', class: 'filterByGroups' },
-    FOLDER: { id: '4', sort_order: 3, name: 'Show only folders', color: 'rgba(120, 120, 120, 0.5)', action: filterByFolder, icon: 'fa-solid fa-folder-plus', class: 'filterByFolder' },
+    FAV: { id: '1', sort_order: 1, name: 'Show only favorites', color: 'rgba(255, 255, 0, 0.5)', filter_state: undefined, action: filterByFav, icon: 'fa-solid fa-star', class: 'filterByFavorites' },
+    GROUP: { id: '0', sort_order: 2, name: 'Show only groups', color: 'rgba(100, 100, 100, 0.5)', filter_state: undefined, action: filterByGroups, icon: 'fa-solid fa-users', class: 'filterByGroups' },
+    FOLDER: { id: '4', sort_order: 3, name: 'Show only folders', color: 'rgba(120, 120, 120, 0.5)', filter_state: undefined, action: filterByFolder, icon: 'fa-solid fa-folder-plus', class: 'filterByFolder' },
     VIEW: { id: '2', sort_order: 4, name: 'Manage tags', color: 'rgba(150, 100, 100, 0.5)', action: onViewTagsListClick, icon: 'fa-solid fa-gear', class: 'manageTags' },
     HINT: { id: '3', sort_order: 5, name: 'Show Tag List', color: 'rgba(150, 100, 100, 0.5)', action: onTagListHintClick, icon: 'fa-solid fa-tags', class: 'showTagList' },
     UNFILTER: { id: '5', sort_order: 6, name: 'Clear all filters', action: onClearAllFiltersClick, icon: 'fa-solid fa-filter-circle-xmark', class: 'clearAllFilters' },
@@ -350,16 +377,69 @@ function getTagBlock(tag, entities, hidden = 0, isUseless = false) {
 }
 
 /**
- * Applies the favorite filter to the character list.
- * @param {FilterHelper} _filterHelper Instance of FilterHelper class. Unused since it needs to be applied to both filters.
+ * Common logic for applying actionable tag filters (Favorites, Groups, Folders).
+ * Persists state to storage only for the main character list.
+ * @param {FilterHelper} filterHelper - Instance of FilterHelper class
+ * @param {object} tag - The actionable tag object
+ * @param {string} filterType - The filter type constant
+ * @param {string} storageKey - The storage key for persistence
  */
-function filterByFav(_filterHelper) {
+function applyActionableTagFilter(filterHelper, tag, filterType, storageKey) {
     const state = toggleTagThreeState($(this));
-    ACTIONABLE_TAGS.FAV.filter_state = state;
-    accountStorage.setItem(ACTIONABLE_FILTER_STORAGE_KEYS.FAV, state);
-    entitiesFilter.setFilterData(FILTER_TYPES.FAV, state);
-    groupCandidatesFilter.setFilterData(FILTER_TYPES.FAV, state);
-    groupMembersFilter.setFilterData(FILTER_TYPES.FAV, state);
+
+    // Only persist to global state and storage for main character list
+    if (isMainCharacterList(filterHelper)) {
+        tag.filter_state = state;
+        accountStorage.setItem(storageKey, state);
+    }
+
+    // Update the filter helper for the current context
+    filterHelper.setFilterData(filterType, state);
+}
+
+/**
+ * Determines the filter state for a tag based on context.
+ * For actionable tags: reads from persisted state (main list) or filter helper (group contexts).
+ * For regular tags: reads from the filter helper's TAG filter data.
+ * @param {object} tag - The tag object
+ * @param {FilterHelper} filterHelper - The filter helper instance
+ * @param {boolean} isFilterActionable - Whether this is an actionable tag with filter_state
+ * @returns {string} The filter state (SELECTED, EXCLUDED, or default)
+ */
+function determineTagFilterState(tag, filterHelper, isFilterActionable) {
+    if (isFilterActionable) {
+        // For actionable tags (Favorites, Groups, Folders):
+        // - In main list: read from tag.filter_state (persisted globally)
+        // - In group contexts: read from filter helper (independent, non-persistent)
+        if (isMainCharacterList(filterHelper)) {
+            return tag.filter_state || DEFAULT_FILTER_STATE;
+        } else {
+            // Read from filter helper for group contexts
+            const filterType = TAG_ID_TO_FILTER_TYPE.get(tag.id) || null;
+            if (filterType) {
+                return filterHelper.getFilterData(filterType) || DEFAULT_FILTER_STATE;
+            }
+        }
+    } else {
+        // For regular tag filters, read from the filter helper for this context
+        const filterData = filterHelper.getFilterData(FILTER_TYPES.TAG);
+
+        if (filterData?.selected?.includes(tag.id)) {
+            return 'SELECTED';
+        } else if (filterData?.excluded?.includes(tag.id)) {
+            return 'EXCLUDED';
+        }
+    }
+
+    return DEFAULT_FILTER_STATE;
+}
+
+/**
+ * Applies the favorite filter to the character list.
+ * @param {FilterHelper} filterHelper Instance of FilterHelper class.
+ */
+function filterByFav(filterHelper) {
+    applyActionableTagFilter.call(this, filterHelper, ACTIONABLE_TAGS.FAV, FILTER_TYPES.FAV, ACTIONABLE_FILTER_STORAGE_KEYS.FAV);
 }
 
 /**
@@ -367,10 +447,7 @@ function filterByFav(_filterHelper) {
  * @param {FilterHelper} filterHelper Instance of FilterHelper class.
  */
 function filterByGroups(filterHelper) {
-    const state = toggleTagThreeState($(this));
-    ACTIONABLE_TAGS.GROUP.filter_state = state;
-    accountStorage.setItem(ACTIONABLE_FILTER_STORAGE_KEYS.GROUP, state);
-    filterHelper.setFilterData(FILTER_TYPES.GROUP, state);
+    applyActionableTagFilter.call(this, filterHelper, ACTIONABLE_TAGS.GROUP, FILTER_TYPES.GROUP, ACTIONABLE_FILTER_STORAGE_KEYS.GROUP);
 }
 
 /**
@@ -385,10 +462,7 @@ function filterByFolder(filterHelper) {
         return;
     }
 
-    const state = toggleTagThreeState($(this));
-    ACTIONABLE_TAGS.FOLDER.filter_state = state;
-    accountStorage.setItem(ACTIONABLE_FILTER_STORAGE_KEYS.FOLDER, state);
-    filterHelper.setFilterData(FILTER_TYPES.FOLDER, state);
+    applyActionableTagFilter.call(this, filterHelper, ACTIONABLE_TAGS.FOLDER, FILTER_TYPES.FOLDER, ACTIONABLE_FILTER_STORAGE_KEYS.FOLDER);
 }
 
 function loadTagsSettings(settings) {
@@ -1109,18 +1183,13 @@ function appendTagToList(listElement, tag, { removable = false, isFilter = false
 
     // If this is a tag for a general list and its either a filter or actionable, lets mark its current state
     if ((isFilter || clickableAction) && isGeneralList) {
-        // Get the filter state from the appropriate filter helper instead of the global tag object
         const filterHelper = getFilterHelper($(listElement));
-        const filterData = filterHelper.getFilterData(FILTER_TYPES.TAG);
-        let filterState = DEFAULT_FILTER_STATE;
+        const isFilterActionable = clickableAction && 'filter_state' in tag;
 
-        if (filterData && filterData.selected && filterData.selected.includes(tag.id)) {
-            filterState = 'SELECTED';
-        } else if (filterData && filterData.excluded && filterData.excluded.includes(tag.id)) {
-            filterState = 'EXCLUDED';
+        if (isFilter || isFilterActionable) {
+            const filterState = determineTagFilterState(tag, filterHelper, isFilterActionable);
+            toggleTagThreeState(tagElement, { stateOverride: filterState });
         }
-
-        toggleTagThreeState(tagElement, { stateOverride: filterState });
     }
 
     if (isFilter) {
@@ -1144,9 +1213,11 @@ function onTagFilterClick(listElement) {
 
     let state = toggleTagThreeState($(this));
 
-    // Only save to global tag state if we're in the character list (not group contexts)
     const filterHelper = getFilterHelper($(listElement));
-    if (existingTag && filterHelper === entitiesFilter) {
+
+    // Always update the tag's filter_state for the main character list (for persistence)
+    // For group contexts, we only update the filter helper state, not the global tag object
+    if (existingTag && isMainCharacterList(filterHelper)) {
         existingTag.filter_state = state;
         saveSettingsDebounced();
     }
@@ -2305,8 +2376,7 @@ function restoreSavedTagFilters() {
         if (favState) {
             ACTIONABLE_TAGS.FAV.filter_state = favState;
             entitiesFilter.setFilterData(FILTER_TYPES.FAV, favState, true);
-            groupCandidatesFilter.setFilterData(FILTER_TYPES.FAV, favState, true);
-            groupMembersFilter.setFilterData(FILTER_TYPES.FAV, favState, true);
+            // Group contexts start with default state, not persisted state
         }
         if (groupState) {
             ACTIONABLE_TAGS.GROUP.filter_state = groupState;
@@ -2315,6 +2385,26 @@ function restoreSavedTagFilters() {
         if (folderState) {
             ACTIONABLE_TAGS.FOLDER.filter_state = folderState;
             entitiesFilter.setFilterData(FILTER_TYPES.FOLDER, folderState, true);
+        }
+
+        // Restore regular tag filter states from tag objects to entitiesFilter
+        // This ensures that saved tag filters are properly loaded for the main character list
+        const selectedTagIds = [];
+        const excludedTagIds = [];
+
+        for (const tag of tags) {
+            if (tag.filter_state === FILTER_STATES.SELECTED) {
+                selectedTagIds.push(tag.id);
+            } else if (tag.filter_state === FILTER_STATES.EXCLUDED) {
+                excludedTagIds.push(tag.id);
+            }
+        }
+
+        if (selectedTagIds.length > 0 || excludedTagIds.length > 0) {
+            entitiesFilter.setFilterData(FILTER_TYPES.TAG, {
+                excluded: excludedTagIds,
+                selected: selectedTagIds,
+            }, true);
         }
     } catch (e) {
         console.warn('Failed to restore actionable filter states from account storage', e);


### PR DESCRIPTION
Adds the taxon controls found on the main character list, and the add a character to group list, to the member list for group chats.

This allows you to filter a GC down based on characters likely to be active at once, i.e. you could have a party group, for members of your party, then an enemies group, etc

<img width="1432" height="762" alt="CleanShot 2026-01-13 at 17 59 49@2x" src="https://github.com/user-attachments/assets/a7fffcb8-e338-40cb-ab2c-9e108248618e" />
