### PR TITLE
feat(sd): Add generation status indicator and improve abort handling

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -4790,7 +4790,8 @@ function isValidState() {
     }
 }
 
-let buttonAbortController = null;
+/** @type {WeakMap<JQuery<HTMLElement>, AbortController>} */
+const buttonAbortControllers = new WeakMap();
 
 /**
  * "Paintbrush" button handler to generate a new image for a message.
@@ -4814,9 +4815,18 @@ async function sdMessageButton($icon, { animate } = {}) {
 
     const classes = { busy: 'fa-hourglass', idle: 'fa-paintbrush', animation: 'fa-fade' };
     const context = getContext();
+    const abortController = (() => {
+        if (buttonAbortControllers.has($icon)) {
+            return buttonAbortControllers.get($icon);
+        } else {
+            const controller = new AbortController();
+            buttonAbortControllers.set($icon, controller);
+            return controller;
+        }
+    })();
 
     if ($icon.hasClass(classes.busy)) {
-        buttonAbortController?.abort('Aborted by user');
+        abortController.abort('Aborted by user');
         console.log('Previous image is still being generated...');
         return;
     }
@@ -4854,13 +4864,12 @@ async function sdMessageButton($icon, { animate } = {}) {
         $media = messageElement.find(`.mes_media_container[data-index="${index}"]`).find('.mes_img, .mes_video');
     }
 
-    buttonAbortController = new AbortController();
     const newMediaAttachment = await generateMediaSwipe(
         selectedMedia,
         message,
         () => setBusyIcon(true),
         () => setBusyIcon(false),
-        buttonAbortController,
+        abortController,
     );
 
     if (!newMediaAttachment) {

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2892,12 +2892,7 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         imagePath = await sendGenerationRequest(generationType, prompt, negativePromptPrefix, characterName, callback, initiator, abortController.signal);
     } catch (err) {
         // Check if this was an intentional abort by user
-        const isAborted = abortController.signal.aborted ||
-            err.message === 'Aborted by user' ||
-            err.name === 'AbortError' ||
-            err.type === 'aborted' ||
-            (err.message && err.message.includes('aborted'));
-        if (isAborted) {
+        if (abortController.signal.aborted) {
             console.log('SD: Image generation aborted by user');
             toastr.info('Image generation stopped.', 'Image Generation');
             return;
@@ -3236,11 +3231,7 @@ async function sendGenerationRequest(generationType, prompt, additionalNegativeP
         }
     } catch (err) {
         // Check if this was an intentional abort by user
-        const isAborted = signal?.aborted ||
-            err.name === 'AbortError' ||
-            err.type === 'aborted' ||
-            (err.message && err.message.includes('aborted'));
-        if (isAborted) {
+        if (signal?.aborted) {
             console.log('SD: Image generation aborted by user');
             toastr.info('Image generation stopped.', 'Image Generation');
             return;

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -4790,7 +4790,7 @@ function isValidState() {
     }
 }
 
-/** @type {WeakMap<JQuery<HTMLElement>, AbortController>} */
+/** @type {WeakMap<HTMLElement, AbortController>} */
 const buttonAbortControllers = new WeakMap();
 
 /**
@@ -4816,11 +4816,12 @@ async function sdMessageButton($icon, { animate } = {}) {
     const classes = { busy: 'fa-hourglass', idle: 'fa-paintbrush', animation: 'fa-fade' };
     const context = getContext();
     const abortController = (() => {
-        if (buttonAbortControllers.has($icon)) {
-            return buttonAbortControllers.get($icon);
+        const nativeElement = $icon.get(0);
+        if (buttonAbortControllers.has(nativeElement)) {
+            return buttonAbortControllers.get(nativeElement);
         } else {
             const controller = new AbortController();
-            buttonAbortControllers.set($icon, controller);
+            buttonAbortControllers.set(nativeElement, controller);
             return controller;
         }
     })();

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -72,7 +72,9 @@ const CUSTOM_STOP_EVENT = 'sd_stop_generation';
 
 // Generation tracking for status indicator
 let activeGenerations = 0;
+/** @type {JQuery<HTMLElement>|null} */
 let generationToast = null;
+
 const sources = {
     extras: 'extras',
     horde: 'horde',

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -4724,7 +4724,6 @@ async function addSDGenButtons() {
     const stopGenButton = $('#sd_stop_gen');
     stopGenButton.hide();
     stopGenButton.on('click', () => eventSource.emit(CUSTOM_STOP_EVENT));
-
 }
 
 function isValidState() {

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2864,9 +2864,6 @@ async function generatePicture(initiator, args, trigger, message, callback) {
 
     const stopListener = () => abortController.abort('Aborted by user');
 
-    // Track this generation for status indicator
-    startGenerationTracking();
-
     try {
         const combineNegatives = (prefix) => { negativePromptPrefix = combinePrefixes(negativePromptPrefix, prefix); };
 
@@ -2879,6 +2876,8 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         await eventSource.emit(event_types.SD_PROMPT_PROCESSING, eventData);
         prompt = eventData.prompt; // Allow extensions to modify the prompt
 
+        // Track this generation for status indicator
+        startGenerationTracking();
         // Show stop button after prompt is ready (prompt generation uses separate abort mechanism)
         $(stopButton).show();
         eventSource.once(CUSTOM_STOP_EVENT, stopListener);
@@ -3106,8 +3105,10 @@ function getUserAvatarUrl() {
  * @returns {Promise<string>} - A promise that resolves when the prompt generation completes.
  */
 async function generatePrompt(quietPrompt) {
+    const toast = toastr.info('Generating image prompt with an LLM...', 'Image Generation');
     const reply = await generateQuietPrompt({ quietPrompt });
     const processedReply = processReply(reply);
+    toastr.clear(toast);
 
     if (!processedReply) {
         toastr.error('Prompt generation produced no text. Make sure you\'re using a valid instruct template and try again', 'Image Generation');

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -4832,7 +4832,7 @@ async function sdMessageButton($icon, { animate } = {}) {
 
     if ($icon.hasClass(classes.busy)) {
         abortController.abort('Aborted by user');
-        console.log('Previous image is still being generated...');
+        console.log('SD: Image generation aborted by user');
         return;
     }
 

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -4809,6 +4809,10 @@ async function sdMessageButton($icon, { animate } = {}) {
         $icon.toggleClass(classes.idle, !isBusy);
         $icon.toggleClass(classes.busy, isBusy);
         $media.toggleClass(classes.animation, isBusy);
+
+        // Update generation counter toast
+        const trackingFunction = isBusy ? startGenerationTracking : endGenerationTracking;
+        trackingFunction();
     }
 
     let $media = jQuery();

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -69,6 +69,10 @@ const MODULE_NAME = 'sd';
 // This is a 1x1 transparent PNG
 const PNG_PIXEL = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 const CUSTOM_STOP_EVENT = 'sd_stop_generation';
+
+// Generation tracking for status indicator
+let activeGenerations = 0;
+let generationToast = null;
 const sources = {
     extras: 'extras',
     horde: 'horde',
@@ -2743,6 +2747,60 @@ function ensureSelectionExists(setting, selector) {
 }
 
 /**
+ * Updates the generation status indicator based on active generation count.
+ * Shows/hides various UI indicators to inform user of background image generation.
+ */
+function updateGenerationIndicator() {
+    if (activeGenerations > 0) {
+        // Show persistent toast if not already showing
+        if (!generationToast) {
+            const countText = activeGenerations > 1 ? ` (${activeGenerations})` : '';
+            generationToast = toastr.info(
+                `<i class="fa-solid fa-spinner fa-spin"></i> Generating image${countText}...`,
+                'Image Generation',
+                {
+                    timeOut: 0,
+                    extendedTimeOut: 0,
+                    tapToDismiss: true,
+                    escapeHtml: false,
+                    onHidden: () => {
+                        generationToast = null;
+                    },
+                },
+            );
+        } else if (activeGenerations > 1) {
+            // Update count in existing toast
+            const toastMessage = $(generationToast).find('.toast-message');
+            if (toastMessage.length) {
+                toastMessage.html(`<i class="fa-solid fa-spinner fa-spin"></i> Generating image (${activeGenerations})...`);
+            }
+        }
+    } else {
+        // Hide toast when done
+        if (generationToast) {
+            toastr.clear(generationToast);
+            generationToast = null;
+        }
+    }
+}
+
+/**
+ * Increments the active generation counter and updates indicators.
+ */
+function startGenerationTracking() {
+    activeGenerations++;
+    updateGenerationIndicator();
+}
+
+/**
+ * Decrements the active generation counter and updates indicators.
+ */
+function endGenerationTracking() {
+    activeGenerations = Math.max(0, activeGenerations - 1);
+    updateGenerationIndicator();
+}
+
+/**
  * Generates an image based on the given trigger word.
  * @param {string} initiator The initiator of the image generation
  * @param {Record<string, object>} args Command arguments
@@ -2804,6 +2862,9 @@ async function generatePicture(initiator, args, trigger, message, callback) {
 
     const stopListener = () => abortController.abort('Aborted by user');
 
+    // Track this generation for status indicator
+    startGenerationTracking();
+
     try {
         const combineNegatives = (prefix) => { negativePromptPrefix = combinePrefixes(negativePromptPrefix, prefix); };
 
@@ -2816,6 +2877,7 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         await eventSource.emit(event_types.SD_PROMPT_PROCESSING, eventData);
         prompt = eventData.prompt; // Allow extensions to modify the prompt
 
+        // Show stop button after prompt is ready (prompt generation uses separate abort mechanism)
         $(stopButton).show();
         eventSource.once(CUSTOM_STOP_EVENT, stopListener);
 
@@ -2826,6 +2888,18 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         // generate the image
         imagePath = await sendGenerationRequest(generationType, prompt, negativePromptPrefix, characterName, callback, initiator, abortController.signal);
     } catch (err) {
+        // Check if this was an intentional abort by user
+        const isAborted = abortController.signal.aborted ||
+            err.message === 'Aborted by user' ||
+            err.name === 'AbortError' ||
+            err.type === 'aborted' ||
+            (err.message && err.message.includes('aborted'));
+        if (isAborted) {
+            console.log('SD: Image generation aborted by user');
+            toastr.info('Image generation stopped.', 'Image Generation');
+            return;
+        }
+
         console.trace(err);
         // errors here are most likely due to text generation failure
         // sendGenerationRequest mostly deals with its own errors
@@ -2838,6 +2912,7 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         $(stopButton).hide();
         restoreOriginalDimensions(dimensions);
         eventSource.removeListener(CUSTOM_STOP_EVENT, stopListener);
+        endGenerationTracking();
     }
 
     return imagePath;
@@ -3155,6 +3230,17 @@ async function sendGenerationRequest(generationType, prompt, additionalNegativeP
             throw new Error('Endpoint did not return image data.');
         }
     } catch (err) {
+        // Check if this was an intentional abort by user
+        const isAborted = signal?.aborted ||
+            err.name === 'AbortError' ||
+            err.type === 'aborted' ||
+            (err.message && err.message.includes('aborted'));
+        if (isAborted) {
+            console.log('SD: Image generation aborted by user');
+            toastr.info('Image generation stopped.', 'Image Generation');
+            return;
+        }
+
         console.error('Image generation request error: ', err);
         toastr.error('Image generation failed. Please try again.' + '\n\n' + String(err), 'Image Generation');
         return;
@@ -4642,6 +4728,7 @@ async function addSDGenButtons() {
     const stopGenButton = $('#sd_stop_gen');
     stopGenButton.hide();
     stopGenButton.on('click', () => eventSource.emit(CUSTOM_STOP_EVENT));
+
 }
 
 function isValidState() {

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2752,11 +2752,13 @@ function ensureSelectionExists(setting, selector) {
  */
 function updateGenerationIndicator() {
     if (activeGenerations > 0) {
+        const countText = activeGenerations > 1 ? ` (${activeGenerations})` : '';
+        const toastText = `<i class="fa-solid fa-spinner fa-spin"></i> ${t`Generating image`}${countText}...`;
+
         // Show persistent toast if not already showing
         if (!generationToast) {
-            const countText = activeGenerations > 1 ? ` (${activeGenerations})` : '';
             generationToast = toastr.info(
-                `<i class="fa-solid fa-spinner fa-spin"></i> Generating image${countText}...`,
+                toastText,
                 'Image Generation',
                 {
                     timeOut: 0,
@@ -2772,7 +2774,7 @@ function updateGenerationIndicator() {
             // Update count in existing toast
             const toastMessage = $(generationToast).find('.toast-message');
             if (toastMessage.length) {
-                toastMessage.html(`<i class="fa-solid fa-spinner fa-spin"></i> Generating image (${activeGenerations})...`);
+                toastMessage.html(toastText);
             }
         }
     } else {


### PR DESCRIPTION
## Summary
- Add persistent toast notification showing image generation in progress
- Improve abort handling to show friendly message instead of error

<img width="332" height="78" alt="Screenshot 2026-01-14 at 18 25 21" src="https://github.com/user-attachments/assets/49397678-0a39-43c3-9eea-4801698cd9d9" />
<img width="332" height="78" alt="Screenshot 2026-01-14 at 18 25 38" src="https://github.com/user-attachments/assets/5f232f76-b4b7-49b2-a271-a42e57c03f61" />

## Changes
- Add generation tracking with `activeGenerations` counter
- Show toast with spinner during generation ("Generating image...")
- Support multiple concurrent generations with count display
- Click toast to dismiss (generation continues in background)
- Handle abort gracefully in both `generatePicture()` and `sendGenerationRequest()`
- Show "Image generation stopped" info message instead of error on abort

## Test plan
- [x] Trigger image generation, verify toast appears with spinner
- [x] Trigger multiple generations, verify count updates
- [x] Click toast to dismiss, verify generation continues
- [x] Click stop button, verify friendly "Image generation stopped" message
- [x] Let generation complete, verify toast auto-clears

Closes #5014

🤖 Generated with [Claude Code](https://claude.com/claude-code)