### PR TITLE
Implemented caching for inline media.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1831,6 +1831,13 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
             mes = mes.replace(/\ufffe/g, '"');
         }
 
+        // Intercept image links and route to local cache
+        mes = mes.replace(/!\[(.*?)\]\((.*?)\)/g, (match, alt, url) => {
+            // Encode the original URL to safely pass it as a query parameter
+            const encodedUrl = encodeURIComponent(url);
+            return `![${alt}](api/files/cached?url=${encodedUrl})`;
+        });
+
         mes = mes.replaceAll('\\begin{align*}', '$$');
         mes = mes.replaceAll('\\end{align*}', '$$');
         mes = converter.makeHtml(mes);

--- a/public/script.js
+++ b/public/script.js
@@ -1831,13 +1831,6 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
             mes = mes.replace(/\ufffe/g, '"');
         }
 
-        // Intercept image links and route to local cache
-        mes = mes.replace(/!\[(.*?)\]\((.*?)\)/g, (match, alt, url) => {
-            // Encode the original URL to safely pass it as a query parameter
-            const encodedUrl = encodeURIComponent(url);
-            return `![${alt}](api/files/cached?url=${encodedUrl})`;
-        });
-
         mes = mes.replaceAll('\\begin{align*}', '$$');
         mes = mes.replaceAll('\\end{align*}', '$$');
         mes = converter.makeHtml(mes);

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -1975,8 +1975,18 @@ export function addDOMPurifyHooks() {
         }
 
         const isMediaAllowed = isExternalMediaAllowed();
-        if (isMediaAllowed) {
-            return;
+
+        function handleURL(node, src, type = 'src') {
+            if (isMediaAllowed) {
+                // Intercept image links and route to local cache
+                const encodedUrl = encodeURIComponent(src);
+                // Encode the original URL to safely pass it as a query parameter
+                node.setAttribute(type, `api/files/cached?url=${encodedUrl}`);
+                return;
+            }
+            console.warn('External media blocked', src);
+            mediaBlocked = true;
+            node.remove();
         }
 
         if (!(node instanceof Element)) {
@@ -2005,6 +2015,7 @@ export function addDOMPurifyHooks() {
                         const [url] = srcsetUrl.trim().split(' ');
 
                         if (isExternalUrl(url)) {
+                            //TODO
                             console.warn('External media blocked', url);
                             node.remove();
                             mediaBlocked = true;
@@ -2014,15 +2025,11 @@ export function addDOMPurifyHooks() {
                 }
 
                 if (src && isExternalUrl(src)) {
-                    console.warn('External media blocked', src);
-                    mediaBlocked = true;
-                    node.remove();
+                    handleURL(node, src, 'src');
                 }
 
                 if (data && isExternalUrl(data)) {
-                    console.warn('External media blocked', data);
-                    mediaBlocked = true;
-                    node.remove();
+                    handleURL(node, data, 'data');
                 }
 
                 if (mediaBlocked && (node instanceof HTMLMediaElement)) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,6 +23,7 @@ export const USER_DIRECTORY_TEMPLATE = Object.freeze({
     user: 'user',
     avatars: 'User Avatars',
     userImages: 'user/images',
+    userCache: 'user/cache',
     groups: 'groups',
     groupChats: 'group chats',
     chats: 'chats',

--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -99,3 +99,56 @@ router.post('/verify', async (request, response) => {
         return response.sendStatus(500);
     }
 });
+
+router.get('/cached', async (request, response) => {
+    try {
+        const url = String(request.query.url);
+        if (!url) {
+            return response.status(400).send('No URL specified');
+        }
+
+        // Generates a unique cache file path based on the URL.
+        const cachePath = getCachePath(url, request.user.directories.userCache);
+
+        // Check if file is already cached
+        try {
+            await fs.promises.access(cachePath);
+        } catch {
+            // File not found: Fetch, Save, then proceed
+            const fetchResponse = await fetch(url);
+            if (!fetchResponse.ok) {
+                return response.status(fetchResponse.status).send('Failed to fetch remote resource');
+            }
+
+            const buffer = new Uint8Array(await fetchResponse.arrayBuffer());
+
+            // Ensure directory exists and save
+            await fs.promises.mkdir(path.dirname(cachePath), { recursive: true });
+            await fs.promises.writeFile(cachePath, buffer);
+
+            console.info(`Cached new media: ${cachePath} from ${request.user.profile.handle}`);
+        }
+
+        return response.sendFile(cachePath);
+    } catch (error) {
+        console.error(error);
+        return response.sendStatus(500);
+    }
+});
+
+/**
+ * Generates a unique cache file path based on the URL.
+ * Preserves the original file extension for correct MIME type handling.
+ */
+function getCachePath(url, cacheDir) {
+    const parsedUrl = new URL(url);
+
+    // Limit the maximum name length to 255 characters: https://en.wikipedia.org/wiki/Long_filename
+    const overflowLength = Math.max(parsedUrl.hostname.length - 255, 0);
+
+    // Remove protocol and join domain + truncated path.
+    const safeDir = sanitize(parsedUrl.hostname);
+    const safeName = sanitize(parsedUrl.pathname.slice(overflowLength));
+
+    return path.resolve(cacheDir, safeDir, safeName);
+}

--- a/src/users.js
+++ b/src/users.js
@@ -78,6 +78,7 @@ const STORAGE_KEYS = {
  * @property {string} user - The directory where the user's public data is stored
  * @property {string} avatars - The directory where the avatars are stored
  * @property {string} userImages - The directory where the images are stored
+ * @property {string} userCache - The directory where media is cached
  * @property {string} groups - The directory where the groups are stored
  * @property {string} groupChats - The directory where the group chats are stored
  * @property {string} chats - The directory where the chats are stored
@@ -1078,5 +1079,6 @@ router.use('/characters/*', createRouteHandler(req => req.user.directories.chara
 router.use('/User%20Avatars/*', createRouteHandler(req => req.user.directories.avatars));
 router.use('/assets/*', createRouteHandler(req => req.user.directories.assets));
 router.use('/user/images/*', createRouteHandler(req => req.user.directories.userImages));
+router.use('/user/cache/*', createRouteHandler(req => req.user.directories.userCache));
 router.use('/user/files/*', createRouteHandler(req => req.user.directories.files));
 router.use('/scripts/extensions/third-party/*', createExtensionsRouteHandler(req => req.user.directories.extensions));


### PR DESCRIPTION
PR for https://github.com/SillyTavern/SillyTavern/issues/5112

This caches media to `user/cache/MediaHostname/MediaPath`.

This approach uses the server as a proxy, If I had used the existing `api/file/upload` endpoint then latency would be have been increased.
The client would have had to query `user/images/char/img.png`, wait for a `404`, download the image, then upload it to the server.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
