### PR TITLE
Add Opus 4.6 support with adaptive thinking and max effort

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2110,15 +2110,6 @@
                                             </strong>
                                         </div>
                                     </div>
-                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="claude">
-                                        <label for="openai_adaptive_thinking" class="checkbox_label" title="Enable adaptive thinking for Claude Opus 4.6+. Uses dynamic thinking depth controlled by reasoning effort." data-i18n="[title]Enable adaptive thinking for Claude Opus 4.6+. Uses dynamic thinking depth controlled by reasoning effort.">
-                                            <input id="openai_adaptive_thinking" type="checkbox" />
-                                            <span data-i18n="Adaptive Thinking">Adaptive Thinking</span>
-                                        </label>
-                                        <div class="toggle-description justifyLeft marginBot5 wide100p" data-i18n="Enables adaptive thinking mode for Claude Opus 4.6+. Uses effort-based thinking depth instead of token budget.">
-                                            Enables adaptive thinking mode for Claude Opus 4.6+. Uses effort-based thinking depth instead of token budget.
-                                        </div>
-                                    </div>
                                     <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt">
                                         <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
                                             <label for="openai_reasoning_effort">

--- a/public/index.html
+++ b/public/index.html
@@ -2110,6 +2110,15 @@
                                             </strong>
                                         </div>
                                     </div>
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="claude">
+                                        <label for="openai_adaptive_thinking" class="checkbox_label" title="Enable adaptive thinking for Claude Opus 4.6+. Uses dynamic thinking depth controlled by reasoning effort." data-i18n="[title]Enable adaptive thinking for Claude Opus 4.6+. Uses dynamic thinking depth controlled by reasoning effort.">
+                                            <input id="openai_adaptive_thinking" type="checkbox" />
+                                            <span data-i18n="Adaptive Thinking">Adaptive Thinking</span>
+                                        </label>
+                                        <div class="toggle-description justifyLeft marginBot5 wide100p" data-i18n="Enables adaptive thinking mode for Claude Opus 4.6+. Uses effort-based thinking depth instead of token budget.">
+                                            Enables adaptive thinking mode for Claude Opus 4.6+. Uses effort-based thinking depth instead of token budget.
+                                        </div>
+                                    </div>
                                     <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt">
                                         <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
                                             <label for="openai_reasoning_effort">

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -354,6 +354,7 @@ export const settingsToUpdate = {
     function_calling: ['#openai_function_calling', 'function_calling', true, false],
     show_thoughts: ['#openai_show_thoughts', 'show_thoughts', true, false],
     reasoning_effort: ['#openai_reasoning_effort', 'reasoning_effort', false, false],
+    adaptive_thinking: ['#openai_adaptive_thinking', 'adaptive_thinking', true, false],
     verbosity: ['#openai_verbosity', 'verbosity', false, false],
     enable_web_search: ['#openai_enable_web_search', 'enable_web_search', true, false],
     seed: ['#seed_openai', 'seed', false, false],
@@ -460,6 +461,7 @@ const default_settings = {
     custom_prompt_post_processing: custom_prompt_post_processing_types.NONE,
     show_thoughts: true,
     reasoning_effort: reasoning_effort_types.auto,
+    adaptive_thinking: false,
     verbosity: verbosity_levels.auto,
     enable_web_search: false,
     request_images: false,
@@ -2561,6 +2563,7 @@ export async function createGenerationParameters(settings, model, type, messages
         'group_names': getGroupNames(),
         'include_reasoning': Boolean(settings.show_thoughts),
         'reasoning_effort': getReasoningEffort(settings, model),
+        'adaptive_thinking': Boolean(settings.adaptive_thinking),
         'enable_web_search': Boolean(settings.enable_web_search),
         'request_images': Boolean(settings.request_images),
         'request_image_resolution': String(settings.request_image_resolution),
@@ -6715,6 +6718,11 @@ export function initOpenAI() {
 
     $('#openai_reasoning_effort').on('input', function () {
         oai_settings.reasoning_effort = String($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#openai_adaptive_thinking').on('input', function () {
+        oai_settings.adaptive_thinking = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -354,7 +354,6 @@ export const settingsToUpdate = {
     function_calling: ['#openai_function_calling', 'function_calling', true, false],
     show_thoughts: ['#openai_show_thoughts', 'show_thoughts', true, false],
     reasoning_effort: ['#openai_reasoning_effort', 'reasoning_effort', false, false],
-    adaptive_thinking: ['#openai_adaptive_thinking', 'adaptive_thinking', true, false],
     verbosity: ['#openai_verbosity', 'verbosity', false, false],
     enable_web_search: ['#openai_enable_web_search', 'enable_web_search', true, false],
     seed: ['#seed_openai', 'seed', false, false],
@@ -461,7 +460,6 @@ const default_settings = {
     custom_prompt_post_processing: custom_prompt_post_processing_types.NONE,
     show_thoughts: true,
     reasoning_effort: reasoning_effort_types.auto,
-    adaptive_thinking: false,
     verbosity: verbosity_levels.auto,
     enable_web_search: false,
     request_images: false,
@@ -2563,7 +2561,6 @@ export async function createGenerationParameters(settings, model, type, messages
         'group_names': getGroupNames(),
         'include_reasoning': Boolean(settings.show_thoughts),
         'reasoning_effort': getReasoningEffort(settings, model),
-        'adaptive_thinking': Boolean(settings.adaptive_thinking),
         'enable_web_search': Boolean(settings.enable_web_search),
         'request_images': Boolean(settings.request_images),
         'request_image_resolution': String(settings.request_image_resolution),
@@ -6718,11 +6715,6 @@ export function initOpenAI() {
 
     $('#openai_reasoning_effort').on('input', function () {
         oai_settings.reasoning_effort = String($(this).val());
-        saveSettingsDebounced();
-    });
-
-    $('#openai_adaptive_thinking').on('input', function () {
-        oai_settings.adaptive_thinking = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2398,7 +2398,10 @@ function getReasoningEffort(settings = null, model = null) {
                     ? reasoning_effort_types.min
                     : reasoning_effort_types.low;
             case reasoning_effort_types.max:
-                return reasoning_effort_types.high;
+                // 'max' is supported on Claude Opus 4.6+ and GPT-5+
+                return /claude-opus-4[.-]6/.test(model) || /^gpt-5/.test(model)
+                    ? reasoning_effort_types.max
+                    : reasoning_effort_types.high;
             default:
                 return settings.reasoning_effort;
         }

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2389,7 +2389,8 @@ router.post('/generate', async function (request, response) {
 
         // Apply Claude Opus 4.6+ adaptive thinking for OpenAI-compatible endpoints
         const isClaudeOpus46 = /claude-opus-4[.-]6/.test(request.body.model);
-        if (isClaudeOpus46) {
+        const isOpenRouterEndpoint = request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.OPENROUTER;
+        if (isClaudeOpus46 && isOpenRouterEndpoint) {
             const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, request.body.reasoning_effort, requestBody.stream, request.body.model);
             if (typeof budgetTokens === 'string') {
                 requestBody.thinking = { type: 'adaptive' };

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -224,7 +224,6 @@ async function sendClaudeRequest(request, response) {
         const useSystemPrompt = Boolean(request.body.use_sysprompt);
         const convertedPrompt = convertClaudeMessages(request.body.messages, request.body.assistant_prefill, useSystemPrompt, useTools, getPromptNames(request));
         const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6)/.test(request.body.model);
-        const useAdaptiveThinking = /^claude-(opus-4-6)/.test(request.body.model);
         const useWebSearch = /^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6)/.test(request.body.model) && Boolean(request.body.enable_web_search);
         const isLimitedSampling = /^claude-(opus-4-1|sonnet-4-5|haiku-4-5|opus-4-5|opus-4-6)/.test(request.body.model);
         const useVerbosity = /^claude-(opus-4-5|opus-4-6)/.test(request.body.model);
@@ -305,44 +304,21 @@ async function sendClaudeRequest(request, response) {
             }
         }
 
-        let reasoningEffort = request.body.reasoning_effort;
+        const reasoningEffort = request.body.reasoning_effort;
         const isAdaptiveThinkingEnabled = Boolean(request.body.adaptive_thinking);
+        const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream, request.body.model, isAdaptiveThinkingEnabled);
 
-        // 'max' effort is only supported on Claude Opus 4.6+, fall back to 'high' for other models
-        if (reasoningEffort === 'max' && !useAdaptiveThinking) {
-            reasoningEffort = 'high';
-            console.info(color.blue('Max reasoning effort is only supported on Claude Opus 4.6+. Falling back to high.'));
-        }
-
-        const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream);
-
-        // Handle adaptive thinking for Claude Opus 4.6+
-        // Adaptive thinking uses thinking: { type: "adaptive" } with output_config: { effort: "..." }
-        if (useThinking && useAdaptiveThinking && isAdaptiveThinkingEnabled && reasoningEffort !== 'auto') {
-            // No prefill when thinking
+        // Adaptive thinking: returns a string effort level (like Gemini 3)
+        if (useThinking && typeof budgetTokens === 'string') {
             fixThinkingPrefill = true;
-            requestBody.thinking = {
-                type: 'adaptive',
-            };
-
-            // Map reasoning effort to effort levels for output_config
-            const effortMap = {
-                'min': 'low',
-                'low': 'low',
-                'medium': 'medium',
-                'high': 'high',
-                'max': 'max',
-            };
-            const effort = effortMap[reasoningEffort] || 'high';
+            requestBody.thinking = { type: 'adaptive' };
             requestBody.output_config ??= {};
-            requestBody.output_config.effort = effort;
-
-            // NO I CAN'T SILENTLY IGNORE THE TEMPERATURE.
+            requestBody.output_config.effort = budgetTokens;
             delete requestBody.temperature;
             delete requestBody.top_p;
             delete requestBody.top_k;
         } else if (useThinking && Number.isInteger(budgetTokens)) {
-            // No prefill when thinking
+            // Traditional thinking: returns a numeric budget
             fixThinkingPrefill = true;
             const minThinkTokens = 1024;
             if (requestBody.max_tokens <= minThinkTokens) {
@@ -355,8 +331,6 @@ async function sendClaudeRequest(request, response) {
                 type: 'enabled',
                 budget_tokens: budgetTokens,
             };
-
-            // NO I CAN'T SILENTLY IGNORE THE TEMPERATURE.
             delete requestBody.temperature;
             delete requestBody.top_p;
             delete requestBody.top_k;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -305,8 +305,7 @@ async function sendClaudeRequest(request, response) {
         }
 
         const reasoningEffort = request.body.reasoning_effort;
-        const isAdaptiveThinkingEnabled = Boolean(request.body.adaptive_thinking);
-        const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream, request.body.model, isAdaptiveThinkingEnabled);
+        const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream, request.body.model);
 
         // Adaptive thinking: returns a string effort level (like Gemini 3)
         if (useThinking && typeof budgetTokens === 'string') {
@@ -314,9 +313,6 @@ async function sendClaudeRequest(request, response) {
             requestBody.thinking = { type: 'adaptive' };
             requestBody.output_config ??= {};
             requestBody.output_config.effort = budgetTokens;
-            delete requestBody.temperature;
-            delete requestBody.top_p;
-            delete requestBody.top_k;
         } else if (useThinking && Number.isInteger(budgetTokens)) {
             // Traditional thinking: returns a numeric budget
             fixThinkingPrefill = true;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -224,6 +224,7 @@ async function sendClaudeRequest(request, response) {
         const useSystemPrompt = Boolean(request.body.use_sysprompt);
         const convertedPrompt = convertClaudeMessages(request.body.messages, request.body.assistant_prefill, useSystemPrompt, useTools, getPromptNames(request));
         const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6)/.test(request.body.model);
+        const useAdaptiveThinking = /^claude-(opus-4-6)/.test(request.body.model);
         const useWebSearch = /^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6)/.test(request.body.model) && Boolean(request.body.enable_web_search);
         const isLimitedSampling = /^claude-(opus-4-1|sonnet-4-5|haiku-4-5|opus-4-5|opus-4-6)/.test(request.body.model);
         const useVerbosity = /^claude-(opus-4-5|opus-4-6)/.test(request.body.model);
@@ -304,10 +305,43 @@ async function sendClaudeRequest(request, response) {
             }
         }
 
-        const reasoningEffort = request.body.reasoning_effort;
+        let reasoningEffort = request.body.reasoning_effort;
+        const isAdaptiveThinkingEnabled = Boolean(request.body.adaptive_thinking);
+
+        // 'max' effort is only supported on Claude Opus 4.6+, fall back to 'high' for other models
+        if (reasoningEffort === 'max' && !useAdaptiveThinking) {
+            reasoningEffort = 'high';
+            console.info(color.blue('Max reasoning effort is only supported on Claude Opus 4.6+. Falling back to high.'));
+        }
+
         const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream);
 
-        if (useThinking && Number.isInteger(budgetTokens)) {
+        // Handle adaptive thinking for Claude Opus 4.6+
+        // Adaptive thinking uses thinking: { type: "adaptive" } with output_config: { effort: "..." }
+        if (useThinking && useAdaptiveThinking && isAdaptiveThinkingEnabled && reasoningEffort !== 'auto') {
+            // No prefill when thinking
+            fixThinkingPrefill = true;
+            requestBody.thinking = {
+                type: 'adaptive',
+            };
+
+            // Map reasoning effort to effort levels for output_config
+            const effortMap = {
+                'min': 'low',
+                'low': 'low',
+                'medium': 'medium',
+                'high': 'high',
+                'max': 'max',
+            };
+            const effort = effortMap[reasoningEffort] || 'high';
+            requestBody.output_config ??= {};
+            requestBody.output_config.effort = effort;
+
+            // NO I CAN'T SILENTLY IGNORE THE TEMPERATURE.
+            delete requestBody.temperature;
+            delete requestBody.top_p;
+            delete requestBody.top_k;
+        } else if (useThinking && Number.isInteger(budgetTokens)) {
             // No prefill when thinking
             fixThinkingPrefill = true;
             const minThinkTokens = 1024;
@@ -332,8 +366,8 @@ async function sendClaudeRequest(request, response) {
             convertedPrompt.messages[convertedPrompt.messages.length - 1].role = 'user';
         }
 
-        // Verbosity = 'effort' (same values as OpenAI)
-        if (useVerbosity && request.body.verbosity) {
+        // Verbosity = 'effort' (same values as OpenAI) - only if not already set by adaptive thinking
+        if (useVerbosity && request.body.verbosity && !requestBody.output_config?.effort) {
             betaHeaders.push('effort-2025-11-24');
             requestBody.output_config ??= {};
             requestBody.output_config.effort = request.body.verbosity;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -313,6 +313,8 @@ async function sendClaudeRequest(request, response) {
             requestBody.thinking = { type: 'adaptive' };
             requestBody.output_config ??= {};
             requestBody.output_config.effort = budgetTokens;
+            // top_k is not allowed in adaptive mode
+            delete requestBody.top_k;
         } else if (useThinking && Number.isInteger(budgetTokens)) {
             // Traditional thinking: returns a numeric budget
             fixThinkingPrefill = true;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2387,6 +2387,29 @@ router.post('/generate', async function (request, response) {
             ...bodyParams,
         };
 
+        // Apply Claude Opus 4.6+ adaptive thinking for OpenAI-compatible endpoints
+        const isClaudeOpus46 = /claude-opus-4[.-]6/.test(request.body.model);
+        if (isClaudeOpus46) {
+            const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, request.body.reasoning_effort, requestBody.stream, request.body.model);
+            if (typeof budgetTokens === 'string') {
+                requestBody.thinking = { type: 'adaptive' };
+                requestBody.output_config ??= {};
+                requestBody.output_config.effort = budgetTokens;
+                // Remove OpenRouter-style reasoning param to avoid conflicts
+                delete requestBody.reasoning;
+            }
+            delete requestBody.top_k;
+        }
+
+        // Claude 4+ models cannot have both temperature and top_p
+        if (/claude-(opus-4[.-]1|sonnet-4[.-]5|haiku-4[.-]5|opus-4[.-]5|opus-4[.-]6)/.test(request.body.model)) {
+            if (requestBody.top_p < 1) {
+                delete requestBody.temperature;
+            } else {
+                delete requestBody.top_p;
+            }
+        }
+
         if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM) {
             excludeKeysByYaml(requestBody, request.body.custom_exclude_body);
         }

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1117,7 +1117,7 @@ export function cachingSystemPromptForOpenRouter(messages, ttl = undefined) {
  * @returns {number|string|null} Budget tokens, effort string, or null
  */
 export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, model = '') {
-    const isAdaptiveModel = /^claude-(opus-4-6)/.test(model);
+    const isAdaptiveModel = /claude-(opus-4[.-]6)/.test(model);
 
     // Adaptive thinking for Opus 4.6+: return effort string (like Gemini 3)
     if (isAdaptiveModel) {

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1109,12 +1109,41 @@ export function cachingSystemPromptForOpenRouter(messages, ttl = undefined) {
 
 /**
  * Calculate the Claude budget tokens for a given reasoning effort.
+ * Returns a string effort level for adaptive thinking (Opus 4.6+), a number for traditional thinking, or null for auto.
  * @param {number} maxTokens Maximum tokens
  * @param {string} reasoningEffort Reasoning effort
  * @param {boolean} stream If streaming is enabled
- * @returns {number?} Budget tokens
+ * @param {string} model Model name
+ * @param {boolean} adaptiveThinking Whether adaptive thinking is enabled
+ * @returns {number|string|null} Budget tokens, effort string, or null
  */
-export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream) {
+export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, model = '', adaptiveThinking = false) {
+    const isAdaptiveModel = /^claude-(opus-4-6)/.test(model);
+
+    // Adaptive thinking for Opus 4.6+: return effort string (like Gemini 3)
+    if (isAdaptiveModel && adaptiveThinking) {
+        switch (reasoningEffort) {
+            case REASONING_EFFORT.auto:
+                return null;
+            case REASONING_EFFORT.min:
+                return 'low';
+            case REASONING_EFFORT.low:
+                return 'low';
+            case REASONING_EFFORT.medium:
+                return 'medium';
+            case REASONING_EFFORT.high:
+                return 'high';
+            case REASONING_EFFORT.max:
+                return 'max';
+        }
+        return null;
+    }
+
+    // 'max' effort is only supported on Opus 4.6+, fall back to 'high'
+    if (reasoningEffort === REASONING_EFFORT.max && !isAdaptiveModel) {
+        reasoningEffort = REASONING_EFFORT.high;
+    }
+
     let budgetTokens = 0;
 
     switch (reasoningEffort) {

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1114,14 +1114,13 @@ export function cachingSystemPromptForOpenRouter(messages, ttl = undefined) {
  * @param {string} reasoningEffort Reasoning effort
  * @param {boolean} stream If streaming is enabled
  * @param {string} model Model name
- * @param {boolean} adaptiveThinking Whether adaptive thinking is enabled
  * @returns {number|string|null} Budget tokens, effort string, or null
  */
-export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, model = '', adaptiveThinking = false) {
+export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, model = '') {
     const isAdaptiveModel = /^claude-(opus-4-6)/.test(model);
 
     // Adaptive thinking for Opus 4.6+: return effort string (like Gemini 3)
-    if (isAdaptiveModel && adaptiveThinking) {
+    if (isAdaptiveModel) {
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
                 return null;


### PR DESCRIPTION
- Add claude-opus-4-6 to model selector
- Add Adaptive Thinking toggle for Claude (uses thinking: {type: 'adaptive'})
- Add max effort level for Reasoning Effort (Opus 4.6+ only, falls back to high)
- Adaptive thinking sends output_config.effort alongside the thinking mode
- Max effort falls back to high on models that don't support it

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
