### PR TITLE
add a prompt to fill in between two consecutives assistant messages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4325,6 +4325,10 @@
                                         <small data-i18n="User Filler Message">User Filler Message</small>
                                         <textarea id="instruct_user_alignment_message" data-macros class="text_pole textarea_compact autoSetHeight"></textarea>
                                     </div>
+                                    <div class="flexAuto" title="Will be inserted between consecutive assistant messages." data-i18n="[title]Will be inserted between consecutive assistant messages.">
+                                        <small data-i18n="Assistant Filler Message">Assistant Filler Message</small>
+                                        <textarea id="instruct_consecutive_assistant_message" class="text_pole textarea_compact autoSetHeight"></textarea>
+                                    </div>
                                 </div>
                             </details>
                         </div>

--- a/public/script.js
+++ b/public/script.js
@@ -4600,51 +4600,74 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     let continue_mag = '';
     let userMessageIndices = [];
     const lastUserMessageIndex = coreChat.findLastIndex(x => x.is_user);
+    let currentMessageIsAssistant = false;
+    let nextMessageIsAssistant = false;
+    let inBetweenConsecutiveMessages = substituteParams(power_user.instruct.consecutive_assistant_message);
 
-    for (let i = coreChat.length - 1, j = 0; i >= 0; i--, j++) {
+    for (let i = 0, j = 0; i < coreChat.length; i++, j++) {
+
         if (main_api == 'openai') {
-            chat2[i] = coreChat[j].mes;
-            if (i === 0 && isContinue) {
-                chat2[i] = chat2[i].slice(0, chat2[i].lastIndexOf(coreChat[j].mes) + coreChat[j].mes.length);
-                continue_mag = coreChat[j].mes;
+            chat2[j] = coreChat[j].mes;
+            if (i === coreChat.length - 1 && isContinue) {
+                chat2[j] = chat2[j].slice(0, chat2[j].lastIndexOf(coreChat[i].mes) + coreChat[i].mes.length);
+                continue_mag = coreChat[i].mes;
             }
             continue;
         }
 
-        chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, false);
-
-        if (j === 0 && isInstruct) {
+        if (i === 0 && isInstruct) {
             // Reformat with the first output sequence (if any)
-            chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.FIRST);
-        }
-
-        if (lastUserMessageIndex >= 0 && j === lastUserMessageIndex && isInstruct) {
+            chat2[j] = formatMessageHistoryItem(coreChat[i], isInstruct, force_output_sequence.FIRST);
+        } else if (lastUserMessageIndex >= 0 && i === lastUserMessageIndex && isInstruct) {
             // Reformat with the last input sequence (if any)
-            chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.LAST);
+            chat2[j] = formatMessageHistoryItem(coreChat[i], isInstruct, force_output_sequence.LAST);
+        } else {
+            chat2[j] = formatMessageHistoryItem(coreChat[i], isInstruct, false);
         }
 
         // Do not suffix the message for continuation
-        if (i === 0 && isContinue) {
+        if (i === coreChat.length - 1 && isContinue) {
             // Pick something that's very unlikely to be in a message
             const FORMAT_TOKEN = '\u0000\ufffc\u0000\ufffd';
 
             if (isInstruct) {
-                const originalMessage = String(coreChat[j].mes ?? '');
-                coreChat[j].mes = originalMessage.replaceAll(FORMAT_TOKEN, '') + FORMAT_TOKEN;
+                const originalMessage = String(coreChat[i].mes ?? '');
+                coreChat[i].mes = originalMessage.replaceAll(FORMAT_TOKEN, '') + FORMAT_TOKEN;
                 // Reformat with the last output sequence (if any)
-                chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.LAST);
-                coreChat[j].mes = originalMessage;
+                chat2[j] = formatMessageHistoryItem(coreChat[i], isInstruct, force_output_sequence.LAST);
+                coreChat[i].mes = originalMessage;
             }
 
-            chat2[i] = chat2[i].includes(FORMAT_TOKEN)
-                ? chat2[i].slice(0, chat2[i].lastIndexOf(FORMAT_TOKEN))
-                : chat2[i].slice(0, chat2[i].lastIndexOf(coreChat[j].mes) + coreChat[j].mes.length);
-            continue_mag = coreChat[j].mes;
+            chat2[j] = chat2[j].includes(FORMAT_TOKEN)
+                ? chat2[j].slice(0, chat2[j].lastIndexOf(FORMAT_TOKEN))
+                : chat2[j].slice(0, chat2[j].lastIndexOf(coreChat[i].mes) + coreChat[i].mes.length);
+            continue_mag = coreChat[i].mes;
         }
 
-        if (coreChat[j].is_user) {
-            userMessageIndices.push(i);
+        if (coreChat[i].is_user) {
+            userMessageIndices.push(j);
+        } else {
+            currentMessageIsAssistant = (!coreChat[i].is_system && !coreChat[i].is_user);
+
+            if (i == coreChat.length - 1) {
+                nextMessageIsAssistant = !isContinue;
+            } else {
+                nextMessageIsAssistant = (!coreChat[i + 1].is_system && !coreChat[i + 1].is_user);
+            }
+
+            if ((inBetweenConsecutiveMessages !== "") && currentMessageIsAssistant && nextMessageIsAssistant) {
+                // add a prompt to fill in between two consecutives assistant messages
+                j++;
+                chat2[j] = inBetweenConsecutiveMessages;
+            }
         }
+    }
+
+    chat2.reverse();
+
+    // reverse indices
+    for (let i = 0; i < chat2.length; i++) {
+        userMessageIndices[i] = chat2.length - i - 1;
     }
 
     let addUserAlignment = isInstruct && power_user.instruct.user_alignment_message;

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -45,6 +45,7 @@ const controls = [
     { id: 'instruct_names_behavior', property: 'names_behavior', isCheckbox: false },
     { id: 'instruct_system_same_as_user', property: 'system_same_as_user', isCheckbox: true, trigger: true },
     { id: 'instruct_sequences_as_stop_strings', property: 'sequences_as_stop_strings', isCheckbox: true },
+    { id: 'instruct_consecutive_assistant_message', property: 'consecutive_assistant_message', isCheckbox: false },
 ];
 
 /**
@@ -80,6 +81,7 @@ function migrateInstructModeSettings(settings) {
         system_same_as_user: false,
         names_behavior: names_behavior_types.FORCE,
         sequences_as_stop_strings: true,
+        consecutive_assistant_message: '',
         story_string_prefix: '',
         story_string_suffix: '',
     };

--- a/public/scripts/macros/definitions/instruct-macros.js
+++ b/public/scripts/macros/definitions/instruct-macros.js
@@ -52,6 +52,8 @@ export function registerInstructMacros() {
 
     registerSimple(['instructFirstUserPrefix', 'instructFirstInput'], () => power_user.instruct.first_input_sequence || power_user.instruct.input_sequence, instEnabled, 'Instruct first user / input prefix sequence.');
     registerSimple(['instructLastUserPrefix', 'instructLastInput'], () => power_user.instruct.last_input_sequence || power_user.instruct.input_sequence, instEnabled, 'Instruct last user / input prefix sequence.');
+    
+    registerSimple(['instructConsecutiveAssistantMessage'], () => power_user.instruct.consecutive_assistant_message, instEnabled, 'Instruct consecutive assistant message.');
 
     // System prompt macros
     registerSimple(['defaultSystemPrompt', 'instructSystem', 'instructSystemPrompt'], () => power_user.sysprompt.content, sysEnabled, 'Default system prompt.');

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -239,6 +239,8 @@ export const power_user = {
         story_string_prefix: '',
         story_string_suffix: '',
         stop_sequence: '',
+        consecutive_assistant_message: '',
+        
         wrap: true,
         macro: true,
         names_behavior: names_behavior_types.FORCE,


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Fixes this issue: https://github.com/SillyTavern/SillyTavern/issues/4248

I added a field named "Assistant Filler Message" to the "misc sequences" section of the instruct template. LLMs are always very much confused when we don't respect the template "user > assistant > user > assistant ...". Whatever is written in this field will be inserted between two consecutive assistant messages. So for instance, it allows to mimic an user prompt, or a system prompt. Unlike "last assistant prefix" or "assistant prefix", this field is only active between two consecutive assistant messages, and not between an user message and an assistant message.