### PR TITLE
Feat/Allow to bulk toggle all third-party extensions from Manage Extensions

### DIFF
--- a/public/css/extensions-panel.css
+++ b/public/css/extensions-panel.css
@@ -39,7 +39,7 @@ label[for="extensions_autoconnect"] {
     text-align: left;
 }
 
-.extensions_info h3 {
+.extensions_info h3:not(.margin0) {
     margin-bottom: 0.5em;
 }
 
@@ -110,6 +110,10 @@ label[for="extensions_autoconnect"] {
 
 .extensions_info .extension_name.update_available {
     color: limegreen;
+}
+
+.extensions_info .third_party_toolbar {
+    user-select: none;
 }
 
 input.extension_missing[type="checkbox"] {

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -912,11 +912,11 @@ async function showExtensionsDetails() {
             await oldPopup.completeCancelled();
         }
         const htmlErrors = getExtensionLoadErrorsHtml();
-        const htmlDefault = $('<div class="marginBot10"><h3 class="textAlignCenter">' + t`Built-in Extensions:` + '</h3></div>');
+        const htmlDefault = $('<div class="marginBot10"><h3>' + t`Built-in Extensions:` + '</h3></div>');
 
         const htmlExternal = $(`<div class="marginBot10">
             <div class="flex-container alignitemscenter spaceBetween flexnowrap marginBot10">
-                <h3 class="textAlignCenter margin0">${t`Installed Extensions:`}</h3>
+                <h3 class="margin0">${t`Installed Extensions:`}</h3>
                 <div class="flex-container third_party_toolbar"></div>
             </div>
         </div>`);

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -300,6 +300,67 @@ function onEnableExtensionClick() {
 }
 
 /**
+ * Handles toggling all extensions on or off.
+ * @param {Object[]} extensionsToToggle
+ * @param {JQuery<HTMLElement>} toggleContainer
+ * @returns {Object[]} Updated extensionsToToggle array
+ */
+function onToggleAllExtensions(extensionsToToggle, toggleContainer) {
+    const extensionNames = Object.keys(manifests);
+    const thirdPartyExtensions = extensionNames.filter(name => getExtensionType(name) === 'local' || getExtensionType(name) === 'global');
+
+    const checkIfDisabled = (name) => {
+        const toggleIndex = extensionsToToggle.findIndex(ext => ext.name === name);
+
+        if (toggleIndex >= 0) return !extensionsToToggle[toggleIndex].enable;
+        else return extension_settings.disabledExtensions.includes(name);
+    };
+
+    if (thirdPartyExtensions.length === 0) return;
+
+    requiresReload = true;
+
+    let enable = true;
+
+    for (const name of thirdPartyExtensions) {
+        const isEnabled = !checkIfDisabled(name);
+
+        if (isEnabled) {
+            enable = false;
+            break;
+        }
+    }
+
+    const toggleHandler = enable ? enableExtension : disableExtension;
+
+    for (const name of thirdPartyExtensions) {
+        const isDisabled = checkIfDisabled(name);
+        const doToggleExtension = enable ? isDisabled : !isDisabled;
+
+        if (doToggleExtension) {
+            console.log(`${name}:`, enable);
+
+            const toggleIndex = extensionsToToggle.findIndex(ext => ext.name === name);
+
+            if (toggleIndex >= 0) {
+                extensionsToToggle[toggleIndex].toggleHandler = toggleHandler;
+                extensionsToToggle[toggleIndex].enable = enable;
+            }
+            else extensionsToToggle.push({ name, toggleHandler, enable });
+
+            toggleContainer
+                .find(`.extension_block[data-name="${name.replace('third-party', '')}"] .extension_toggle input`)
+                .prop('checked', enable)
+                .toggleClass('toggle_enable', !enable)
+                .toggleClass('toggle_disable', enable)
+                .toggleClass('checkbox_disabled', !enable);
+        }
+    }
+
+    return extensionsToToggle;
+}
+
+/**
  * Enables an extension by name.
  * @param {string} name Extension name
  * @param {boolean} [reload=true] If true, reload the page after enabling the extension
@@ -867,6 +928,7 @@ async function showExtensionsDetails() {
         const sortByName = accountStorage.getItem(sortOrderKey) === 'true';
         const sortFn = sortByName ? sortManifestsByName : sortManifestsByOrder;
         const extensions = Object.entries(manifests).sort((a, b) => sortFn(a[1], b[1])).map(getExtensionData);
+        let extensionsToToggle = [];
 
         extensions.forEach(value => {
             const { isExternal, extensionHtml } = value;
@@ -901,6 +963,24 @@ async function showExtensionsDetails() {
             updateEnabledOnlyButton.textContent = t`Update enabled`;
             updateEnabledOnlyButton.addEventListener('click', () => updateAction(false));
 
+            const toggleAllExtensionsButton = document.createElement('button');
+            toggleAllExtensionsButton.classList.add('menu_button', 'menu_button_icon');
+            toggleAllExtensionsButton.textContent = t`Toggle all extensions`;
+            toggleAllExtensionsButton.addEventListener('click', () => {
+                extensionsToToggle = onToggleAllExtensions(extensionsToToggle, htmlExternal);
+
+                for (const extension of extensionsToToggle) {
+                    const { name } = extension;
+
+                    htmlExternal
+                        .find(`.extension_block[data-name="${name.replace('third-party', '')}"] .extension_toggle input`)
+                        .off('click')
+                        .one('click', () => {
+                            extensionsToToggle = extensionsToToggle.filter(ext => ext.name !== name);
+                        });
+                }
+            });
+
             const flexExpander = document.createElement('div');
             flexExpander.classList.add('expander');
 
@@ -913,7 +993,7 @@ async function showExtensionsDetails() {
                 await showExtensionsDetails();
             });
 
-            toolbar.append(updateAllButton, updateEnabledOnlyButton, flexExpander, sortOrderButton);
+            toolbar.append(updateAllButton, updateEnabledOnlyButton, toggleAllExtensionsButton, flexExpander, sortOrderButton);
             html.prepend(toolbar);
         }
 
@@ -929,6 +1009,18 @@ async function showExtensionsDetails() {
                 if (waitingForSave) {
                     return false;
                 }
+
+                for (const extension of extensionsToToggle) {
+                    const { name, toggleHandler } = extension;
+
+                    try {
+                        await toggleHandler(name, false);
+                    } catch (error) {
+                        console.error(`Could not toggle extension ${name}:`, error);
+                        toastr.error(t`Could not toggle extension ${name}. See console for details.`);
+                    }
+                }
+
                 if (stateChanged) {
                     waitingForSave = true;
                     const toast = toastr.info(t`The page will be reloaded shortly...`, t`Extensions state changed`);
@@ -937,6 +1029,7 @@ async function showExtensionsDetails() {
                     waitingForSave = false;
                     requiresReload = true;
                 }
+
                 return true;
             },
         });

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -913,7 +913,14 @@ async function showExtensionsDetails() {
         }
         const htmlErrors = getExtensionLoadErrorsHtml();
         const htmlDefault = $('<div class="marginBot10"><h3 class="textAlignCenter">' + t`Built-in Extensions:` + '</h3></div>');
-        const htmlExternal = $('<div class="marginBot10"><h3 class="textAlignCenter">' + t`Installed Extensions:` + '</h3></div>');
+
+        const htmlExternal = $(`<div class="marginBot10">
+            <div class="flex-container alignitemscenter spaceBetween flexnowrap marginBot10">
+                <h3 class="textAlignCenter margin0">${t`Installed Extensions:`}</h3>
+                <div class="flex-container third_party_toolbar"></div>
+            </div>
+        </div>`);
+
         const htmlLoading = $(`<div class="flex-container alignItemsCenter justifyCenter marginTop10 marginBot5">
             <i class="fa-solid fa-spinner fa-spin"></i>
             <span>` + t`Loading third-party extensions... Please wait...` + `</span>
@@ -963,7 +970,6 @@ async function showExtensionsDetails() {
             const toggleAllExtensionsButton = document.createElement('div');
             toggleAllExtensionsButton.classList.add('menu_button', 'menu_button_icon');
             toggleAllExtensionsButton.title = t`Bulk toggle third-party extensions.`;
-
             toggleAllExtensionsButton.innerHTML = `
                 <span>${t`Toggle extensions`}</span>
                 <div class="fa-solid fa-circle-info opacity50p"></div>
@@ -1021,7 +1027,8 @@ async function showExtensionsDetails() {
                 await showExtensionsDetails();
             });
 
-            toolbar.append(updateAllButton, updateEnabledOnlyButton, toggleAllExtensionsButton, restoreBulkToggledExtensionsButton, flexExpander, sortOrderButton);
+            toolbar.append(updateAllButton, updateEnabledOnlyButton, flexExpander, sortOrderButton);
+            htmlExternal.find('.third_party_toolbar').append(restoreBulkToggledExtensionsButton, toggleAllExtensionsButton);
             html.prepend(toolbar);
         }
 

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -336,8 +336,6 @@ function onToggleAllExtensions(extensionsToToggle, toggleContainer) {
         const doToggleExtension = enable ? isDisabled : !isDisabled;
 
         if (doToggleExtension) {
-            console.log(`${name}:`, enable);
-
             const toggleIndex = extensionsToToggle.findIndex(ext => ext.name === name);
 
             if (toggleIndex >= 0) {

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -318,8 +318,6 @@ function onToggleAllExtensions(extensionsToToggle, toggleContainer) {
 
     if (thirdPartyExtensions.length === 0) return;
 
-    requiresReload = true;
-
     let enable = true;
 
     for (const name of thirdPartyExtensions) {
@@ -1011,9 +1009,15 @@ async function showExtensionsDetails() {
                 }
 
                 for (const extension of extensionsToToggle) {
-                    const { name, toggleHandler } = extension;
+                    const { name, toggleHandler, enable } = extension;
+                    const isDisabled = extension_settings.disabledExtensions.includes(name);
 
                     try {
+                        if (isDisabled && !enable) continue;
+                        if (!isDisabled && enable) continue;
+
+                        requiresReload = true;
+
                         await toggleHandler(name, false);
                     } catch (error) {
                         console.error(`Could not toggle extension ${name}:`, error);

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -968,6 +968,11 @@ async function showExtensionsDetails() {
                 <span>${t`Toggle extensions`}</span>
                 <div class="fa-solid fa-circle-info opacity50p"></div>
             `;
+
+            const restoreBulkToggledExtensionsButton = document.createElement('div');
+            restoreBulkToggledExtensionsButton.classList.add('menu_button', 'menu_button_icon', 'fa-solid', 'fa-arrow-right-rotate', 'displayNone');
+            restoreBulkToggledExtensionsButton.title = t`Restore toggled extensions.\n\nIt does not restore extensions toggled individually.`;
+
             toggleAllExtensionsButton.addEventListener('click', () => {
                 extensionsToToggle = onToggleAllExtensions(extensionsToToggle, htmlExternal);
 
@@ -981,6 +986,27 @@ async function showExtensionsDetails() {
                             extensionsToToggle = extensionsToToggle.filter(ext => ext.name !== name);
                         });
                 }
+
+                const restoreButtonHandler = extensionsToToggle.length > 0 ? 'remove' : 'add';
+
+                restoreBulkToggledExtensionsButton.classList[restoreButtonHandler]('displayNone');
+            });
+
+            restoreBulkToggledExtensionsButton.addEventListener('click', () => {
+                for (const extension of extensionsToToggle) {
+                    const { name } = extension;
+                    const isDisabled = extension_settings.disabledExtensions.includes(name);
+
+                    htmlExternal
+                        .find(`.extension_block[data-name="${name.replace('third-party', '')}"] .extension_toggle input`)
+                        .prop('checked', !isDisabled)
+                        .toggleClass('toggle_enable', isDisabled)
+                        .toggleClass('toggle_disable', !isDisabled)
+                        .toggleClass('checkbox_disabled', isDisabled);
+                }
+
+                extensionsToToggle = [];
+                restoreBulkToggledExtensionsButton.classList.add('displayNone');
             });
 
             const flexExpander = document.createElement('div');
@@ -995,7 +1021,7 @@ async function showExtensionsDetails() {
                 await showExtensionsDetails();
             });
 
-            toolbar.append(updateAllButton, updateEnabledOnlyButton, toggleAllExtensionsButton, flexExpander, sortOrderButton);
+            toolbar.append(updateAllButton, updateEnabledOnlyButton, toggleAllExtensionsButton, restoreBulkToggledExtensionsButton, flexExpander, sortOrderButton);
             html.prepend(toolbar);
         }
 

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -307,13 +307,13 @@ function onEnableExtensionClick() {
  */
 function onToggleAllExtensions(extensionsToToggle, toggleContainer) {
     const extensionNames = Object.keys(manifests);
-    const thirdPartyExtensions = extensionNames.filter(name => getExtensionType(name) === 'local' || getExtensionType(name) === 'global');
+    const thirdPartyExtensions = extensionNames.filter(name => ['local', 'global'].includes(getExtensionType(name)));
 
     const checkIfDisabled = (name) => {
-        const toggleIndex = extensionsToToggle.findIndex(ext => ext.name === name);
-
-        if (toggleIndex >= 0) return !extensionsToToggle[toggleIndex].enable;
-        else return extension_settings.disabledExtensions.includes(name);
+        const toggle = extensionsToToggle.find(ext => ext.name === name);
+        return toggle
+            ? !toggle.enable
+            : extension_settings.disabledExtensions.includes(name);
     };
 
     if (thirdPartyExtensions.length === 0) return [];
@@ -336,13 +336,14 @@ function onToggleAllExtensions(extensionsToToggle, toggleContainer) {
         const doToggleExtension = enable ? isDisabled : !isDisabled;
 
         if (doToggleExtension) {
-            const toggleIndex = extensionsToToggle.findIndex(ext => ext.name === name);
+            const toggle = extensionsToToggle.find(ext => ext.name === name);
 
-            if (toggleIndex >= 0) {
-                extensionsToToggle[toggleIndex].toggleHandler = toggleHandler;
-                extensionsToToggle[toggleIndex].enable = enable;
+            if (toggle) {
+                toggle.toggleHandler = toggleHandler;
+                toggle.enable = enable;
+            } else {
+                extensionsToToggle.push({ name, toggleHandler, enable });
             }
-            else extensionsToToggle.push({ name, toggleHandler, enable });
 
             toggleContainer
                 .find(`.extension_block[data-name="${name.replace('third-party', '')}"] .extension_toggle input`)

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -960,9 +960,14 @@ async function showExtensionsDetails() {
             updateEnabledOnlyButton.textContent = t`Update enabled`;
             updateEnabledOnlyButton.addEventListener('click', () => updateAction(false));
 
-            const toggleAllExtensionsButton = document.createElement('button');
+            const toggleAllExtensionsButton = document.createElement('div');
             toggleAllExtensionsButton.classList.add('menu_button', 'menu_button_icon');
-            toggleAllExtensionsButton.textContent = t`Toggle all extensions`;
+            toggleAllExtensionsButton.title = t`Bulk toggle third-party extensions.`;
+
+            toggleAllExtensionsButton.innerHTML = `
+                <span>${t`Toggle extensions`}</span>
+                <div class="fa-solid fa-circle-info opacity50p"></div>
+            `;
             toggleAllExtensionsButton.addEventListener('click', () => {
                 extensionsToToggle = onToggleAllExtensions(extensionsToToggle, htmlExternal);
 

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -316,7 +316,7 @@ function onToggleAllExtensions(extensionsToToggle, toggleContainer) {
         else return extension_settings.disabledExtensions.includes(name);
     };
 
-    if (thirdPartyExtensions.length === 0) return;
+    if (thirdPartyExtensions.length === 0) return [];
 
     let enable = true;
 


### PR DESCRIPTION
## Change
This adds a button in the Manage Extensions popup that will toggle all third-party extensions on/off.
- Built-in extensions are not affected.
- If the state of toggles is mixed, it will turn them off.
- If all toggles are in the same state, it will swap them to the opposite state.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
