### PR TITLE
Recent Chats: Add pin functionality

### DIFF
--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -115,6 +115,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     cursor: pointer;
     gap: 10px;
     border: 1px solid var(--SmartThemeBorderColor);
+    position: relative;
 }
 
 .welcomeRecent .recentChatList .recentChat .avatar {
@@ -220,6 +221,14 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 
 .welcomeRecent .recentChatList .showMoreChats.rotated {
     transform: rotate(180deg);
+}
+
+.welcomeRecent .recentChatList .recentChat .recentChatPinned {
+    top: 1px;
+    left: 1px;
+    position: absolute;
+    opacity: 0.8;
+    color: var(--SmartThemeQuoteColor);
 }
 
 @media screen and (max-width: 1000px) {

--- a/public/scripts/templates/welcomePanel.html
+++ b/public/scripts/templates/welcomePanel.html
@@ -44,6 +44,11 @@
         {{#each chats}}
             {{#with this}}
             <div class="recentChat {{#if hidden}}hidden{{/if}} {{#if is_group}}group{{/if}}" data-file="{{chat_name}}" data-avatar="{{avatar}}" data-group="{{group}}">
+                {{#if pinned}}
+                    <div class="recentChatPinned">
+                        <i class="fa-solid fa-thumbtack fa-fw fa-xs" title="Pinned chat" data-i18n="[title]Pinned chat"></i>
+                    </div>
+                {{/if}}
                 <div class="avatar" title="[Character] {{char_name}}&#10;File: {{avatar}}">
                     <img src="{{char_thumbnail}}" alt="{{char_name}}">
                 </div>
@@ -56,6 +61,9 @@
                         </div>
                         <small class="chatDate" title="{{date_long}}">{{date_short}}</small>
                         <div class="chatActions">
+                            <button class="menu_button menu_button_icon pinChat {{#if pinned}}active{{/if}}" title="Pin chat" data-i18n="[title]Pin chat">
+                                <i class="fa-solid fa-thumbtack fa-fw"></i>
+                            </button>
                             <button class="menu_button menu_button_icon renameChat" title="Rename chat" data-i18n="[title]Rename chat">
                                 <i class="fa-solid fa-pen-to-square fa-fw"></i>
                             </button>

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -35,7 +35,7 @@ import { callGenericPopup, POPUP_TYPE } from './popup.js';
 import { getMessageTimeStamp } from './RossAscends-mods.js';
 import { renderTemplateAsync } from './templates.js';
 import { accountStorage } from './util/AccountStorage.js';
-import { sortMoments, timestampToMoment } from './utils.js';
+import { flashHighlight, sortMoments, timestampToMoment } from './utils.js';
 
 const assistantAvatarKey = 'assistant';
 const pinnedChatsKey = 'pinnedChats';
@@ -381,7 +381,7 @@ async function sendWelcomePanel(chats, expand = false) {
             });
         });
         fragment.querySelectorAll('.recentChat .pinChat').forEach((pinButton) => {
-            pinButton.addEventListener('click', (event) => {
+            pinButton.addEventListener('click', async (event) => {
                 event.stopPropagation();
                 const chatItem = pinButton.closest('.recentChat');
                 if (!chatItem) {
@@ -397,7 +397,7 @@ async function sendWelcomePanel(chats, expand = false) {
                 }
                 const currentlyPinned = PinnedChatsManager.isPinned(recentChat);
                 PinnedChatsManager.toggle(recentChat, !currentlyPinned);
-                void refreshWelcomeScreen();
+                await refreshWelcomeScreen({ flashChat: recentChat });
             });
         });
         chatElement.append(fragment.firstChild);
@@ -588,9 +588,11 @@ async function deleteRecentGroupChat(groupId, fileName) {
 
 /**
  * Reopens the welcome screen and restores the scroll position.
+ * @param {object} param Additional parameters
+ * @param {RecentChat} [param.flashChat] Recent chat to flash (if any)
  * @returns {Promise<void>}
  */
-async function refreshWelcomeScreen() {
+async function refreshWelcomeScreen({ flashChat = null } = {}) {
     const chatElement = document.getElementById('chat');
     if (!chatElement) {
         console.error('Chat element not found');
@@ -603,8 +605,24 @@ async function refreshWelcomeScreen() {
 
     await openWelcomeScreen({ force: true, expand });
 
-    // Restore scroll position
-    chatElement.scrollTop = scrollTop + (chatElement.scrollHeight - scrollHeight);
+    // Restore scroll position or flash specific chat
+    if (flashChat) {
+        const recentChats = Array.from(chatElement.querySelectorAll('.recentChat'));
+        const chatToFlash = recentChats.find(el => {
+            const file = el.getAttribute('data-file');
+            const group = el.getAttribute('data-group');
+            const avatar = el.getAttribute('data-avatar');
+            return file === flashChat.chat_name &&
+                ((flashChat.is_group && group === flashChat.group) || (!flashChat.is_group && avatar === flashChat.avatar));
+        });
+        if (chatToFlash instanceof HTMLElement) {
+            chatElement.scrollTop = chatToFlash.offsetTop - chatElement.offsetTop - (chatToFlash.clientHeight / 2);
+            flashHighlight($(chatToFlash));
+        }
+    } else {
+        // Restore scroll position
+        chatElement.scrollTop = scrollTop + (chatElement.scrollHeight - scrollHeight);
+    }
 }
 
 /**

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -38,10 +38,117 @@ import { accountStorage } from './util/AccountStorage.js';
 import { sortMoments, timestampToMoment } from './utils.js';
 
 const assistantAvatarKey = 'assistant';
+const pinnedChatsKey = 'pinnedChats';
 const defaultAssistantAvatar = 'default_Assistant.png';
 
 const DEFAULT_DISPLAYED = 3;
 const MAX_DISPLAYED = 15;
+
+/**
+ * @typedef {Pick<RecentChat, 'group' | 'avatar' | 'file_name'>} PinnedChat
+ */
+
+/**
+ * Manages pinned chat storage and operations.
+ */
+class PinnedChatsManager {
+    /** @type {Record<string, PinnedChat> | null} */
+    static #cachedState = null;
+
+    /**
+     * Initializes the cached state from storage.
+     * Should be called once on app init.
+     */
+    static init() {
+        this.#cachedState = this.#loadFromStorage();
+    }
+
+    /**
+     * Loads state from storage.
+     * @returns {Record<string, PinnedChat>}
+     */
+    static #loadFromStorage() {
+        const pinnedState = /** @type {Record<string, PinnedChat>} */ ({});
+        const value = accountStorage.getItem(pinnedChatsKey);
+        if (value) {
+            try {
+                Object.assign(pinnedState, JSON.parse(value));
+            } catch (error) {
+                console.warn('Failed to parse pinned chats from storage.', error);
+            }
+        }
+        return pinnedState;
+    }
+
+    /**
+     * Generates a key for pinned chat storage.
+     * @param {RecentChat} recentChat Recent chat data
+     * @returns {string} Key for pinned chat storage
+     */
+    static getKey(recentChat) {
+        return `${recentChat.group ? 'group_' + recentChat.group : ''}${recentChat.avatar ? 'char_' + recentChat.avatar : ''}_${recentChat.file_name}`;
+    }
+
+    /**
+     * Gets the pinned chat state from cache.
+     * @returns {Record<string, PinnedChat>}
+     */
+    static getState() {
+        if (this.#cachedState === null) {
+            this.#cachedState = this.#loadFromStorage();
+        }
+        return this.#cachedState;
+    }
+
+    /**
+     * Saves the pinned chat state to storage and updates cache.
+     * @param {Record<string, PinnedChat>} state The state to save
+     */
+    static #saveState(state) {
+        this.#cachedState = state;
+        accountStorage.setItem(pinnedChatsKey, JSON.stringify(state));
+    }
+
+    /**
+     * Checks if a chat is pinned.
+     * @param {RecentChat} recentChat Recent chat data
+     * @returns {boolean} True if the chat is pinned, false otherwise
+     */
+    static isPinned(recentChat) {
+        const pinKey = this.getKey(recentChat);
+        const pinState = this.getState();
+        return pinKey in pinState;
+    }
+
+    /**
+     * Toggles the pinned state of a chat.
+     * @param {RecentChat} recentChat Recent chat data
+     * @param {boolean} pinned New pinned state
+     */
+    static toggle(recentChat, pinned) {
+        const pinKey = this.getKey(recentChat);
+        const pinState = { ...this.getState() };
+        if (pinned) {
+            pinState[pinKey] = {
+                group: recentChat.group,
+                avatar: recentChat.avatar,
+                file_name: recentChat.file_name,
+            };
+        } else {
+            delete pinState[pinKey];
+        }
+        this.#saveState(pinState);
+    }
+
+    /**
+     * Gets all pinned chats.
+     * @returns {PinnedChat[]}
+     */
+    static getAll() {
+        const pinState = this.getState();
+        return Object.values(pinState);
+    }
+}
 
 export function getPermanentAssistantAvatar() {
     const assistantAvatar = accountStorage.getItem(assistantAvatarKey);
@@ -273,6 +380,26 @@ async function sendWelcomePanel(chats, expand = false) {
                 }
             });
         });
+        fragment.querySelectorAll('.recentChat .pinChat').forEach((pinButton) => {
+            pinButton.addEventListener('click', (event) => {
+                event.stopPropagation();
+                const chatItem = pinButton.closest('.recentChat');
+                if (!chatItem) {
+                    return;
+                }
+                const avatarId = chatItem.getAttribute('data-avatar');
+                const groupId = chatItem.getAttribute('data-group');
+                const fileName = chatItem.getAttribute('data-file');
+                const recentChat = chats.find(c => c.chat_name === fileName && ((c.is_group && c.group === groupId) || (!c.is_group && c.avatar === avatarId)));
+                if (!recentChat) {
+                    console.error('Recent chat not found for pinning.');
+                    return;
+                }
+                const currentlyPinned = PinnedChatsManager.isPinned(recentChat);
+                PinnedChatsManager.toggle(recentChat, !currentlyPinned);
+                void refreshWelcomeScreen();
+            });
+        });
         chatElement.append(fragment.firstChild);
         if (expand) {
             chatElement.querySelectorAll('button.showMoreChats').forEach((button) => {
@@ -499,12 +626,14 @@ async function refreshWelcomeScreen() {
  * @property {string} group Group ID (if applicable)
  * @property {boolean} is_group Indicates if the chat is a group chat
  * @property {boolean} hidden Chat will be hidden by default
+ * @property {boolean} pinned Indicates if the chat is pinned
  */
 async function getRecentChats() {
     const response = await fetch('/api/chats/recent', {
         method: 'POST',
         headers: getRequestHeaders(),
-        body: JSON.stringify({ max: MAX_DISPLAYED }),
+        body: JSON.stringify({ max: MAX_DISPLAYED, pinned: PinnedChatsManager.getAll() }),
+        cache: 'no-cache',
     });
 
     if (!response.ok) {
@@ -520,9 +649,22 @@ async function getRecentChats() {
     }
 
     const dataWithEntities = data
-        .sort((a, b) => sortMoments(timestampToMoment(a.last_mes), timestampToMoment(b.last_mes)))
         .map(chat => ({ chat, character: characters.find(x => x.avatar === chat.avatar), group: groups.find(x => x.id === chat.group) }))
-        .filter(t => t.character || t.group);
+        .filter(t => t.character || t.group)
+        .sort((a, b) => {
+            const isAPinned = PinnedChatsManager.isPinned(a.chat);
+            const isBPinned = PinnedChatsManager.isPinned(b.chat);
+            const momentComparison = sortMoments(timestampToMoment(a.chat.last_mes), timestampToMoment(b.chat.last_mes));
+
+            if (isAPinned && !isBPinned) {
+                return -1;
+            }
+            if (!isAPinned && isBPinned) {
+                return 1;
+            }
+
+            return momentComparison;
+        });
 
     dataWithEntities.forEach(({ chat, character, group }, index) => {
         const chatTimestamp = timestampToMoment(chat.last_mes);
@@ -535,6 +677,7 @@ async function getRecentChats() {
         chat.hidden = index >= DEFAULT_DISPLAYED;
         chat.avatar = chat.avatar || '';
         chat.group = chat.group || '';
+        chat.pinned = PinnedChatsManager.isPinned(chat);
     });
 
     return dataWithEntities.map(t => t.chat);
@@ -648,6 +791,8 @@ export function assignCharacterAsAssistant(characterId) {
 }
 
 export function initWelcomeScreen() {
+    PinnedChatsManager.init();
+
     const events = [event_types.CHAT_CHANGED, event_types.APP_READY];
     for (const event of events) {
         eventSource.makeFirst(event, openWelcomeScreen);

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -617,7 +617,7 @@ async function refreshWelcomeScreen({ flashChat = null } = {}) {
         });
         if (chatToFlash instanceof HTMLElement) {
             chatElement.scrollTop = chatToFlash.offsetTop - chatElement.offsetTop - (chatToFlash.clientHeight / 2);
-            flashHighlight($(chatToFlash));
+            flashHighlight($(chatToFlash), 1000);
         }
     } else {
         // Restore scroll position


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

This pull request introduces a new feature to allow users to pin recent chats in the welcome screen, making it easier to keep important conversations accessible. The implementation includes a new `PinnedChatsManager` for managing pinned state, updates to both client and server logic to handle pinning, UI changes to display pinned status, and sorting improvements so pinned chats appear at the top.

**Pinned Chat Feature Implementation**

* Added a `PinnedChatsManager` class in `welcome-screen.js` to manage storing, toggling, and retrieving pinned chats using persistent storage.
* Modified the recent chats API and client logic to send pinned chat info to the server and ensure pinned chats are always displayed, sorted above non-pinned chats. [[1]](diffhunk://#diff-baf1d43a7409e0f3aa9148d1fd3624e985e102b535e41bf9c3e1ba558c04c185R647-R654) [[2]](diffhunk://#diff-0230085b6537a8040ad3407d1c293926356e12811a014b9940d29db1ceba9f64L953-R957) [[3]](diffhunk://#diff-0230085b6537a8040ad3407d1c293926356e12811a014b9940d29db1ceba9f64L1020-R1033) [[4]](diffhunk://#diff-baf1d43a7409e0f3aa9148d1fd3624e985e102b535e41bf9c3e1ba558c04c185L523-R685) [[5]](diffhunk://#diff-baf1d43a7409e0f3aa9148d1fd3624e985e102b535e41bf9c3e1ba558c04c185R698)

**UI/UX Enhancements**

* Updated the `welcomePanel.html` template to show a pin icon for pinned chats and add a pin/unpin button to each recent chat entry. [[1]](diffhunk://#diff-bcd83247836e7f2303a82f434fc4373b10fd48b96b541f90bdc7ce4b41e4f575R47-R51) [[2]](diffhunk://#diff-bcd83247836e7f2303a82f434fc4373b10fd48b96b541f90bdc7ce4b41e4f575R64-R66)
* Added CSS for the pinned chat indicator and improved avatar container positioning for visual clarity. [[1]](diffhunk://#diff-4419f113e65ec46b82cfcab2e15c870d394293900b8348d0aa0b1fee93cf8e6eR118) [[2]](diffhunk://#diff-4419f113e65ec46b82cfcab2e15c870d394293900b8348d0aa0b1fee93cf8e6eR226-R233)

**Interaction Improvements**

* Implemented event handlers to toggle pinned status via the pin button, and added logic to highlight and scroll to a chat when its pinned state changes. [[1]](diffhunk://#diff-baf1d43a7409e0f3aa9148d1fd3624e985e102b535e41bf9c3e1ba558c04c185R383-R402) [[2]](diffhunk://#diff-baf1d43a7409e0f3aa9148d1fd3624e985e102b535e41bf9c3e1ba558c04c185R591-R595) [[3]](diffhunk://#diff-baf1d43a7409e0f3aa9148d1fd3624e985e102b535e41bf9c3e1ba558c04c185R608-R626)
* Ensured pinned chat state is initialized on welcome screen load.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
