### PR TITLE
Adding Slash Commands for Vector Storage Extension

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -24,7 +24,7 @@ import {
 import { collapseNewlines, registerDebugFunction } from '../../power-user.js';
 import { SECRET_KEYS, secret_state } from '../../secrets.js';
 import { getDataBankAttachments, getDataBankAttachmentsForSource, getFileAttachment } from '../../chats.js';
-import { debounce, getStringHash as calculateHash, waitUntilCondition, onlyUnique, splitRecursive, trimToStartSentence, trimToEndSentence, escapeHtml, isFalseBoolean, isTrueBoolean } from '../../utils.js';
+import { debounce, getStringHash as calculateHash, waitUntilCondition, onlyUnique, splitRecursive, trimToStartSentence, trimToEndSentence, escapeHtml, isTrueBoolean } from '../../utils.js';
 import { debounce_timeout } from '../../constants.js';
 import { getSortedEntries } from '../../world-info.js';
 import { textgen_types, textgenerationwebui_settings } from '../../textgen-settings.js';
@@ -2037,7 +2037,6 @@ jQuery(async () => {
         returns: ARGUMENT_TYPE.LIST,
     }));
 
-
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'vector-threshold',
         helpString: 'Set the vector score threshold or return the current threshold if no argument is provided.',
@@ -2046,8 +2045,6 @@ jQuery(async () => {
             SlashCommandArgument.fromProps({
                 description: 'Score threshold (number).',
                 typeList: [ARGUMENT_TYPE.NUMBER],
-                isRequired: false,
-                acceptsMultiple: false,
             }),
         ],
         callback: async (_args, value) => {
@@ -2057,8 +2054,8 @@ jQuery(async () => {
             }
 
             const parsed = Number(raw);
-            if (!Number.isFinite(parsed)) {
-                toastr.warning('Score threshold must be a number.');
+            if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+                toastr.warning('Score threshold must be a number between 0 and 1.');
                 return '';
             }
 
@@ -2078,8 +2075,6 @@ jQuery(async () => {
             SlashCommandArgument.fromProps({
                 description: 'Query messages (number >= 0).',
                 typeList: [ARGUMENT_TYPE.NUMBER],
-                isRequired: false,
-                acceptsMultiple: false,
             }),
         ],
         callback: async (_args, value) => {
@@ -2103,15 +2098,13 @@ jQuery(async () => {
     }));
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'vector-maxentries',
+        name: 'vector-max-entries',
         helpString: 'Set the vector world info max entries or returns the current max entries if no argument is provided',
         returns: 'world info max entries',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: 'Max entries (number >= 0).',
                 typeList: [ARGUMENT_TYPE.NUMBER],
-                isRequired: false,
-                acceptsMultiple: false,
             }),
         ],
         callback: async (_args, value) => {
@@ -2140,10 +2133,8 @@ jQuery(async () => {
         returns: 'boolean for if chat vectorization is enabled',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
-                description: 'Is chat vectorization enabled',
+                description: 'boolean to set whether chat vectorization is enabled',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
-                isRequired: false,
-                acceptsMultiple: false,
                 enumList: commonEnumProviders.boolean('trueFalse')(),
             }),
         ],
@@ -2153,12 +2144,7 @@ jQuery(async () => {
                 return String(settings.enabled_chats);
             }
 
-            const parsed = isTrueBoolean(raw) ? true : isFalseBoolean(raw) ? false : null;
-            if (parsed === null) {
-                toastr.warning('Vectors enabled for chats must be true or false.');
-                return '';
-            }
-
+            const parsed = isTrueBoolean(raw);
             $('#vectors_enabled_chats')
                 .prop('checked', parsed)
                 .trigger('input');
@@ -2173,10 +2159,8 @@ jQuery(async () => {
         returns: 'boolean for if file vectorization is enabled',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
-                description: 'Is file vectorization enabled',
+                description: 'boolean to set whether file vectorization is enabled',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
-                isRequired: false,
-                acceptsMultiple: false,
                 enumList: commonEnumProviders.boolean('trueFalse')(),
             }),
         ],
@@ -2186,12 +2170,7 @@ jQuery(async () => {
                 return String(settings.enabled_files);
             }
 
-            const parsed = isTrueBoolean(raw) ? true : isFalseBoolean(raw) ? false : null;
-            if (parsed === null) {
-                toastr.warning('Vectors enabled for files must be true or false.');
-                return '';
-            }
-
+            const parsed = isTrueBoolean(raw) ;
             $('#vectors_enabled_files')
                 .prop('checked', parsed)
                 .trigger('input');
@@ -2206,10 +2185,8 @@ jQuery(async () => {
         returns: 'boolean for if world info vectorization is enabled',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
-                description: 'Is world info vectorization enabled',
+                description: 'boolean to set whether world info vectorization is enabled',
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
-                isRequired: false,
-                acceptsMultiple: false,
                 enumList: commonEnumProviders.boolean('trueFalse')(),
             }),
         ],
@@ -2219,12 +2196,7 @@ jQuery(async () => {
                 return String(settings.enabled_world_info);
             }
 
-            const parsed = isTrueBoolean(raw) ? true : isFalseBoolean(raw) ? false : null;
-            if (parsed === null) {
-                toastr.warning('Vectors enabled for world info must be true or false.');
-                return '';
-            }
-
+            const parsed = isTrueBoolean(raw);
             $('#vectors_enabled_world_info')
                 .prop('checked', parsed)
                 .trigger('input');

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -2037,28 +2037,35 @@ jQuery(async () => {
     }));
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'vector-threshold-set',
-        callback: async (_, value) => {
-            const parsed = Number(value);
+        name: 'vector-threshold',
+        helpString: 'Set the vector score threshold or return the current threshold if no argument is provided.',
+        returns: 'score threshold value',
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Score threshold (number).',
+                typeList: [ARGUMENT_TYPE.NUMBER],
+                isRequired: false,
+                acceptsMultiple: false,
+            }),
+        ],
+        callback: async (_args, value) => {
+            const raw = String(value ?? '').trim();
+            if (!raw) {
+                return String(settings.score_threshold);
+            }
+
+            const parsed = Number(raw);
             if (!Number.isFinite(parsed)) {
                 toastr.warning('Score threshold must be a number.');
                 return '';
             }
 
-            settings.score_threshold = parsed;
-            Object.assign(extension_settings.vectors, settings);
-            saveSettingsDebounced();
             $('#vectors_score_threshold')
-                .val(settings.score_threshold)
+                .val(parsed)
                 .trigger('input');
 
             return String(settings.score_threshold);
         },
-        helpString: 'Set the vector score threshold to a numeric value.',
-        unnamedArgumentList: [
-            new SlashCommandArgument('Score threshold (number).', ARGUMENT_TYPE.NUMBER, true, false),
-        ],
-        returns: ARGUMENT_TYPE.STRING,
     }));
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -24,7 +24,7 @@ import {
 import { collapseNewlines, registerDebugFunction } from '../../power-user.js';
 import { SECRET_KEYS, secret_state } from '../../secrets.js';
 import { getDataBankAttachments, getDataBankAttachmentsForSource, getFileAttachment } from '../../chats.js';
-import { debounce, getStringHash as calculateHash, waitUntilCondition, onlyUnique, splitRecursive, trimToStartSentence, trimToEndSentence, escapeHtml } from '../../utils.js';
+import { debounce, getStringHash as calculateHash, waitUntilCondition, onlyUnique, splitRecursive, trimToStartSentence, trimToEndSentence, escapeHtml, isFalseBoolean, isTrueBoolean } from '../../utils.js';
 import { debounce_timeout } from '../../constants.js';
 import { getSortedEntries } from '../../world-info.js';
 import { textgen_types, textgenerationwebui_settings } from '../../textgen-settings.js';
@@ -32,6 +32,7 @@ import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '../../slash-commands/SlashCommandArgument.js';
 import { SlashCommandEnumValue, enumTypes } from '../../slash-commands/SlashCommandEnumValue.js';
+import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { slashCommandReturnHelper } from '../../slash-commands/SlashCommandReturnHelper.js';
 import { generateWebLlmChatPrompt, isWebLlmSupported } from '../shared.js';
 import { WebLlmVectorProvider } from './webllm.js';
@@ -2036,6 +2037,7 @@ jQuery(async () => {
         returns: ARGUMENT_TYPE.LIST,
     }));
 
+
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'vector-threshold',
         helpString: 'Set the vector score threshold or return the current threshold if no argument is provided.',
@@ -2069,133 +2071,166 @@ jQuery(async () => {
     }));
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'vector-query-set',
-        callback: async (_, value) => {
-            const parsed = Number(value);
+        name: 'vector-query',
+        helpString: 'Set the vector query messages or returns the current query messages count if no argument is provided',
+        returns: 'the query messages value',
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Query messages (number >= 0).',
+                typeList: [ARGUMENT_TYPE.NUMBER],
+                isRequired: false,
+                acceptsMultiple: false,
+            }),
+        ],
+        callback: async (_args, value) => {
+            const raw = String(value ?? '').trim();
+            if (!raw) {
+                return String(settings.query);
+            }
+
+            const parsed = Number(raw);
             if (!Number.isFinite(parsed) || parsed < 0) {
                 toastr.warning('Query messages must be a number greater than or equal to 0.');
                 return '';
             }
 
-            settings.query = parsed;
-            Object.assign(extension_settings.vectors, settings);
-            saveSettingsDebounced();
-
             $('#vectors_query')
-                .val(settings.query)
+                .val(parsed)
                 .trigger('input');
 
             return String(settings.query);
         },
-        helpString: 'Set the vector query messages to a numeric value >= 0.',
-        unnamedArgumentList: [
-            new SlashCommandArgument('Query messages (number >= 0).', ARGUMENT_TYPE.NUMBER, true, false),
-        ],
-        returns: ARGUMENT_TYPE.STRING,
     }));
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'vector-maxentries-set',
-        callback: async (_, value) => {
-            const parsed = Number(value);
+        name: 'vector-maxentries',
+        helpString: 'Set the vector world info max entries or returns the current max entries if no argument is provided',
+        returns: 'world info max entries',
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Max entries (number >= 0).',
+                typeList: [ARGUMENT_TYPE.NUMBER],
+                isRequired: false,
+                acceptsMultiple: false,
+            }),
+        ],
+        callback: async (_args, value) => {
+            const raw = String(value ?? '').trim();
+            if (!raw) {
+                return String(settings.max_entries);
+            }
+
+            const parsed = Number(raw);
             if (!Number.isFinite(parsed) || parsed < 0) {
                 toastr.warning('Max entries must be a number greater than or equal to 0.');
                 return '';
             }
 
-            settings.max_entries = parsed;
-            Object.assign(extension_settings.vectors, settings);
-            saveSettingsDebounced();
-
             $('#vectors_max_entries')
-                .val(settings.max_entries)
+                .val(parsed)
                 .trigger('input');
 
             return String(settings.max_entries);
         },
-        helpString: 'Set the vector world info max entries to a numeric value >= 0.',
-        unnamedArgumentList: [
-            new SlashCommandArgument('Max entries (number >= 0).', ARGUMENT_TYPE.NUMBER, true, false),
-        ],
-        returns: ARGUMENT_TYPE.STRING,
     }));
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'vector-chats-set',
-        callback: async (_, value) => {
-            const parsed = String(value);
-            if (parsed !== 'true' && parsed !== 'false') {
-                toastr.warning('Vectors Enabled for chats must be true or false.');
+        name: 'vector-chats-state',
+        helpString: 'Set whether chat vectorization is enabled or return the current boolean if no argument is provided',
+        returns: 'boolean for if chat vectorization is enabled',
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Is chat vectorization enabled',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                isRequired: false,
+                acceptsMultiple: false,
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
+        callback: async (_args, value) => {
+            const raw = String(value ?? '').trim();
+            if (!raw) {
+                return String(settings.enabled_chats);
+            }
+
+            const parsed = isTrueBoolean(raw) ? true : isFalseBoolean(raw) ? false : null;
+            if (parsed === null) {
+                toastr.warning('Vectors enabled for chats must be true or false.');
                 return '';
             }
 
-            settings.enabled_chats = parsed === 'true';
-            Object.assign(extension_settings.vectors, settings);
-            saveSettingsDebounced();
-
             $('#vectors_enabled_chats')
-                .prop('checked', settings.enabled_chats)
+                .prop('checked', parsed)
                 .trigger('input');
 
             return String(settings.enabled_chats);
         },
-        helpString: 'Set whether chat vectorization is enabled (true/false).',
-        unnamedArgumentList: [
-            new SlashCommandArgument('Enabled (true/false).', ARGUMENT_TYPE.BOOLEAN, true, false),
-        ],
-        returns: ARGUMENT_TYPE.STRING,
     }));
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'vector-files-set',
-        callback: async (_, value) => {
-            const parsed = String(value);
-            if (parsed !== 'true' && parsed !== 'false') {
-                toastr.warning('Vectors enabled for Files must be true or false.');
+        name: 'vector-files-state',
+        helpString: 'Set whether file vectorization is enabled or return the current boolean if no argument is provided',
+        returns: 'boolean for if file vectorization is enabled',
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Is file vectorization enabled',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                isRequired: false,
+                acceptsMultiple: false,
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
+        callback: async (_args, value) => {
+            const raw = String(value ?? '').trim();
+            if (!raw) {
+                return String(settings.enabled_files);
+            }
+
+            const parsed = isTrueBoolean(raw) ? true : isFalseBoolean(raw) ? false : null;
+            if (parsed === null) {
+                toastr.warning('Vectors enabled for files must be true or false.');
                 return '';
             }
 
-            settings.enabled_files = parsed === 'true';
-            Object.assign(extension_settings.vectors, settings);
-            saveSettingsDebounced();
-
             $('#vectors_enabled_files')
-                .prop('checked', settings.enabled_files)
+                .prop('checked', parsed)
                 .trigger('input');
 
             return String(settings.enabled_files);
         },
-        helpString: 'Set whether file vectorization is enabled (true/false).',
-        unnamedArgumentList: [
-            new SlashCommandArgument('Enabled (true/false).', ARGUMENT_TYPE.BOOLEAN, true, false),
-        ],
-        returns: ARGUMENT_TYPE.STRING,
     }));
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'vector-worldinfo-set',
-        callback: async (_, value) => {
-            const parsed = String(value);
-            if (parsed !== 'true' && parsed !== 'false') {
-                toastr.warning('Vectors Enabled for World Info must be true or false.');
+        name: 'vector-worldinfo-state',
+        helpString: 'Set whether world info vectorization is enabled or return the current boolean if no argument is provided',
+        returns: 'boolean for if world info vectorization is enabled',
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'Is world info vectorization enabled',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                isRequired: false,
+                acceptsMultiple: false,
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
+        callback: async (_args, value) => {
+            const raw = String(value ?? '').trim();
+            if (!raw) {
+                return String(settings.enabled_world_info);
+            }
+
+            const parsed = isTrueBoolean(raw) ? true : isFalseBoolean(raw) ? false : null;
+            if (parsed === null) {
+                toastr.warning('Vectors enabled for world info must be true or false.');
                 return '';
             }
 
-            settings.enabled_world_info = parsed === 'true';
-            Object.assign(extension_settings.vectors, settings);
-            saveSettingsDebounced();
-
             $('#vectors_enabled_world_info')
-                .prop('checked', settings.enabled_world_info)
+                .prop('checked', parsed)
                 .trigger('input');
 
             return String(settings.enabled_world_info);
         },
-        helpString: 'Set whether world info vectorization is enabled (true/false).',
-        unnamedArgumentList: [
-            new SlashCommandArgument('Enabled (true/false).', ARGUMENT_TYPE.BOOLEAN, true, false),
-        ],
-        returns: ARGUMENT_TYPE.STRING,
     }));
 
     registerDebugFunction('purge-everything', 'Purge all vector indices', 'Obliterate all stored vectors for all sources. No mercy.', async () => {

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -2114,8 +2114,8 @@ jQuery(async () => {
             }
 
             const parsed = Number(raw);
-            if (!Number.isFinite(parsed) || parsed < 0) {
-                toastr.warning('Max entries must be a number greater than or equal to 0.');
+            if (!Number.isFinite(parsed) || parsed <= 0) {
+                toastr.warning('Max entries must be a number greater than 0.');
                 return '';
             }
 

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -2036,6 +2036,161 @@ jQuery(async () => {
         returns: ARGUMENT_TYPE.LIST,
     }));
 
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'vector-threshold-set',
+        callback: async (_, value) => {
+            const parsed = Number(value);
+            if (!Number.isFinite(parsed)) {
+                toastr.warning('Score threshold must be a number.');
+                return '';
+            }
+
+            settings.score_threshold = parsed;
+            Object.assign(extension_settings.vectors, settings);
+            saveSettingsDebounced();
+            $('#vectors_score_threshold')
+                .val(settings.score_threshold)
+                .trigger('input');
+
+            return String(settings.score_threshold);
+        },
+        helpString: 'Set the vector score threshold to a numeric value.',
+        unnamedArgumentList: [
+            new SlashCommandArgument('Score threshold (number).', ARGUMENT_TYPE.NUMBER, true, false),
+        ],
+        returns: ARGUMENT_TYPE.STRING,
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'vector-query-set',
+        callback: async (_, value) => {
+            const parsed = Number(value);
+            if (!Number.isFinite(parsed) || parsed < 0) {
+                toastr.warning('Query messages must be a number greater than or equal to 0.');
+                return '';
+            }
+
+            settings.query = parsed;
+            Object.assign(extension_settings.vectors, settings);
+            saveSettingsDebounced();
+
+            $('#vectors_query')
+                .val(settings.query)
+                .trigger('input');
+
+            return String(settings.query);
+        },
+        helpString: 'Set the vector query messages to a numeric value >= 0.',
+        unnamedArgumentList: [
+            new SlashCommandArgument('Query messages (number >= 0).', ARGUMENT_TYPE.NUMBER, true, false),
+        ],
+        returns: ARGUMENT_TYPE.STRING,
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'vector-maxentries-set',
+        callback: async (_, value) => {
+            const parsed = Number(value);
+            if (!Number.isFinite(parsed) || parsed < 0) {
+                toastr.warning('Max entries must be a number greater than or equal to 0.');
+                return '';
+            }
+
+            settings.max_entries = parsed;
+            Object.assign(extension_settings.vectors, settings);
+            saveSettingsDebounced();
+
+            $('#vectors_max_entries')
+                .val(settings.max_entries)
+                .trigger('input');
+
+            return String(settings.max_entries);
+        },
+        helpString: 'Set the vector world info max entries to a numeric value >= 0.',
+        unnamedArgumentList: [
+            new SlashCommandArgument('Max entries (number >= 0).', ARGUMENT_TYPE.NUMBER, true, false),
+        ],
+        returns: ARGUMENT_TYPE.STRING,
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'vector-chats-set',
+        callback: async (_, value) => {
+            const parsed = String(value);
+            if (parsed !== 'true' && parsed !== 'false') {
+                toastr.warning('Vectors Enabled for chats must be true or false.');
+                return '';
+            }
+
+            settings.enabled_chats = parsed === 'true';
+            Object.assign(extension_settings.vectors, settings);
+            saveSettingsDebounced();
+
+            $('#vectors_enabled_chats')
+                .prop('checked', settings.enabled_chats)
+                .trigger('input');
+
+            return String(settings.enabled_chats);
+        },
+        helpString: 'Set whether chat vectorization is enabled (true/false).',
+        unnamedArgumentList: [
+            new SlashCommandArgument('Enabled (true/false).', ARGUMENT_TYPE.BOOLEAN, true, false),
+        ],
+        returns: ARGUMENT_TYPE.STRING,
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'vector-files-set',
+        callback: async (_, value) => {
+            const parsed = String(value);
+            if (parsed !== 'true' && parsed !== 'false') {
+                toastr.warning('Vectors enabled for Files must be true or false.');
+                return '';
+            }
+
+            settings.enabled_files = parsed === 'true';
+            Object.assign(extension_settings.vectors, settings);
+            saveSettingsDebounced();
+
+            $('#vectors_enabled_files')
+                .prop('checked', settings.enabled_files)
+                .trigger('input');
+
+            return String(settings.enabled_files);
+        },
+        helpString: 'Set whether file vectorization is enabled (true/false).',
+        unnamedArgumentList: [
+            new SlashCommandArgument('Enabled (true/false).', ARGUMENT_TYPE.BOOLEAN, true, false),
+        ],
+        returns: ARGUMENT_TYPE.STRING,
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'vector-worldinfo-set',
+        callback: async (_, value) => {
+            const parsed = String(value);
+            if (parsed !== 'true' && parsed !== 'false') {
+                toastr.warning('Vectors Enabled for World Info must be true or false.');
+                return '';
+            }
+
+            settings.enabled_world_info = parsed === 'true';
+            Object.assign(extension_settings.vectors, settings);
+            saveSettingsDebounced();
+
+            $('#vectors_enabled_world_info')
+                .prop('checked', settings.enabled_world_info)
+                .trigger('input');
+
+            return String(settings.enabled_world_info);
+        },
+        helpString: 'Set whether world info vectorization is enabled (true/false).',
+        unnamedArgumentList: [
+            new SlashCommandArgument('Enabled (true/false).', ARGUMENT_TYPE.BOOLEAN, true, false),
+        ],
+        returns: ARGUMENT_TYPE.STRING,
+    }));
+
     registerDebugFunction('purge-everything', 'Purge all vector indices', 'Obliterate all stored vectors for all sources. No mercy.', async () => {
         if (!confirm('Are you sure?')) {
             return;


### PR DESCRIPTION
Added slash commands for setting the following settings in Vector Storage:
- Query Messages
- Score Threshold*
- World Info Max Entries
- Enable for World Info/Files/Chat

*Note: it was deliberate that to allow a negative number here. I actually have a use case where I am running this with a negative number.

Included and tested code to refresh the UI values in the extension panel when these settings are updated. 

**Testing:** All commands start with /vector so if tester types that into input window, these commands will come up (assuming Vector Storage extension is enabled). 

**Reason** for adding these slash commands: I have STScripts that I run on chat switch to have different settings for different chats. Wanted to be able to adjust these vector settings as well.

## Checklist:

- [ X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
  - P.S. This is my first time contributing to a github project. I read the file and tried to follow instructions. Apologies in advance if I missed something.
