### PR TITLE
feat(openrouter): disable reasoning if Request model reasoning is off and effort is minimum

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2151,6 +2151,9 @@
                                             <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-style options: low, medium, high. Minimum and maximum are aliased to low and high. Auto does not send an effort level.">
                                                 OpenAI-style options: low, medium, high. Minimum and maximum are aliased to low and high. Auto does not send an effort level.
                                             </div>
+                                            <strong class="toggle-description justifyLeft marginBot5" data-source="openrouter">
+                                                Request model reasoning = Off with Reasoning Effort = Minimum disables reasoning entirely on models that support that, but can cause errors with some models.
+                                            </strong>
                                             <div class="toggle-description justifyLeft marginBot5" data-source="claude" data-i18n="Allocates a portion of the response length for thinking (min: 1024 tokens, low: 10%, medium: 25%, high: 50%, max: 95%), but minimum 1024 tokens. Auto does not request thinking.">
                                                 Allocates a portion of the response length for thinking (min: 1024 tokens, low: 10%, medium: 25%, high: 50%, max: 95%), but minimum 1024 tokens. Auto does not request thinking.
                                             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -2129,7 +2129,7 @@
                                             <span data-i18n="Allows the model to return its thinking process.">
                                                 Allows the model to return its thinking process.
                                             </span>
-                                            <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot">
+                                            <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter">
                                                 This setting affects visibility only.
                                             </strong>
                                         </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2462,6 +2462,10 @@ function getReasoningEffort(settings = null, model = null) {
             case reasoning_effort_types.auto:
                 return undefined;
             case reasoning_effort_types.min:
+                if (chat_completion_sources.OPENROUTER === settings.chat_completion_source && !settings.show_thoughts) {
+                    return 'none';
+                }
+
                 return [chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source) && /^gpt-5/.test(model)
                     ? reasoning_effort_types.min
                     : reasoning_effort_types.low;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2107,8 +2107,8 @@ router.post('/generate', async function (request, response) {
                 bodyParams['route'] = 'fallback';
             }
 
-            if (request.body.reasoning_effort || !includeReasoning) {
-                bodyParams['reasoning']['effort'] = includeReasoning ? request.body.reasoning_effort : 'none';
+            if (request.body.reasoning_effort) {
+                bodyParams['reasoning']['effort'] = request.body.reasoning_effort;
             }
 
             if (request.body.verbosity) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2070,10 +2070,13 @@ router.post('/generate', async function (request, response) {
             apiKey = readSecret(request.user.directories, SECRET_KEYS.OPENROUTER);
             // OpenRouter needs to pass the Referer and X-Title: https://openrouter.ai/docs#requests
             headers = { ...OPENROUTER_HEADERS };
+            const includeReasoning = Boolean(request.body.include_reasoning);
             bodyParams = {
-                'transforms': getOpenRouterTransforms(request),
-                'plugins': getOpenRouterPlugins(request),
-                'include_reasoning': Boolean(request.body.include_reasoning),
+                transforms: getOpenRouterTransforms(request),
+                plugins: getOpenRouterPlugins(request),
+                reasoning: {
+                    exclude: !includeReasoning,
+                },
             };
 
             if (request.body.min_p !== undefined) {
@@ -2104,8 +2107,8 @@ router.post('/generate', async function (request, response) {
                 bodyParams['route'] = 'fallback';
             }
 
-            if (request.body.reasoning_effort) {
-                bodyParams['reasoning'] = { effort: request.body.reasoning_effort };
+            if (request.body.reasoning_effort || !includeReasoning) {
+                bodyParams['reasoning']['effort'] = includeReasoning ? request.body.reasoning_effort : 'none';
             }
 
             if (request.body.verbosity) {


### PR DESCRIPTION
Closes #4181 

See https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#legacy-parameters for the `include_reasoning` change.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
