### PR TITLE
Superseeded by #5085 - Basic concurrency for `/api/chats/search`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,8 @@
                 "eslint": "^8.57.1",
                 "eslint-plugin-jest": "^27.9.0",
                 "eslint-plugin-jsdoc": "^48.10.0",
-                "eslint-plugin-playwright": "^2.3.0"
+                "eslint-plugin-playwright": "^2.3.0",
+                "p-queue": "^9.1.0"
             },
             "engines": {
                 "node": ">= 18"
@@ -4842,6 +4843,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6967,6 +6975,36 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-queue": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
+            "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eventemitter3": "^5.0.1",
+                "p-timeout": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+            "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -167,6 +167,8 @@
         "eslint": "^8.57.1",
         "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-jsdoc": "^48.10.0",
-        "eslint-plugin-playwright": "^2.3.0"
+        "eslint-plugin-playwright": "^2.3.0",
+        "eventemitter3": "^5.0.4",
+        "p-queue": "^9.1.0"
     }
 }

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -841,6 +841,7 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
         const { query, avatar_url, group_id } = request.body;
         let chatFiles = [];
 
+        let directoryPath = '';
         if (group_id) {
             // Find group's chat IDs first
             const groupDir = path.join(request.user.directories.groups);
@@ -865,41 +866,29 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
             }
 
             // Find group chat files for given group ID
-            const groupChatsDir = path.join(request.user.directories.groupChats);
-            chatFiles = [];
-            await Promise.allSettled(targetGroup.chats
-                .map(async chatId => {
-                    const filePath = path.join(groupChatsDir, `${chatId}.jsonl`);
-                    if (!fs.existsSync(filePath)) return null;
-                    const stats = await fs.promises.stat(filePath);
-                    chatFiles.push({
-                        file_name: chatId,
-                        stats,
-                        path: filePath,
-                    });
-                }));
+            directoryPath = path.join(request.user.directories.groupChats);
         } else {
             // Regular character chat directory
             const character_name = avatar_url.replace('.png', '');
-            const directoryPath = path.join(request.user.directories.chats, character_name);
+            directoryPath = path.join(request.user.directories.chats, character_name);
 
-            if (!fs.existsSync(directoryPath)) {
-                return response.send([]);
-            }
-
-            chatFiles = [];
-            await Promise.allSettled(fs.readdirSync(directoryPath)
-                .filter(file => file.endsWith('.jsonl'))
-                .map(async fileName => {
-                    const filePath = path.join(directoryPath, fileName);
-                    const stats = await fs.promises.stat(filePath);
-                    chatFiles.push({
-                        file_name: fileName,
-                        stats,
-                        path: filePath,
-                    });
-                }));
         }
+        if (!fs.existsSync(directoryPath)) {
+            return response.send([]);
+        }
+
+        chatFiles = [];
+        await Promise.allSettled(fs.readdirSync(directoryPath)
+            .filter(file => file.endsWith('.jsonl'))
+            .map(async fileName => {
+                const filePath = path.join(directoryPath, fileName);
+                const stats = await fs.promises.stat(filePath);
+                chatFiles.push({
+                    file_name: fileName,
+                    stats,
+                    path: filePath,
+                });
+            }));
 
         const dataQueue = new PQueue({ concurrency: 100 });
         const results = [];

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -17,9 +17,9 @@ import {
     removeOldBackups,
     formatBytes,
     tryWriteFileSync,
-    tryReadFileSync,
     tryDeleteFile,
     readFirstLine,
+    tryReadFileAsync,
 } from '../util.js';
 
 const isBackupEnabled = !!getConfigValue('backups.chat.enabled', true, 'boolean');
@@ -474,12 +474,12 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
 /**
  * Gets the chat as an object.
  * @param {string} chatFilePath The full chat file path.
- * @returns {Array}} If the chatFilePath cannot be read, this will return [].
+ * @returns {Promise<Array>}} If the chatFilePath cannot be read, this will return [].
  */
-export function getChatData(chatFilePath) {
+export async function getChatData(chatFilePath) {
     let chatData = [];
 
-    const chatJSON = tryReadFileSync(chatFilePath) ?? '';
+    const chatJSON = await tryReadFileAsync(chatFilePath) ?? '';
     if (chatJSON.length > 0) {
         const lines = chatJSON.split('\n');
         // Iterate through the array of strings and parse each line as JSON
@@ -491,7 +491,7 @@ export function getChatData(chatFilePath) {
     return chatData;
 }
 
-router.post('/get', validateAvatarUrlMiddleware, function (request, response) {
+router.post('/get', validateAvatarUrlMiddleware, async function (request, response) {
     try {
         const dirName = String(request.body.avatar_url).replace('.png', '');
         const directoryPath = path.join(request.user.directories.chats, dirName);
@@ -510,7 +510,7 @@ router.post('/get', validateAvatarUrlMiddleware, function (request, response) {
         const chatFileName = `${String(request.body.file_name)}.jsonl`;
         const chatFilePath = path.join(directoryPath, sanitize(chatFileName));
 
-        return response.send(getChatData(chatFilePath));
+        return response.send(await getChatData(chatFilePath));
     } catch (error) {
         console.error(error);
         return response.send({});
@@ -754,7 +754,7 @@ router.post('/import', validateAvatarUrlMiddleware, function (request, response)
     }
 });
 
-router.post('/group/get', (request, response) => {
+router.post('/group/get', async (request, response) => {
     if (!request.body || !request.body.id) {
         return response.sendStatus(400);
     }
@@ -762,7 +762,7 @@ router.post('/group/get', (request, response) => {
     const id = request.body.id;
     const chatFilePath = path.join(request.user.directories.groupChats, sanitize(`${id}.jsonl`));
 
-    return response.send(getChatData(chatFilePath));
+    return response.send(await getChatData(chatFilePath));
 });
 
 router.post('/group/info', async (request, response) => {
@@ -832,7 +832,7 @@ router.post('/group/save', async function (request, response) {
     }
 });
 
-router.post('/search', validateAvatarUrlMiddleware, function (request, response) {
+router.post('/search', validateAvatarUrlMiddleware, async function (request, response) {
     try {
         const { query, avatar_url, group_id } = request.body;
         let chatFiles = [];
@@ -862,18 +862,18 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
 
             // Find group chat files for given group ID
             const groupChatsDir = path.join(request.user.directories.groupChats);
-            chatFiles = targetGroup.chats
-                .map(chatId => {
+            chatFiles = [];
+            await Promise.allSettled(targetGroup.chats
+                .map(async chatId => {
                     const filePath = path.join(groupChatsDir, `${chatId}.jsonl`);
                     if (!fs.existsSync(filePath)) return null;
-                    const stats = fs.statSync(filePath);
-                    return {
+                    const stats = await fs.promises.stat(filePath);
+                    chatFiles.push({
                         file_name: chatId,
                         file_size: formatBytes(stats.size),
                         path: filePath,
-                    };
-                })
-                .filter(x => x);
+                    });
+                }));
         } else {
             // Regular character chat directory
             const character_name = avatar_url.replace('.png', '');
@@ -883,32 +883,33 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
                 return response.send([]);
             }
 
-            chatFiles = fs.readdirSync(directoryPath)
+            chatFiles = [];
+            await Promise.allSettled(fs.readdirSync(directoryPath)
                 .filter(file => file.endsWith('.jsonl'))
-                .map(fileName => {
+                .map(async fileName => {
                     const filePath = path.join(directoryPath, fileName);
-                    const stats = fs.statSync(filePath);
-                    return {
+                    const stats = await fs.promises.stat(filePath);
+                    chatFiles.push({
                         file_name: fileName,
                         file_size: formatBytes(stats.size),
                         path: filePath,
-                    };
-                });
+                    });
+                }));
         }
 
         const results = [];
 
         // Search logic
-        for (const chatFile of chatFiles) {
-            const data = getChatData(chatFile.path);
+        await Promise.allSettled(chatFiles.map(async chatFile => {
+            const data = await getChatData(chatFile.path);
             const messages = data.filter(x => x && typeof x.mes === 'string');
 
             if (query && messages.length === 0) {
-                continue;
+                return;
             }
 
             const lastMessage = messages[messages.length - 1];
-            const lastMesDate = lastMessage?.send_date || new Date(fs.statSync(chatFile.path).mtimeMs).toISOString();
+            const lastMesDate = lastMessage?.send_date || new Date(await fs.promises.stat(chatFile.path).mtimeMs).toISOString();
 
             // If no search query, just return metadata
             if (!query) {
@@ -919,7 +920,7 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
                     last_mes: lastMesDate,
                     preview_message: getPreviewMessage(messages),
                 });
-                continue;
+                return;
             }
 
             // Search through title and messages of the chat
@@ -936,7 +937,7 @@ router.post('/search', validateAvatarUrlMiddleware, function (request, response)
                     preview_message: getPreviewMessage(messages),
                 });
             }
-        }
+        }));
 
         // Sort by last message date descending
         results.sort((a, b) => new Date(b.last_mes).getTime() - new Date(a.last_mes).getTime());

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -22,6 +22,7 @@ import {
     tryReadFileAsync,
     readQueue,
 } from '../util.js';
+import PQueue from 'p-queue';
 
 const isBackupEnabled = !!getConfigValue('backups.chat.enabled', true, 'boolean');
 const maxTotalChatBackups = Number(getConfigValue('backups.chat.maxTotalBackups', -1, 'number'));
@@ -901,46 +902,50 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
                 }));
         }
 
+        const dataQueue = new PQueue({ concurrency: 100 });
         const results = [];
 
         // Search logic
         await Promise.allSettled(chatFiles.map(async chatFile => {
-            const data = await getChatData(chatFile.path);
-            const messages = data.filter(x => x && typeof x.mes === 'string');
+            //Don't handle more than 100 files concurrently to prevent an OOM.
+            await dataQueue.add(async () => {
+                const data = await getChatData(chatFile.path);
+                const messages = data.filter(x => x && typeof x.mes === 'string');
 
-            if (query && messages.length === 0) {
-                return;
-            }
+                if (query && messages.length === 0) {
+                    return;
+                }
 
-            const lastMessage = messages[messages.length - 1];
-            const lastMesDate = lastMessage?.send_date || chatFile.date_modified;
+                const lastMessage = messages[messages.length - 1];
+                const lastMesDate = lastMessage?.send_date || chatFile.date_modified;
 
-            // If no search query, just return metadata
-            if (!query) {
-                results.push({
-                    file_name: chatFile.file_name,
-                    file_size: chatFile.file_size,
-                    message_count: messages.length,
-                    last_mes: lastMesDate,
-                    preview_message: getPreviewMessage(messages),
-                });
-                return;
-            }
+                // If no search query, just return metadata
+                if (!query) {
+                    results.push({
+                        file_name: chatFile.file_name,
+                        file_size: chatFile.file_size,
+                        message_count: messages.length,
+                        last_mes: lastMesDate,
+                        preview_message: getPreviewMessage(messages),
+                    });
+                    return;
+                }
 
-            // Search through title and messages of the chat
-            const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
-            const text = [path.parse(chatFile.path).name, ...messages.map(message => message?.mes)].join('\n').toLowerCase();
-            const hasMatch = fragments.every(fragment => text.includes(fragment));
+                // Search through title and messages of the chat
+                const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
+                const text = [path.parse(chatFile.path).name, ...messages.map(message => message?.mes)].join('\n').toLowerCase();
+                const hasMatch = fragments.every(fragment => text.includes(fragment));
 
-            if (hasMatch) {
-                results.push({
-                    file_name: chatFile.file_name,
-                    file_size: chatFile.file_size,
-                    message_count: messages.length,
-                    last_mes: lastMesDate,
-                    preview_message: getPreviewMessage(messages),
-                });
-            }
+                if (hasMatch) {
+                    results.push({
+                        file_name: chatFile.file_name,
+                        file_size: chatFile.file_size,
+                        message_count: messages.length,
+                        last_mes: lastMesDate,
+                        preview_message: getPreviewMessage(messages),
+                    });
+                }
+            });
         }));
 
         // Sort by last message date descending

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -20,6 +20,7 @@ import {
     tryDeleteFile,
     readFirstLine,
     tryReadFileAsync,
+    readQueue,
 } from '../util.js';
 
 const isBackupEnabled = !!getConfigValue('backups.chat.enabled', true, 'boolean');
@@ -479,16 +480,18 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
 export async function getChatData(chatFilePath) {
     let chatData = [];
 
-    const chatJSON = await tryReadFileAsync(chatFilePath) ?? '';
-    if (chatJSON.length > 0) {
-        const lines = chatJSON.split('\n');
-        // Iterate through the array of strings and parse each line as JSON
-        chatData = lines.map(line => tryParse(line)).filter(x => x);
-    } else {
-        console.warn(`File not found: ${chatFilePath}. The chat does not exist or is empty.`);
-    }
+    return readQueue.add(async () => {
+        const chatJSON = await tryReadFileAsync(chatFilePath) ?? '';
+        if (chatJSON.length > 0) {
+            const lines = chatJSON.split('\n');
+            // Iterate through the array of strings and parse each line as JSON
+            chatData = lines.map(line => tryParse(line)).filter(x => x);
+        } else {
+            console.warn(`File not found: ${chatFilePath}. The chat does not exist or is empty.`);
+        }
 
-    return chatData;
+        return chatData;
+    });
 }
 
 router.post('/get', validateAvatarUrlMiddleware, async function (request, response) {

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -19,7 +19,7 @@ import {
     tryWriteFileSync,
     tryDeleteFile,
     readFirstLine,
-    tryReadFileAsync,
+    parseJSONL,
 } from '../util.js';
 
 const isBackupEnabled = !!getConfigValue('backups.chat.enabled', true, 'boolean');
@@ -477,15 +477,13 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
  * @returns {Promise<Array>}} If the chatFilePath cannot be read, this will return [].
  */
 export async function getChatData(chatFilePath) {
-    let chatData = [];
 
-    const chatJSON = await tryReadFileAsync(chatFilePath) ?? '';
-    if (chatJSON.length > 0) {
-        const lines = chatJSON.split('\n');
-        // Iterate through the array of strings and parse each line as JSON
-        chatData = lines.map(line => tryParse(line)).filter(x => x);
+    const chatData = await parseJSONL(chatFilePath) ?? '';
+    if (chatData.length > 0) {
+        // Remove empty.
+        return chatData.filter(x => x);
     } else {
-        console.warn(`File not found: ${chatFilePath}. The chat does not exist or is empty.`);
+        console.warn(`Data not found: ${chatFilePath}. The chat does not exist or is invalid/empty.`);
     }
 
     return chatData;

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -476,7 +476,7 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
 /**
  * Gets the chat as an object.
  * @param {string} chatFilePath The full chat file path.
- * @returns {Promise<Array>}} If the chatFilePath cannot be read, this will return [].
+ * @returns {Promise<Array>} If the chatFilePath cannot be read, this will return [].
  */
 export async function getChatData(chatFilePath) {
     let chatData = [];
@@ -874,7 +874,7 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
                     const stats = await fs.promises.stat(filePath);
                     chatFiles.push({
                         file_name: chatId,
-                        file_size: formatBytes(stats.size),
+                        stats,
                         path: filePath,
                     });
                 }));
@@ -895,8 +895,7 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
                     const stats = await fs.promises.stat(filePath);
                     chatFiles.push({
                         file_name: fileName,
-                        file_size: formatBytes(stats.size),
-                        date_modified: new Date(stats.mtimeMs).toISOString(),
+                        stats,
                         path: filePath,
                     });
                 }));
@@ -917,29 +916,22 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
                 }
 
                 const lastMessage = messages[messages.length - 1];
-                const lastMesDate = lastMessage?.send_date || chatFile.date_modified;
+                const lastMesDate = lastMessage?.send_date || new Date(chatFile.stats.mtimeMs).toISOString();
 
-                // If no search query, just return metadata
-                if (!query) {
-                    results.push({
-                        file_name: chatFile.file_name,
-                        file_size: chatFile.file_size,
-                        message_count: messages.length,
-                        last_mes: lastMesDate,
-                        preview_message: getPreviewMessage(messages),
-                    });
-                    return;
+                // If there's no search query, return all files.
+                let hasMatch = false;
+                if (query) {
+                    // Search through title and messages of the chat
+                    const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
+                    const text = [path.parse(chatFile.path).name, ...messages.map(message => message?.mes)].join('\n').toLowerCase();
+                    hasMatch = fragments.every(fragment => text.includes(fragment));
                 }
 
-                // Search through title and messages of the chat
-                const fragments = query.trim().toLowerCase().split(/\s+/).filter(x => x);
-                const text = [path.parse(chatFile.path).name, ...messages.map(message => message?.mes)].join('\n').toLowerCase();
-                const hasMatch = fragments.every(fragment => text.includes(fragment));
 
-                if (hasMatch) {
+                if (!query || hasMatch) {
                     results.push({
                         file_name: chatFile.file_name,
-                        file_size: chatFile.file_size,
+                        file_size: formatBytes(chatFile.stats.size),
                         message_count: messages.length,
                         last_mes: lastMesDate,
                         preview_message: getPreviewMessage(messages),

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -19,7 +19,7 @@ import {
     tryWriteFileSync,
     tryDeleteFile,
     readFirstLine,
-    parseJSONL,
+    tryReadFileAsync,
 } from '../util.js';
 
 const isBackupEnabled = !!getConfigValue('backups.chat.enabled', true, 'boolean');
@@ -477,13 +477,15 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
  * @returns {Promise<Array>}} If the chatFilePath cannot be read, this will return [].
  */
 export async function getChatData(chatFilePath) {
+    let chatData = [];
 
-    const chatData = await parseJSONL(chatFilePath) ?? '';
-    if (chatData.length > 0) {
-        // Remove empty.
-        return chatData.filter(x => x);
+    const chatJSON = await tryReadFileAsync(chatFilePath) ?? '';
+    if (chatJSON.length > 0) {
+        const lines = chatJSON.split('\n');
+        // Iterate through the array of strings and parse each line as JSON
+        chatData = lines.map(line => tryParse(line)).filter(x => x);
     } else {
-        console.warn(`Data not found: ${chatFilePath}. The chat does not exist or is invalid/empty.`);
+        console.warn(`File not found: ${chatFilePath}. The chat does not exist or is empty.`);
     }
 
     return chatData;

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -895,6 +895,7 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
                     chatFiles.push({
                         file_name: fileName,
                         file_size: formatBytes(stats.size),
+                        date_modified: new Date(stats.mtimeMs).toISOString(),
                         path: filePath,
                     });
                 }));
@@ -912,7 +913,7 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
             }
 
             const lastMessage = messages[messages.length - 1];
-            const lastMesDate = lastMessage?.send_date || new Date(await fs.promises.stat(chatFile.path).mtimeMs).toISOString();
+            const lastMesDate = lastMessage?.send_date || chatFile.date_modified;
 
             // If no search query, just return metadata
             if (!query) {

--- a/src/util.js
+++ b/src/util.js
@@ -1506,6 +1506,34 @@ export function tryReadFileSync(filePath) {
 }
 
 /**
+ * Async code that returns true if a file exists.
+ * https://stackoverflow.com/a/35008327
+ * @param {string} file
+ * @returns {Promise<boolean>}
+ */
+function checkFileExists(file) {
+    return fs.promises.access(file, fs.constants.F_OK)
+        .then(() => true)
+        .catch(() => false);
+}
+
+/**
+* Asynchronously Attempts to read a file as utf8.
+* @param {string} filePath
+* @returns {Promise<string|null>}
+*/
+export async function tryReadFileAsync(filePath) {
+    try {
+        if (await checkFileExists(filePath)) {
+            return await fs.promises.readFile(filePath, 'utf8');
+        }
+    } catch (error) {
+        console.error(`Error reading ${filePath}: ${error.message}`);
+    }
+    return null;
+}
+
+/**
 * Attempts to delete a file.
 * @param {string} filePath Target file.
 * @returns {boolean} Returns true if the file was found and deleted.

--- a/src/util.js
+++ b/src/util.js
@@ -1506,44 +1506,6 @@ export function tryReadFileSync(filePath) {
 }
 
 /**
- * Returns the valid objects from a JSONL file, invalid lines are skipped.
- * This was written by an LLM to avoid the bottleneck that appears when attempting to split a file by `\n`.
- * @param {string} jsonlFilePath The full JSONL file path.
- * @returns {Promise<Array>}} If the jsonlFilePath cannot be read, or all lines are not valid json, this will return [].
- */
-export async function parseJSONL(jsonlFilePath) {
-    try {
-        const buffer = await fs.promises.readFile(jsonlFilePath); // Keep as Buffer
-        const chatData = [];
-        let start = 0;
-        let index = 0;
-
-        // 10 is the ASCII byte code for '\n'
-        while ((index = buffer.indexOf(10, start)) !== -1) {
-            if (index > start) {
-                // Decode ONLY this slice to utf-8 string right before parsing
-                const line = buffer.toString('utf8', start, index);
-                const parsed = tryParse(line);
-                if (parsed) chatData.push(parsed);
-            }
-            start = index + 1;
-        }
-
-        // Handle tail
-        if (start < buffer.length) {
-            const line = buffer.toString('utf8', start);
-            const parsed = tryParse(line);
-            if (parsed) chatData.push(parsed);
-        }
-
-        return chatData;
-    } catch (error) {
-        console.error(`Error reading ${jsonlFilePath}: ${error.message}`);
-    }
-    return [];
-}
-
-/**
  * Async code that returns true if a file exists.
  * https://stackoverflow.com/a/35008327
  * @param {string} file

--- a/src/util.js
+++ b/src/util.js
@@ -1598,44 +1598,4 @@ export function invalidateFirefoxCache(file, request, response) {
 }
 
 // https://github.com/sindresorhus/p-queue
-
-
-class QueueClass {
-    constructor(warnItems = 20) {
-        this._queue = [];
-        this.warnItems = warnItems;
-    }
-
-    enqueue(run, options) {
-        this._queue.push(run);
-
-        if (this._queue.length > this.warnItems) {
-            console.warn(`Warning: There are ${this._queue.length} reads queued!`);
-        }
-    }
-
-    // https://github.com/sindresorhus/p-queue/blob/main/source/priority-queue.ts
-    setPriority(id, priority) {
-        const index = this._queue.findIndex((element) => element.id === id);
-        if (index === -1) {
-            throw new ReferenceError(`No promise function with the id "${id}" exists in the queue.`);
-        }
-
-        const [item] = this._queue.splice(index, 1);
-        this.enqueue(item.run, { priority, id });
-    }
-
-    dequeue() {
-        return this._queue.shift();
-    }
-
-    get size() {
-        return this._queue.length;
-    }
-
-    filter(options) {
-        return this._queue;
-    }
-}
-
-export const readQueue = new PQueue({ concurrency: 20, queueClass: QueueClass });
+export const readQueue = new PQueue({ concurrency: 20 });

--- a/src/util.js
+++ b/src/util.js
@@ -1506,6 +1506,44 @@ export function tryReadFileSync(filePath) {
 }
 
 /**
+ * Returns the valid objects from a JSONL file, invalid lines are skipped.
+ * This was written by an LLM to avoid the bottleneck that appears when attempting to split a file by `\n`.
+ * @param {string} jsonlFilePath The full JSONL file path.
+ * @returns {Promise<Array>}} If the jsonlFilePath cannot be read, or all lines are not valid json, this will return [].
+ */
+export async function parseJSONL(jsonlFilePath) {
+    try {
+        const buffer = await fs.promises.readFile(jsonlFilePath); // Keep as Buffer
+        const chatData = [];
+        let start = 0;
+        let index = 0;
+
+        // 10 is the ASCII byte code for '\n'
+        while ((index = buffer.indexOf(10, start)) !== -1) {
+            if (index > start) {
+                // Decode ONLY this slice to utf-8 string right before parsing
+                const line = buffer.toString('utf8', start, index);
+                const parsed = tryParse(line);
+                if (parsed) chatData.push(parsed);
+            }
+            start = index + 1;
+        }
+
+        // Handle tail
+        if (start < buffer.length) {
+            const line = buffer.toString('utf8', start);
+            const parsed = tryParse(line);
+            if (parsed) chatData.push(parsed);
+        }
+
+        return chatData;
+    } catch (error) {
+        console.error(`Error reading ${jsonlFilePath}: ${error.message}`);
+    }
+    return [];
+}
+
+/**
  * Async code that returns true if a file exists.
  * https://stackoverflow.com/a/35008327
  * @param {string} file

--- a/src/util.js
+++ b/src/util.js
@@ -22,6 +22,7 @@ import { LOG_LEVELS, CHAT_COMPLETION_SOURCES, MEDIA_REQUEST_TYPE } from './const
 import { serverDirectory } from './server-directory.js';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import { isFirefox } from './express-common.js';
+import PQueue from 'p-queue';
 
 /**
  * Parsed config object.
@@ -1595,3 +1596,46 @@ export function invalidateFirefoxCache(file, request, response) {
         response.setHeader('Cache-Control', 'must-understand, no-store');
     }
 }
+
+// https://github.com/sindresorhus/p-queue
+
+
+class QueueClass {
+    constructor(warnItems = 20) {
+        this._queue = [];
+        this.warnItems = warnItems;
+    }
+
+    enqueue(run, options) {
+        this._queue.push(run);
+
+        if (this._queue.length > this.warnItems) {
+            console.warn(`Warning: There are ${this._queue.length} reads queued!`);
+        }
+    }
+
+    // https://github.com/sindresorhus/p-queue/blob/main/source/priority-queue.ts
+    setPriority(id, priority) {
+        const index = this._queue.findIndex((element) => element.id === id);
+        if (index === -1) {
+            throw new ReferenceError(`No promise function with the id "${id}" exists in the queue.`);
+        }
+
+        const [item] = this._queue.splice(index, 1);
+        this.enqueue(item.run, { priority, id });
+    }
+
+    dequeue() {
+        return this._queue.shift();
+    }
+
+    get size() {
+        return this._queue.length;
+    }
+
+    filter(options) {
+        return this._queue;
+    }
+}
+
+export const readQueue = new PQueue({ concurrency: 20, queueClass: QueueClass });


### PR DESCRIPTION
### This was superseeded by https://github.com/SillyTavern/SillyTavern/pull/5085

This PR may solve: https://github.com/SillyTavern/SillyTavern/issues/5045
~~I didn't benchmark performance, but this should work.~~
I tested this on a hundred 14MB chat files with 5k messages each.
`for i in {1..100}; do cp 5k.jsonl "5k-$i.jsonl"; done`

Request latency did not appear to improve, and 1000 chat files caused an OOM.

Should I close this PR?

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
