### PR TITLE
Docker healthcheck update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ RUN \
 # Fix extension repos permissions
 RUN git config --global --add safe.directory "*"
 
+# Set default heartbeat interval (30 seconds)
+ENV SILLYTAVERN_HEARTBEAT_INTERVAL="30"
+
 # Healthcheck
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
   CMD node healthcheck.cjs || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN git config --global --add safe.directory "*"
 
 # Healthcheck
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
-  CMD node healthcheck.cjs
+  CMD node healthcheck.cjs || exit 1
 
 EXPOSE 8000
 

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -38,6 +38,9 @@ browserLaunch:
   avoidLocalhost: false
 # Server port
 port: 8000
+# Interval in seconds to write a heartbeat file. Set to 0 to disable.
+# This is used primarily for Docker healthchecks.
+heartbeatInterval: 0
 # -- SSL options --
 ssl:
   # Enable SSL/TLS encryption

--- a/docker/healthcheck.cjs
+++ b/docker/healthcheck.cjs
@@ -1,77 +1,34 @@
-const http = require('http');
-const https = require('https');
 const fs = require('fs');
 const path = require('path');
 
-// Determine paths relative to where the app is running
-const appDir = process.cwd();
-const configPath = path.join(appDir, 'config.yaml');
+// Default to 30 seconds if not set
+const intervalSeconds = parseInt(process.env.SILLYTAVERN_HEARTBEAT_INTERVAL || '30');
+const intervalMs = intervalSeconds * 1000;
 
-let config = {
-    port: 8000,
-    ssl: { enabled: false }
-};
+// Allow a grace period (2 missed beats)
+const threshold = intervalMs * 2;
 
-// 1. Load from Config File using 'yaml' lib if available, or regex fallback
+const dataRoot = process.env.SILLYTAVERN_DATA_ROOT || path.join(__dirname, 'data');
+const heartbeatFile = path.join(dataRoot, 'heartbeat.json');
+
 try {
-    if (fs.existsSync(configPath)) {
-        const fileContent = fs.readFileSync(configPath, 'utf8');
-        try {
-            const yaml = require('yaml');
-            const parsed = yaml.parse(fileContent);
-            if (parsed) {
-                if (parsed.port) config.port = parsed.port;
-                if (parsed.ssl) config.ssl = { ...config.ssl, ...parsed.ssl };
-            }
-        } catch (e) {
-            // Fallback to Regex if yaml lib fails or isn't found
-            const portMatch = fileContent.match(/^port:\s*(\d+)/m);
-            if (portMatch) config.port = parseInt(portMatch[1]);
-            const sslMatch = fileContent.match(/ssl:\s*[\s\S]*?enabled:\s*(true|false)/);
-            if (sslMatch) config.ssl.enabled = (sslMatch[1] === 'true');
-        }
+    if (!fs.existsSync(heartbeatFile)) {
+        console.error(`Heartbeat file not found at: ${heartbeatFile}`);
+        process.exit(1);
     }
+
+    const stats = fs.statSync(heartbeatFile);
+    const lastModified = stats.mtimeMs;
+    const now = Date.now();
+    const diff = now - lastModified;
+
+    if (diff > threshold) {
+        console.error(`Server is unresponsive. Last heartbeat was ${Math.round(diff / 1000)} seconds ago.`);
+        process.exit(1);
+    }
+
+    process.exit(0);
 } catch (err) {
-    // Ignore config errors, stick to defaults/env
+    console.error('Healthcheck error:', err.message);
+    process.exit(1);
 }
-
-// 2. Override with Environment Variables (Docker specific)
-if (process.env.SILLYTAVERN_PORT) config.port = parseInt(process.env.SILLYTAVERN_PORT);
-if (process.env.SILLYTAVERN_SSL_ENABLED) config.ssl.enabled = (process.env.SILLYTAVERN_SSL_ENABLED === 'true');
-
-const protocol = config.ssl.enabled ? https : http;
-
-const requestOptions = {
-    host: '127.0.0.1',
-    port: config.port,
-    path: '/api/health',
-    timeout: 2000,
-    rejectUnauthorized: false,
-    headers: { 'User-Agent': 'Docker-Healthcheck' }
-};
-
-const performCheck = (options) => {
-    const req = protocol.get(options, (res) => {
-        if (res.statusCode === 200) {
-            process.exit(0);
-        } else {
-            console.error(`Health Check Failed: HTTP ${res.statusCode}`);
-            process.exit(1);
-        }
-    });
-
-    req.on('error', (err) => {
-        console.error(`Health Check Failed: ${err.message}`);
-        // IPv6 Fallback
-        if (options.host === '127.0.0.1') {
-            console.log('Retrying with IPv6 [::1]...');
-            performCheck({ ...options, host: '::1' });
-        } else {
-            process.exit(1);
-        }
-    });
-
-    req.end();
-};
-
-performCheck(requestOptions);

--- a/docker/healthcheck.cjs
+++ b/docker/healthcheck.cjs
@@ -3,69 +3,75 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 
-// Check environment variable first, then try to parse config.yaml, default to 8000
-let port = process.env.SILLYTAVERN_PORT || 8000;
+// Determine paths relative to where the app is running
+const appDir = process.cwd();
+const configPath = path.join(appDir, 'config.yaml');
 
-if (!process.env.SILLYTAVERN_PORT) {
-    try {
-        const configPath = path.join(process.cwd(), 'config', 'config.yaml');
-        if (fs.existsSync(configPath)) {
-            const content = fs.readFileSync(configPath, 'utf8');
-            // Look for "port: 1234" pattern
-            const portMatch = content.match(/^port:\s*(\d+)/m);
-            if (portMatch) {
-                port = parseInt(portMatch[1], 10);
+let config = {
+    port: 8000,
+    ssl: { enabled: false }
+};
+
+// 1. Load from Config File using 'yaml' lib if available, or regex fallback
+try {
+    if (fs.existsSync(configPath)) {
+        const fileContent = fs.readFileSync(configPath, 'utf8');
+        try {
+            const yaml = require('yaml');
+            const parsed = yaml.parse(fileContent);
+            if (parsed) {
+                if (parsed.port) config.port = parsed.port;
+                if (parsed.ssl) config.ssl = { ...config.ssl, ...parsed.ssl };
             }
+        } catch (e) {
+            // Fallback to Regex if yaml lib fails or isn't found
+            const portMatch = fileContent.match(/^port:\s*(\d+)/m);
+            if (portMatch) config.port = parseInt(portMatch[1]);
+            const sslMatch = fileContent.match(/ssl:\s*[\s\S]*?enabled:\s*(true|false)/);
+            if (sslMatch) config.ssl.enabled = (sslMatch[1] === 'true');
         }
-    } catch (e) {
-        // Silently fail and use default/env port
     }
+} catch (err) {
+    // Ignore config errors, stick to defaults/env
 }
 
-// Healthcheck Logic
-function tryConnect(host, isSsl) {
-    const protocol = isSsl ? https : http;
-    const options = {
-        hostname: host,
-        port: port,
-        path: '/',
-        method: 'GET',
-        rejectUnauthorized: false, // Allow self-signed certs
-        timeout: 2000,
-        family: host === '::1' ? 6 : 4, // Explicitly state IP family
-        headers: {
-            'User-Agent': 'Server Healthcheck' // Custom User-Agent for logs
-        }
-    };
+// 2. Override with Environment Variables (Docker specific)
+if (process.env.SILLYTAVERN_PORT) config.port = parseInt(process.env.SILLYTAVERN_PORT);
+if (process.env.SILLYTAVERN_SSL_ENABLED) config.ssl.enabled = (process.env.SILLYTAVERN_SSL_ENABLED === 'true');
 
-    const req = protocol.request(options, (res) => {
-        // Any response means the server is alive
-        process.exit(0);
+const protocol = config.ssl.enabled ? https : http;
+
+const requestOptions = {
+    host: '127.0.0.1',
+    port: config.port,
+    path: '/api/health',
+    timeout: 2000,
+    rejectUnauthorized: false,
+    headers: { 'User-Agent': 'Docker-Healthcheck' }
+};
+
+const performCheck = (options) => {
+    const req = protocol.get(options, (res) => {
+        if (res.statusCode === 200) {
+            process.exit(0);
+        } else {
+            console.error(`Health Check Failed: HTTP ${res.statusCode}`);
+            process.exit(1);
+        }
     });
 
     req.on('error', (err) => {
-        // Case 1: IPv4 failed (Connection Refused) -> Try IPv6
-        if (host === '127.0.0.1' && err.code === 'ECONNREFUSED') {
-            tryConnect('::1', isSsl);
-            return;
+        console.error(`Health Check Failed: ${err.message}`);
+        // IPv6 Fallback
+        if (options.host === '127.0.0.1') {
+            console.log('Retrying with IPv6 [::1]...');
+            performCheck({ ...options, host: '::1' });
+        } else {
+            process.exit(1);
         }
-
-        // Case 2: Protocol mismatch (HTTP -> HTTPS)
-        // ECONNRESET/HPE_INVALID_CONSTANT usually means we sent HTTP to an HTTPS port
-        if (!isSsl && (err.code === 'ECONNRESET' || err.code === 'HPE_INVALID_CONSTANT')) {
-            tryConnect(host, true);
-            return;
-        }
-
-        // Case 3: Genuine Failure
-        // If we are already on IPv6 or SSL and still failing, print error and exit
-        console.error(`Healthcheck failed: ${err.message} (${host}:${port})`);
-        process.exit(1);
     });
 
     req.end();
-}
+};
 
-// Start by trying IPv4 + HTTP.
-// It will automatically fallback to IPv6 or HTTPS if needed.
-tryConnect('127.0.0.1', false);
+performCheck(requestOptions);

--- a/src/command-line.js
+++ b/src/command-line.js
@@ -229,6 +229,11 @@ export class CommandLineParser {
                 type: 'array',
                 describe: 'Request proxy bypass list (space separated list of hosts)',
             })
+            .option('heartbeatInterval', {
+                type: 'number',
+                default: null,
+                describe: 'Interval in seconds to write a heartbeat file. 0 to disable.',
+            })
             /* DEPRECATED options */
             .option('autorun', {
                 type: 'boolean',
@@ -289,6 +294,7 @@ export class CommandLineParser {
             enableIPv4: stringToBool(cliArguments.enableIPv4) ?? stringToBool(getConfigValue('protocol.ipv4', defaultConfig.enableIPv4)) ?? defaultConfig.enableIPv4,
             enableIPv6: stringToBool(cliArguments.enableIPv6) ?? stringToBool(getConfigValue('protocol.ipv6', defaultConfig.enableIPv6)) ?? defaultConfig.enableIPv6,
             dnsPreferIPv6: cliArguments.dnsPreferIPv6 ?? getConfigValue('dnsPreferIPv6', defaultConfig.dnsPreferIPv6, 'boolean'),
+            heartbeatInterval: cliArguments.heartbeatInterval ?? (process.env.SILLYTAVERN_HEARTBEAT_INTERVAL ? Number(process.env.SILLYTAVERN_HEARTBEAT_INTERVAL) : getConfigValue('heartbeatInterval', 0, 'number')),
             browserLaunchEnabled: cliArguments.browserLaunchEnabled ?? cliArguments.autorun ?? getConfigValue('browserLaunch.enabled', defaultConfig.browserLaunchEnabled, 'boolean'),
             browserLaunchHostname: cliArguments.browserLaunchHostname ?? cliArguments.autorunHostname ?? getConfigValue('browserLaunch.hostname', defaultConfig.browserLaunchHostname),
             browserLaunchPort: cliArguments.browserLaunchPort ?? cliArguments.autorunPortOverride ?? getConfigValue('browserLaunch.port', defaultConfig.browserLaunchPort, 'number'),

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -109,6 +109,11 @@ const CORS = cors({
 
 app.use(CORS);
 
+// Public health check endpoint
+app.get('/api/health', (req, res) => {
+    res.sendStatus(200);
+});
+
 if (cliArgs.listen && cliArgs.basicAuthMode) {
     app.use(basicAuthMiddleware);
 }

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -1,4 +1,5 @@
 // native node modules
+import fs from 'node:fs';
 import path from 'node:path';
 import util from 'node:util';
 import net from 'node:net';
@@ -108,11 +109,6 @@ const CORS = cors({
 });
 
 app.use(CORS);
-
-// Public health check endpoint
-app.get('/api/health', (req, res) => {
-    res.sendStatus(200);
-});
 
 if (cliArgs.listen && cliArgs.basicAuthMode) {
     app.use(basicAuthMiddleware);
@@ -352,6 +348,28 @@ async function postSetupTasks(result) {
         } catch (error) {
             console.error('Failed to launch the browser. Open the URL manually.', error);
         }
+    }
+
+    if (cliArgs.heartbeatInterval > 0) {
+        // Convert seconds to milliseconds for the timer
+        const intervalMs = cliArgs.heartbeatInterval * 1000;
+        const heartbeatPath = path.join(cliArgs.dataRoot, 'heartbeat.json');
+
+        console.log(`Heartbeat enabled. Updating ${heartbeatPath} every ${cliArgs.heartbeatInterval} seconds`);
+
+        const writeHeartbeat = () => {
+            try {
+                fs.writeFileSync(heartbeatPath, JSON.stringify({ timestamp: Date.now() }));
+            } catch (err) {
+                console.error('Failed to write heartbeat file:', err.message);
+            }
+        };
+
+        // Write immediately
+        writeHeartbeat();
+
+        // Loop using the converted milliseconds
+        setInterval(writeHeartbeat, intervalMs).unref();
     }
 
     setWindowTitle('SillyTavern WebServer');


### PR DESCRIPTION
feat(docker): switch to heartbeat file healthcheck mechanism

- Replaced network-based check with a file-based heartbeat approach.
- Updated `src/command-line.js`: Added `heartbeatInterval` argument with explicit ENV override (`SILLYTAVERN_HEARTBEAT_INTERVAL`).
- Updated `src/server-main.js`: Added logic to write `heartbeat.json` to data directory at set intervals.
- Rewrote `docker/healthcheck.cjs`: Script now monitors the heartbeat file timestamp (zero dependencies, no config parsing required).
- Updated `Dockerfile`: Sets default heartbeat interval to 30s and ensures script availability.
- Updated `config.yaml`: Added `heartbeatInterval` defaulting to 0 (disabled) for non-Docker users.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
