### PR TITLE
Suppress error messages when Firefox unloads the tab

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9463,6 +9463,11 @@ function addAlternateGreeting(template, greeting, index, getArray, popup) {
  * @param {Event} [e] Event that triggered the function call.
  */
 export async function createOrEditCharacter(e) {
+    if (!settingsReady) {
+        console.warn('Settings not ready, aborting character creation/editing.');
+        return;
+    }
+
     $('#rm_info_avatar').html('');
     const formData = new FormData(/** @type {HTMLFormElement} */($('#form_create').get(0)));
     formData.set('fav', String(fav_ch_checked));

--- a/public/script.js
+++ b/public/script.js
@@ -388,7 +388,7 @@ let chatSaveTimeout;
 let importFlashTimeout;
 export let isChatSaving = false;
 let firstRun = false;
-let settingsReady = false;
+export let settingsReady = false;
 let currentVersion = '0.0.0';
 export let displayVersion = 'SillyTavern';
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -4016,6 +4016,11 @@ jQuery(() => {
         power_user.experimental_macro_engine = !!$(this).prop('checked');
         saveSettingsDebounced();
 
+        // Check if the app is ready before showing the toast
+        if (!eventSource.autoFireLastArgs.has(event_types.APP_READY)) {
+            return;
+        }
+
         eventSource.once(event_types.SETTINGS_UPDATED, function() {
             toastr.warning(
                 t`Click here to reload.`,

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -30,6 +30,7 @@ import {
     extension_prompt_types,
     extension_prompt_roles,
     deleteMessage,
+    settingsReady,
 } from '../script.js';
 import { isMobile, initMovingUI, favsToHotswap } from './RossAscends-mods.js';
 import {
@@ -4017,7 +4018,7 @@ jQuery(() => {
         saveSettingsDebounced();
 
         // Check if the app is ready before showing the toast
-        if (!eventSource.autoFireLastArgs.has(event_types.APP_READY)) {
+        if (!settingsReady) {
             return;
         }
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Adds initialization guards to prevent premature function execution during Firefox's tab unload/reload cycle

Supersedes #4989

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
