### PR TITLE
Backgrounds metadata population and frontend colors

### DIFF
--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -43,7 +43,7 @@ const THUMBNAIL_CONFIG = {
 
 /**
  * Cache for image metadata.
- * @type {Map<string, object>}
+ * @type {Map<string, import('../../src/endpoints/image-metadata.js').ImageMetadata>}
  */
 const METADATA_CACHE = new Map();
 
@@ -586,6 +586,7 @@ export async function getBackgrounds() {
 
 /**
  * Preloads all image metadata to use dominant colors as placeholders.
+ * @return {Promise<void>}
  */
 async function preloadImageMetadata() {
     try {

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -589,9 +589,10 @@ export async function getBackgrounds() {
  */
 async function preloadImageMetadata() {
     try {
-        const response = await fetch('/api/image-metadata/all?prefix=backgrounds/', {
-            method: 'GET',
+        const response = await fetch('/api/image-metadata/all', {
+            method: 'POST',
             headers: getRequestHeaders(),
+            body: JSON.stringify({ prefix: 'backgrounds/' }),
         });
         if (response.ok) {
             const data = await response.json();

--- a/public/scripts/backgrounds.js
+++ b/public/scripts/backgrounds.js
@@ -42,6 +42,12 @@ const THUMBNAIL_CONFIG = {
 };
 
 /**
+ * Cache for image metadata.
+ * @type {Map<string, object>}
+ */
+const METADATA_CACHE = new Map();
+
+/**
  * Background source types.
  * @readonly
  * @enum {number}
@@ -88,6 +94,18 @@ function createThumbnailElement(imageData) {
     const clipper = document.createElement('div');
     clipper.className = 'thumbnail-clipper lazy-load-background';
     clipper.style.backgroundImage = PLACEHOLDER_IMAGE;
+
+    // Apply dominant color and aspect ratio as placeholder if available
+    const metadataKey = isCustom ? bg : `backgrounds/${bg}`;
+    const metadata = METADATA_CACHE.get(metadataKey);
+    if (metadata) {
+        if (metadata.dominantColor) {
+            clipper.style.backgroundColor = metadata.dominantColor;
+        }
+        if (metadata.aspectRatio) {
+            thumbnail.css('aspect-ratio', metadata.aspectRatio);
+        }
+    }
 
     const titleElement = thumbnail.find('.BGSampleTitle');
     clipper.appendChild(titleElement.get(0));
@@ -548,6 +566,8 @@ function renderChatBackgrounds(backgrounds) {
 }
 
 export async function getBackgrounds() {
+    const metadataPromise = preloadImageMetadata();
+
     const response = await fetch('/api/backgrounds/all', {
         method: 'POST',
         headers: getRequestHeaders(),
@@ -557,8 +577,33 @@ export async function getBackgrounds() {
         const { images, config } = await response.json();
         Object.assign(THUMBNAIL_CONFIG, config);
 
+        await metadataPromise;
+
         renderSystemBackgrounds(images);
         highlightSelectedBackground();
+    }
+}
+
+/**
+ * Preloads all image metadata to use dominant colors as placeholders.
+ */
+async function preloadImageMetadata() {
+    try {
+        const response = await fetch('/api/image-metadata/all?prefix=backgrounds/', {
+            method: 'GET',
+            headers: getRequestHeaders(),
+        });
+        if (response.ok) {
+            const data = await response.json();
+            if (data?.images) {
+                METADATA_CACHE.clear();
+                for (const [path, metadata] of Object.entries(data.images)) {
+                    METADATA_CACHE.set(path, metadata);
+                }
+            }
+        }
+    } catch (error) {
+        console.error('[ImageMetadata] Failed to preload metadata:', error);
     }
 }
 

--- a/src/endpoints/backgrounds.js
+++ b/src/endpoints/backgrounds.js
@@ -14,13 +14,6 @@ export const router = express.Router();
 router.post('/all', async function (request, response) {
     const images = getImages(request.user.directories.backgrounds);
     const config = { width: thumbnailDimensions.bg[0], height: thumbnailDimensions.bg[1] };
-
-    // Generate metadata for images not from /upload
-    const relativePaths = images.map(img => path.join('backgrounds', img));
-    getOrGenerateMetadataBatch(request.user.directories.root, relativePaths, 'bg').catch(err => {
-        console.warn('[Backgrounds] Failed to generate metadata:', err.message);
-    });
-
     response.json({ images, config });
 });
 

--- a/src/endpoints/backgrounds.js
+++ b/src/endpoints/backgrounds.js
@@ -5,15 +5,22 @@ import express from 'express';
 import sanitize from 'sanitize-filename';
 
 import { invalidateThumbnail } from './thumbnails.js';
-import { thumbnailDimensions } from './image-metadata.js';
+import { getOrGenerateMetadataBatch, removeMetadata, renameMetadata, thumbnailDimensions } from './image-metadata.js';
 import { getImages } from '../util.js';
 import { getFileNameValidationFunction } from '../middleware/validateFileName.js';
 
 export const router = express.Router();
 
-router.post('/all', function (request, response) {
+router.post('/all', async function (request, response) {
     const images = getImages(request.user.directories.backgrounds);
     const config = { width: thumbnailDimensions.bg[0], height: thumbnailDimensions.bg[1] };
+
+    // Generate metadata for images not from /upload
+    const relativePaths = images.map(img => path.join('backgrounds', img));
+    getOrGenerateMetadataBatch(request.user.directories.root, relativePaths, 'bg').catch(err => {
+        console.warn('[Backgrounds] Failed to generate metadata:', err.message);
+    });
+
     response.json({ images, config });
 });
 
@@ -34,6 +41,13 @@ router.post('/delete', getFileNameValidationFunction('bg'), function (request, r
 
     fs.unlinkSync(fileName);
     invalidateThumbnail(request.user.directories, 'bg', request.body.bg);
+
+    // Remove metadata for deleted image
+    const relativePath = path.join('backgrounds', request.body.bg);
+    removeMetadata(request.user.directories.root, relativePath).catch(err => {
+        console.warn('[Backgrounds] Failed to remove metadata:', err.message);
+    });
+
     return response.send('ok');
 });
 
@@ -56,6 +70,14 @@ router.post('/rename', function (request, response) {
     fs.copyFileSync(oldFileName, newFileName);
     fs.unlinkSync(oldFileName);
     invalidateThumbnail(request.user.directories, 'bg', request.body.old_bg);
+
+    // Update metadata for renamed image
+    const oldRelativePath = path.join('backgrounds', request.body.old_bg);
+    const newRelativePath = path.join('backgrounds', request.body.new_bg);
+    renameMetadata(request.user.directories.root, oldRelativePath, newRelativePath).catch(err => {
+        console.warn('[Backgrounds] Failed to rename metadata:', err.message);
+    });
+
     return response.send('ok');
 });
 
@@ -69,6 +91,13 @@ router.post('/upload', function (request, response) {
         fs.copyFileSync(img_path, path.join(request.user.directories.backgrounds, filename));
         fs.unlinkSync(img_path);
         invalidateThumbnail(request.user.directories, 'bg', filename);
+
+        // Generate metadata for the new image
+        const relativePath = path.join('backgrounds', filename);
+        getOrGenerateMetadataBatch(request.user.directories.root, [relativePath], 'bg').catch(err => {
+            console.warn('[Backgrounds] Failed to generate metadata for upload:', err.message);
+        });
+
         response.send(filename);
     } catch (err) {
         console.error(err);

--- a/src/endpoints/image-metadata.js
+++ b/src/endpoints/image-metadata.js
@@ -188,13 +188,14 @@ export async function writeMetadataIndex(userDataRoot, metadata) {
  * @param {string} userDataRoot - Path to the user data directory root
  * @param {string[]} relativePaths - Array of relative paths from userDataRoot
  * @param {ThumbnailType} type - The thumbnail type for resolution calculation.
- * @returns {Promise<Object.<string, ImageMetadata>>} Map of relativePath to metadata
+ * @returns {Promise<{results: Object.<string, ImageMetadata>, generatedCount: number}>} Results map and count of newly generated
  */
 export async function getOrGenerateMetadataBatch(userDataRoot, relativePaths, type) {
     /** @type {Object.<string, ImageMetadata>} */
     const results = {};
     const index = await readMetadataIndex(userDataRoot);
     let indexModified = false;
+    let generatedCount = 0;
 
     for (const relativePath of relativePaths) {
         // Normalize the path to use forward slashes for consistent keys
@@ -230,6 +231,7 @@ export async function getOrGenerateMetadataBatch(userDataRoot, relativePaths, ty
             index.images[posixPath] = metadata;
             results[relativePath] = metadata;
             indexModified = true;
+            generatedCount++;
         } catch (error) {
             console.warn(`[ImageMetadata] Failed to generate metadata for ${relativePath}:`, error.message);
         }
@@ -240,7 +242,7 @@ export async function getOrGenerateMetadataBatch(userDataRoot, relativePaths, ty
         await writeMetadataIndex(userDataRoot, index);
     }
 
-    return results;
+    return { results, generatedCount };
 }
 
 /**
@@ -339,14 +341,13 @@ export async function initializeMetadataForDirectory(userDataRoot, subDirectory,
     const relativePaths = images.map(img => path.join(subDirectory, img));
 
     // Generate metadata for new images
-    const results = await getOrGenerateMetadataBatch(userDataRoot, relativePaths, type);
+    const { results, generatedCount } = await getOrGenerateMetadataBatch(userDataRoot, relativePaths, type);
 
-    const processedCount = Object.keys(results).length;
-    if (processedCount > 0) {
-        console.log(`[ImageMetadata] Initialized metadata for ${processedCount} images in ${subDirectory}`);
+    if (generatedCount > 0) {
+        console.log(`[ImageMetadata] Generated metadata for ${generatedCount} new images in ${subDirectory}`);
     }
 
-    return processedCount;
+    return Object.keys(results).length;
 }
 
 export const router = express.Router();
@@ -385,7 +386,7 @@ router.post('/', async function (request, response) {
                 return response.status(404).json({ error: 'File not found.' });
             }
 
-            const metadataResults = await getOrGenerateMetadataBatch(userDataRoot, [relativePath], type);
+            const { results: metadataResults } = await getOrGenerateMetadataBatch(userDataRoot, [relativePath], type);
             const metadata = metadataResults[relativePath];
 
             if (!metadata) {
@@ -412,7 +413,7 @@ router.post('/', async function (request, response) {
             }
 
             // Process all valid paths in a single batch
-            const batchMetadata = await getOrGenerateMetadataBatch(userDataRoot, validPaths, type);
+            const { results: batchMetadata } = await getOrGenerateMetadataBatch(userDataRoot, validPaths, type);
 
             for (const relativePath of validPaths) {
                 if (batchMetadata[relativePath]) {
@@ -429,6 +430,35 @@ router.post('/', async function (request, response) {
 
     } catch (error) {
         console.error('[ImageMetadata] API error:', error);
+        return response.status(500).json({ error: 'Internal server error.' });
+    }
+});
+
+/**
+ * GET /api/image-metadata/all
+ * Get all metadata from the index.
+ * @query {string} [prefix] - Optional path prefix to filter results
+ */
+router.get('/all', async function (request, response) {
+    try {
+        const userDataRoot = request.user.directories.root;
+        const prefix = String(request.query.prefix || '');
+        const index = await readMetadataIndex(userDataRoot);
+
+        // If prefix specified, filter to only matching paths
+        if (prefix) {
+            const filteredImages = {};
+            for (const [key, value] of Object.entries(index.images)) {
+                if (key.startsWith(prefix)) {
+                    filteredImages[key] = value;
+                }
+            }
+            return response.json({ version: index.version, images: filteredImages });
+        }
+
+        return response.json(index);
+    } catch (error) {
+        console.error('[ImageMetadata] Failed to read metadata index:', error);
         return response.status(500).json({ error: 'Internal server error.' });
     }
 });

--- a/src/endpoints/image-metadata.js
+++ b/src/endpoints/image-metadata.js
@@ -10,7 +10,7 @@ import { imageSize } from 'image-size';
 import writeFileAtomic from 'write-file-atomic';
 import express from 'express';
 import { Jimp } from '../jimp.js';
-import { getConfigValue, isPathUnderParent } from '../util.js';
+import { getConfigValue, getImages, isPathUnderParent } from '../util.js';
 
 export const METADATA_FILE = 'image-metadata.json';
 
@@ -315,6 +315,38 @@ export async function cleanupOrphanedMetadata(userDataRoot) {
     }
 
     return orphanedPaths;
+}
+
+/**
+ * Initializes metadata for all images in a directory.
+ * @param {string} userDataRoot - Path to the user data directory root
+ * @param {string} subDirectory - Subdirectory relative to userDataRoot
+ * @param {ThumbnailType} type - The thumbnail type for resolution calculation
+ * @returns {Promise<number>} Number of images processed
+ */
+export async function initializeMetadataForDirectory(userDataRoot, subDirectory, type) {
+    const fullDir = path.join(userDataRoot, subDirectory);
+
+    let images;
+    try {
+        images = getImages(fullDir);
+    } catch {
+        // Directory doesn't exist or can't be read
+        return 0;
+    }
+
+    // Convert to relative paths from userDataRoot
+    const relativePaths = images.map(img => path.join(subDirectory, img));
+
+    // Generate metadata for new images
+    const results = await getOrGenerateMetadataBatch(userDataRoot, relativePaths, type);
+
+    const processedCount = Object.keys(results).length;
+    if (processedCount > 0) {
+        console.log(`[ImageMetadata] Initialized metadata for ${processedCount} images in ${subDirectory}`);
+    }
+
+    return processedCount;
 }
 
 export const router = express.Router();

--- a/src/endpoints/image-metadata.js
+++ b/src/endpoints/image-metadata.js
@@ -435,14 +435,14 @@ router.post('/', async function (request, response) {
 });
 
 /**
- * GET /api/image-metadata/all
+ * POST /api/image-metadata/all
  * Get all metadata from the index.
- * @query {string} [prefix] - Optional path prefix to filter results
+ * @body {string} [prefix] - Optional path prefix to filter results
  */
-router.get('/all', async function (request, response) {
+router.post('/all', async function (request, response) {
     try {
         const userDataRoot = request.user.directories.root;
-        const prefix = String(request.query.prefix || '');
+        const prefix = String(request.body.prefix || '');
         const index = await readMetadataIndex(userDataRoot);
 
         // If prefix specified, filter to only matching paths

--- a/src/endpoints/image-metadata.js
+++ b/src/endpoints/image-metadata.js
@@ -350,6 +350,21 @@ export async function initializeMetadataForDirectory(userDataRoot, subDirectory,
     return Object.keys(results).length;
 }
 
+/**
+ * Initializes image metadata for all users' background directories.
+ * @param {Array<{root: string}>} userDirectories - List of user directory objects
+ * @returns {Promise<void>}
+ */
+export async function initializeAllUserMetadata(userDirectories) {
+    try {
+        for (const userDir of userDirectories) {
+            await initializeMetadataForDirectory(userDir.root, 'backgrounds', 'bg');
+        }
+    } catch (error) {
+        console.error('[ImageMetadata] Failed to initialize background metadata:', error.message);
+    }
+}
+
 export const router = express.Router();
 
 /**

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -69,7 +69,7 @@ import { redirectDeprecatedEndpoints, ServerStartup, setupPrivateEndpoints } fro
 import { diskCache } from './endpoints/characters.js';
 import { migrateFlatSecrets } from './endpoints/secrets.js';
 import { migrateGroupChatsMetadataFormat } from './endpoints/groups.js';
-import { initializeMetadataForDirectory } from './endpoints/image-metadata.js';
+import { initializeAllUserMetadata } from './endpoints/image-metadata.js';
 
 // Work around a node v20.0.0, v20.1.0, and v20.2.0 bug. The issue was fixed in v20.3.0.
 // https://github.com/nodejs/node/issues/47822#issuecomment-1564708870
@@ -277,6 +277,9 @@ async function preSetupTasks() {
     await settingsInit();
     await statsInit();
 
+    // Initialize image metadata
+    await initializeAllUserMetadata(directories);
+
     const pluginsDirectory = path.join(serverDirectory, 'plugins');
     const cleanupPlugins = await loadPlugins(app, pluginsDirectory);
     const consoleTitle = process.title;
@@ -402,18 +405,6 @@ async function postSetupTasks(result) {
 
     setupLogLevel();
     serverEvents.emit(EVENT_NAMES.SERVER_STARTED, { url: browserLaunchUrl });
-
-    // Initialize image metadata
-    (async () => {
-        try {
-            const directories = await getUserDirectoriesList();
-            for (const userDir of directories) {
-                await initializeMetadataForDirectory(userDir.root, 'backgrounds', 'bg');
-            }
-        } catch (error) {
-            console.error('[ImageMetadata] Failed to initialize background metadata:', error.message);
-        }
-    })();
 }
 
 /**

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -69,6 +69,7 @@ import { redirectDeprecatedEndpoints, ServerStartup, setupPrivateEndpoints } fro
 import { diskCache } from './endpoints/characters.js';
 import { migrateFlatSecrets } from './endpoints/secrets.js';
 import { migrateGroupChatsMetadataFormat } from './endpoints/groups.js';
+import { initializeMetadataForDirectory } from './endpoints/image-metadata.js';
 
 // Work around a node v20.0.0, v20.1.0, and v20.2.0 bug. The issue was fixed in v20.3.0.
 // https://github.com/nodejs/node/issues/47822#issuecomment-1564708870
@@ -401,6 +402,18 @@ async function postSetupTasks(result) {
 
     setupLogLevel();
     serverEvents.emit(EVENT_NAMES.SERVER_STARTED, { url: browserLaunchUrl });
+
+    // Initialize image metadata
+    (async () => {
+        try {
+            const directories = await getUserDirectoriesList();
+            for (const userDir of directories) {
+                await initializeMetadataForDirectory(userDir.root, 'backgrounds', 'bg');
+            }
+        } catch (error) {
+            console.error('[ImageMetadata] Failed to initialize background metadata:', error.message);
+        }
+    })();
 }
 
 /**


### PR DESCRIPTION
### Improvements
*   **Enhanced Background Thumbnails:** Implemented placeholders for background thumbnails.
    *   Thumbnails now display a **dominant color** while the image is loading.
*   **Metadata Preloading:** The background selection UI now preloads image metadata to ensure immediate display of placeholder properties.
*   **Server Startup:** Added a routine to automatically generate missing metadata (dominant color, resolution) for the `backgrounds` directory on server launch.

### Technical Changes
*   **Backgrounds API:** Updated file management endpoints (`upload`, `rename`, `delete`, `list`) to automatically maintain the associated metadata files.
*   **New Endpoint:** Added `GET /api/image-metadata/all` endpoint (with optional `prefix` filter) to allow the frontend to fetch bulk image metadata.
*   **Refactoring:** `getOrGenerateMetadataBatch` now returns the count of generated items and provides specific batch logic for directory initialization. This is to clarify startup saying "initalized" instead of "processed", and removes the comment when nothing happens.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
