### PR TITLE
Add `APP_INIT` event before hideLoader in initialization sequence, before `APP_READY` fires

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -730,7 +730,7 @@ async function firstLoadInit() {
     initAccessibility();
     addDebugFunctions();
     doDailyExtensionUpdatesCheck();
-    await eventSource.emit(event_types.APP_INIT);
+    await eventSource.emit(event_types.APP_INITIALIZED);
     await hideLoader();
     await fixViewport();
     await eventSource.emit(event_types.APP_READY);

--- a/public/script.js
+++ b/public/script.js
@@ -730,6 +730,7 @@ async function firstLoadInit() {
     initAccessibility();
     addDebugFunctions();
     doDailyExtensionUpdatesCheck();
+    await eventSource.emit(event_types.APP_INIT);
     await hideLoader();
     await fixViewport();
     await eventSource.emit(event_types.APP_READY);

--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -1,6 +1,7 @@
 import { EventEmitter } from '../lib/eventemitter.js';
 
 export const event_types = {
+    APP_INIT: 'app_init',
     APP_READY: 'app_ready',
     EXTRAS_CONNECTED: 'extras_connected',
     MESSAGE_SWIPED: 'message_swiped',

--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from '../lib/eventemitter.js';
 
 export const event_types = {
-    APP_INIT: 'app_init',
+    APP_INITIALIZED: 'app_initialized',
     APP_READY: 'app_ready',
     EXTRAS_CONNECTED: 'extras_connected',
     MESSAGE_SWIPED: 'message_swiped',


### PR DESCRIPTION
#### Reasoning
When setting up an extension, setup/init can be done either directly via the `jQuery(async function ()` directly, which will run the init right during the extension init step, one extension after the other, and **before** many of the other init steps of core SillyTavern, or you can register an event handler to `APP_READY` and have your setup run when all the init is done.

But this event fires after the loader icon is hidden already, so the UI is already visible and responsive for the user to use.  
If you want to do UI setup or have operations that might run longer than a few milliseconds, you might want to hide them behind the loader, but still after stuff like setting up slash commands, world info, etc... everything that comes after extension init.

## Copilot Summary
This pull request introduces a new application initialization event to the event system and updates the initial loading sequence to emit this event. The most important changes are grouped below:

Event System Enhancements:

* Added a new event type `APP_INIT` to the `event_types` object in `public/scripts/events.js`, enabling other parts of the application to listen for the app initialization phase.

Initialization Sequence Updates:

* Modified the `firstLoadInit` function in `public/script.js` to emit the `APP_INIT` event before hiding the loader and fixing the viewport, allowing for better coordination of initialization tasks.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).