### PR TITLE
Feat/Add GLM tokenizer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4423,6 +4423,7 @@
                                     <option value="8">Yi</option>
                                     <option value="11">Claude 1/2</option>
                                     <option value="18">DeepSeek V3</option>
+                                    <option value="20">GLM</option>
                                     <option value="6">API (WebUI / koboldcpp)</option>
                                 </select>
                             </div>

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -33,6 +33,7 @@ export const tokenizers = {
     NEMO: 17,
     DEEPSEEK: 18,
     COMMAND_A: 19,
+    GLM: 20,
     BEST_MATCH: 99,
 };
 
@@ -49,6 +50,7 @@ export const ENCODE_TOKENIZERS = [
     tokenizers.COMMAND_A,
     tokenizers.NEMO,
     tokenizers.DEEPSEEK,
+    tokenizers.GLM,
     // uncomment when NovelAI releases Kayra and Clio weights, lol
     //tokenizers.NERD,
     //tokenizers.NERD2,
@@ -145,6 +147,11 @@ const TOKENIZER_URLS = {
         encode: '/api/tokenizers/deepseek/encode',
         decode: '/api/tokenizers/deepseek/decode',
         count: '/api/tokenizers/deepseek/encode',
+    },
+    [tokenizers.GLM]: {
+        encode: '/api/tokenizers/glm46/encode',
+        decode: '/api/tokenizers/glm46/decode',
+        count: '/api/tokenizers/glm46/encode',
     },
     [tokenizers.API_TEXTGENERATIONWEBUI]: {
         encode: '/api/tokenizers/remote/textgenerationwebui/encode',
@@ -337,6 +344,9 @@ export function getTokenizerBestMatch(forApi) {
             }
             if (model.includes('deepseek')) {
                 return tokenizers.DEEPSEEK;
+            }
+            if (model.includes('glm-4.6') || model.includes('glm-4.7')) {
+                return tokenizers.GLM;
             }
             if (model.includes('yi')) {
                 return tokenizers.YI;

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -229,6 +229,7 @@ class WebTokenizer {
         try {
             const pathToModel = await getPathToTokenizer(this.#model, this.#fallbackModel);
             const fileBuffer = await fs.promises.readFile(pathToModel);
+            console.info('Tokenizer Path', pathToModel);
             this.#instance = await Tokenizer.fromJSON(fileBuffer);
             console.info('Instantiated the tokenizer for', path.parse(pathToModel).name);
             return this.#instance;
@@ -253,6 +254,7 @@ const commandATokenizer = new WebTokenizer('https://github.com/SillyTavern/Silly
 const qwen2Tokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/qwen2.json.gz', 'src/tokenizers/llama3.json');
 const nemoTokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/nemo.json.gz', 'src/tokenizers/llama3.json');
 const deepseekTokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/deepseek.json.gz', 'src/tokenizers/llama3.json');
+const glm46Tokenizer = new WebTokenizer('https://github.com/SillyTavern/SillyTavern-Tokenizers/raw/main/glm-4.6.json.gz', 'src/tokenizers/llama3.json');
 
 export const sentencepieceTokenizers = [
     'llama',
@@ -272,6 +274,7 @@ export const webTokenizers = [
     'qwen2',
     'nemo',
     'deepseek',
+    'glm',
 ];
 
 /**
@@ -343,6 +346,10 @@ export function getWebTokenizer(model) {
 
     if (model.includes('deepseek')) {
         return deepseekTokenizer;
+    }
+
+    if (model.includes('glm')) {
+        return glm46Tokenizer;
     }
 
     return null;
@@ -487,6 +494,10 @@ export function getTokenizerModel(requestModel) {
 
     if (requestModel.includes('deepseek')) {
         return 'deepseek';
+    }
+
+    if (requestModel.includes('glm-4.6') || requestModel.includes('glm-4.7')) {
+        return 'glm';
     }
 
     if (requestModel.includes('gemma') || requestModel.includes('gemini') || requestModel.includes('learnlm')) {
@@ -743,6 +754,7 @@ router.post('/command-r/encode', createWebTokenizerEncodingHandler(commandRToken
 router.post('/command-a/encode', createWebTokenizerEncodingHandler(commandATokenizer));
 router.post('/nemo/encode', createWebTokenizerEncodingHandler(nemoTokenizer));
 router.post('/deepseek/encode', createWebTokenizerEncodingHandler(deepseekTokenizer));
+router.post('/glm46/encode', createWebTokenizerEncodingHandler(glm46Tokenizer));
 router.post('/llama/decode', createSentencepieceDecodingHandler(spp_llama));
 router.post('/nerdstash/decode', createSentencepieceDecodingHandler(spp_nerd));
 router.post('/nerdstash_v2/decode', createSentencepieceDecodingHandler(spp_nerd_v2));
@@ -758,6 +770,7 @@ router.post('/command-r/decode', createWebTokenizerDecodingHandler(commandRToken
 router.post('/command-a/decode', createWebTokenizerDecodingHandler(commandATokenizer));
 router.post('/nemo/decode', createWebTokenizerDecodingHandler(nemoTokenizer));
 router.post('/deepseek/decode', createWebTokenizerDecodingHandler(deepseekTokenizer));
+router.post('/glm46/decode', createWebTokenizerDecodingHandler(glm46Tokenizer));
 
 router.post('/openai/encode', async function (req, res) {
     try {
@@ -820,6 +833,11 @@ router.post('/openai/encode', async function (req, res) {
 
         if (queryModel.includes('deepseek')) {
             const handler = createWebTokenizerEncodingHandler(deepseekTokenizer);
+            return handler(req, res);
+        }
+
+        if (queryModel.includes('glm')) {
+            const handler = createWebTokenizerEncodingHandler(glm46Tokenizer);
             return handler(req, res);
         }
 
@@ -893,6 +911,11 @@ router.post('/openai/decode', async function (req, res) {
 
         if (queryModel.includes('deepseek')) {
             const handler = createWebTokenizerDecodingHandler(deepseekTokenizer);
+            return handler(req, res);
+        }
+
+        if (queryModel.includes('glm')) {
+            const handler = createWebTokenizerDecodingHandler(glm46Tokenizer);
             return handler(req, res);
         }
 
@@ -983,6 +1006,13 @@ router.post('/openai/count', async function (req, res) {
         if (model === 'deepseek') {
             const instance = await deepseekTokenizer.get();
             if (!instance) throw new Error('Failed to load the DeepSeek tokenizer');
+            num_tokens = countWebTokenizerTokens(instance, req.body);
+            return res.send({ 'token_count': num_tokens });
+        }
+
+        if (model === 'glm-4.6' || model === 'glm-4.7') {
+            const instance = await glm46Tokenizer.get();
+            if (!instance) throw new Error('Failed to load the GLM tokenizer');
             num_tokens = countWebTokenizerTokens(instance, req.body);
             return res.send({ 'token_count': num_tokens });
         }


### PR DESCRIPTION
## Change
- Adds the GLM tokenizer that can be found in [SillyTavern-Tokenizers](https://github.com/SillyTavern/SillyTavern-Tokenizers) to the tokenizer selection of the `AI Response Formatting` tab of the UI.

## WIP
This will be a draft until it actually works.
- [ ] There's an error trying to instantiate the GLM tokenizer from `WebTokenizer.get` - [LIne of code](https://github.com/leandrojofre/SillyTavern/blob/feat/7-add-tokenizers-for-text-completions/src/endpoints/tokenizers.js#L233)

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/5bf79a0a-03d0-4a44-8733-77106542b365" />

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
