### PR TITLE
Macros 2.0 - `list`-supported Macros Autocomplete Improvements

### DIFF
--- a/public/css/macros.css
+++ b/public/css/macros.css
@@ -566,6 +566,11 @@
     font-size: 0.8em;
 }
 
+.macro-ac-arg-hint .macro-ac-arg-hint-small {
+    font-size: 0.85em;
+    opacity: 0.8;
+}
+
 .macro-ac-hint-type {
     font-family: var(--monoFontFamily);
     font-size: 0.85em;

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -223,15 +223,20 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
         // Determine current argument index for highlighting
         const currentArgIndex = this.#context?.currentArgIndex ?? -1;
 
-        // Render argument hint banner if we're typing an argument (and no warning)
-        if (!warning && currentArgIndex >= 0) {
+        // For most warnings, we can still highlight which argument we are currently at.
+        // This even goes for "too many arguments" when navigating the cursor back to
+        // a valid argument.
+        // Extend this in the future, if *some* warnings don't make sense to still highlight args.
+        const hightlightArgsHint = currentArgIndex >= 0;
+
+        // Render argument hint banner if we're typing an argument
+        if (hightlightArgsHint && currentArgIndex >= 0) {
             const hint = this.#renderArgumentHint();
             if (hint) frag.append(hint);
         }
 
         // Reuse MacroBrowser's renderMacroDetails with options
-        // Don't highlight args if there's a warning
-        const details = renderMacroDetails(this.#macro, { currentArgIndex: warning ? -1 : currentArgIndex });
+        const details = renderMacroDetails(this.#macro, { currentArgIndex: hightlightArgsHint ? currentArgIndex : -1 });
 
         // Add class for autocomplete-specific styling overrides
         details.classList.add('macro-ac-details');
@@ -273,6 +278,22 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
         // List-arg macros can accept args even if maxArgs === 0
         if (this.#context.separatorCount > 0 && maxArgs === 0 && !hasList) {
             return 'This macro does not accept any arguments.';
+        }
+
+        // Check list bounds (min/max) if the macro has a list with constraints
+        if (hasList && typeof this.#macro.list === 'object') {
+            const listItemCount = Math.max(0, argCount - maxArgs);
+            const listMin = this.#macro.list.min ?? 0;
+            const listMax = this.#macro.list.max ?? null;
+
+            if (listItemCount < listMin) {
+                const needed = listMin - listItemCount;
+                return `Not enough list items yet: this macro requires at least ${listMin} item${listMin === 1 ? '' : 's'}, but only ${listItemCount} provided. Add ${needed} more.`;
+            }
+
+            if (listMax !== null && listItemCount > listMax) {
+                return `Too many list items: this macro accepts at most ${listMax} item${listMax === 1 ? '' : 's'}, but ${listItemCount} provided.`;
+            }
         }
 
         return null;

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -355,8 +355,22 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
             // List argument hint
             const listIndex = argIndex - this.#macro.maxArgs + 1;
             const totalListItems = this.#context.args.length - this.#macro.maxArgs;
+
             const text = document.createElement('span');
             text.innerHTML = `<strong>List item ${listIndex}</strong>${(listIndex < totalListItems ? ` (of ${totalListItems})` : '')}`;
+
+            const listInfo = document.createElement('span');
+            listInfo.classList.add('macro-ac-arg-hint-small');
+            const minMax = [];
+            if (this.#macro.list.min > 0) minMax.push(`min: ${this.#macro.list.min}`);
+            if (this.#macro.list.max !== null) minMax.push(`max: ${this.#macro.list.max}`);
+            if (minMax.length > 0) {
+                listInfo.textContent = ` (list, ${minMax.join(', ')})`;
+            } else {
+                listInfo.textContent = ' (variable-length list)';
+            }
+            text.appendChild(listInfo);
+
             hint.append(text);
         } else {
             // Unnamed argument hint (required or optional)

--- a/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
+++ b/public/scripts/autocomplete/EnhancedMacroAutoCompleteOption.js
@@ -261,7 +261,7 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
         // Space-separated syntax provides 1 arg; with scoped content you can provide a 2nd arg
         // So it's valid for macros with maxArgs <= 2 (or with list args)
         if (this.#context.hasSpaceArgContent) {
-            if (maxArgs === 0) {
+            if (maxArgs === 0 && !hasList) {
                 return 'This macro does not accept any arguments. Remove the space or use a different macro.';
             }
             if (!hasList && maxArgs > 2) {
@@ -270,7 +270,8 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
         }
 
         // Check if trying to add args to a no-arg macro via ::
-        if (this.#context.separatorCount > 0 && maxArgs === 0) {
+        // List-arg macros can accept args even if maxArgs === 0
+        if (this.#context.separatorCount > 0 && maxArgs === 0 && !hasList) {
             return 'This macro does not accept any arguments.';
         }
 
@@ -353,8 +354,9 @@ export class EnhancedMacroAutoCompleteOption extends AutoCompleteOption {
         if (isListArg) {
             // List argument hint
             const listIndex = argIndex - this.#macro.maxArgs + 1;
+            const totalListItems = this.#context.args.length - this.#macro.maxArgs;
             const text = document.createElement('span');
-            text.innerHTML = `<strong>List item ${listIndex}</strong>`;
+            text.innerHTML = `<strong>List item ${listIndex}</strong>${(listIndex < totalListItems ? ` (of ${totalListItems})` : '')}`;
             hint.append(text);
         } else {
             // Unnamed argument hint (required or optional)

--- a/public/scripts/autocomplete/MacroAutoCompleteHelper.js
+++ b/public/scripts/autocomplete/MacroAutoCompleteHelper.js
@@ -112,8 +112,9 @@ export function findUnclosedScopesRegex(text) {
             }
         } else {
             // Check if macro can accept scoped content
+            // List-arg macros don't support scopes - they accept arbitrary inline args instead
             const macroDef = macroSystem.registry.getPrimaryMacro(name);
-            if (macroDef && macroDef.maxArgs > 0) {
+            if (macroDef && macroDef.maxArgs > 0 && macroDef.list === null) {
                 // Try to find closing }} to extract trailing whitespace
                 let paddingAfter = '';
                 const afterMatch = text.slice(match.index + match[0].length);

--- a/public/scripts/macros/engine/MacroCstWalker.js
+++ b/public/scripts/macros/engine/MacroCstWalker.js
@@ -1309,15 +1309,13 @@ class MacroCstWalker {
         const argumentNodes = /** @type {CstNode[]} */ (argumentsNode?.children?.argument || []);
         const currentArgCount = argumentNodes.length;
 
+        // List-arg macros don't support scoped content - they accept arbitrary inline args instead
+        if (def.list) {
+            return false;
+        }
+
         // Check if adding 1 more argument (scoped content) would be valid
         const newArgCount = currentArgCount + 1;
-
-        // Macro must accept at least newArgCount arguments
-        // For macros with list args, they can accept unlimited after maxArgs
-        if (def.list) {
-            // With list: valid if newArgCount >= minArgs (list can absorb extra)
-            return newArgCount >= def.minArgs;
-        }
 
         // Without list: newArgCount must be between minArgs and maxArgs
         return newArgCount >= def.minArgs && newArgCount <= def.maxArgs;


### PR DESCRIPTION
This PR improves the macro autocomplete experience by adding proper validation and visual feedback for list argument constraints, while fixing several issues with scoped content detection and argument highlighting.

## What Changed

- **List Argument Validation**: Added min/max constraint checking for list arguments with clear warning messages when too few or too many items are provided
- **Enhanced Visual Hints**: Display list constraints (min/max values) in autocomplete hints with new styling for constraint information
- **Scoped Content Fix**: Correctly prevented list-arg macros from being treated as supporting scoped content
- **Improved Argument Highlighting**: Continue highlighting current argument position even when warnings are present, allowing better navigation

## Why These Changes

The macro system needed better handling of list arguments with constraints. Previously, macros with `list: { min: 2, max: 5 }` would not validate the actual number of list items provided, leading to potential runtime errors. Additionally, list-arg macros were incorrectly being treated as supporting scoped content, which caused confusing autocomplete suggestions.

## How It Works

**List Validation**: When typing list arguments, the system now checks if the number of items falls within the defined min/max bounds and shows specific warnings:
- "Not enough list items yet: this macro requires at least X items, but only Y provided. Add Z more."
- "Too many list items: this macro accepts at most X items, but Y provided."

**Visual Feedback**: List argument hints now show constraint information like "(list, min: 2, max: 5)" or "(variable-length list)" for unlimited lists.

**Scope Detection**: Updated the scope detection logic to exclude macros with `list` definitions from being considered as supporting scoped content, since they only accept arbitrary inline arguments.

## Impact

These changes provide:
- Clearer feedback when list argument constraints are violated
- Better autocomplete suggestions that don't suggest scoped content for list-arg macros
- Improved user experience with continued argument highlighting even during error states
- More accurate macro validation that prevents runtime errors from incorrect argument counts

The changes make the macro system more robust and user-friendly, especially for complex macros that use constrained list arguments.

## Copilot Summary
This pull request improves the handling and user feedback for macros with list arguments in the macro autocomplete system. The changes clarify where list-argument macros are supported, enhance error and hint messages, and improve the UI for argument hints.

**Macro argument validation and error handling:**

* Prevented macros with list arguments from accepting scoped content, both in the parser (`MacroCstWalker.js`) and autocomplete helper (`MacroAutoCompleteHelper.js`). This ensures list-arg macros only accept inline arguments, not scoped content. [[1]](diffhunk://#diff-763175bd6b061dc9c59c051ed4afe698540540a12279a2d11730e9323017b248L1312-R1319) [[2]](diffhunk://#diff-13f786d89098744e562b03280adf48a12b7a4d0633c1930f9577255fa58b06faR115-R117)
* Improved validation logic for macros with list arguments to enforce minimum and maximum list item counts, providing specific error messages if the number of list items is out of bounds. [[1]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bL273-R298) [[2]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bL264-R269)

**Autocomplete UI and feedback improvements:**

* Enhanced argument hint banners for list-argument macros to show which list item is being edited, the total count, and display min/max constraints. Added a new `.macro-ac-arg-hint-small` style for this information. [[1]](diffhunk://#diff-d4accab94305b3467b8b1ae0ba23d40fa274ff4677f0b7a1e0f7f87b8dade39bR378-R394) [[2]](diffhunk://#diff-1f59cf9d34ea2d41b9a090d3a54c385023903eb1339b1378f35af163a84d4977R569-R573)
* Updated argument highlighting logic in autocomplete so that argument hints are shown even when there are warnings, allowing users to see which argument is active unless there is a reason not to highlight.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).