### PR TITLE
feat(sd): Add Z.AI GLM-Image model support

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -323,6 +323,9 @@ const defaultSettings = {
     openai_quality_gpt: 'auto',
     openai_duration: '8',
 
+    // Z.AI settings
+    zai_coding_api: false,
+
     style: 'Default',
     styles: defaultStyles,
 
@@ -531,6 +534,7 @@ async function loadSettings() {
     $('#sd_openai_quality').val(extension_settings.sd.openai_quality);
     $('#sd_openai_quality_gpt').val(extension_settings.sd.openai_quality_gpt);
     $('#sd_openai_duration').val(extension_settings.sd.openai_duration);
+    $('#sd_zai_coding_api').prop('checked', extension_settings.sd.zai_coding_api);
     $('#sd_comfy_type').val(extension_settings.sd.comfy_type);
     $('#sd_comfy_url').val(extension_settings.sd.comfy_url);
     $('#sd_comfy_prompt').val(extension_settings.sd.comfy_prompt);
@@ -979,6 +983,13 @@ const resolutionOptions = {
     sd_res_1024x1536: { width: 1024, height: 1536, name: '1024x1536 (2:3, ChatGPT)' },
     sd_res_1024x1792: { width: 1024, height: 1792, name: '1024x1792 (4:7, DALL-E)' },
     sd_res_1792x1024: { width: 1792, height: 1024, name: '1792x1024 (7:4, DALL-E)' },
+    sd_res_1280x1280: { width: 1280, height: 1280, name: '1280x1280 (1:1, Z.AI)' },
+    sd_res_1568x1056: { width: 1568, height: 1056, name: '1568x1056 (3:2, Z.AI)' },
+    sd_res_1056x1568: { width: 1056, height: 1568, name: '1056x1568 (2:3, Z.AI)' },
+    sd_res_1472x1088: { width: 1472, height: 1088, name: '1472x1088 (4:3, Z.AI)' },
+    sd_res_1088x1472: { width: 1088, height: 1472, name: '1088x1472 (3:4, Z.AI)' },
+    sd_res_1728x960: { width: 1728, height: 960, name: '1728x960 (16:9, Z.AI)' },
+    sd_res_960x1728: { width: 960, height: 1728, name: '960x1728 (9:16, Z.AI)' },
 };
 
 function onResolutionChange() {
@@ -1055,6 +1066,11 @@ async function onOpenAiQualitySelect() {
 
 async function onOpenAiDurationSelect() {
     extension_settings.sd.openai_duration = String($('#sd_openai_duration').find(':selected').val());
+    saveSettingsDebounced();
+}
+
+function onZaiCodingApiChange() {
+    extension_settings.sd.zai_coding_api = !!$('#sd_zai_coding_api').prop('checked');
     saveSettingsDebounced();
 }
 
@@ -4333,6 +4349,7 @@ async function generateZaiImage(prompt, signal) {
                 model: extension_settings.sd.model,
                 quality: extension_settings.sd.openai_quality,
                 size: `${width}x${height}`,
+                use_coding_api: extension_settings.sd.zai_coding_api,
             }),
         });
 
@@ -5347,6 +5364,7 @@ jQuery(async () => {
     $('#sd_openai_style').on('change', onOpenAiStyleSelect);
     $('#sd_openai_quality').on('change', onOpenAiQualitySelect);
     $('#sd_openai_duration').on('input', onOpenAiDurationSelect);
+    $('#sd_zai_coding_api').on('input', onZaiCodingApiChange);
     $('#sd_multimodal_captioning').on('input', onMultimodalCaptioningInput);
     $('#sd_snap').on('input', onSnapInput);
     $('#sd_clip_skip').on('input', onClipSkipInput);

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -59,7 +59,7 @@ import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnum
 import { ToolManager } from '../../tool-calling.js';
 import { macros, MacroCategory } from '../../macros/macro-system.js';
 import { t, translate } from '../../i18n.js';
-import { oai_settings } from '../../openai.js';
+import { oai_settings, ZAI_ENDPOINT } from '../../openai.js';
 import { power_user } from '/scripts/power-user.js';
 import { MacrosParser } from '/scripts/macros.js';
 
@@ -323,9 +323,6 @@ const defaultSettings = {
     openai_quality_gpt: 'auto',
     openai_duration: '8',
 
-    // Z.AI settings
-    zai_coding_api: false,
-
     style: 'Default',
     styles: defaultStyles,
 
@@ -534,7 +531,6 @@ async function loadSettings() {
     $('#sd_openai_quality').val(extension_settings.sd.openai_quality);
     $('#sd_openai_quality_gpt').val(extension_settings.sd.openai_quality_gpt);
     $('#sd_openai_duration').val(extension_settings.sd.openai_duration);
-    $('#sd_zai_coding_api').prop('checked', extension_settings.sd.zai_coding_api);
     $('#sd_comfy_type').val(extension_settings.sd.comfy_type);
     $('#sd_comfy_url').val(extension_settings.sd.comfy_url);
     $('#sd_comfy_prompt').val(extension_settings.sd.comfy_prompt);
@@ -1066,11 +1062,6 @@ async function onOpenAiQualitySelect() {
 
 async function onOpenAiDurationSelect() {
     extension_settings.sd.openai_duration = String($('#sd_openai_duration').find(':selected').val());
-    saveSettingsDebounced();
-}
-
-function onZaiCodingApiChange() {
-    extension_settings.sd.zai_coding_api = !!$('#sd_zai_coding_api').prop('checked');
     saveSettingsDebounced();
 }
 
@@ -4349,7 +4340,7 @@ async function generateZaiImage(prompt, signal) {
                 model: extension_settings.sd.model,
                 quality: extension_settings.sd.openai_quality,
                 size: `${width}x${height}`,
-                use_coding_api: extension_settings.sd.zai_coding_api,
+                zai_endpoint: ZAI_ENDPOINT.COMMON, // Always use Common API for image generation
             }),
         });
 
@@ -5364,7 +5355,6 @@ jQuery(async () => {
     $('#sd_openai_style').on('change', onOpenAiStyleSelect);
     $('#sd_openai_quality').on('change', onOpenAiQualitySelect);
     $('#sd_openai_duration').on('input', onOpenAiDurationSelect);
-    $('#sd_zai_coding_api').on('input', onZaiCodingApiChange);
     $('#sd_multimodal_captioning').on('input', onMultimodalCaptioningInput);
     $('#sd_snap').on('input', onSnapInput);
     $('#sd_clip_skip').on('input', onClipSkipInput);

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -59,7 +59,7 @@ import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnum
 import { ToolManager } from '../../tool-calling.js';
 import { macros, MacroCategory } from '../../macros/macro-system.js';
 import { t, translate } from '../../i18n.js';
-import { oai_settings, ZAI_ENDPOINT } from '../../openai.js';
+import { oai_settings } from '../../openai.js';
 import { power_user } from '/scripts/power-user.js';
 import { MacrosParser } from '/scripts/macros.js';
 
@@ -4340,7 +4340,6 @@ async function generateZaiImage(prompt, signal) {
                 model: extension_settings.sd.model,
                 quality: extension_settings.sd.openai_quality,
                 size: `${width}x${height}`,
-                zai_endpoint: ZAI_ENDPOINT.COMMON, // Always use Common API for image generation
             }),
         });
 

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2297,7 +2297,12 @@ async function loadGoogleModels() {
 }
 
 async function loadZaiModels() {
-    return ['cogview-4-250304', 'cogvideox-3', 'viduq1-text'].map(name => ({ value: name, text: name }));
+    return [
+        { value: 'glm-image', text: 'GLM-Image' },
+        { value: 'cogview-4-250304', text: 'CogView-4' },
+        { value: 'cogvideox-3', text: 'CogVideoX-3' },
+        { value: 'viduq1-text', text: 'Viduq1-Text' },
+    ];
 }
 
 async function loadOpenRouterModels() {
@@ -4268,6 +4273,7 @@ async function generateGoogleImage(prompt, negativePrompt, signal) {
  * @returns {Promise<{format: string, data: string}>} A promise that resolves when the image generation and processing are complete.
  */
 async function generateZaiImage(prompt, signal) {
+    // Video generation models (CogVideoX, Viduq1)
     if (/(cogvideox|vidu)/.test(extension_settings.sd.model)) {
         const videoParams = {};
         if (/cogvideox/.test(extension_settings.sd.model)) {
@@ -4298,16 +4304,23 @@ async function generateZaiImage(prompt, signal) {
         const text = await videoResult.text();
         throw new Error(text);
     } else {
-        // Round width and height to nearest multiple of 16, and clamp to 512-2048 range
-        let width = clamp(Math.round(extension_settings.sd.width / 16) * 16, 512, 2048);
-        let height = clamp(Math.round(extension_settings.sd.height / 16) * 16, 512, 2048);
+        // Image generation models (GLM-Image, CogView)
+        // GLM-Image requires multiples of 32, CogView requires multiples of 16
+        const isGlmImage = /glm-image/.test(extension_settings.sd.model);
+        const multiple = isGlmImage ? 32 : 16;
 
-        // Make sure the pixel count does not exceed 2^21px
-        while ((width * height) > Math.pow(2, 21)) {
-            if (width >= height) {
-                width -= 16;
-            } else {
-                height -= 16;
+        // Round width and height to nearest multiple and clamp to 512-2048 range
+        let width = clamp(Math.round(extension_settings.sd.width / multiple) * multiple, 512, 2048);
+        let height = clamp(Math.round(extension_settings.sd.height / multiple) * multiple, 512, 2048);
+
+        // CogView has a 2^21px pixel count limit, GLM-Image does not
+        if (!isGlmImage) {
+            while ((width * height) > Math.pow(2, 21)) {
+                if (width >= height) {
+                    width -= multiple;
+                } else {
+                    height -= multiple;
+                }
             }
         }
 

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -166,13 +166,6 @@
                     </div>
                 </div>
             </div>
-            <div data-sd-source="zai">
-                <label for="sd_zai_coding_api" class="checkbox_label" title="Use Coding API endpoint instead of Common API. Enable this if your API key is from the GLM Coding Plan.">
-                    <input id="sd_zai_coding_api" type="checkbox" />
-                    <span>Use Coding API</span>
-                </label>
-                <small>Enable if using GLM Coding Plan API key</small>
-            </div>
             <div data-sd-source="openai,aimlapi,zai">
                 <div class="flex-container">
                     <div data-sd-model="dall-e-3" class="flex1">

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -167,7 +167,11 @@
                 </div>
             </div>
             <div data-sd-source="zai">
-                <b>Will use Common API. Coding API is not supported!</b>
+                <label for="sd_zai_coding_api" class="checkbox_label" title="Use Coding API endpoint instead of Common API. Enable this if your API key is from the GLM Coding Plan.">
+                    <input id="sd_zai_coding_api" type="checkbox" />
+                    <span>Use Coding API</span>
+                </label>
+                <small>Enable if using GLM Coding Plan API key</small>
             </div>
             <div data-sd-source="openai,aimlapi,zai">
                 <div class="flex-container">

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -184,7 +184,7 @@
                             <option value="high" data-i18n="High">High</option>
                         </select>
                     </div>
-                    <div data-sd-model="dall-e-3,cogview-4-250304,glm-image,cogvideox" class="flex1">
+                    <div data-sd-model="dall-e-3,cogview-4,glm-image,cogvideox" class="flex1">
                         <label for="sd_openai_quality" data-i18n="Image Quality">Image Quality</label>
                         <select id="sd_openai_quality">
                             <option value="standard" data-i18n="Standard">Standard</option>

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -187,7 +187,7 @@
                             <option value="high" data-i18n="High">High</option>
                         </select>
                     </div>
-                    <div data-sd-model="dall-e-3,cogview-4,cogvideox" class="flex1">
+                    <div data-sd-model="dall-e-3,cogview-4-250304,glm-image,cogvideox" class="flex1">
                         <label for="sd_openai_quality" data-i18n="Image Quality">Image Quality</label>
                         <select id="sd_openai_quality">
                             <option value="standard" data-i18n="Standard">Standard</option>

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -166,6 +166,9 @@
                     </div>
                 </div>
             </div>
+            <div data-sd-source="zai">
+                <b>Will use Common API. Coding API is not supported!</b>
+            </div>
             <div data-sd-source="openai,aimlapi,zai">
                 <div class="flex-container">
                     <div data-sd-model="dall-e-3" class="flex1">

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -58,7 +58,7 @@
                 <option value="horde">Stable Horde</option>
                 <option value="togetherai">TogetherAI</option>
                 <option value="xai">xAI (Grok)</option>
-                <option value="zai">Z.AI (CogView)</option>
+                <option value="zai">Z.AI</option>
             </select>
             <div data-sd-source="auto">
                 <label for="sd_auto_url">SD Web UI URL</label>

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -1789,13 +1789,11 @@ zai.post('/generate', async (request, response) => {
             return response.sendStatus(500);
         }
 
-        console.debug('Z.AI fetching image from URL:', url);
         const imageResponse = await fetch(url);
         if (!imageResponse.ok) {
             console.warn('Z.AI image fetch returned an error. Status:', imageResponse.status, imageResponse.statusText);
             return response.sendStatus(500);
         }
-        console.debug('Z.AI image fetch successful, status:', imageResponse.status);
 
         const buffer = await imageResponse.arrayBuffer();
         const image = Buffer.from(buffer).toString('base64');

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -1758,8 +1758,8 @@ zai.post('/generate', async (request, response) => {
 
         console.debug('Z.AI image request:', request.body);
 
-        // Use Coding API endpoint if requested, otherwise Common API
-        const baseUrl = request.body.use_coding_api
+        // Use Coding API endpoint if configured, otherwise Common API
+        const baseUrl = request.body.zai_endpoint === 'coding'
             ? 'https://api.z.ai/api/coding/paas/v4/images/generations'
             : 'https://api.z.ai/api/paas/v4/images/generations';
 

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -1758,7 +1758,12 @@ zai.post('/generate', async (request, response) => {
 
         console.debug('Z.AI image request:', request.body);
 
-        const generateResponse = await fetch('https://api.z.ai/api/paas/v4/images/generations', {
+        // Use Coding API endpoint if requested, otherwise Common API
+        const baseUrl = request.body.use_coding_api
+            ? 'https://api.z.ai/api/coding/paas/v4/images/generations'
+            : 'https://api.z.ai/api/paas/v4/images/generations';
+
+        const generateResponse = await fetch(baseUrl, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -1788,11 +1793,13 @@ zai.post('/generate', async (request, response) => {
             return response.sendStatus(500);
         }
 
+        console.debug('Z.AI fetching image from URL:', url);
         const imageResponse = await fetch(url);
         if (!imageResponse.ok) {
-            console.warn('Z.AI image fetch returned an error.');
+            console.warn('Z.AI image fetch returned an error. Status:', imageResponse.status, imageResponse.statusText);
             return response.sendStatus(500);
         }
+        console.debug('Z.AI image fetch successful, status:', imageResponse.status);
 
         const buffer = await imageResponse.arrayBuffer();
         const image = Buffer.from(buffer).toString('base64');

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -1758,12 +1758,8 @@ zai.post('/generate', async (request, response) => {
 
         console.debug('Z.AI image request:', request.body);
 
-        // Use Coding API endpoint if configured, otherwise Common API
-        const baseUrl = request.body.zai_endpoint === 'coding'
-            ? 'https://api.z.ai/api/coding/paas/v4/images/generations'
-            : 'https://api.z.ai/api/paas/v4/images/generations';
-
-        const generateResponse = await fetch(baseUrl, {
+        // Always use Common API for image generation (Coding API has stricter rate limits)
+        const generateResponse = await fetch('https://api.z.ai/api/paas/v4/images/generations', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

Add support for the new Z.AI GLM-Image model in the Image Generation extension:

- Added `glm-image` to the Z.AI model dropdown with friendly display name
- Handle GLM-Image's requirement for image dimensions in multiples of 32 (vs CogView's multiples of 16)
- Show quality dropdown (standard/HD) for GLM-Image model

## Technical Details

The GLM-Image model uses the same Z.AI API endpoint (`/api/paas/v4/images/generations`) but has different dimension constraints:
- **CogView**: Dimensions must be multiples of 16
- **GLM-Image**: Dimensions must be multiples of 32

The `generateZaiImage` function now detects the selected model and uses the appropriate multiple for dimension rounding.

## Test plan

- [ ] Select Z.AI as image source
- [ ] Verify GLM-Image appears in model dropdown
- [ ] Generate an image with GLM-Image selected
- [ ] Verify quality dropdown (standard/HD) is visible for GLM-Image
- [ ] Verify CogView-4 still works correctly

## References

- [Z.AI GLM-Image Documentation](https://docs.z.ai/guides/image/glm-image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)