### PR TITLE
(chore) World Info slash commands do some console context warn loggings

### DIFF
--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2752,6 +2752,33 @@ export function versionCompare(srcVersion, minVersion) {
 }
 
 /**
+ * Logs a warning to the console for slash command executions.
+ * Strips internal arguments (starting with '_') from the args object for cleaner logging.
+ * @param {string} message - The warning message to log.
+ * @param {Object} args - The arguments object from the slash command, including named arguments and internal values.
+ * @param {{[unnamedArgName: string]: string}} [valueObj=null] - The user-built object containing context for the warning (e.g., { uid: uid }).
+ * @returns {void}
+ */
+export function logSlashCommandWarn(message, args, valueObj = null) {
+    if (valueObj !== null && valueObj !== undefined) {
+        console.warn(message, valueObj, stripInternalArgs(args));
+    } else {
+        console.warn(message, stripInternalArgs(args));
+    }
+    return;
+    function stripInternalArgs(args) {
+        // strip all args/properties that start with an underscore
+        const result = {};
+        for (const [key, value] of Object.entries(args)) {
+            if (!key.startsWith('_')) {
+                result[key] = value;
+            }
+        }
+        return result;
+    }
+}
+
+/**
  * Sets up the scroll-to-top button functionality.
  * @param {object} params Parameters object
  * @param {string} params.scrollContainerId Scrollable container element ID

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1,7 +1,7 @@
 import { Fuse } from '../lib.js';
 
 import { saveSettings, substituteParams, getRequestHeaders, chat_metadata, this_chid, characters, saveCharacterDebounced, menu_type, eventSource, event_types, getExtensionPromptByName, saveMetadata, getCurrentChatId, extension_prompt_roles, create_save, createOrEditCharacter, name1 } from '../script.js';
-import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents, uuidv4, normalizeArray, getUniqueName } from './utils.js';
+import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents, uuidv4, normalizeArray, getUniqueName, logSlashCommandWarn } from './utils.js';
 import { extension_settings, getContext } from './extensions.js';
 import { NOTE_MODULE_NAME, metadata_keys, shouldWIAddPrompt } from './authors-note.js';
 import { isMobile } from './RossAscends-mods.js';
@@ -1059,9 +1059,10 @@ function registerWorldInfoSlashCommands() {
         return getContext().chat.filter(x => !x.is_system).map(x => x.mes);
     }
 
-    async function getEntriesFromFile(file) {
+    async function getEntriesFromFile(file, { args = {}, unnamed = null, callbackName = 'getEntriesFromFile' } = {}) {
         if (!file || !world_names.includes(file)) {
             toastr.warning(t`Valid World Info file name is required`);
+            logSlashCommandWarn(`${callbackName}: Valid World Info file name is required`, args, unnamed);
             return '';
         }
 
@@ -1069,6 +1070,7 @@ function registerWorldInfoSlashCommands() {
 
         if (!data || !('entries' in data)) {
             toastr.warning(t`World Info file has an invalid format`);
+            logSlashCommandWarn(`${callbackName}: World Info file has an invalid format`, args, unnamed);
             return '';
         }
 
@@ -1076,6 +1078,7 @@ function registerWorldInfoSlashCommands() {
 
         if (!entries || entries.length === 0) {
             toastr.warning(t`World Info file has no entries`);
+            logSlashCommandWarn(`${callbackName}: World Info file has no entries`, args, unnamed);
             return '';
         }
 
@@ -1119,6 +1122,7 @@ function registerWorldInfoSlashCommands() {
         const character = findChar({ name: characterIdentifier });
         if (!character) {
             toastr.error(t`Character not found.`);
+            logSlashCommandWarn('getCharBookCallback: Character not found', { type, name, create }, { characterIdentifier });
             return '';
         }
         const books = [];
@@ -1160,6 +1164,7 @@ function registerWorldInfoSlashCommands() {
 
         if (!chatId) {
             toastr.warning(t`Open a chat to get a name of the chat-bound lorebook`);
+            logSlashCommandWarn('getChatBookCallback: Open a chat to get a name of the chat-bound lorebook', args);
             return '';
         }
 
@@ -1205,7 +1210,7 @@ function registerWorldInfoSlashCommands() {
         const file = args.file;
         const field = args.field || 'key';
 
-        const entries = await getEntriesFromFile(file);
+        const entries = await getEntriesFromFile(file, { args, unnamed: { value }, callbackName: 'findBookEntryCallback' });
 
         if (!entries) {
             return '';
@@ -1250,7 +1255,7 @@ function registerWorldInfoSlashCommands() {
         const field = args.field || 'content';
         const tags = getContext().tags;
 
-        const entries = await getEntriesFromFile(file);
+        const entries = await getEntriesFromFile(file, { args, unnamed: { uid }, callbackName: 'getEntryFieldCallback' });
 
         if (!entries) {
             return '';
@@ -1260,11 +1265,14 @@ function registerWorldInfoSlashCommands() {
 
         if (!entry) {
             toastr.warning('Valid UID is required');
+            logSlashCommandWarn('getEntryFieldCallback: Valid UID is required', args, { uid });
+            console.warn();
             return '';
         }
 
         if (!Object.hasOwn(newWorldInfoEntryDefinition, field)) {
             toastr.warning('Valid field name is required');
+            logSlashCommandWarn('getEntryFieldCallback: Valid field name is required', args, { uid });
             return '';
         }
 
@@ -1313,6 +1321,7 @@ function registerWorldInfoSlashCommands() {
 
         if (!data || !('entries' in data)) {
             toastr.warning('Valid World Info file name is required');
+            logSlashCommandWarn('createEntryCallback: Valid World Info file name is required', args);
             return '';
         }
 
@@ -1358,6 +1367,7 @@ function registerWorldInfoSlashCommands() {
 
         if (value === undefined) {
             toastr.warning('Value is required');
+            logSlashCommandWarn('setEntryFieldCallback: Value is required', args, { value });
             return '';
         }
 
@@ -1367,6 +1377,7 @@ function registerWorldInfoSlashCommands() {
 
         if (!data || !('entries' in data)) {
             toastr.warning('Valid World Info file name is required');
+            logSlashCommandWarn('setEntryFieldCallback: Valid World Info file name is required', args, { value });
             return '';
         }
 
@@ -1374,11 +1385,13 @@ function registerWorldInfoSlashCommands() {
 
         if (!entry) {
             toastr.warning('Valid UID is required');
+            logSlashCommandWarn('setEntryFieldCallback: Valid UID is required', args, { value });
             return '';
         }
 
         if (!Object.hasOwn(newWorldInfoEntryDefinition, field)) {
             toastr.warning('Valid field name is required');
+            logSlashCommandWarn('setEntryFieldCallback: Valid field name is required', args, { value });
             return '';
         }
 
@@ -1445,7 +1458,7 @@ function registerWorldInfoSlashCommands() {
         const uid = value;
         const effect = args.effect;
 
-        const entries = await getEntriesFromFile(file);
+        const entries = await getEntriesFromFile(file, { args, unnamed: { uid }, callbackName: 'getTimedEffectCallback' });
 
         if (!entries) {
             return '';
@@ -1456,6 +1469,7 @@ function registerWorldInfoSlashCommands() {
 
         if (!entry) {
             toastr.warning('Valid UID is required');
+            logSlashCommandWarn('getTimedEffectCallback: Valid UID is required', args, { uid });
             return '';
         }
 
@@ -1465,6 +1479,7 @@ function registerWorldInfoSlashCommands() {
 
         if (!timedEffects.isValidEffectType(effect)) {
             toastr.warning('Valid effect type is required');
+            logSlashCommandWarn('getTimedEffectCallback: Valid effect type is required', args, { uid });
             return '';
         }
 
@@ -1488,10 +1503,11 @@ function registerWorldInfoSlashCommands() {
 
         if (value === undefined) {
             toastr.warning('New state is required');
+            logSlashCommandWarn('setTimedEffectCallback: New state is required', args, { value });
             return '';
         }
 
-        const entries = await getEntriesFromFile(file);
+        const entries = await getEntriesFromFile(file, { args, unnamed: { value }, callbackName: 'setTimedEffectCallback' });
 
         if (!entries) {
             return '';
@@ -1502,6 +1518,7 @@ function registerWorldInfoSlashCommands() {
 
         if (!entry) {
             toastr.warning('Valid UID is required');
+            logSlashCommandWarn('setTimedEffectCallback: Valid UID is required', args, { value });
             return '';
         }
 
@@ -1511,11 +1528,13 @@ function registerWorldInfoSlashCommands() {
 
         if (!timedEffects.isValidEffectType(effect)) {
             toastr.warning('Valid effect type is required');
+            logSlashCommandWarn('setTimedEffectCallback: Valid effect type is required', args, { value });
             return '';
         }
 
         if (!entry[effect]) {
             toastr.warning('This entry does not have the selected effect. Configure it in the editor first.');
+            logSlashCommandWarn('setTimedEffectCallback: This entry does not have the selected effect', args, { value });
             return '';
         }
 


### PR DESCRIPTION
Giglio asked for this.

## Copilot Summary
This pull request adds enhanced logging for slash command executions related to World Info management. A new utility function, `logSlashCommandWarn`, is introduced to standardize warning logs by stripping internal arguments and providing relevant context. This function is then integrated into various error handling paths within the World Info slash command callbacks, improving debuggability and traceability of issues.

Key changes include:

**New utility function:**

* Added `logSlashCommandWarn` to `utils.js` for consistent and context-rich warning logs, automatically stripping internal arguments for cleaner output.

**Integration in World Info slash command callbacks:**

* Updated multiple callbacks in `world-info.js` to use `logSlashCommandWarn` when encountering invalid input or missing data, such as missing files, invalid UIDs, or required values. This includes callbacks like `getEntriesFromFile`, `getCharBookCallback`, `findBookEntryCallback`, `getEntryFieldCallback`, `createEntryCallback`, `setEntryFieldCallback`, `getTimedEffectCallback`, and `setTimedEffectCallback`. [[1]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496L1062-R1081) [[2]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496L1208-R1213) [[3]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496L1253-R1258) [[4]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1268-R1275) [[5]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1324) [[6]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1370) [[7]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1380-R1394) [[8]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496L1448-R1461) [[9]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1472) [[10]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1482) [[11]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1506-R1510) [[12]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1521) [[13]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1531-R1537) [[14]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1125) [[15]](diffhunk://#diff-657e264183d3b1542514cd29f037b6f3545f14e673dd29b7491999a849ce8496R1167)

**Codebase maintenance:**

* Updated imports in `world-info.js` to include the new `logSlashCommandWarn` utility.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).