### PR TITLE
Fix: Regex script bypassing depth check on hidden messages

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1698,7 +1698,7 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
 
         const chatMessage = messageId >= 0 ? chat[messageId] : null;
         const isHiddenMessage = chatMessage?.is_system === true;
-        
+
         // Always override the character name
         if(!isHiddenMessage){
             mes = getRegexedString(mes, regexPlacement, {

--- a/public/script.js
+++ b/public/script.js
@@ -1696,12 +1696,17 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         const indexOf = usableMessages.findIndex(x => x.index === Number(messageId));
         const depth = messageId >= 0 && indexOf !== -1 ? (usableMessages.length - indexOf - 1) : undefined;
 
+        const chatMessage = messageId >= 0 ? chat[messageId] : null;
+        const isHiddenMessage = chatMessage?.is_system === true;
+        
         // Always override the character name
-        mes = getRegexedString(mes, regexPlacement, {
-            characterOverride: ch_name,
-            isMarkdown: true,
-            depth: depth,
-        });
+        if(!isHiddenMessage){
+            mes = getRegexedString(mes, regexPlacement, {
+                characterOverride: ch_name,
+                isMarkdown: true,
+                depth: depth,
+            });
+        }
     }
 
     if (power_user.auto_fix_generated_markdown) {

--- a/public/script.js
+++ b/public/script.js
@@ -1645,6 +1645,8 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
     if (!mes) {
         return '';
     }
+    // Preserved the flag for regex application
+    const isHiddenMessage = isSystem;
 
     if (Number(messageId) === 0 && !isSystem && !isUser && !isReasoning) {
         const mesBeforeReplace = mes;
@@ -1695,9 +1697,6 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         const usableMessages = chat.map((x, index) => ({ message: x, index: index })).filter(x => !x.message.is_system);
         const indexOf = usableMessages.findIndex(x => x.index === Number(messageId));
         const depth = messageId >= 0 && indexOf !== -1 ? (usableMessages.length - indexOf - 1) : undefined;
-
-        const chatMessage = messageId >= 0 ? chat[messageId] : null;
-        const isHiddenMessage = chatMessage?.is_system === true;
 
         // Always override the character name
         if(!isHiddenMessage){


### PR DESCRIPTION
## Related Issue
Fixes #4919

This PR fixes a bug where Regex scripts were incorrectly executing on hidden messages (where is_system is true).

## Root Cause Analysis

The issue originated from a logic conflict between script.js and engine.js:

In script.js (around line 1638): The isSystem flag is forcibly set to false for hidden messages (if (isSystem && ch_name !== systemUserName) ...). This allows the message to pass the initial if (!isSystem) check.

Depth Calculation Failure: Later, when calculating depth, the code filters usableMessages based on the original property (x => !x.message.is_system). Since the hidden message is excluded from this list, indexOf returns -1, causing depth to resolve to undefined.

Guard Clause Bypass in engine.js: The undefined depth propagates to public/scripts/extensions/regex/engine.js. The check if (typeof depth === 'number') fails, causing the function to bypass the minDepth validation entirely.


## Checklist:

- [ X ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
