### PR TITLE
Allow reasoning edit to substitute macros on saving the reasoning

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -8157,9 +8157,6 @@ async function messageEditDone(div) {
     }
 
     let { mesBlock, text, mes, bias } = updateMessage(div);
-    if (this_edit_mes_id == 0) {
-        text = substituteParams(text);
-    }
 
     await eventSource.emit(event_types.MESSAGE_EDITED, this_edit_mes_id);
     text = chat[this_edit_mes_id]?.mes ?? text;

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1163,7 +1163,8 @@ function setReasoningEventHandlers() {
         }
 
         const textarea = messageBlock.find('.reasoning_edit_textarea');
-        const newReasoning = String(textarea.val());
+        let newReasoning = String(textarea.val());
+        newReasoning = substituteParams(newReasoning);
         textarea.remove();
         if (newReasoning === message.extra.reasoning) {
             return;


### PR DESCRIPTION
When editing a message, macros are substituted on saving the edit. This is an intended feature.
Editing the reasoning did not substitute macros. This was an oversight.
Consistency would say both functions should behave the same.

This PR fixes that.

See here for how the message editing replaces macros, via `messageEditDone` → `updateMessage`:
https://github.com/SillyTavern/SillyTavern/blob/5149c5c1261aa97f1104004a00972ebc7fe4f694/public/script.js#L7929-L7930

This also removes an unnecessary substitution during message edit that did double substitution, as `updateMessage` will always substitute, no matter what.

## Copilot Summary
This pull request makes targeted updates to the message editing and reasoning workflows to ensure parameter substitution is handled correctly and consistently. The main changes involve shifting where `substituteParams` is called, affecting both general message edits and reasoning edits.

**Parameter substitution logic changes:**

* In `public/script.js`, the call to `substituteParams` during message editing has been removed, meaning parameter substitution is no longer performed for regular message edits at this stage.
* In `public/scripts/reasoning.js`, `substituteParams` is now explicitly called when updating reasoning text, ensuring that any parameters in the reasoning are substituted before saving.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).