### PR TITLE
feat: prompt folder for chat completion presets

### DIFF
--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -17,7 +17,8 @@
     min-height: 1px;
 }
 
-#completion_prompt_manager #completion_prompt_manager_list li {
+#completion_prompt_manager #completion_prompt_manager_list li,
+#completion_prompt_manager #completion_prompt_manager_list ul {
     display: grid;
     grid-template-columns: 4fr 80px 45px;
     margin-bottom: 0.5em;
@@ -42,8 +43,8 @@
 }
 
 
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_list_head .prompt_manager_prompt_tokens,
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_tokens {
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_list_head .prompt_manager_prompt_tokens,
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt .prompt_manager_prompt_tokens {
     font-size: calc(var(--mainFontSize)*0.9);
     text-align: right;
 }
@@ -56,25 +57,25 @@
     padding: 0.5em 0.5em 0;
 }
 
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt {
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt {
     align-items: center;
     padding: 0.5em;
     border: 1px solid var(--SmartThemeBorderColor);
 }
 
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_controls {
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt .prompt_manager_prompt_controls {
     display: flex;
     justify-content: space-between;
     font-size: calc(var(--mainFontSize)*1.2);
 }
 
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_controls span {
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt .prompt_manager_prompt_controls span {
     display: flex;
     height: 18px;
     width: 18px;
 }
 
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt span span span {
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt span span span {
     flex-direction: column;
     justify-content: center;
     margin-left: 0.25em;
@@ -86,7 +87,7 @@
     opacity: 0.4;
 }
 
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt span span:hover {
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt span span:hover {
     opacity: 1;
 }
 
@@ -208,7 +209,7 @@
     border: 1px solid var(--white20a);
 }
 
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .mes_edit {
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt .mes_edit {
     margin-left: 0.5em;
 }
 
@@ -293,6 +294,14 @@
     align-items: center;
 }
 
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt:not(.expanded) .completion_prompt_manager_prompt_items {
+    display: none
+}
+
+#completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt .completion_prompt_manager_prompt_items {
+    display: block;
+}
+
 #completion_prompt_manager_footer_append_prompt {
     font-size: 1em;
 }
@@ -354,7 +363,7 @@
         max-width: 100%;
     }
 
-    #completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt span span span {
+    #completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt span span span {
         margin-left: 0.5em;
     }
 }

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -3,15 +3,15 @@
 import { DOMPurify } from '../lib.js';
 
 import { event_types, eventSource, is_send_press, main_api, substituteParams } from '../script.js';
-import { is_group_generating } from './group-chats.js';
-import { Message, MessageCollection, TokenHandler } from './openai.js';
-import { power_user } from './power-user.js';
-import { debounce, waitUntilCondition, escapeHtml, uuidv4 } from './utils.js';
 import { debounce_timeout } from './constants.js';
-import { renderTemplateAsync } from './templates.js';
-import { Popup } from './popup.js';
+import { is_group_generating } from './group-chats.js';
 import { t } from './i18n.js';
+import { Message, MessageCollection, TokenHandler } from './openai.js';
+import { Popup } from './popup.js';
+import { power_user } from './power-user.js';
 import { isMobile } from './RossAscends-mods.js';
+import { renderTemplateAsync } from './templates.js';
+import { debounce, escapeHtml, uuidv4, waitUntilCondition } from './utils.js';
 
 function debouncePromise(func, delay) {
     let timeoutId;
@@ -196,6 +196,41 @@ class Prompt {
 }
 
 /**
+ * @typedef {Object} PromptFolder
+ * @property {string} identifier
+ * @property {string} name
+ * @property {boolean} enabled
+ * @property {boolean} expanded
+ * @property {string[]} prompts
+ */
+
+/**
+ * @typedef {Object} PromptOrder
+ * @property {number} character_id
+ * @property {PromptOrderEntry[]} order
+ */
+
+/**
+ * @typedef {Object} PromptOrderEntry
+ * @property {string} identifier
+ * @property {boolean} enabled
+ */
+
+/**
+ * @typedef {Object} ServiceSettingsDetermined
+ * @property {number} openai_max_context
+ * @property {number} openai_max_tokens
+ * TODO: should not use Partial
+ * @property {Partial<Prompt>[]} prompts
+ * @property {PromptFolder[]} prompt_folders
+ * @property {PromptOrder[]} prompt_order
+ */
+
+/**
+ * @typedef {Record<string, any> & ServiceSettingsDetermined} ServiceSettings
+ */
+
+/**
  * Representing a collection of prompts.
  */
 export class PromptCollection {
@@ -346,7 +381,10 @@ class PromptManager {
             },
         };
 
-        // Chatcompletion configuration object
+        /**
+         * Chatcompletion configuration object
+         * @type {ServiceSettings|null}
+         */
         this.serviceSettings = null;
 
         // DOM element containing the prompt manager
@@ -432,7 +470,7 @@ class PromptManager {
     init(moduleConfiguration, serviceSettings) {
         this.configuration = Object.assign(this.configuration, moduleConfiguration);
         this.tokenHandler = this.tokenHandler || new TokenHandler(() => { throw new Error('Token handler not set'); });
-        this.serviceSettings = serviceSettings;
+        this.serviceSettings = /** @type {ServiceSettings} */(serviceSettings);
         this.containerElement = document.getElementById(this.configuration.containerIdentifier);
 
         if ('global' === this.configuration.promptOrder.strategy) this.activeCharacter = { id: this.configuration.promptOrder.dummyId };
@@ -791,7 +829,7 @@ class PromptManager {
         // Trigger re-render when token settings are changed
         document.getElementById('openai_max_context').addEventListener('change', (event) => {
             if (!(event.target instanceof HTMLInputElement)) return;
-            this.serviceSettings.openai_max_context = event.target.value;
+            this.serviceSettings.openai_max_context = Number(event.target.value);
             if (this.activeCharacter) this.renderDebounced();
         });
 
@@ -1256,7 +1294,7 @@ class PromptManager {
      * @returns {Prompt|null} The prompt object, or null if not found
      */
     getPromptById(identifier) {
-        return this.serviceSettings.prompts.find(item => item && item.identifier === identifier) ?? null;
+        return /** @type {Prompt|null} */(this.serviceSettings.prompts.find(item => item && item.identifier === identifier) ?? null);
     }
 
     /**
@@ -1266,6 +1304,33 @@ class PromptManager {
      */
     getPromptIndexById(identifier) {
         return this.serviceSettings.prompts.findIndex(item => item.identifier === identifier) ?? null;
+    }
+
+    /**
+     * Finds and returns a folder by its identifier.
+     * @param {string} identifier - Identifier of the folder
+     * @returns {PromptFolder|null} The folder object, or null if not found
+     */
+    getPromptFolderById(identifier) {
+        return this.serviceSettings.prompt_folders.find(item => item.identifier === identifier) ?? null;
+    }
+
+    /**
+     * Finds and returns the index of a prompt folder by its identifier.
+     * @param {string} identifier - Identifier of the prompt folder
+     * @returns {number|null} Index of the prompt, or null if not found
+     */
+    getPromptFolderIndexById(identifier) {
+        return this.serviceSettings.prompt_folders.findIndex(item => item.identifier === identifier) ?? null;
+    }
+
+    /**
+     * Find and returns a folder by a prompt it may contain
+     * @param {string} identifier - Identifier of the prompt folder
+     * @returns {PromptFolder|null} The folder object, or null if not found
+     */
+    getPromptFolderByPromptId(identifier) {
+        return this.serviceSettings.prompt_folders.find(folder => folder.prompts.includes(identifier)) ?? null;
     }
 
     /**
@@ -2082,6 +2147,10 @@ const chatCompletionDefaultPrompts = {
     ],
 };
 
+const promptManagerDefaultPromptFolders = {
+    'prompt_folder': [],
+}
+
 const promptManagerDefaultPromptOrders = {
     'prompt_order': [],
 };
@@ -2138,9 +2207,7 @@ const promptManagerDefaultPromptOrder = [
 ];
 
 export {
-    PromptManager,
-    registerPromptManagerMigration,
-    chatCompletionDefaultPrompts,
-    promptManagerDefaultPromptOrders,
-    Prompt,
+    chatCompletionDefaultPrompts, Prompt, PromptManager, promptManagerDefaultPromptFolders,
+    promptManagerDefaultPromptOrders, registerPromptManagerMigration
 };
+

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -1704,9 +1704,10 @@ class PromptManager {
             rangeBlockDiv.querySelector('#prompt-manager-reset-character').addEventListener('click', this.handleCharacterReset);
 
             const footerDiv = rangeBlockDiv.querySelector(`.${this.configuration.prefix}prompt_manager_footer`);
-            footerDiv.querySelector('.menu_button:nth-child(2)').addEventListener('click', this.handleAppendPrompt);
+            footerDiv.querySelector('.menu_button.fa-file-import').addEventListener('click', this.handleAppendPrompt);
             footerDiv.querySelector('.caution').addEventListener('click', this.handleDeletePrompt);
-            footerDiv.querySelector('.menu_button:last-child').addEventListener('click', this.handleNewPrompt);
+            footerDiv.querySelector('.menu_button.fa-folder-plus').addEventListener('click', this.handleNewFolder);
+            footerDiv.querySelector('.menu_button.fa-plus-square').addEventListener('click', this.handleNewPrompt);
             footerDiv.querySelector('select').selectedIndex = selectedPromptIndex;
 
             // Add prompt export dialogue and options
@@ -1728,83 +1729,92 @@ class PromptManager {
 
         let listItemHtml = await renderTemplateAsync('promptManagerListHeader', { prefix });
 
-        this.getPromptsForCharacter(this.activeCharacter).forEach(prompt => {
-            if (!prompt) return;
+        const renderItem = (order, listClass = 'li') => {
+          const prompt = this.getPromptById(order.identifier);
 
-            const listEntry = this.getPromptOrderEntry(this.activeCharacter, prompt.identifier);
-            const enabledClass = listEntry.enabled ? '' : `${prefix}prompt_manager_prompt_disabled`;
-            const draggableClass = `${prefix}prompt_manager_prompt_draggable`;
-            const markerClass = prompt.marker ? `${prefix}prompt_manager_marker` : '';
-            const tokens = this.tokenHandler?.getCounts()[prompt.identifier] ?? 0;
+          const enabledClass = order.enabled ? '' : `${prefix}prompt_manager_prompt_disabled`;
+          const draggableClass = `${prefix}prompt_manager_prompt_draggable`;
+          const markerClass = prompt.marker ? `${prefix}prompt_manager_marker` : '';
+          const tokens = this.tokenHandler?.getCounts()[prompt.identifier] ?? 0;
 
-            // Warn the user if the chat history goes below certain token thresholds.
-            let warningClass = '';
-            let warningTitle = '';
+          // Warn the user if the chat history goes below certain token thresholds.
+          let warningClass = '';
+          let warningTitle = '';
 
-            const tokenBudget = this.serviceSettings.openai_max_context - this.serviceSettings.openai_max_tokens;
-            if (this.tokenUsage > tokenBudget * 0.8 &&
-                'chatHistory' === prompt.identifier) {
-                const warningThreshold = this.configuration.warningTokenThreshold;
-                const dangerThreshold = this.configuration.dangerTokenThreshold;
+          const tokenBudget = this.serviceSettings.openai_max_context - this.serviceSettings.openai_max_tokens;
+          if (this.tokenUsage > tokenBudget * 0.8 && 'chatHistory' === prompt.identifier) {
+            const warningThreshold = this.configuration.warningTokenThreshold;
+            const dangerThreshold = this.configuration.dangerTokenThreshold;
 
-                if (tokens <= dangerThreshold) {
-                    warningClass = 'fa-solid tooltip fa-triangle-exclamation text_danger';
-                    warningTitle = 'Very little of your chat history is being sent, consider deactivating some other prompts.';
-                } else if (tokens <= warningThreshold) {
-                    warningClass = 'fa-solid tooltip fa-triangle-exclamation text_warning';
-                    warningTitle = 'Only a few messages worth chat history are being sent.';
-                }
+            if (tokens <= dangerThreshold) {
+              warningClass = 'fa-solid tooltip fa-triangle-exclamation text_danger';
+              warningTitle =
+                'Very little of your chat history is being sent, consider deactivating some other prompts.';
+            } else if (tokens <= warningThreshold) {
+              warningClass = 'fa-solid tooltip fa-triangle-exclamation text_warning';
+              warningTitle = 'Only a few messages worth chat history are being sent.';
             }
+          }
 
-            const calculatedTokens = tokens ? tokens : '-';
+          const calculatedTokens = tokens ? tokens : '-';
 
-            let detachSpanHtml = '';
-            if (this.isPromptDeletionAllowed(prompt)) {
-                detachSpanHtml = `
+          let detachSpanHtml = '';
+          if (this.isPromptDeletionAllowed(prompt)) {
+            detachSpanHtml = `
                     <span title="Remove" class="prompt-manager-detach-action caution fa-solid fa-chain-broken fa-xs"></span>
                 `;
-            } else {
-                detachSpanHtml = '<span class="fa-solid"></span>';
-            }
+          } else {
+            detachSpanHtml = '<span class="fa-solid"></span>';
+          }
 
-            let editSpanHtml = '';
-            if (this.isPromptEditAllowed(prompt)) {
-                editSpanHtml = `
+          let editSpanHtml = '';
+          if (this.isPromptEditAllowed(prompt)) {
+            editSpanHtml = `
                     <span title="edit" class="prompt-manager-edit-action fa-solid fa-pencil fa-xs"></span>
                 `;
-            } else {
-                editSpanHtml = '<span class="fa-solid"></span>';
-            }
+          } else {
+            editSpanHtml = '<span class="fa-solid"></span>';
+          }
 
-            let toggleSpanHtml = '';
-            if (this.isPromptToggleAllowed(prompt)) {
-                toggleSpanHtml = `
-                    <span class="prompt-manager-toggle-action ${listEntry.enabled ? 'fa-solid fa-toggle-on' : 'fa-solid fa-toggle-off'}"></span>
+          let toggleSpanHtml = '';
+          if (this.isPromptToggleAllowed(prompt)) {
+            toggleSpanHtml = `
+                    <span class="prompt-manager-toggle-action ${order.enabled ? 'fa-solid fa-toggle-on' : 'fa-solid fa-toggle-off'}"></span>
                 `;
-            } else {
-                toggleSpanHtml = '<span class="fa-solid"></span>';
-            }
+          } else {
+            toggleSpanHtml = '<span class="fa-solid"></span>';
+          }
 
-            const encodedName = escapeHtml(prompt.name);
-            const isMarkerPrompt = prompt.marker && prompt.injection_position !== INJECTION_POSITION.ABSOLUTE;
-            const isSystemPrompt = !prompt.marker && prompt.system_prompt && prompt.injection_position !== INJECTION_POSITION.ABSOLUTE && !prompt.forbid_overrides;
-            const isImportantPrompt = !prompt.marker && prompt.system_prompt && prompt.injection_position !== INJECTION_POSITION.ABSOLUTE && prompt.forbid_overrides;
-            const isUserPrompt = !prompt.marker && !prompt.system_prompt && prompt.injection_position !== INJECTION_POSITION.ABSOLUTE;
-            const isInjectionPrompt = prompt.injection_position === INJECTION_POSITION.ABSOLUTE;
-            const isOverriddenPrompt = Array.isArray(this.overriddenPrompts) && this.overriddenPrompts.includes(prompt.identifier);
-            const importantClass = isImportantPrompt ? `${prefix}prompt_manager_important` : '';
-            const iconLookup = prompt.role === 'system' && (prompt.marker || prompt.system_prompt) ? '' : prompt.role;
+          const encodedName = escapeHtml(prompt.name);
+          const isMarkerPrompt = prompt.marker && prompt.injection_position !== INJECTION_POSITION.ABSOLUTE;
+          const isSystemPrompt =
+            !prompt.marker &&
+            prompt.system_prompt &&
+            prompt.injection_position !== INJECTION_POSITION.ABSOLUTE &&
+            !prompt.forbid_overrides;
+          const isImportantPrompt =
+            !prompt.marker &&
+            prompt.system_prompt &&
+            prompt.injection_position !== INJECTION_POSITION.ABSOLUTE &&
+            prompt.forbid_overrides;
+          const isUserPrompt =
+            !prompt.marker && !prompt.system_prompt && prompt.injection_position !== INJECTION_POSITION.ABSOLUTE;
+          const isInjectionPrompt = prompt.injection_position === INJECTION_POSITION.ABSOLUTE;
+          const isOverriddenPrompt =
+            Array.isArray(this.overriddenPrompts) && this.overriddenPrompts.includes(prompt.identifier);
+          const importantClass = isImportantPrompt ? `${prefix}prompt_manager_important` : '';
+          const iconLookup = prompt.role === 'system' && (prompt.marker || prompt.system_prompt) ? '' : prompt.role;
 
-            //add role icons to the right of prompt name
-            const promptRoles = {
-                assistant: { roleIcon: 'fa-robot', roleTitle: 'Prompt will be sent as Assistant' },
-                user: { roleIcon: 'fa-user', roleTitle: 'Prompt will be sent as User' },
-            };
-            const roleIcon = promptRoles[iconLookup]?.roleIcon || '';
-            const roleTitle = promptRoles[iconLookup]?.roleTitle || '';
+          //add role icons to the right of prompt name
+          const promptRoles = {
+            assistant: { roleIcon: 'fa-robot', roleTitle: 'Prompt will be sent as Assistant' },
+            user: { roleIcon: 'fa-user', roleTitle: 'Prompt will be sent as User' },
+          };
+          const roleIcon = promptRoles[iconLookup]?.roleIcon || '';
+          const roleTitle = promptRoles[iconLookup]?.roleTitle || '';
 
-            listItemHtml += `
-                <li class="${prefix}prompt_manager_prompt ${draggableClass} ${enabledClass} ${markerClass} ${importantClass}" data-pm-identifier="${escapeHtml(prompt.identifier)}">
+          return `
+                <${listClass} class="${prefix}prompt_manager_prompt ${draggableClass} ${enabledClass} ${markerClass} ${importantClass}" type="prompt" data-pm-identifier="${escapeHtml(prompt.identifier)}">
                     <span class="drag-handle">☰</span>
                     <span class="${prefix}prompt_manager_prompt_name" data-pm-name="${encodedName}">
                         ${isMarkerPrompt ? '<span class="fa-fw fa-solid fa-thumb-tack" title="Marker"></span>' : ''}
@@ -1826,8 +1836,42 @@ class PromptManager {
                     </span>
 
                     <span class="prompt_manager_prompt_tokens" data-pm-tokens="${calculatedTokens}"><span class="${warningClass}" title="${warningTitle}"> </span>${calculatedTokens}</span>
+                </${listClass}>
+            `;
+        };
+
+        const renderFolder = order => {
+          const encodedName = escapeHtml(order.name);
+
+          const enabledClass = order.enabled ? '' : `${prefix}prompt_manager_prompt_disabled`;
+          const draggableClass = `${prefix}prompt_manager_prompt_draggable`;
+
+          return `
+                <li class="${prefix}prompt_manager_prompt ${draggableClass} ${enabledClass} ${order.expanded ? 'expanded' : ''}" type="folder" data-pm-identifier="${escapeHtml(order.identifier)}">
+                    <span class="drag-handle">☰</span>
+                    <span class="${prefix}prompt_manager_prompt_name" data-pm-name="${encodedName}">
+                        <span class="fa-fw fa-solid fa-folder" title="Folder"></span>
+                        <span title="${encodedName}">${encodedName}</span>
+                    </span>
+                    <span>
+                        <span class="prompt_manager_prompt_controls">
+                            <span title="Remove" class="prompt-manager-detach-action caution fa-solid fa-chain-broken fa-xs"></span>
+                            <span title="edit" class="prompt-manager-edit-action fa-solid fa-pencil fa-xs"></span>
+                            <span class="prompt-manager-toggle-action ${order.enabled ? 'fa-solid fa-toggle-on' : 'fa-solid fa-toggle-off'}"></span>
+                        </span>
+                    </span>
+                    <span title="expand" class="prompt-manager-expand-action fa-fw fa-solid ${order.expanded ? 'fa-chevron-up' : 'fa-chevron-down'}"></span>
+
+                    <div class="${prefix}prompt_manager_prompt_items">
+                        ${order.items.map(item => renderItem(item, 'ul')).join('')}
+                    </div>
                 </li>
             `;
+        };
+
+        this.getPromptOrderTreeForCharacter(this.activeCharacter).forEach(order => {
+          if (!order) return;
+          listItemHtml += isPromptOrderFolder(order) ? renderFolder(order) : renderItem(order);
         });
 
         promptManagerList.insertAdjacentHTML('beforeend', listItemHtml);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -39,6 +39,7 @@ import {
     INJECTION_POSITION,
     Prompt,
     PromptManager,
+    promptManagerDefaultPromptFolders,
     promptManagerDefaultPromptOrders,
 } from './PromptManager.js';
 
@@ -383,6 +384,7 @@ const default_settings = {
     openai_max_context: max_4k,
     openai_max_tokens: 300,
     ...chatCompletionDefaultPrompts,
+    ...promptManagerDefaultPromptFolders,
     ...promptManagerDefaultPromptOrders,
     send_if_empty: '',
     impersonation_prompt: default_impersonation_prompt,

--- a/public/scripts/templates/promptManagerFooter.html
+++ b/public/scripts/templates/promptManagerFooter.html
@@ -7,5 +7,6 @@
     <a class="menu_button fa-file-import fa-solid fa-fw" id="prompt-manager-import" title="Import a prompt list" data-i18n="[title]Import a prompt list"></a>
     <a class="menu_button fa-file-export fa-solid fa-fw" id="prompt-manager-export" title="Export this prompt list" data-i18n="[title]Export this prompt list"></a>
     <a class="menu_button fa-undo fa-solid fa-fw" id="prompt-manager-reset-character" title="Reset current character" data-i18n="[title]Reset current character"></a>
+    <a class="menu_button fa-folder-plus fa-solid fa-fw" title="New folder" data-i18n="[title]New folder"></a>
     <a class="menu_button fa-plus-square fa-solid fa-fw" title="New prompt" data-i18n="[title]New prompt"></a>
 </div>


### PR DESCRIPTION
Implements prompt folders for chat completion presets:

<details>
<summary> image </summary>
<img width="702" height="364" alt="image" src="https://github.com/user-attachments/assets/6ea8c29a-a6ad-46d8-9918-d182f7bb7ab2" />
</details>

~~This is implemented by allowing a folder-like structure inside `prompt_order`:~~

I prefer to implement it like [this comment](https://github.com/SillyTavern/SillyTavern/pull/5099#issuecomment-3864641967) (but it’s not implemented this way in the code yet).

## Questions before further development

### The whole promot list being re-rendered for every button action

Right now, every button action in the prompt controls triggers a full re-render of the prompt list - even for simple UI-only changes like toggling a prompt.

Because the render function doesn’t know the previous UI state, I currently have to persist folder expansion state inside `prompt_order`.

Is it acceptable to refactor these button handlers to update only the affected DOM nodes instead of calling `this.render()`? (e.g. `fa-toggle-on` to `fa-toggle-off` for the toggle action.)

### Allowance to change the `PromptManager` interface

On the topic of breaking changes: I noticed many methods in `PromptManager` aren’t used outside this file.

However, some third-party extensions may still depend on them - especially those that import `../../../../PromptManager.js` directly instead of using the official stable interface `getContext()`.

Do we need to keep these methods stable as part of a supported API, or is it acceptable to rename/remove them if needed?

## Help wanted

I’m not very familiar with CSS or sortable, and there are a few rough edges in the current UI/UX:

Current UI issue:

- The folder expansion button alignment looks off.
- Prompts inside folders don’t span the full width.
- Prompts can’t be dragged into an empty folder.
- It’s difficult to drag a prompt to the top (“head”) of a folder.
- When draging a prompt and hovering on a folder, the folder won't be expanded automatically.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
