### PR TITLE
Macros 2.0 (v0.7.3) - Variable Shorthand: Comparison Operators & Autocomplete Improvements

### DIFF
--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -499,13 +499,13 @@ export const VariableShorthandDefinitions = new Map([
         type: VariableShorthandType.LOCAL,
         name: 'Local Variable',
         description: 'Access or modify a local variable (scoped to current chat).',
-        operations: ['get', 'set (=)', 'increment (++)', 'decrement (--)', 'add (+=)', 'subtract (-=)', 'logical or (||)', 'nullish coalescing (??)', 'logical or assign (||=)', 'nullish coalescing assign (??=)', 'equals (==)', 'not equals (!=)'],
+        operations: ['get', 'set (=)', 'increment (++)', 'decrement (--)', 'add (+=)', 'subtract (-=)', 'logical or (||)', 'nullish coalescing (??)', 'logical or assign (||=)', 'nullish coalescing assign (??=)', 'equals (==)', 'not equals (!=)', 'greater than (>)', 'greater than or equal (>=)', 'less than (<)', 'less than or equal (<=)'],
     }],
     [VariableShorthandType.GLOBAL, {
         type: VariableShorthandType.GLOBAL,
         name: 'Global Variable',
         description: 'Access or modify a global variable (shared across all chats).',
-        operations: ['get', 'set (=)', 'increment (++)', 'decrement (--)', 'add (+=)', 'subtract (-=)', 'logical or (||)', 'nullish coalescing (??)', 'logical or assign (||=)', 'nullish coalescing assign (??=)', 'equals (==)', 'not equals (!=)'],
+        operations: ['get', 'set (=)', 'increment (++)', 'decrement (--)', 'add (+=)', 'subtract (-=)', 'logical or (||)', 'nullish coalescing (??)', 'logical or assign (||=)', 'nullish coalescing assign (??=)', 'equals (==)', 'not equals (!=)', 'greater than (>)', 'greater than or equal (>=)', 'less than (<)', 'less than or equal (<=)'],
     }],
 ]);
 
@@ -633,6 +633,10 @@ export class VariableShorthandAutoCompleteOption extends AutoCompleteOption {
             `{{${prefix}myvar ??= value}} - Set if undefined, get value`,
             `{{${prefix}myvar == test}} - Compare (returns true/false)`,
             `{{${prefix}myvar != test}} - Compare not equal (returns true/false)`,
+            `{{${prefix}score > 10}} - Greater than (numeric, returns true/false)`,
+            `{{${prefix}score >= 10}} - Greater than or equal (numeric)`,
+            `{{${prefix}score < 10}} - Less than (numeric, returns true/false)`,
+            `{{${prefix}score <= 10}} - Less than or equal (numeric)`,
         ];
         for (const ex of examples) {
             const li = document.createElement('li');
@@ -810,6 +814,10 @@ export class VariableNameAutoCompleteOption extends AutoCompleteOption {
             `{{${prefix}${this.#varName} ??= value}} - Set if undefined, get value`,
             `{{${prefix}${this.#varName} == test}} - Compare (returns true/false)`,
             `{{${prefix}${this.#varName} != test}} - Compare not equal (returns true/false)`,
+            `{{${prefix}${this.#varName} > 10}} - Greater than (numeric)`,
+            `{{${prefix}${this.#varName} >= 10}} - Greater than or equal (numeric)`,
+            `{{${prefix}${this.#varName} < 10}} - Less than (numeric)`,
+            `{{${prefix}${this.#varName} <= 10}} - Less than or equal (numeric)`,
         ];
         for (const ex of examples) {
             const li = document.createElement('li');
@@ -892,6 +900,30 @@ export const VariableOperatorDefinitions = new Map([
         symbol: '!=',
         name: 'Not Equals',
         description: 'Compare the variable value to another value. Returns "true" if not equal, "false" if equal.',
+        needsValue: true,
+    }],
+    ['>', {
+        symbol: '>',
+        name: 'Greater Than',
+        description: 'Numeric comparison. Returns "true" if variable is greater than value, "false" otherwise.',
+        needsValue: true,
+    }],
+    ['>=', {
+        symbol: '>=',
+        name: 'Greater Than or Equal',
+        description: 'Numeric comparison. Returns "true" if variable is greater than or equal to value, "false" otherwise.',
+        needsValue: true,
+    }],
+    ['<', {
+        symbol: '<',
+        name: 'Less Than',
+        description: 'Numeric comparison. Returns "true" if variable is less than value, "false" otherwise.',
+        needsValue: true,
+    }],
+    ['<=', {
+        symbol: '<=',
+        name: 'Less Than or Equal',
+        description: 'Numeric comparison. Returns "true" if variable is less than or equal to value, "false" otherwise.',
         needsValue: true,
     }],
 ]);
@@ -1224,10 +1256,22 @@ export function parseMacroContext(macroText, cursorOffset) {
         } else if (operatorText.startsWith('!=')) {
             variableOperator = '!=';
             i += 2;
+        } else if (operatorText.startsWith('>=')) {
+            variableOperator = '>=';
+            i += 2;
+        } else if (operatorText.startsWith('>')) {
+            variableOperator = '>';
+            i += 1;
+        } else if (operatorText.startsWith('<=')) {
+            variableOperator = '<=';
+            i += 2;
+        } else if (operatorText.startsWith('<')) {
+            variableOperator = '<';
+            i += 1;
         } else if (operatorText.startsWith('=')) {
             variableOperator = '=';
             i += 1;
-        } else if (operatorText.startsWith('+') || operatorText.startsWith('-') || operatorText.startsWith('|') || operatorText.startsWith('?') || operatorText.startsWith('!')) {
+        } else if (operatorText.startsWith('+') || operatorText.startsWith('-') || operatorText.startsWith('|') || operatorText.startsWith('?') || operatorText.startsWith('!') || operatorText.startsWith('>') || operatorText.startsWith('<')) {
             // Partial operator prefix - user is typing an operator
             partialOperator = operatorText[0];
         } else if (operatorText.length > 0 && !/^\s/.test(operatorText)) {

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -39,7 +39,9 @@ import { onboardingExperimentalMacroEngine } from '../macros/engine/MacroDiagnos
  * @property {boolean} isVariableShorthand - Whether this is a variable shorthand (starts with . or $).
  * @property {'.'|'$'|null} variablePrefix - The variable prefix (. for local, $ for global), or null.
  * @property {string} variableName - The variable name being typed (after the prefix).
+ * @property {number} variableNameEnd - The end of the variable name (for partial matches).
  * @property {string|null} variableOperator - The operator typed (=, ++, --, +=), or null.
+ * @property {number} variableOperatorEnd - The end of the variable operator (for partial matches).
  * @property {string} variableValue - The value after the operator (for = and +=).
  * @property {boolean} isTypingVariableName - Whether cursor is in the variable name area.
  * @property {boolean} isTypingOperator - Whether cursor is at/after variable name, ready for operator.
@@ -832,6 +834,18 @@ export class VariableNameAutoCompleteOption extends AutoCompleteOption {
 }
 
 /**
+ * Checks if an operator is a short one that could be a prefix of a longer operator.
+ * For example, '>' is a prefix of '>=', '<' is a prefix of '<='.
+ * @param {string} op - The operator to check.
+ * @returns {boolean} True if the operator could be a prefix of a longer operator.
+ */
+function isShortOperatorPrefix(op) {
+    // These operators could have longer variants typed after them
+    const shortPrefixes = ['>', '<', '=', '|', '?', '+', '-', '!'];
+    return shortPrefixes.includes(op);
+}
+
+/**
  * Variable shorthand operators with metadata.
  * @type {Map<string, { symbol: string, name: string, description: string, needsValue: boolean }>}
  */
@@ -1274,12 +1288,16 @@ export function parseMacroContext(macroText, cursorOffset) {
         } else if (operatorText.startsWith('+') || operatorText.startsWith('-') || operatorText.startsWith('|') || operatorText.startsWith('?') || operatorText.startsWith('!') || operatorText.startsWith('>') || operatorText.startsWith('<')) {
             // Partial operator prefix - user is typing an operator
             partialOperator = operatorText[0];
-        } else if (operatorText.length > 0 && !/^\s/.test(operatorText)) {
+        } else if (operatorText.length > 0 && !/^\s/.test(operatorText) && !operatorText.startsWith('}')) {
             // There's non-whitespace after the variable name that isn't a valid operator
             // This is an invalid trailing character (e.g., $my$ or .var@test)
+            // Exception: } is the closing brace, not an invalid char
             hasInvalidTrailingChars = true;
             invalidTrailingChars = operatorText.trim();
         }
+
+        // Track where the operator ends (for cursor position checks)
+        const variableOperatorEnd = i;
 
         // Check if operator requires a value
         const operatorDef = variableOperator ? VariableOperatorDefinitions.get(variableOperator) : null;
@@ -1300,11 +1318,15 @@ export function parseMacroContext(macroText, cursorOffset) {
             // Cursor is before the prefix - still in flags area conceptually
             isTypingVariableName = false;
         } else if (cursorOffset <= variableNameEnd) {
-            // Cursor is in the variable name
+            // Cursor is in the variable name area (including at the end)
             isTypingVariableName = true;
-        } else if (!variableOperator && !hasInvalidTrailingChars) {
+        } else if (variableName.length > 0 && !variableOperator && !hasInvalidTrailingChars) {
             // Cursor is after variable name but no operator yet (and no invalid chars)
-            // This includes partial operator prefixes like '+', '-', '|', '?'
+            // This includes partial operator prefixes like '+', '-', '|', '?', '>', '<'
+            isTypingOperator = true;
+        } else if (variableName.length > 0 && variableOperator && isShortOperatorPrefix(variableOperator) && cursorOffset <= variableOperatorEnd) {
+            // Short operator that could be prefix of longer one (e.g., > could become >=)
+            // But ONLY if cursor is still in the operator area, not past it into value
             isTypingOperator = true;
         } else if (operatorNeedsValue) {
             // Operator that requires value - cursor is in value area
@@ -1336,7 +1358,9 @@ export function parseMacroContext(macroText, cursorOffset) {
             isVariableShorthand,
             variablePrefix,
             variableName,
+            variableNameEnd,
             variableOperator,
+            variableOperatorEnd,
             variableValue,
             isTypingVariableName,
             isTypingOperator,

--- a/public/scripts/macros/engine/MacroCstWalker.js
+++ b/public/scripts/macros/engine/MacroCstWalker.js
@@ -574,6 +574,22 @@ class MacroCstWalker {
                         operation = 'notEquals';
                         hasValueExpr = true;
                         break;
+                    case '>':
+                        operation = 'greaterThan';
+                        hasValueExpr = true;
+                        break;
+                    case '>=':
+                        operation = 'greaterThanOrEqual';
+                        hasValueExpr = true;
+                        break;
+                    case '<':
+                        operation = 'lessThan';
+                        hasValueExpr = true;
+                        break;
+                    case '<=':
+                        operation = 'lessThanOrEqual';
+                        hasValueExpr = true;
+                        break;
                     default:
                         logMacroInternalError({ message: `Lexer found macro operator that is not implemented for variable shorthand expressions in macro node '${macroNode.name}'.` });
                         break;
@@ -712,6 +728,50 @@ class MacroCstWalker {
                 const currentValue = normalize(vars.get(varName));
                 const compareValue = normalize(lazyValue());
                 return currentValue !== compareValue ? 'true' : 'false';
+            }
+
+            case 'greaterThan': {
+                // Numeric greater than comparison
+                const currentNum = Number(vars.get(varName));
+                const compareNum = Number(lazyValue());
+                if (isNaN(currentNum) || isNaN(compareNum)) {
+                    logMacroRuntimeWarning({ message: `Variable shorthand ">" operator requires numeric values. Got: "${vars.get(varName)}" > "${lazyValue()}"` });
+                    return 'false';
+                }
+                return currentNum > compareNum ? 'true' : 'false';
+            }
+
+            case 'greaterThanOrEqual': {
+                // Numeric greater than or equal comparison
+                const currentNum = Number(vars.get(varName));
+                const compareNum = Number(lazyValue());
+                if (isNaN(currentNum) || isNaN(compareNum)) {
+                    logMacroRuntimeWarning({ message: `Variable shorthand ">=" operator requires numeric values. Got: "${vars.get(varName)}" >= "${lazyValue()}"` });
+                    return 'false';
+                }
+                return currentNum >= compareNum ? 'true' : 'false';
+            }
+
+            case 'lessThan': {
+                // Numeric less than comparison
+                const currentNum = Number(vars.get(varName));
+                const compareNum = Number(lazyValue());
+                if (isNaN(currentNum) || isNaN(compareNum)) {
+                    logMacroRuntimeWarning({ message: `Variable shorthand "<" operator requires numeric values. Got: "${vars.get(varName)}" < "${lazyValue()}"` });
+                    return 'false';
+                }
+                return currentNum < compareNum ? 'true' : 'false';
+            }
+
+            case 'lessThanOrEqual': {
+                // Numeric less than or equal comparison
+                const currentNum = Number(vars.get(varName));
+                const compareNum = Number(lazyValue());
+                if (isNaN(currentNum) || isNaN(compareNum)) {
+                    logMacroRuntimeWarning({ message: `Variable shorthand "<=" operator requires numeric values. Got: "${vars.get(varName)}" <= "${lazyValue()}"` });
+                    return 'false';
+                }
+                return currentNum <= compareNum ? 'true' : 'false';
             }
 
             default:

--- a/public/scripts/macros/engine/MacroLexer.js
+++ b/public/scripts/macros/engine/MacroLexer.js
@@ -132,6 +132,14 @@ const Tokens = Object.freeze({
             DoubleEquals: createToken({ name: 'Var.DoubleEquals', pattern: /==/ }),
             /** Not equals comparison operator (`!=`) - compares variable to value, returns inverted result */
             NotEquals: createToken({ name: 'Var.NotEquals', pattern: /!=/ }),
+            /** Greater than or equal comparison operator (`>=`) - must come before GreaterThan */
+            GreaterThanOrEqual: createToken({ name: 'Var.GreaterThanOrEqual', pattern: />=/ }),
+            /** Greater than comparison operator (`>`) */
+            GreaterThan: createToken({ name: 'Var.GreaterThan', pattern: />/ }),
+            /** Less than or equal comparison operator (`<=`) - must come before LessThan */
+            LessThanOrEqual: createToken({ name: 'Var.LessThanOrEqual', pattern: /<=/ }),
+            /** Less than comparison operator (`<`) */
+            LessThan: createToken({ name: 'Var.LessThan', pattern: /</ }),
             /** Add/append operator (`+=`) - must come before Equals to avoid conflict */
             PlusEquals: createToken({ name: 'Var.PlusEquals', pattern: /\+=/ }),
             /** Set operator (`=`) */
@@ -258,6 +266,10 @@ const Def = {
             enter(Tokens.Var.Operators.MinusEquals, modes.var_value, { andExits: modes.var_after_identifier }),
             enter(Tokens.Var.Operators.DoubleEquals, modes.var_value, { andExits: modes.var_after_identifier }),
             enter(Tokens.Var.Operators.NotEquals, modes.var_value, { andExits: modes.var_after_identifier }),
+            enter(Tokens.Var.Operators.GreaterThanOrEqual, modes.var_value, { andExits: modes.var_after_identifier }),
+            enter(Tokens.Var.Operators.GreaterThan, modes.var_value, { andExits: modes.var_after_identifier }),
+            enter(Tokens.Var.Operators.LessThanOrEqual, modes.var_value, { andExits: modes.var_after_identifier }),
+            enter(Tokens.Var.Operators.LessThan, modes.var_value, { andExits: modes.var_after_identifier }),
             enter(Tokens.Var.Operators.PlusEquals, modes.var_value, { andExits: modes.var_after_identifier }),
             enter(Tokens.Var.Operators.Equals, modes.var_value, { andExits: modes.var_after_identifier }),
             // If we see the end, exit

--- a/public/scripts/macros/engine/MacroParser.js
+++ b/public/scripts/macros/engine/MacroParser.js
@@ -92,63 +92,29 @@ class MacroParser extends CstParser {
             $.OPTION2(() => $.SUBRULE($.variableOperator));
         });
 
-        // Variable operator: ++, --, = value, += value, -= value, ||, ??, ||=, ??=, ==, !=
+        // Variable operator: ++, --, = value, += value, -= value, ||, ??, ||=, ??=, ==, !=, >, >=, <, <=
         $.variableOperator = $.RULE('variableOperator', () => {
             $.OR4([
                 { ALT: () => $.CONSUME(Tokens.Var.Operators.Increment, { LABEL: 'Var.operator' }) },
                 { ALT: () => $.CONSUME(Tokens.Var.Operators.Decrement, { LABEL: 'Var.operator' }) },
                 {
                     ALT: () => {
-                        $.CONSUME(Tokens.Var.Operators.NullishCoalescingEquals, { LABEL: 'Var.operator' });
+                        $.OR5([
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.NullishCoalescingEquals, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.NullishCoalescing, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.LogicalOrEquals, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.LogicalOr, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.MinusEquals, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.DoubleEquals, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.NotEquals, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.GreaterThanOrEqual, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.GreaterThan, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.LessThanOrEqual, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.LessThan, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.PlusEquals, { LABEL: 'Var.operator' }) },
+                            { ALT: () => $.CONSUME(Tokens.Var.Operators.Equals, { LABEL: 'Var.operator' }) },
+                        ]);
                         $.SUBRULE($.variableValue, { LABEL: 'Var.value' });
-                    },
-                },
-                {
-                    ALT: () => {
-                        $.CONSUME(Tokens.Var.Operators.NullishCoalescing, { LABEL: 'Var.operator' });
-                        $.SUBRULE2($.variableValue, { LABEL: 'Var.value' });
-                    },
-                },
-                {
-                    ALT: () => {
-                        $.CONSUME(Tokens.Var.Operators.LogicalOrEquals, { LABEL: 'Var.operator' });
-                        $.SUBRULE3($.variableValue, { LABEL: 'Var.value' });
-                    },
-                },
-                {
-                    ALT: () => {
-                        $.CONSUME(Tokens.Var.Operators.LogicalOr, { LABEL: 'Var.operator' });
-                        $.SUBRULE4($.variableValue, { LABEL: 'Var.value' });
-                    },
-                },
-                {
-                    ALT: () => {
-                        $.CONSUME(Tokens.Var.Operators.MinusEquals, { LABEL: 'Var.operator' });
-                        $.SUBRULE5($.variableValue, { LABEL: 'Var.value' });
-                    },
-                },
-                {
-                    ALT: () => {
-                        $.CONSUME(Tokens.Var.Operators.DoubleEquals, { LABEL: 'Var.operator' });
-                        $.SUBRULE6($.variableValue, { LABEL: 'Var.value' });
-                    },
-                },
-                {
-                    ALT: () => {
-                        $.CONSUME(Tokens.Var.Operators.NotEquals, { LABEL: 'Var.operator' });
-                        $.SUBRULE7($.variableValue, { LABEL: 'Var.value' });
-                    },
-                },
-                {
-                    ALT: () => {
-                        $.CONSUME(Tokens.Var.Operators.PlusEquals, { LABEL: 'Var.operator' });
-                        $.SUBRULE8($.variableValue, { LABEL: 'Var.value' });
-                    },
-                },
-                {
-                    ALT: () => {
-                        $.CONSUME(Tokens.Var.Operators.Equals, { LABEL: 'Var.operator' });
-                        $.SUBRULE9($.variableValue, { LABEL: 'Var.value' });
                     },
                 },
             ]);

--- a/tests/frontend/MacroEngine.e2e.js
+++ b/tests/frontend/MacroEngine.e2e.js
@@ -2698,6 +2698,102 @@ test.describe('MacroEngine', () => {
             expect(output).toBe('true');
         });
 
+        // {{.myvar > value}} - greater than comparison (numeric)
+        test('should return true when variable is greater than value with >', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar > 5}}', { local: { myvar: '10' } });
+            expect(output).toBe('true');
+        });
+
+        test('should return false when variable is not greater than value with >', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar > 10}}', { local: { myvar: '5' } });
+            expect(output).toBe('false');
+        });
+
+        test('should return false when variable equals value with >', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar > 10}}', { local: { myvar: '10' } });
+            expect(output).toBe('false');
+        });
+
+        test('should return false for non-numeric values with >', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar > 5}}', { local: { myvar: 'abc' } });
+            expect(output).toBe('false');
+        });
+
+        // {{.myvar >= value}} - greater than or equal comparison (numeric)
+        test('should return true when variable is greater than value with >=', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar >= 5}}', { local: { myvar: '10' } });
+            expect(output).toBe('true');
+        });
+
+        test('should return true when variable equals value with >=', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar >= 10}}', { local: { myvar: '10' } });
+            expect(output).toBe('true');
+        });
+
+        test('should return false when variable is less than value with >=', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar >= 10}}', { local: { myvar: '5' } });
+            expect(output).toBe('false');
+        });
+
+        // {{.myvar < value}} - less than comparison (numeric)
+        test('should return true when variable is less than value with <', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar < 10}}', { local: { myvar: '5' } });
+            expect(output).toBe('true');
+        });
+
+        test('should return false when variable is not less than value with <', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar < 5}}', { local: { myvar: '10' } });
+            expect(output).toBe('false');
+        });
+
+        test('should return false when variable equals value with <', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar < 10}}', { local: { myvar: '10' } });
+            expect(output).toBe('false');
+        });
+
+        test('should return false for non-numeric values with <', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar < 5}}', { local: { myvar: 'abc' } });
+            expect(output).toBe('false');
+        });
+
+        // {{.myvar <= value}} - less than or equal comparison (numeric)
+        test('should return true when variable is less than value with <=', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar <= 10}}', { local: { myvar: '5' } });
+            expect(output).toBe('true');
+        });
+
+        test('should return true when variable equals value with <=', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar <= 10}}', { local: { myvar: '10' } });
+            expect(output).toBe('true');
+        });
+
+        test('should return false when variable is greater than value with <=', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar <= 5}}', { local: { myvar: '10' } });
+            expect(output).toBe('false');
+        });
+
+        // Negative numbers with comparison operators
+        test('should handle negative numbers with > operator', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar > -5}}', { local: { myvar: '0' } });
+            expect(output).toBe('true');
+        });
+
+        test('should handle negative numbers with < operator', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar < 0}}', { local: { myvar: '-5' } });
+            expect(output).toBe('true');
+        });
+
+        // Decimal numbers with comparison operators
+        test('should handle decimal numbers with >= operator', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar >= 3.14}}', { local: { myvar: '3.14' } });
+            expect(output).toBe('true');
+        });
+
+        test('should handle decimal numbers with <= operator', async ({ page }) => {
+            const output = await evaluateWithEngineAndVariables(page, '{{.myvar <= 2.5}}', { local: { myvar: '2.49' } });
+            expect(output).toBe('true');
+        });
+
         // Global variable versions of new operators
         test('should use || with global variable', async ({ page }) => {
             const output = await evaluateWithEngineAndVariables(page, '{{$myvar || globaldefault}}', { global: { myvar: '' } });


### PR DESCRIPTION
This PR extends the variable shorthand macro system with comparison operators and significantly improves the autocomplete experience for variable shorthands.

### New Features

#### Comparison Operators

Added four new comparison operators for variable shorthands, enabling inline condition checks:

- `>` — Greater than
- `>=` — Greater than or equal
- `<` — Less than
- `<=` — Less than or equal

**Example usage:**
```
{{$score>50}}     // Returns true/false
{{.health<=0}}    // Check if health depleted
{{$level>=10}}    // Check minimum level
```

These operators complement the existing logical operators (`||`, `??`, `||=`, `??=`) and arithmetic operators (`=`, `+=`, `-=`, `++`, `--`).

### Autocomplete Enhancements

The autocomplete system for variable shorthands received a significant overhaul to provide a smoother, more intuitive editing experience.

#### Operator Suggestions

- **Immediate operator hints**: When typing a variable name that matches an existing variable, operators are now shown immediately—no need to type a space first
- **Partial operator completion**: Typing `+` now suggests `++` and `+=`; typing `>` suggests both `>` and `>=`
- **Smart insertion**: Selecting an operator inserts it at the cursor position without replacing the already-typed variable name

#### Context Display

- **Consistent context feedback**: When typing a value (e.g., `{{$myvar>=5}}`), the autocomplete now always shows greyed-out, non-selectable entries for the prefix, variable name, and operator—providing clear visual feedback of what you've typed
- **Works with whitespace**: Context display now works correctly regardless of spacing (e.g., `{{ $myNumber >= 5 }}`)

#### Bug Fixes

- Fixed operators not appearing when variable name matches exactly without trailing space
- Fixed operator autocomplete replacing the variable name instead of inserting after it
- Fixed single-character operators (`>`, `<`) incorrectly triggering operator mode when already typing a value
- Fixed context options not appearing for operators that require values when whitespace was present
- Fixed closing braces `}}` being incorrectly flagged as invalid trailing characters

### Technical Notes

The autocomplete now tracks actual character positions within the macro text rather than relying on string length calculations, ensuring correct behavior regardless of whitespace formatting.

## Copilot Summary
This pull request adds support for numeric comparison operators (`>`, `>=`, `<`, `<=`) in macro variable shorthand expressions. These new operators can now be used in macros for both local and global variables, and are integrated throughout the autocomplete, parsing, and execution logic. The changes include updates to documentation, autocomplete suggestions, parsing, and runtime evaluation to ensure a seamless user experience.

**Macro variable shorthand enhancements:**

* Added support for numeric comparison operators (`>`, `>=`, `<`, `<=`) to both local and global variable shorthand operations, including documentation and autocomplete examples. [[1]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bL502-R510) [[2]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR638-R641) [[3]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR819-R822) [[4]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR919-R942)
* Updated operator definitions and metadata to include the new comparison operators, with descriptions and value requirements.
* Improved autocomplete context parsing to recognize and handle the new operators, including cursor position logic and partial operator prefixes. [[1]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR42-R44) [[2]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR836-R847) [[3]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1273-R1301) [[4]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bL1259-R1329) [[5]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1361-R1363)

**Macro engine parsing and execution:**

* Extended the macro lexer and parser to recognize the new comparison operators, ensuring correct tokenization and parsing order. [[1]](diffhunk://#diff-2827513de6ad694faaf2815fd7ac188abe20d29f8986e733576da8a9e0aca7c1R135-R142) [[2]](diffhunk://#diff-2827513de6ad694faaf2815fd7ac188abe20d29f8986e733576da8a9e0aca7c1R269-R272) [[3]](diffhunk://#diff-4afa06774e8cd52320f1adf8c1211cc3e7b842510580e178727f9a56acb04a0fL95-L153)
* Implemented runtime logic for `greaterThan`, `greaterThanOrEqual`, `lessThan`, and `lessThanOrEqual` operations in the macro engine, including numeric conversion and error handling for non-numeric values. [[1]](diffhunk://#diff-763175bd6b061dc9c59c051ed4afe698540540a12279a2d11730e9323017b248R577-R592) [[2]](diffhunk://#diff-763175bd6b061dc9c59c051ed4afe698540540a12279a2d11730e9323017b248R733-R776)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).