### PR TITLE
Fix: HTTP Basic Auth fails when password contains colons

### DIFF
--- a/src/middleware/basicAuth.js
+++ b/src/middleware/basicAuth.js
@@ -32,9 +32,13 @@ const basicAuthMiddleware = async function (request, response, callback) {
     }
 
     const usePerUserAuth = PER_USER_BASIC_AUTH && ENABLE_ACCOUNTS;
-    const [username, password] = Buffer.from(credentials, 'base64')
-        .toString('utf8')
-        .split(':');
+    const decoded = Buffer.from(credentials, 'base64').toString('utf8');
+    const colonIndex = decoded.indexOf(':');
+    if (colonIndex === -1) {
+        return unauthorizedResponse(response);
+    }
+    const username = decoded.substring(0, colonIndex);
+    const password = decoded.substring(colonIndex + 1);
 
     if (!usePerUserAuth && username === basicAuthUserName && password === basicAuthUserPassword) {
         return callback();

--- a/src/middleware/basicAuth.js
+++ b/src/middleware/basicAuth.js
@@ -32,13 +32,10 @@ const basicAuthMiddleware = async function (request, response, callback) {
     }
 
     const usePerUserAuth = PER_USER_BASIC_AUTH && ENABLE_ACCOUNTS;
-    const decoded = Buffer.from(credentials, 'base64').toString('utf8');
-    const colonIndex = decoded.indexOf(':');
-    if (colonIndex === -1) {
-        return unauthorizedResponse(response);
-    }
-    const username = decoded.substring(0, colonIndex);
-    const password = decoded.substring(colonIndex + 1);
+    const [username, ...passwordParts] = Buffer.from(credentials, 'base64')
+        .toString('utf8')
+        .split(':');
+    const password = passwordParts.join(':');
 
     if (!usePerUserAuth && username === basicAuthUserName && password === basicAuthUserPassword) {
         return callback();

--- a/src/users.js
+++ b/src/users.js
@@ -822,13 +822,10 @@ async function basicUserLogin(request) {
         return false;
     }
 
-    const decoded = Buffer.from(credentials, 'base64').toString('utf8');
-    const colonIndex = decoded.indexOf(':');
-    if (colonIndex === -1) {
-        return false;
-    }
-    const username = decoded.substring(0, colonIndex);
-    const password = decoded.substring(colonIndex + 1);
+    const [username, ...passwordParts] = Buffer.from(credentials, 'base64')
+        .toString('utf8')
+        .split(':');
+    const password = passwordParts.join(':');
 
     const userHandles = await getAllUserHandles();
     for (const userHandle of userHandles) {

--- a/src/users.js
+++ b/src/users.js
@@ -822,9 +822,13 @@ async function basicUserLogin(request) {
         return false;
     }
 
-    const [username, password] = Buffer.from(credentials, 'base64')
-        .toString('utf8')
-        .split(':');
+    const decoded = Buffer.from(credentials, 'base64').toString('utf8');
+    const colonIndex = decoded.indexOf(':');
+    if (colonIndex === -1) {
+        return false;
+    }
+    const username = decoded.substring(0, colonIndex);
+    const password = decoded.substring(colonIndex + 1);
 
     const userHandles = await getAllUserHandles();
     for (const userHandle of userHandles) {


### PR DESCRIPTION
The credentials in HTTP Basic Auth are formatted as `base64(username:password)`. Per RFC 7617, the username must not contain a colon, but the password can. The previous code used `.split(':')` which splits on all colons, truncating passwords that contain ':' characters. Fix by splitting only on the first colon.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
