### PR TITLE
Add `/reroll-pick` command to reset `{{pick}}` macro

### DIFF
--- a/public/scripts/macros/definitions/core-macros.js
+++ b/public/scripts/macros/definitions/core-macros.js
@@ -375,9 +375,9 @@ export function registerCoreMacros() {
             const offset = globalOffset;
 
             // Reroll seed allows users to reset all picks in the chat via /reroll-pick command
-            const rerollSeed = chat_metadata.pick_reroll_seed ?? 0;
+            const rerollSeed = chat_metadata.pick_reroll_seed || null;
 
-            const combinedSeedString = `${chatIdHash}-${rawContentHash}-${offset}-${rerollSeed}`;
+            const combinedSeedString = [chatIdHash, rawContentHash, offset, rerollSeed].filter(it => it != null).join('-');
             const finalSeed = getStringHash(combinedSeedString);
             const rng = seedrandom(String(finalSeed));
             const randomIndex = Math.floor(rng() * list.length);

--- a/public/scripts/macros/definitions/core-macros.js
+++ b/public/scripts/macros/definitions/core-macros.js
@@ -377,7 +377,7 @@ export function registerCoreMacros() {
             // Reroll seed allows users to reset all picks in the chat via /reroll-pick command
             const rerollSeed = chat_metadata.pick_reroll_seed || null;
 
-            const combinedSeedString = [chatIdHash, rawContentHash, offset, rerollSeed].filter(it => it != null).join('-');
+            const combinedSeedString = [chatIdHash, rawContentHash, offset, rerollSeed].filter(it => it !== null).join('-');
             const finalSeed = getStringHash(combinedSeedString);
             const rng = seedrandom(String(finalSeed));
             const randomIndex = Math.floor(rng() * list.length);

--- a/public/scripts/macros/definitions/core-macros.js
+++ b/public/scripts/macros/definitions/core-macros.js
@@ -342,7 +342,12 @@ export function registerCoreMacros() {
     MacroRegistry.registerMacro('pick', {
         category: MacroCategory.RANDOM,
         list: true,
-        description: 'Picks a random item from a list, but keeps the choice stable for a given chat and macro position.',
+        description: 'Picks a random item from a list, but keeps the choice stable for a given chat and macro position. Can be rerolled via /reroll-pick slash command.',
+        // TODO: add expanded documentation once HTML details are supported
+        // descriptionDetails: `
+        //     <p>Picks a random item from a list, but keeps the choice stable for a given chat and macro position.</p>
+        //     <p>The choice can be reset per chat using the <code>/reroll-pick</code> slash command.</p>
+        // `,
         returns: 'Stable randomly selected item from the list.',
         exampleUsage: ['{{pick::blonde::brown::red::black::blue}}'],
         handler: ({ list, globalOffset, env }) => {
@@ -369,7 +374,10 @@ export function registerCoreMacros() {
             // nested inside arguments or scoped content
             const offset = globalOffset;
 
-            const combinedSeedString = `${chatIdHash}-${rawContentHash}-${offset}`;
+            // Reroll seed allows users to reset all picks in the chat via /reroll-pick command
+            const rerollSeed = chat_metadata.pick_reroll_seed ?? 0;
+
+            const combinedSeedString = `${chatIdHash}-${rawContentHash}-${offset}-${rerollSeed}`;
             const finalSeed = getStringHash(combinedSeedString);
             const rng = seedrandom(String(finalSeed));
             const randomIndex = Math.floor(rng() * list.length);

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3122,7 +3122,7 @@ export function initDefaultSlashCommands() {
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: t`Optional seed value to set. If not provided, increments current seed by 1.`,
-                typeList: [ARGUMENT_TYPE.NUMBER]
+                typeList: [ARGUMENT_TYPE.NUMBER],
             }),
         ],
         helpString: `

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3103,6 +3103,48 @@ export function initDefaultSlashCommands() {
         },
     }));
 
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'reroll-pick',
+        callback: (_, value) => {
+            const currentSeed = chat_metadata.pick_reroll_seed ?? 0;
+            const parsedValue = value ? parseInt(String(value), 10) : NaN;
+
+            if (!isNaN(parsedValue)) {
+                chat_metadata.pick_reroll_seed = parsedValue;
+            } else {
+                chat_metadata.pick_reroll_seed = currentSeed + 1;
+            }
+
+            saveMetadataDebounced();
+            return String(chat_metadata.pick_reroll_seed);
+        },
+        returns: t`The new reroll seed value.`,
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: t`Optional seed value to set. If not provided, increments current seed by 1.`,
+                typeList: [ARGUMENT_TYPE.NUMBER]
+            }),
+        ],
+        helpString: `
+            <div>
+                ${t`Rerolls all <code>{{pick}}</code> macro choices in the current chat.`}
+            </div>
+            <div>
+                ${t`The <code>{{pick}}</code> macro normally keeps stable choices per chat. This command changes the seed used for all picks, causing them to resolve to (possibly) different values.`}
+            </div>
+            <div>
+                ${t`If a number is provided, sets the seed to that value. Otherwise, increments the current seed by 1.`}
+            </div>
+            <div>
+                <strong>${t`Example:`}</strong>
+                <ul>
+                    <li><pre><code>/reroll-pick</code></pre> ${t`Increments the seed by 1.`}</li>
+                    <li><pre><code>/reroll-pick 5</code></pre> ${t`Sets the seed to 5.`}</li>
+                </ul>
+            </div>
+        `,
+    }));
+
     registerVariableCommands();
 }
 

--- a/tests/frontend/MacroEngine.e2e.js
+++ b/tests/frontend/MacroEngine.e2e.js
@@ -664,8 +664,8 @@ test.describe('MacroEngine', () => {
                         const chatIdHash = chat_metadata.chat_id_hash ?? 0;
                         const rawContentHash = env.contentHash;
                         const offset = globalOffset;
-                        const rerollSeed = chat_metadata.pick_reroll_seed ?? 0;
-                        const combinedSeedString = `${chatIdHash}-${rawContentHash}-${offset}-${rerollSeed}`;
+                        const rerollSeed = chat_metadata.pick_reroll_seed || null;
+                        const combinedSeedString = [chatIdHash, rawContentHash, offset, rerollSeed].filter(it => it != null).join('-');
                         // Return both the seed and what would be picked for validation
                         const finalSeed = getStringHash(combinedSeedString);
                         const rng = seedrandom(String(finalSeed));

--- a/tests/frontend/MacroEngine.e2e.js
+++ b/tests/frontend/MacroEngine.e2e.js
@@ -664,7 +664,8 @@ test.describe('MacroEngine', () => {
                         const chatIdHash = chat_metadata.chat_id_hash ?? 0;
                         const rawContentHash = env.contentHash;
                         const offset = globalOffset;
-                        const combinedSeedString = `${chatIdHash}-${rawContentHash}-${offset}`;
+                        const rerollSeed = chat_metadata.pick_reroll_seed ?? 0;
+                        const combinedSeedString = `${chatIdHash}-${rawContentHash}-${offset}-${rerollSeed}`;
                         // Return both the seed and what would be picked for validation
                         const finalSeed = getStringHash(combinedSeedString);
                         const rng = seedrandom(String(finalSeed));

--- a/tests/frontend/MacroEngine.e2e.js
+++ b/tests/frontend/MacroEngine.e2e.js
@@ -665,7 +665,7 @@ test.describe('MacroEngine', () => {
                         const rawContentHash = env.contentHash;
                         const offset = globalOffset;
                         const rerollSeed = chat_metadata.pick_reroll_seed || null;
-                        const combinedSeedString = [chatIdHash, rawContentHash, offset, rerollSeed].filter(it => it != null).join('-');
+                        const combinedSeedString = [chatIdHash, rawContentHash, offset, rerollSeed].filter(it => it !== null).join('-');
                         // Return both the seed and what would be picked for validation
                         const finalSeed = getStringHash(combinedSeedString);
                         const rng = seedrandom(String(finalSeed));


### PR DESCRIPTION
### What this does

This adds the ability to reroll all `{{pick}}` macro choices in a chat. Previously, once a pick was made, it was fixed forever based on the chat and macro position. Now users can manually reset all picks if they want different results.

### Why

The `{{pick}}` macro is great for stable random choices (e.g., picking a character's hair color once and keeping it consistent). However, sometimes users want to "try again" with different random outcomes — maybe the initial picks didn't work well together, or they just want variety.

### How it works

- A new **reroll seed** is stored in chat metadata (defaults to `0`)
- The seed is part of the hash that determines pick outcomes
- Users can change the seed via the `/reroll-pick` slash command, causing all picks to resolve to (potentially) different values

### Usage

```stscript
/reroll-pick
```
Increments the seed by 1, rerolling all picks.

```stscript
/reroll-pick 5
```
Sets the seed to a specific value.

### Notes

- The reroll affects **all** `{{pick}}` macros, everywhere, based on the context of the current chat (whether they are in char fields, WI, QRs, etc...)
- Each increment will produce different (but still stable) results
- Setting the seed back to `0` restores the original picks

## Copilot Summary
This pull request enhances the behavior and user control of the `pick` macro by introducing a new `/reroll-pick` slash command. This command allows users to reset or set the randomization seed for all `pick` macro choices within a chat, making the random selections re-evaluatable. The implementation includes updates to macro documentation, macro logic, and the slash command system, along with corresponding test adjustments.

**Macro functionality and documentation improvements:**

* Updated the `pick` macro's description to mention that choices can be rerolled using the `/reroll-pick` command, and added a placeholder for expanded documentation.
* Modified the random seed calculation for the `pick` macro to include a `pick_reroll_seed` value from `chat_metadata`, allowing the result to change when this seed is updated.

**Slash command system enhancements:**

* Added a new `/reroll-pick` slash command that lets users increment or set the `pick_reroll_seed` for the current chat, which triggers a reroll for all `pick` macro choices. The command includes help text and supports an optional numeric argument.

**Testing updates:**

* Updated macro engine tests to account for the new `pick_reroll_seed` in the seed calculation, ensuring test accuracy with the new reroll logic.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).