### PR TITLE
Macros 2.0 - Optional scoped content + improved closing-tag autocomplete

### DIFF
--- a/public/css/macros.css
+++ b/public/css/macros.css
@@ -507,6 +507,28 @@
     border-radius: 3px;
 }
 
+/* OPTIONAL badge for optional scoped content */
+.macro-ac-optional-badge {
+    display: inline-block;
+    background: linear-gradient(135deg, #f0ad4e, #ec971f);
+    color: #000;
+    font-weight: bold;
+    font-size: 0.75em;
+    padding: 0.15em 0.5em;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+/* Smaller variant for use in autocomplete list items */
+.macro-ac-optional-badge-small {
+    font-size: 0.65em;
+    padding: 0.1em 0.35em;
+    vertical-align: middle;
+    color: #f0ad4e;
+}
+
 /* Closing tag autocomplete option */
 .autoComplete > .item.macro-closing-tag-item > .type {
     color: var(--ac-color-matchedText, var(--SmartThemeBorderColor));

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -1166,6 +1166,10 @@ export class MacroClosingTagAutoCompleteOption extends AutoCompleteOption {
         // Make selectable so TAB completion works (valueProvider alone makes it non-selectable)
         this.makeSelectable = true;
 
+        // nameOffset = 2 to skip the {{ prefix in the display for fuzzy highlighting
+        // The name is /macroName but display shows {{/macroName}}
+        this.nameOffset = 2;
+
         // Highest priority - closing tags should always appear at the very top
         this.sortPriority = 1;
     }

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -36,6 +36,7 @@ import { onboardingExperimentalMacroEngine } from '../macros/engine/MacroDiagnos
  * @property {boolean} hasSpaceArgContent - Whether there's actual content after the space (not just whitespace).
  * @property {number} separatorCount - Number of '::' separators found.
  * @property {boolean} [isInScopedContent] - Whether cursor is in scoped content (after }} but before closing tag).
+ * @property {boolean} [isScopedContentOptional] - Whether the scoped content is optional (for display purposes).
  * @property {string} [scopedMacroName] - Name of the scoped macro if in scoped content.
  * @property {boolean} isVariableShorthand - Whether this is a variable shorthand (starts with . or $).
  * @property {'.'|'$'|null} variablePrefix - The variable prefix (. for local, $ for global), or null.
@@ -307,12 +308,23 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
         const info = document.createElement('div');
         info.classList.add('macro-ac-scoped-info');
 
+        // If the scoped content is optional, show a prominent OPTIONAL badge
+        if (this.#context.isScopedContentOptional) {
+            const optionalBadge = document.createElement('span');
+            optionalBadge.classList.add('macro-ac-optional-badge');
+            optionalBadge.textContent = 'OPTIONAL';
+            info.append(optionalBadge);
+        }
+
         const icon = document.createElement('i');
         icon.classList.add('fa-solid', 'fa-layer-group');
         info.append(icon);
 
         const text = document.createElement('span');
-        text.innerHTML = `Typing <strong>scoped content</strong> for <code>{{${this.#context.scopedMacroName}}}</code>. Close with <code>{{/${this.#context.scopedMacroName}}}</code>`;
+        const closingHint = this.#context.isScopedContentOptional
+            ? `Can optionally close with <code>{{/${this.#context.scopedMacroName}}}</code>`
+            : `Close with <code>{{/${this.#context.scopedMacroName}}}</code>`;
+        text.innerHTML = `Typing <strong>scoped content</strong> for <code>{{${this.#context.scopedMacroName}}}</code>. ${closingHint}`;
         info.append(text);
 
         return info;
@@ -1113,12 +1125,20 @@ export class MacroClosingTagAutoCompleteOption extends AutoCompleteOption {
     /** @type {string} */
     #paddingAfter;
 
+    /** @type {boolean} */
+    #isOptional;
+
+    /** @type {number} */
+    #nestingLevel;
+
     /**
      * @param {string} macroName - The name of the macro to close.
      * @param {Object} [options] - Optional configuration.
      * @param {string} [options.paddingBefore=''] - Whitespace after {{ in opening tag (target padding).
      * @param {string} [options.paddingAfter=''] - Whitespace before }} in opening tag (target padding).
      * @param {string} [options.currentPadding=''] - Whitespace the user has already typed after {{.
+     * @param {boolean} [options.isOptional=false] - Whether this closing tag is for an optional scope.
+     * @param {number} [options.nestingLevel=0] - Nesting level (0 = innermost).
      */
     constructor(macroName, options = {}) {
         // The closing tag is what we're suggesting - use /macroName as the name for matching
@@ -1127,6 +1147,8 @@ export class MacroClosingTagAutoCompleteOption extends AutoCompleteOption {
         this.#macroName = macroName;
         this.#paddingBefore = options.paddingBefore ?? '';
         this.#paddingAfter = options.paddingAfter ?? '';
+        this.#isOptional = options.isOptional ?? false;
+        this.#nestingLevel = options.nestingLevel ?? 0;
 
         // Calculate the replacement offset to replace any existing whitespace the user typed
         // This allows us to normalize the whitespace to match the opening tag's style
@@ -1195,7 +1217,21 @@ export class MacroClosingTagAutoCompleteOption extends AutoCompleteOption {
         help.classList.add('help');
         const content = document.createElement('span');
         content.classList.add('helpContent');
-        content.textContent = `Close the {{${this.#macroName}}} scoped macro.`;
+
+        // Build description based on optional status and nesting
+        if (this.#isOptional) {
+            const optionalBadge = document.createElement('span');
+            optionalBadge.classList.add('macro-ac-optional-badge', 'macro-ac-optional-badge-small');
+            optionalBadge.textContent = 'OPTIONAL';
+            content.append(optionalBadge);
+            content.append(' ');
+
+            const nestingInfo = this.#nestingLevel > 0 ? ` (nested ${this.#nestingLevel} level${this.#nestingLevel > 1 ? 's' : ''} deep)` : '';
+            content.append(document.createTextNode(`Optionally close {{${this.#macroName}}}${nestingInfo}`));
+        } else {
+            content.textContent = `Close the {{${this.#macroName}}} scoped macro.`;
+        }
+
         help.append(content);
         li.append(help);
 
@@ -1212,6 +1248,14 @@ export class MacroClosingTagAutoCompleteOption extends AutoCompleteOption {
         const details = document.createElement('div');
         details.classList.add('macro-closing-tag-details');
 
+        // If optional, show badge at the top
+        if (this.#isOptional) {
+            const optionalBadge = document.createElement('span');
+            optionalBadge.classList.add('macro-ac-optional-badge');
+            optionalBadge.textContent = 'OPTIONAL';
+            details.append(optionalBadge);
+        }
+
         // Header
         const header = document.createElement('h3');
         header.innerHTML = `Close <code>{{${this.#macroName}}}</code>`;
@@ -1219,7 +1263,12 @@ export class MacroClosingTagAutoCompleteOption extends AutoCompleteOption {
 
         // Description
         const desc = document.createElement('p');
-        desc.textContent = `Inserts the closing tag {{/${this.#macroName}}} to complete the scoped macro. The content between the opening and closing tags will be passed as the last argument.`;
+        if (this.#isOptional) {
+            const nestingInfo = this.#nestingLevel > 0 ? ` This scope is nested ${this.#nestingLevel} level${this.#nestingLevel > 1 ? 's' : ''} deep.` : '';
+            desc.textContent = `Optionally inserts the closing tag {{/${this.#macroName}}}. The scoped content for this macro is optional - you can close it or leave it open.${nestingInfo}`;
+        } else {
+            desc.textContent = `Inserts the closing tag {{/${this.#macroName}}} to complete the scoped macro. The content between the opening and closing tags will be passed as the last argument.`;
+        }
         details.append(desc);
 
         frag.append(details);

--- a/public/scripts/autocomplete/MacroAutoComplete.js
+++ b/public/scripts/autocomplete/MacroAutoComplete.js
@@ -120,7 +120,7 @@ export function setMacroAutoComplete(textarea, { autocompleteMode = MACRO_AUTOCO
     const ac = new AutoComplete(
         textarea,
         () => shouldActivateMacroAutocomplete(ac.text, textarea.selectionStart, { isForced: ac.isShowForced, autocompleteMode }),
-        (text, index) => getMacroAutoCompleteAt(text, index),
+        (text, index) => getMacroAutoCompleteAt(text, index, { isForced: ac.isShowForced }),
         true, // isFloating - always use floating mode for free text macro autocomplete
     );
 

--- a/public/scripts/autocomplete/MacroAutoCompleteHelper.js
+++ b/public/scripts/autocomplete/MacroAutoCompleteHelper.js
@@ -621,20 +621,48 @@ export function buildEnhancedMacroOptions(context, textUpToCursor, { isForced = 
         }
     }
 
-    // If typing args/closing brace but no macro matches, add a "no match" indicator
+    // If typing args/closing brace but no macro matches, check for closing macro context
     if (shouldShowMatchingMacroDetails && !hasMatchingMacro && context.identifier.length > 0) {
-        const noMatchOption = new SimpleAutoCompleteOption({
-            name: context.identifier,
-            symbol: '❌',
-            description: `No macro found: "${context.identifier}"`,
-            detailedDescription: `The macro name <code>${context.identifier}</code> does not exist.<br><br>Check spelling or use a different macro name.`,
-            type: 'error',
-        });
-        noMatchOption.valueProvider = () => '';
-        noMatchOption.makeSelectable = false;
-        noMatchOption.matchProvider = () => true; // Always show
-        noMatchOption.sortPriority = 0; // Top priority
-        options.unshift(noMatchOption);
+        // Check if this is a closing macro (starts with /) - show original macro's details
+        // Note: We look up the macro directly, not from unclosedScopes, because the closing tag
+        // itself may have already closed the scope by this point in the text
+        const isClosingMacro = context.identifier.startsWith('/');
+        const closingMacroName = isClosingMacro ? context.identifier.slice(1) : null;
+        const macroDef = closingMacroName ? macroSystem.registry.getPrimaryMacro(closingMacroName) : null;
+
+        if (macroDef) {
+            // Show the original macro's details for the closing tag
+            // Create a context that shows we're closing the scope (no argument highlight)
+            const closingContext = /** @type {MacroAutoCompleteContext} */ ({
+                ...context,
+                identifier: macroDef.name,
+                currentArgIndex: -1, // No argument highlight
+                isClosingTag: true,
+            });
+            const closingOption = new EnhancedMacroAutoCompleteOption(macroDef, closingContext);
+            closingOption.valueProvider = () => '';
+            closingOption.makeSelectable = false;
+            closingOption.matchProvider = () => true;
+            closingOption.sortPriority = 0;
+            options.unshift(closingOption);
+            hasMatchingMacro = true; // Prevent "no match" message
+        }
+
+        // Only show "no match" if we didn't find a matching closing scope
+        if (!hasMatchingMacro) {
+            const noMatchOption = new SimpleAutoCompleteOption({
+                name: context.identifier,
+                symbol: '❌',
+                description: `No macro found: "${context.identifier}"`,
+                detailedDescription: `The macro name <code>${context.identifier}</code> does not exist.<br><br>Check spelling or use a different macro name.`,
+                type: 'error',
+            });
+            noMatchOption.valueProvider = () => '';
+            noMatchOption.makeSelectable = false;
+            noMatchOption.matchProvider = () => true; // Always show
+            noMatchOption.sortPriority = 0; // Top priority
+            options.unshift(noMatchOption);
+        }
     }
 
     return options;
@@ -985,6 +1013,33 @@ export async function buildMacroAutoCompleteResult(text, cursorPos, {
                 }
             }
         }
+
+        // Check if this is a closing tag ({{/macroName}}) - show original macro's details
+        // Note: We look up the macro directly, not from unclosedScopes, because the closing tag
+        // itself has already closed the scope by this point in the text
+        if (context.identifier.startsWith('/')) {
+            const closingMacroName = context.identifier.slice(1);
+            const macroDef = macroSystem.registry.getPrimaryMacro(closingMacroName);
+            if (macroDef) {
+                const closingContext = /** @type {MacroAutoCompleteContext} */ ({
+                    ...context,
+                    identifier: macroDef.name,
+                    currentArgIndex: -1, // No argument highlight
+                    isClosingTag: true,
+                });
+                const closingOption = new EnhancedMacroAutoCompleteOption(macroDef, closingContext);
+                closingOption.valueProvider = () => '';
+                closingOption.makeSelectable = false;
+
+                return new AutoCompleteNameResult(
+                    macroDef.name,
+                    macro.start + 2,
+                    [closingOption],
+                    false,
+                );
+            }
+        }
+
         // Not a scoped macro, just clear arg highlighting
         context.currentArgIndex = -1;
     }

--- a/public/scripts/autocomplete/MacroAutoCompleteHelper.js
+++ b/public/scripts/autocomplete/MacroAutoCompleteHelper.js
@@ -55,6 +55,7 @@ import { extension_settings } from '../extensions.js';
  * @property {MacroInfo|null} [macro=null] - Macro info if cursor is inside a macro
  * @property {string|null} [textUpToCursor=null] - Pre-computed text up to cursor
  * @property {UnclosedScope[]|null} [unclosedScopes=null] - Pre-computed unclosed scopes
+ * @property {boolean} [isForced=false] - Whether autocomplete was force-triggered (Ctrl+Space)
  */
 
 /** @typedef {(EnhancedMacroAutoCompleteOption|MacroFlagAutoCompleteOption|MacroClosingTagAutoCompleteOption|VariableShorthandAutoCompleteOption|VariableNameAutoCompleteOption|VariableOperatorAutoCompleteOption|VariableValueContextAutoCompleteOption|SimpleAutoCompleteOption)} AnyMacroAutoCompleteOption */
@@ -102,9 +103,12 @@ export function findUnclosedScopesRegex(text) {
         const name = match[3];
 
         if (isClosing) {
-            // Pop matching opener (case-insensitive)
-            if (stack.length > 0 && stack[stack.length - 1].name.toLowerCase() === name.toLowerCase()) {
-                stack.pop();
+            // Find matching opener in stack (case-insensitive)
+            // When closing an outer scope, all inner unclosed scopes are implicitly closed
+            const matchIndex = stack.findLastIndex(s => s.name.toLowerCase() === name.toLowerCase());
+            if (matchIndex !== -1) {
+                // Pop everything from matchIndex to end (inclusive) - closes the matched scope and all nested ones
+                stack.splice(matchIndex);
             }
         } else {
             // Check if macro can accept scoped content
@@ -130,6 +134,70 @@ export function findUnclosedScopesRegex(text) {
     }
 
     return stack;
+}
+
+/**
+ * Checks if a scoped macro's scope content is optional (i.e., all required args are already filled).
+ * Used to determine whether to show the scope hint by default or only when forced.
+ *
+ * @param {UnclosedScope} scope - The unclosed scope info.
+ * @param {string} textUpToCursor - The text up to cursor to parse the macro content.
+ * @returns {boolean} - True if the scope content is optional.
+ */
+function isScopeOptional(scope, textUpToCursor) {
+    const def = macroSystem.registry.getPrimaryMacro(scope.name);
+    if (!def) {
+        // Unknown macro - treat scope as required (show hint)
+        return false;
+    }
+
+    // Find the macro's closing }} to extract its content
+    const openingEnd = textUpToCursor.indexOf('}}', scope.startOffset);
+    if (openingEnd === -1) {
+        // Macro not closed yet - can't determine
+        return false;
+    }
+
+    // Extract content between {{ and }} to count arguments
+    const macroContent = textUpToCursor.slice(scope.startOffset + 2, openingEnd);
+    const context = parseMacroContext(macroContent, macroContent.length);
+
+    // Count current arguments (including space-separated arg if present)
+    const currentArgCount = context.args.length;
+
+    // The scoped content would be the next argument (currentArgCount + 1)
+    // Scope is optional if:
+    // 1. Current args already meet minArgs requirement, AND
+    // 2. Adding one more (scope) would still be <= maxArgs
+    const wouldBeArgIndex = currentArgCount; // 0-indexed
+    const scopeIsOptional = currentArgCount >= def.minArgs && wouldBeArgIndex < def.maxArgs;
+
+    // Check if the argument at wouldBeArgIndex is marked as optional in the definition
+    if (def.unnamedArgDefs && def.unnamedArgDefs[wouldBeArgIndex]) {
+        return def.unnamedArgDefs[wouldBeArgIndex].optional === true;
+    }
+
+    // If no explicit arg definition, use the min/max args logic
+    return scopeIsOptional;
+}
+
+/**
+ * Filters unclosed scopes to exclude those with optional scope content.
+ * Used when autocomplete is not force-triggered (Ctrl+Space).
+ *
+ * @param {UnclosedScope[]} unclosedScopes - The unclosed scopes to filter.
+ * @param {string} textUpToCursor - The text up to cursor.
+ * @param {boolean} isForced - Whether autocomplete was force-triggered.
+ * @returns {UnclosedScope[]} - Filtered scopes (excludes optional scopes unless forced).
+ */
+function filterOptionalScopes(unclosedScopes, textUpToCursor, isForced) {
+    if (isForced) {
+        // When forced, show all scopes including optional ones
+        return unclosedScopes;
+    }
+
+    // Filter out scopes where the scope content is optional
+    return unclosedScopes.filter(scope => !isScopeOptional(scope, textUpToCursor));
 }
 
 /**
@@ -385,9 +453,11 @@ export function buildVariableShorthandOptions(context, opts = {}) {
  * When typing arguments (after ::), prioritizes the exact macro match.
  * @param {MacroAutoCompleteContext} context
  * @param {string} [textUpToCursor] - Full document text up to cursor, for unclosed scope detection.
+ * @param {Object} [opts] - Additional options.
+ * @param {boolean} [opts.isForced=false] - Whether autocomplete was force-triggered (Ctrl+Space).
  * @returns {AnyMacroAutoCompleteOption[]}
  */
-export function buildEnhancedMacroOptions(context, textUpToCursor) {
+export function buildEnhancedMacroOptions(context, textUpToCursor, { isForced = false } = {}) {
     /** @type {AnyMacroAutoCompleteOption[]} */
     const options = [];
 
@@ -395,26 +465,53 @@ export function buildEnhancedMacroOptions(context, textUpToCursor) {
         return buildVariableShorthandOptions(context);
     }
 
-    // Check for unclosed scoped macros and suggest closing tags first
+    // Check for unclosed scoped macros and suggest closing tags
+    // Iterate from innermost to outermost, adding optional scopes and stopping at first required scope
     const unclosedScopes = findUnclosedScopes(textUpToCursor);
     if (unclosedScopes.length > 0) {
-        // Suggest closing the innermost (last) unclosed scope first
-        const innermostScope = unclosedScopes[unclosedScopes.length - 1];
-        // Preserve whitespace padding from the opening tag
-        // Pass currentPadding so the closing tag can replace user-typed whitespace with the target padding
-        const closingOption = new MacroClosingTagAutoCompleteOption(innermostScope.name, {
-            paddingBefore: innermostScope.paddingBefore,
-            paddingAfter: innermostScope.paddingAfter,
-            currentPadding: context.paddingBefore,
-        });
-        options.push(closingOption);
+        let firstRequiredPriority = 1; // Priority for the first required (non-optional) scope
+        let optionalPriority = 3; // Lower priority for optional scopes
+        let foundRequired = false;
+        let elseOptionAdded = false;
 
-        // If inside a scoped {{if}}, also suggest {{else}}
-        if (innermostScope.name === 'if') {
-            const macroDef = macroSystem.registry.getPrimaryMacro('else');
-            const elseOption = new EnhancedMacroAutoCompleteOption(macroDef);
-            elseOption.sortPriority = 2;
-            options.push(elseOption);
+        // Iterate from innermost (last) to outermost (first)
+        for (let i = unclosedScopes.length - 1; i >= 0; i--) {
+            const scope = unclosedScopes[i];
+            const isOptional = isScopeOptional(scope, textUpToCursor);
+            const nestingLevel = unclosedScopes.length - 1 - i; // 0 = innermost
+
+            // If we've already found a required scope, stop adding more
+            if (foundRequired && !isOptional) break;
+
+            const closingOption = new MacroClosingTagAutoCompleteOption(scope.name, {
+                paddingBefore: scope.paddingBefore,
+                paddingAfter: scope.paddingAfter,
+                currentPadding: context.paddingBefore,
+                isOptional: isOptional,
+                nestingLevel: nestingLevel,
+            });
+
+            if (isOptional) {
+                closingOption.sortPriority = optionalPriority++;
+            } else {
+                // First required scope gets top priority
+                closingOption.sortPriority = firstRequiredPriority;
+                foundRequired = true;
+            }
+
+            options.push(closingOption);
+
+            // If inside a scoped {{if}}, also suggest {{else}} (only once, for innermost if)
+            if (!elseOptionAdded && scope.name === 'if') {
+                const macroDef = macroSystem.registry.getPrimaryMacro('else');
+                const elseOption = new EnhancedMacroAutoCompleteOption(macroDef);
+                elseOption.sortPriority = 2;
+                options.push(elseOption);
+                elseOptionAdded = true;
+            }
+
+            // Stop once we've added a required scope
+            if (foundRequired) break;
         }
     }
 
@@ -788,6 +885,7 @@ export async function buildMacroAutoCompleteResult(text, cursorPos, {
     macro = null,
     textUpToCursor = null,
     unclosedScopes = null,
+    isForced = false,
 } = {}) {
     // Compute textUpToCursor if not provided
     if (textUpToCursor === null) {
@@ -799,10 +897,14 @@ export async function buildMacroAutoCompleteResult(text, cursorPos, {
         unclosedScopes = findUnclosedScopes(textUpToCursor);
     }
 
+    // Filter out optional scopes unless forced (Ctrl+Space)
+    // This prevents intrusive hints for macros like {{trim}} where scope is optional
+    const filteredScopes = filterOptionalScopes(unclosedScopes, textUpToCursor, isForced);
+
     // If cursor is NOT inside a macro, check if we're in scoped content
     if (!macro) {
-        if (unclosedScopes.length > 0) {
-            const scopedMacro = unclosedScopes[unclosedScopes.length - 1];
+        if (filteredScopes.length > 0) {
+            const scopedMacro = filteredScopes[filteredScopes.length - 1];
 
             // Find where the opening macro ends
             const openingEnd = text.indexOf('}}', scopedMacro.startOffset);
@@ -811,10 +913,14 @@ export async function buildMacroAutoCompleteResult(text, cursorPos, {
                 const macroContent = text.slice(scopedMacro.startOffset + 2, openingEnd);
                 const baseContext = parseMacroContext(macroContent, macroContent.length);
 
+                // Check if this scope is optional (for display purposes)
+                const scopeIsOptional = isScopeOptional(scopedMacro, textUpToCursor);
+
                 const scopedContext = {
                     ...baseContext,
                     currentArgIndex: baseContext.args.length,
                     isInScopedContent: true,
+                    isScopedContentOptional: scopeIsOptional,
                     scopedMacroName: scopedMacro.name,
                 };
 
@@ -848,15 +954,19 @@ export async function buildMacroAutoCompleteResult(text, cursorPos, {
 
     if (isCursorAtClosing) {
         // Cursor is at the closing }} - check if this is an unclosed scoped macro
-        if (unclosedScopes.length > 0) {
-            const scopedMacro = unclosedScopes[unclosedScopes.length - 1];
+        if (filteredScopes.length > 0) {
+            const scopedMacro = filteredScopes[filteredScopes.length - 1];
             // Check if the current macro IS the unclosed scoped macro
             if (scopedMacro.startOffset === macro.start) {
                 // Show scoped context - cursor is right at the end of the opening tag
+                // Check if this scope is optional (for display purposes)
+                const scopeIsOptional = isScopeOptional(scopedMacro, textUpToCursor);
+
                 const scopedContext = {
                     ...context,
                     currentArgIndex: context.args.length,
                     isInScopedContent: true,
+                    isScopedContentOptional: scopeIsOptional,
                     scopedMacroName: scopedMacro.name,
                 };
 
@@ -1041,9 +1151,11 @@ export async function buildMacroAutoCompleteResult(text, cursorPos, {
  *
  * @param {string} text - The full text content.
  * @param {number} cursorPos - The cursor position.
+ * @param {Object} [options={}] - Additional options.
+ * @param {boolean} [options.isForced=false] - Whether autocomplete was force-triggered (Ctrl+Space).
  * @returns {Promise<AutoCompleteNameResult|null>}
  */
-export async function getMacroAutoCompleteAt(text, cursorPos) {
+export async function getMacroAutoCompleteAt(text, cursorPos, { isForced = false } = {}) {
     const macro = findMacroAtCursor(text, cursorPos);
-    return buildMacroAutoCompleteResult(text, cursorPos, { macro });
+    return buildMacroAutoCompleteResult(text, cursorPos, { macro, isForced });
 }

--- a/public/scripts/macros/engine/MacroCstWalker.js
+++ b/public/scripts/macros/engine/MacroCstWalker.js
@@ -231,9 +231,12 @@ class MacroCstWalker {
             if (!info) continue;
 
             if (info.isClosing) {
-                // Closing tag - pop matching opener from stack (case-insensitive match)
-                if (unclosedStack.length > 0 && unclosedStack[unclosedStack.length - 1].name.toLowerCase() === info.name.toLowerCase()) {
-                    unclosedStack.pop();
+                // Find matching opener in stack (case-insensitive)
+                // When closing an outer scope, all inner unclosed scopes are implicitly closed
+                const matchIndex = unclosedStack.findLastIndex(s => s.name.toLowerCase() === info.name.toLowerCase());
+                if (matchIndex !== -1) {
+                    // Pop everything from matchIndex to end (inclusive) - closes the matched scope and all nested ones
+                    unclosedStack.splice(matchIndex);
                 }
                 // If no matching opener, ignore (orphan closing tag)
             } else {


### PR DESCRIPTION
This PR improves the Macros 2.0 autocomplete UX for **scoped macros**, with a focus on making closing-tag completion clearer and reducing noise when the scoped content is optional.

## Why
As Macros 2.0 prompts get more complex (especially with nested scoped macros), autocomplete can become “technically correct but annoying”:
- Optional scoped content currently looks the same as required scope, which adds visual noise and makes it unclear whether you *must* close a scope.
- When multiple scopes are nested, closing-tag completion benefits from better prioritization and clearer context.
- While typing `{{/macroName}}`, autocomplete can lose useful context and appear like a “no match” situation even though the macro itself is known.

## What changed (user-facing)
- **Optional scope detection:** Autocomplete can now identify when scoped content is optional (based on macro argument requirements) and surface that intent in the UI.
- **Less noise by default:** Optional scope hints are filtered out unless the user force-triggers autocomplete (Ctrl+Space).
- **Clear UI cues:** Optional scopes are labeled with an **OPTIONAL** badge (both in scoped-content info and relevant autocomplete items).
- **Better closing-tag suggestions for nested scopes:** Multiple closing-tag options can be shown (innermost → outermost), with nesting level context to reduce “which one am I closing?” ambiguity.
- **Better context when typing closing tags:** When entering `{{/…}}`, autocomplete shows the original macro’s details as context instead of behaving like an empty/failed match.

## What changed (macro engine runtime)
- **Treatment of unclosed scoped macros**: New execution logic of the CST macro walker treats unclosed scoped macros (both optional ones, that is okay, and non-optional ones that mean invalid syntax) as unclosed and ignores them, if a more outer-ish scope is closed, and then ignores them for any future scoped macro logic. This fixes any potential weird logic of matching closed macros in a cross-way instead of inner to outer.

**Impact:** This can change runtime behavior in edge cases involving scoped/block macros (especially ambiguous or partially-specified closes), by making scope resolution follow the CST-derived structure more consistently.

## How to test
- In any prompt field with macro autocomplete enabled:
  1. Type a scoped macro where the scope is optional and confirm optional hints are hidden by default, but appear with Ctrl+Space (and show the OPTIONAL badge).
  2. Create nested scoped macros and type `{{/` — confirm multiple closing tags are suggested in sensible order (inner first) with nesting info.
  3. Type `{{/macroName}}` for an existing macro and confirm autocomplete shows macro details/context instead of a “no match”-style experience.

## Notes
- This is an autocomplete/UI change; macro evaluation behavior is not the focus here.
- Includes small styling additions to support the OPTIONAL badge.

## Copilot Summary
This pull request enhances the macro autocomplete experience by adding support for optional scoped content in macros. It introduces logic to detect when a macro's scoped content is optional (based on macro definitions and argument counts), and updates the autocomplete UI to visually indicate optional scopes, reducing intrusive suggestions for optional content. The changes also improve the accuracy and clarity of closing tag suggestions and related UI elements.

**Macro autocomplete improvements:**

* Added logic to determine if a macro's scoped content is optional by analyzing macro definitions and argument counts, and to filter out optional scopes from autocomplete suggestions unless autocomplete is force-triggered (Ctrl+Space). This prevents unnecessary hints for macros where the scope is not required. [[1]](diffhunk://#diff-13f786d89098744e562b03280adf48a12b7a4d0633c1930f9577255fa58b06faR139-R202) [[2]](diffhunk://#diff-13f786d89098744e562b03280adf48a12b7a4d0633c1930f9577255fa58b06faR456-R514) [[3]](diffhunk://#diff-13f786d89098744e562b03280adf48a12b7a4d0633c1930f9577255fa58b06faR916) [[4]](diffhunk://#diff-13f786d89098744e562b03280adf48a12b7a4d0633c1930f9577255fa58b06faR928-R935)
* Updated the context and autocomplete option builders to propagate and utilize the `isScopedContentOptional` and `isForced` properties, ensuring that optional scopes are handled correctly throughout the autocomplete pipeline. [[1]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR39) [[2]](diffhunk://#diff-13f786d89098744e562b03280adf48a12b7a4d0633c1930f9577255fa58b06faR58) [[3]](diffhunk://#diff-f5c8d2d4dc9b2207f5b9d7c91cfda19f31d81bcebfda98e4878649d52769a9f9L123-R123) [[4]](diffhunk://#diff-13f786d89098744e562b03280adf48a12b7a4d0633c1930f9577255fa58b06faR916)

**User interface enhancements:**

* Added prominent "OPTIONAL" badges (with both regular and small variants) to the autocomplete UI for optional scoped content and closing tag suggestions, improving clarity for users. [[1]](diffhunk://#diff-1f59cf9d34ea2d41b9a090d3a54c385023903eb1339b1378f35af163a84d4977R510-R531) [[2]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR311-R327) [[3]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1224-R1238) [[4]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1255-R1275)
* Enhanced the description and details for closing tag suggestions to clearly indicate when the scope is optional, including nesting information where relevant. [[1]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1128-R1141) [[2]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1150-R1151) [[3]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1169-R1172) [[4]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1224-R1238) [[5]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR1255-R1275)

**Autocomplete logic and bug fixes:**

* Improved the logic for handling unclosed macro scopes: when closing an outer scope, all nested unclosed scopes are now properly closed, fixing edge cases in scope detection.
* Enhanced the handling and display of macro closing tag suggestions, including correct priority ordering and context-sensitive display of `{{else}}` for `{{if}}` macros. [[1]](diffhunk://#diff-13f786d89098744e562b03280adf48a12b7a4d0633c1930f9577255fa58b06faR456-R514) [[2]](diffhunk://#diff-13f786d89098744e562b03280adf48a12b7a4d0633c1930f9577255fa58b06faL527-R652)

These changes collectively make macro autocomplete more intelligent, less intrusive, and more informative for users working with macros that have optional scoped content.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://youtu.be/e-GwojpaoQI?si=RJ5H2brolPe0Uv-9).
