### PR TITLE
Handle empty avatar field, return original for !bg instead of 404

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7314,6 +7314,9 @@ async function read_avatar_load(input) {
  * @returns {string} The URL for the thumbnail
  */
 export function getThumbnailUrl(type, file, t = false) {
+    if (!file || file === 'none') {
+        return default_avatar;
+    }
     return `/thumbnail?type=${type}&file=${encodeURIComponent(file)}${t ? `&t=${Date.now()}` : ''}`;
 }
 

--- a/src/endpoints/thumbnails.js
+++ b/src/endpoints/thumbnails.js
@@ -290,7 +290,10 @@ publicRouter.get('/', async function (request, response) {
         }
 
         // Send a 404 so the frontend can display a placeholder
-        return response.sendStatus(404);
+        if (type === 'bg') {
+            return response.sendStatus(404);
+        }
+        return serveOriginal();
 
     } catch (error) {
         console.error('Failed getting thumbnail', error);


### PR DESCRIPTION
This PR makes two changes.

The bug report:
```
NotFoundError: Not Found
    at createHttpError (E:\SillyTavern\SillyTavern-Launcher\SillyTavern\node_modules\send\index.js:978:12)
    at SendStream.error (E:\SillyTavern\SillyTavern-Launcher\SillyTavern\node_modules\send\index.js:270:31)
    at SendStream.pipe (E:\SillyTavern\SillyTavern-Launcher\SillyTavern\node_modules\send\index.js:579:14)
    at sendfile (E:\SillyTavern\SillyTavern-Launcher\SillyTavern\node_modules\express\lib\response.js:1140:8)
    at ServerResponse.sendFile (E:\SillyTavern\SillyTavern-Launcher\SillyTavern\node_modules\express\lib\response.js:449:3)
    at file:///E:/SillyTavern/SillyTavern-Launcher/SillyTavern/src/endpoints/thumbnails.js:289:29
    at Layer.handle [as handle_request] (E:\SillyTavern\SillyTavern-Launcher\SillyTavern\node_modules\express\lib\router\layer.js:95:5)
    at next (E:\SillyTavern\SillyTavern-Launcher\SillyTavern\node_modules\express\lib\router\route.js:149:13)
    at Route.dispatch (E:\SillyTavern\SillyTavern-Launcher\SillyTavern\node_modules\express\lib\router\route.js:119:3)
    at Layer.handle [as handle_request] (E:\SillyTavern\SillyTavern-Launcher\SillyTavern\node_modules\express\lib\router\layer.js:95:5)
```
and later the 404 was on an empty filename, which meant the avatar field was falsy.
```
localhost/thumbnail?type=avatar&file=.png
```

This change means if the avatar field isn't valid, it returns the default placeholder.

Additionally, I realized sending a 404 for thumbnails when they don't exist only makes sense for backgrounds.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
