### PR TITLE
Add `clearData` option to `clearChat` function

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -834,13 +834,12 @@ export async function selectCharacterById(id, { switchMenu = true } = {}) {
     if (selected_group || String(this_chid) !== String(id)) {
         //if clicked on a different character from what was currently selected
         if (!is_send_press) {
-            await clearChat();
+            await wipeChat();
             cancelTtsPlay();
             resetSelectedGroup();
             this_edit_mes_id = undefined;
             selected_button = 'character_edit';
             setCharacterId(id);
-            chat.length = 0;
             chat_metadata = {};
             await getChat();
         }
@@ -1348,8 +1347,7 @@ export async function deleteCharacterChatByName(characterId, fileName) {
 }
 
 export async function replaceCurrentChat() {
-    await clearChat();
-    chat.length = 0;
+    await wipeChat();
 
     const chatsResponse = await fetch('/api/characters/chats', {
         method: 'POST',
@@ -1620,14 +1618,21 @@ export const reloadChatMutex = new SimpleMutex(reloadCurrentChatUnsafe);
 export const reloadCurrentChat = reloadChatMutex.update.bind(reloadChatMutex);
 
 /**
+ * Erases the `chat` and removes the message elements.
+ */
+export async function wipeChat() {
+    await clearChat();
+    chat.length = 0;
+}
+
+/**
  * Reloads the current chat unsafely, without mutex protection.
  * Use `reloadCurrentChat` instead to ensure thread safety.
  * @returns {Promise<void>} A promise that resolves when the chat is reloaded.
  */
 export async function reloadCurrentChatUnsafe() {
     preserveNeutralChat();
-    await clearChat();
-    chat.length = 0;
+    await wipeChat();
 
     if (selected_group) {
         await getGroupChat(selected_group, true);
@@ -7509,9 +7514,8 @@ function getFirstMessage() {
 
 export async function openCharacterChat(file_name) {
     await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 10);
-    await clearChat();
+    await wipeChat();
     characters[this_chid].chat = file_name;
-    chat.length = 0;
     chat_metadata = {};
     await getChat();
     $('#selected_chat_pole').val(file_name);
@@ -10353,8 +10357,7 @@ export async function doNewChat({ deleteCurrentChat = false } = {}) {
 
     //Fix it; New chat doesn't create while open create character menu
     await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 10);
-    await clearChat();
-    chat.length = 0;
+    await wipeChat();
 
     chat_file_for_del = getCurrentChatDetails()?.sessionName;
 
@@ -10473,8 +10476,7 @@ export async function renameChat(oldFileName, newName) {
 export async function closeCurrentChat() {
     if (is_send_press == false) {
         await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 10);
-        await clearChat();
-        chat.length = 0;
+        await wipeChat();
         resetSelectedGroup();
         setCharacterId(undefined);
         setCharacterName('');

--- a/public/script.js
+++ b/public/script.js
@@ -837,7 +837,7 @@ export async function selectCharacterById(id, { switchMenu = true } = {}) {
     if (selected_group || String(this_chid) !== String(id)) {
         //if clicked on a different character from what was currently selected
         if (!is_send_press) {
-            await wipeChat();
+            await clearChat({ clearData: true });
             cancelTtsPlay();
             resetSelectedGroup();
             this_edit_mes_id = undefined;
@@ -1350,7 +1350,7 @@ export async function deleteCharacterChatByName(characterId, fileName) {
 }
 
 export async function replaceCurrentChat() {
-    await wipeChat();
+    await clearChat({ clearData: true });
 
     const chatsResponse = await fetch('/api/characters/chats', {
         method: 'POST',
@@ -1528,7 +1528,12 @@ export function cancelDebouncedChatSave() {
     }
 }
 
-export async function clearChat() {
+/**
+ * Visually removes all chat message elements.
+ * @param {object} [options] Options
+ * @param {boolean} [options.clearData=false] Optionally clear the chat array's contents.
+ */
+export async function clearChat({ clearData = false } = {}) {
     cancelDebouncedChatSave();
     cancelDebouncedMetadataSave();
     closeMessageEditor();
@@ -1545,6 +1550,8 @@ export async function clearChat() {
 
     await saveItemizedPrompts(getCurrentChatId());
     itemizedPrompts.length = 0;
+
+    if (clearData) chat.length = 0;
 }
 
 export async function deleteLastMessage() {
@@ -1621,21 +1628,13 @@ export const reloadChatMutex = new SimpleMutex(reloadCurrentChatUnsafe);
 export const reloadCurrentChat = reloadChatMutex.update.bind(reloadChatMutex);
 
 /**
- * Erases the `chat` and removes the message elements.
- */
-export async function wipeChat() {
-    await clearChat();
-    chat.length = 0;
-}
-
-/**
  * Reloads the current chat unsafely, without mutex protection.
  * Use `reloadCurrentChat` instead to ensure thread safety.
  * @returns {Promise<void>} A promise that resolves when the chat is reloaded.
  */
 export async function reloadCurrentChatUnsafe() {
     preserveNeutralChat();
-    await wipeChat();
+    await clearChat({ clearData: true });
 
     if (selected_group) {
         await getGroupChat(selected_group, true);
@@ -7517,7 +7516,7 @@ function getFirstMessage() {
 
 export async function openCharacterChat(file_name) {
     await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 10);
-    await wipeChat();
+    await clearChat({ clearData: true });
     characters[this_chid].chat = file_name;
     chat_metadata = {};
     await getChat();
@@ -10356,7 +10355,7 @@ export async function doNewChat({ deleteCurrentChat = false } = {}) {
 
     //Fix it; New chat doesn't create while open create character menu
     await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 10);
-    await wipeChat();
+    await clearChat({ clearData: true });
 
     chat_file_for_del = getCurrentChatDetails()?.sessionName;
 
@@ -10475,7 +10474,7 @@ export async function renameChat(oldFileName, newName) {
 export async function closeCurrentChat() {
     if (is_send_press == false) {
         await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 10);
-        await wipeChat();
+        await clearChat({ clearData: true });
         resetSelectedGroup();
         setCharacterId(undefined);
         setCharacterName('');

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -79,6 +79,7 @@ import {
     unshallowCharacter,
     chatElement,
     ensureMessageMediaIsArray,
+    wipeChat,
 } from '../script.js';
 import { printTagList, createTagMapFromList, applyTagsOnCharacterSelect, tag_map, applyTagsOnGroupSelect, printTagFilters, tag_filter_type } from './tags.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
@@ -2039,14 +2040,13 @@ export async function openGroupById(groupId) {
 
         if (selected_group !== groupId) {
             groupChatQueueOrder = new Map();
-            await clearChat();
+            await wipeChat();
             cancelTtsPlay();
             selected_group = groupId;
             setCharacterId(undefined);
             setCharacterName('');
             setEditedMessageId(undefined);
             updateChatMetadata({}, true);
-            chat.length = 0;
             await getGroupChat(groupId);
             return true;
         }
@@ -2152,8 +2152,7 @@ export async function createNewGroupChat(groupId) {
         return;
     }
 
-    await clearChat();
-    chat.length = 0;
+    await wipeChat();
     const newChatName = humanizedDateTime();
     group.chats.push(newChatName);
     group.chat_id = newChatName;
@@ -2209,8 +2208,7 @@ export async function openGroupChat(groupId, chatId) {
         return;
     }
 
-    await clearChat();
-    chat.length = 0;
+    await wipeChat();
     group.chat_id = chatId;
     group.date_last_chat = Date.now();
     updateChatMetadata({}, true);

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -79,7 +79,6 @@ import {
     unshallowCharacter,
     chatElement,
     ensureMessageMediaIsArray,
-    wipeChat,
 } from '../script.js';
 import { printTagList, createTagMapFromList, applyTagsOnCharacterSelect, tag_map, applyTagsOnGroupSelect, printTagFilters, tag_filter_type } from './tags.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
@@ -2040,7 +2039,7 @@ export async function openGroupById(groupId) {
 
         if (selected_group !== groupId) {
             groupChatQueueOrder = new Map();
-            await wipeChat();
+            await clearChat({ clearData: true });
             cancelTtsPlay();
             selected_group = groupId;
             setCharacterId(undefined);
@@ -2152,7 +2151,7 @@ export async function createNewGroupChat(groupId) {
         return;
     }
 
-    await wipeChat();
+    await clearChat({ clearData: true });
     const newChatName = humanizedDateTime();
     group.chats.push(newChatName);
     group.chat_id = newChatName;
@@ -2208,7 +2207,7 @@ export async function openGroupChat(groupId, chatId) {
         return;
     }
 
-    await wipeChat();
+    await clearChat({ clearData: true });
     group.chat_id = chatId;
     group.date_last_chat = Date.now();
     updateChatMetadata({}, true);


### PR DESCRIPTION
Centralized `await clearChat();` and `chat.length = 0;` into `wipeChat()`

This will remove the scattered `tree.setChatTree({});` in [feat/chat-tree](https://github.com/SillyTavern/SillyTavern/pull/4573.)

Should `wipeChat()` emit an event?

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
