### PR TITLE
Macros 2.0 - [Chore] Allow registration of aliases for existing macros

### DIFF
--- a/public/scripts/macros/engine/MacroRegistry.js
+++ b/public/scripts/macros/engine/MacroRegistry.js
@@ -200,11 +200,6 @@ class MacroRegistry {
         name = typeof name === 'string' ? name.trim() : String(name);
 
         try {
-            const nameKey = name.toLowerCase();
-            if (this.#macros.has(nameKey)) {
-                logMacroRegisterWarning({ macroName: name, message: `Macro "${name}" is already registered and will be overwritten.` });
-            }
-
             // Detect extension/third-party status from call stack
             const { isExtension, isThirdParty, source } = detectMacroSource();
 
@@ -213,22 +208,12 @@ class MacroRegistry {
                 source: { name: source, isExtension, isThirdParty },
             });
 
-            this.#macros.set(nameKey, definition);
+            // Register the primary macro
+            this.#registerMacroEntry(name, definition);
 
             // Register alias entries pointing to the same definition
             for (const { alias, visible } of definition.aliases) {
-                const aliasKey = alias.toLowerCase();
-                if (this.#macros.has(aliasKey)) {
-                    logMacroRegisterWarning({ macroName: name, message: `Alias "${alias}" for macro "${name}" overwrites an existing macro.` });
-                }
-                /** @type {MacroDefinition} */
-                const aliasEntry = {
-                    ...definition,
-                    name: alias, // The lookup name is the alias (preserves original casing for display)
-                    aliasOf: name,
-                    aliasVisible: visible,
-                };
-                this.#macros.set(aliasKey, aliasEntry);
+                this.#registerMacroEntry(alias, definition, { primaryMacroName: name, aliasVisible: visible });
             }
 
             return definition;
@@ -240,6 +225,97 @@ class MacroRegistry {
             });
             return null;
         }
+    }
+
+    /**
+     * Registers an alias for an existing macro.
+     * The alias will point to the same handler and metadata as the original macro.
+     * Errors during registration are caught and logged, the alias will not be registered, and the function returns false.
+     *
+     * @param {string} targetMacroName - The name of the existing macro to create an alias for.
+     * @param {string} aliasName - The alias name (identifier).
+     * @param {Object} [options] - Alias registration options.
+     * @param {boolean} [options.visible=true] - Whether this alias appears in documentation/autocomplete.
+     * @returns {boolean} True if the alias was registered successfully, false if registration failed.
+     */
+    registerMacroAlias(targetMacroName, aliasName, { visible = true } = {}) {
+        // Extract names early for error logging
+        targetMacroName = typeof targetMacroName === 'string' ? targetMacroName.trim() : String(targetMacroName);
+        aliasName = typeof aliasName === 'string' ? aliasName.trim() : String(aliasName);
+
+        try {
+            // Validate alias name
+            if (!isIdentifierValid(aliasName)) {
+                throw new Error(`Alias name "${aliasName}" is invalid. Must start with a letter, followed by alphanumeric characters or hyphens.`);
+            }
+
+            // Check that alias is not the same as target (case insensitive)
+            if (aliasName.toLowerCase() === targetMacroName.toLowerCase()) {
+                throw new Error(`Alias name "${aliasName}" cannot be the same as the target macro name (case insensitive).`);
+            }
+
+            // Check that target macro exists
+            const targetDefinition = this.getMacro(targetMacroName);
+            if (!targetDefinition) {
+                throw new Error(`Target macro "${targetMacroName}" is not registered.`);
+            }
+
+            // Get the primary definition (in case target is itself an alias)
+            const primaryDefinition = targetDefinition.aliasOf ? this.getMacro(targetDefinition.aliasOf) : targetDefinition;
+            if (!primaryDefinition) {
+                throw new Error(`Could not resolve primary definition for target macro "${targetMacroName}".`);
+            }
+
+            // Detect extension/third-party status from call stack
+            const { isExtension, isThirdParty, source } = detectMacroSource();
+
+            // Create alias definition with source detection
+            const aliasDefinition = {
+                ...primaryDefinition,
+                source: { name: source, isExtension, isThirdParty },
+            };
+
+            // Register the alias using the shared utility
+            this.#registerMacroEntry(aliasName, aliasDefinition, { primaryMacroName: primaryDefinition.name, aliasVisible: visible });
+
+            return true;
+        } catch (error) {
+            logMacroRegisterError({
+                message: `Failed to register alias "${aliasName}" for macro "${targetMacroName}". The alias will not be available.`,
+                macroName: aliasName,
+                error,
+            });
+            return false;
+        }
+    }
+
+    /**
+     * Shared utility for registering macro entries (primary or alias).
+     *
+     * @param {string} name - The registration name (primary macro or alias).
+     * @param {MacroDefinition} definition - The definition to register.
+     * @param {Object} [options={}] - Options for alias registration.
+     * @param {string} [options.primaryMacroName=null] - For aliases, the primary macro name.
+     * @param {boolean} [options.aliasVisible=null] - For aliases, visibility flag.
+     */
+    #registerMacroEntry(name, definition, { primaryMacroName = null, aliasVisible = null } = {}) {
+        const nameKey = name.toLowerCase();
+
+        if (this.#macros.has(nameKey)) {
+            const warningType = primaryMacroName ? `Alias "${name}" for macro "${primaryMacroName}"` : `Macro "${name}"`;
+            const warningMessage = primaryMacroName ? 'overwrites an existing macro.' : 'is already registered and will be overwritten.';
+            logMacroRegisterWarning({ macroName: primaryMacroName || name, message: `${warningType} ${warningMessage}` });
+        }
+
+        /** @type {MacroDefinition} */
+        const entry = primaryMacroName ? {
+            ...definition,
+            name: name, // The lookup name is the alias (preserves original casing for display)
+            aliasOf: primaryMacroName,
+            aliasVisible: aliasVisible,
+        } : definition;
+
+        this.#macros.set(nameKey, entry);
     }
 
     /**

--- a/public/scripts/macros/macro-system.js
+++ b/public/scripts/macros/macro-system.js
@@ -55,6 +55,7 @@ export const macros = {
 
     // shorthand functions
     register: MacroRegistry.registerMacro.bind(MacroRegistry),
+    registerAlias: MacroRegistry.registerMacroAlias.bind(MacroRegistry),
 };
 
 /**


### PR DESCRIPTION
Adds the ability to register macro aliases without creating full macro definitions. This enables extensions to provide alternative names for existing macros while keeping proper source tracking for where each alias was registered.

### What Changed

- **New [registerMacroAlias()](cci:1://file:///d:/code/SillyTavern/public/scripts/macros/engine/MacroRegistry.js:229:4-289:5) method** - Extensions can now register aliases that point to existing macros
- **Refactored internal registration logic** - Extracted shared code into a reusable helper to avoid duplication
- **Added public shorthand** - `macros.registerAlias()` available alongside `macros.register()`
- **Comprehensive test coverage** - 12 new tests covering valid usage, rejection cases, and warning scenarios

### Why These Changes

When building extensions that want to provide alternative names for built-in macros (e.g., `rand` as an alias for `random`), the previous approach required registering a completely new macro that copied the handler and all metadata. This felt semantically wrong—an alias isn't really a new macro, it's just another name for an existing one.

The new approach makes this distinction explicit: aliases share the handler and metadata with their target but maintain their own source tracking, so you can tell where each alias was registered from (which might be a different extension than where the primary macro was defined).

### How It Works

Extensions call `macros.registerAlias('existingMacro', 'newAlias')` to create an alias. The registry:
- Validates the alias name follows identifier rules
- Prevents self-aliasing (alias can't match target name)
- Resolves alias chains to the primary definition
- Tracks the calling extension as the alias's source
- Warns if the alias overwrites an existing macro
- Aliases extract the source where they are registered

### Impact

- Extensions can now cleanly provide macro aliases without workarounds
- Source tracking remains accurate for debugging and documentation
- Autocomplete/docs can distinguish aliases from primary macros via `aliasOf` and `aliasVisible` properties


## Copilot Summary
This pull request adds robust support for registering macro aliases in the `MacroRegistry`, including a new public API, improved internal logic, and comprehensive tests. The changes make it easier and safer to create, validate, and manage aliases for macros, with clear error handling and warnings for edge cases.

**Macro alias registration enhancements:**

* Added a new method `registerMacroAlias` to `MacroRegistry`, allowing registration of aliases for existing macros with validation, error handling, and options for visibility. This method ensures aliases cannot shadow the target macro (case-insensitive), must have valid identifiers, and always resolve to the primary macro definition.
* Refactored macro and alias registration logic into a shared private method `#registerMacroEntry`, centralizing warning and overwrite handling for both primary macros and aliases. [[1]](diffhunk://#diff-a333ffa33ac4df78ae65e3bdf5fc33dc4fdfd5364714943ca009faa98997e29cL216-R216) [[2]](diffhunk://#diff-a333ffa33ac4df78ae65e3bdf5fc33dc4fdfd5364714943ca009faa98997e29cR230-R320)
* Updated the main macro system API (`macros`) to expose `registerAlias` as a shorthand for the new alias registration method.

**Testing improvements:**

* Added extensive end-to-end tests for `registerMacroAlias`, covering valid registrations, error cases (invalid names, non-existent targets, overwrites), visibility options, source object independence, and case-insensitive behavior.
* Introduced the helper function `registerAliasAndCaptureErrors` for capturing and asserting error messages during alias registration tests.
* Improved test naming for clarity by renaming test groups to better reflect their purpose (e.g., `register valid`, `register reject`). [[1]](diffhunk://#diff-c49807418cd0cc125c22d4059e999c6d4f75d403cfd66f957307e9a701d3401bL8-R8) [[2]](diffhunk://#diff-c49807418cd0cc125c22d4059e999c6d4f75d403cfd66f957307e9a701d3401bL45-R45)

**Internal logic and safety:**

* Removed duplicate warning logic from the main macro registration flow, delegating all entry registration to the new shared utility. [[1]](diffhunk://#diff-a333ffa33ac4df78ae65e3bdf5fc33dc4fdfd5364714943ca009faa98997e29cL203-L207) [[2]](diffhunk://#diff-a333ffa33ac4df78ae65e3bdf5fc33dc4fdfd5364714943ca009faa98997e29cL216-R216)

These changes collectively make macro aliasing more powerful, maintainable, and reliable.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).