### PR TITLE
Fix/Do not spam saveSettingsDebounced in AccountStorage

### DIFF
--- a/public/scripts/util/AccountStorage.js
+++ b/public/scripts/util/AccountStorage.js
@@ -103,6 +103,12 @@ class AccountStorage {
             console.warn(`AccountStorage not ready (trying to write to ${key})`);
         }
 
+        const hasPropertySet = Object.hasOwn(this.#state, key) && this.#state[key] === String(value);
+
+        if (hasPropertySet) {
+            return;
+        }
+
         this.#state[key] = String(value);
         saveSettingsDebounced();
     }


### PR DESCRIPTION
## Change
- Pretty much what the title says. It runs a check to prevent saving a `key` - `value` pair already existent in the `AccountStorage` record.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
