### PR TITLE
feat(server): make CORS middleware configurable

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -89,7 +89,7 @@ cors:
   # Allow credentials (cookies, authorization headers)
   credentials: false
   # Preflight cache max age in seconds (optional)
-  maxAge: 0
+  maxAge: null
 # -- REQUEST PROXY CONFIGURATION --
 requestProxy:
   # If a proxy is enabled, all outgoing HTTP/HTTPS requests will be routed through it.

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -71,6 +71,25 @@ basicAuthUser:
   password: "password"
 # Enables CORS proxy middleware
 enableCorsProxy: false
+# CORS settings (applied to all routes)
+cors:
+  # Enable or disable CORS middleware
+  enabled: true
+  # Allowed origins. Use "null" to match the default browser file origin.
+  # You can set "*" to allow any origin, or a list of allowed origins.
+  origin:
+    - "null"
+  # Allowed methods
+  methods:
+    - "OPTIONS"
+  # Allowed request headers (optional)
+  allowedHeaders: []
+  # Exposed response headers (optional)
+  exposedHeaders: []
+  # Allow credentials (cookies, authorization headers)
+  credentials: false
+  # Preflight cache max age in seconds (optional)
+  maxAge: 0
 # -- REQUEST PROXY CONFIGURATION --
 requestProxy:
   # If a proxy is enabled, all outgoing HTTP/HTTPS requests will be routed through it.

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -103,12 +103,31 @@ app.use(bodyParser.json({ limit: '500mb' }));
 app.use(bodyParser.urlencoded({ extended: true, limit: '500mb' }));
 
 // CORS Settings //
-const CORS = cors({
-    origin: 'null',
-    methods: ['OPTIONS'],
-});
+const corsEnabled = getConfigValue('cors.enabled', true, 'boolean');
+if (corsEnabled) {
+    const corsOrigin = getConfigValue('cors.origin', 'null');
+    const corsMethods = getConfigValue('cors.methods', ['OPTIONS']);
+    const corsAllowedHeaders = getConfigValue('cors.allowedHeaders', null);
+    const corsExposedHeaders = getConfigValue('cors.exposedHeaders', null);
+    const corsCredentials = getConfigValue('cors.credentials', false, 'boolean');
+    const corsMaxAge = getConfigValue('cors.maxAge', null, 'number');
 
-app.use(CORS);
+    const corsOptions = {
+        origin: corsOrigin,
+        methods: corsMethods,
+        credentials: corsCredentials,
+    };
+    if (corsAllowedHeaders && (Array.isArray(corsAllowedHeaders) ? corsAllowedHeaders.length > 0 : true)) {
+        corsOptions.allowedHeaders = corsAllowedHeaders;
+    }
+    if (corsExposedHeaders && (Array.isArray(corsExposedHeaders) ? corsExposedHeaders.length > 0 : true)) {
+        corsOptions.exposedHeaders = corsExposedHeaders;
+    }
+    if (corsMaxAge !== null) {
+        corsOptions.maxAge = corsMaxAge;
+    }
+    app.use(cors(corsOptions));
+}
 
 if (cliArgs.listen && cliArgs.basicAuthMode) {
     app.use(basicAuthMiddleware);

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -110,14 +110,14 @@ if (corsEnabled) {
     const corsAllowedHeaders = getConfigValue('cors.allowedHeaders', null);
     const corsExposedHeaders = getConfigValue('cors.exposedHeaders', null);
     const corsCredentials = getConfigValue('cors.credentials', false, 'boolean');
-    const corsMaxAge = getConfigValue('cors.maxAge', null, 'number');
+    const corsMaxAge = getConfigValue('cors.maxAge', 0, 'number');
 
     const corsOptions = {
         origin: corsOrigin,
         methods: corsMethods,
         credentials: corsCredentials,
     };
-    if (corsAllowedHeaders && (Array.isArray(corsAllowedHeaders) ? corsAllowedHeaders.length > 0 : true)) {
+    if (Array.isArray(corsAllowedHeaders) ? corsAllowedHeaders.length > 0 : true) {
         corsOptions.allowedHeaders = corsAllowedHeaders;
     }
     if (corsExposedHeaders && (Array.isArray(corsExposedHeaders) ? corsExposedHeaders.length > 0 : true)) {

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -120,7 +120,7 @@ if (corsEnabled) {
     if (Array.isArray(corsAllowedHeaders) ? corsAllowedHeaders.length > 0 : true) {
         corsOptions.allowedHeaders = corsAllowedHeaders;
     }
-    if (corsExposedHeaders && (Array.isArray(corsExposedHeaders) ? corsExposedHeaders.length > 0 : true)) {
+    if (Array.isArray(corsExposedHeaders) ? corsExposedHeaders.length > 0 : true) {
         corsOptions.exposedHeaders = corsExposedHeaders;
     }
     if (corsMaxAge !== null) {

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -110,7 +110,7 @@ if (corsEnabled) {
     const corsAllowedHeaders = getConfigValue('cors.allowedHeaders', null);
     const corsExposedHeaders = getConfigValue('cors.exposedHeaders', null);
     const corsCredentials = getConfigValue('cors.credentials', false, 'boolean');
-    const corsMaxAge = getConfigValue('cors.maxAge', 0, 'number');
+    const corsMaxAge = getConfigValue('cors.maxAge', null, 'number');
 
     /** @type {cors.CorsOptions} */
     const corsOptions = {

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -107,8 +107,8 @@ const corsEnabled = getConfigValue('cors.enabled', true, 'boolean');
 if (corsEnabled) {
     const corsOrigin = getConfigValue('cors.origin', 'null');
     const corsMethods = getConfigValue('cors.methods', ['OPTIONS']);
-    const corsAllowedHeaders = getConfigValue('cors.allowedHeaders', null);
-    const corsExposedHeaders = getConfigValue('cors.exposedHeaders', null);
+    const corsAllowedHeaders = getConfigValue('cors.allowedHeaders', []);
+    const corsExposedHeaders = getConfigValue('cors.exposedHeaders', []);
     const corsCredentials = getConfigValue('cors.credentials', false, 'boolean');
     const corsMaxAge = getConfigValue('cors.maxAge', null, 'number');
 
@@ -127,6 +127,7 @@ if (corsEnabled) {
     if (corsMaxAge !== null && Number.isInteger(corsMaxAge)) {
         corsOptions.maxAge = corsMaxAge;
     }
+    console.log('CORS enabled with the following settings:', corsOptions);
     app.use(cors(corsOptions));
 }
 

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -127,7 +127,6 @@ if (corsEnabled) {
     if (corsMaxAge !== null && Number.isInteger(corsMaxAge)) {
         corsOptions.maxAge = corsMaxAge;
     }
-    console.log('CORS enabled with the following settings:', corsOptions);
     app.use(cors(corsOptions));
 }
 

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -112,18 +112,19 @@ if (corsEnabled) {
     const corsCredentials = getConfigValue('cors.credentials', false, 'boolean');
     const corsMaxAge = getConfigValue('cors.maxAge', 0, 'number');
 
+    /** @type {cors.CorsOptions} */
     const corsOptions = {
         origin: corsOrigin,
         methods: corsMethods,
         credentials: corsCredentials,
     };
-    if (Array.isArray(corsAllowedHeaders) ? corsAllowedHeaders.length > 0 : true) {
+    if (Array.isArray(corsAllowedHeaders) && corsAllowedHeaders.length > 0) {
         corsOptions.allowedHeaders = corsAllowedHeaders;
     }
-    if (Array.isArray(corsExposedHeaders) ? corsExposedHeaders.length > 0 : true) {
+    if (Array.isArray(corsExposedHeaders) && corsExposedHeaders.length > 0) {
         corsOptions.exposedHeaders = corsExposedHeaders;
     }
-    if (corsMaxAge !== null) {
+    if (corsMaxAge !== null && Number.isInteger(corsMaxAge)) {
         corsOptions.maxAge = corsMaxAge;
     }
     app.use(cors(corsOptions));


### PR DESCRIPTION
## abstract

Add detailed configuration options for CORS in config.yaml, including origin, methods, headers, credentials, and max age. Update server initialization to apply these settings dynamically instead of using hardcoded values.

Currently SillyTavern forces origin: "null" and only allows OPTIONS, which breaks normal browser-based cross‑origin requests (especially plugin APIs) even when the server is otherwise  correctly configured. With this change, users can explicitly allow their frontend origin without weakening defaults.

Default behavior is unchanged.
 If you don’t touch the config, it stays as strict as before.
 
 
<img width="1751" height="217" alt="image" src="https://github.com/user-attachments/assets/27f6b2f3-6f9e-4280-823d-7055644e9c04" />

 The initial 403 I saw was caused by multi‑user mode being enabled (I hadn’t verified that during the first test). 
After logging in correctly, the API responses were fine.

<img width="1626" height="590" alt="image" src="https://github.com/user-attachments/assets/c85755d3-d0a0-4c71-ac53-63659f406c1f" />
 
Example image of API successfully returned.

## What this enables

  - Power users can develop frontend tools against SillyTavern’s API without hacks
  - Server plugins no longer need to open extra HTTP ports just to bypass CORS

## Example
```yml
  cors:
    enabled: true
    origin:
      - "http://127.0.0.1:5501"
    methods:
      - OPTIONS
      - GET
      - POST
    allowedHeaders:
      - Content-Type
      - Authorization
```


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
