### PR TITLE
Fix/Remove non-samplers from sampler selection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2436,7 +2436,7 @@
                                     <h4 data-i18n="Model Providers">Model Providers</h4>
                                     <select id="openrouter_providers_text" class="openrouter_providers" multiple>
                                     </select>
-                                    <label class="checkbox_label" data-tg-samplers="openrouter_allow_fallbacks" data-i18n="[title]Automatically chooses an alternative provider if chosen providers can't serve your request." for="openrouter_allow_fallbacks_textgenerationwebui" title="Automatically chooses an alternative provider if chosen providers can't serve your request.">
+                                    <label class="checkbox_label" data-i18n="[title]Automatically chooses an alternative provider if chosen providers can't serve your request." for="openrouter_allow_fallbacks_textgenerationwebui" title="Automatically chooses an alternative provider if chosen providers can't serve your request.">
                                         <input id="openrouter_allow_fallbacks_textgenerationwebui" type="checkbox" />
                                         <span data-i18n="Allow fallback providers">Allow fallback providers</span>
                                     </label>

--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -220,7 +220,7 @@ async function listSamplers(main_api, arrayOnly = false) {
     let availableSamplers;
     if (main_api === 'textgenerationwebui') {
         availableSamplers = TGsamplerNames;
-        const valuesToRemove = new Set(['streaming', 'bypass_status_check', 'custom_model', 'legacy_api', 'extensions']);
+        const valuesToRemove = new Set(['streaming', 'bypass_status_check', 'custom_model', 'generic_model', 'openrouter_allow_fallbacks', 'legacy_api', 'extensions']);
         availableSamplers = availableSamplers.filter(sampler => !valuesToRemove.has(sampler));
         availableSamplers.sort();
     }


### PR DESCRIPTION
## Commit
- [Fix](https://github.com/SillyTavern/SillyTavern/commit/f7819a217f92a5dca3501d12aa851b1889f5719e) - Remove non-samplers from sampler selection popup
> Removed OR's fallback providers checkbox and the generic model and URL inputs for Custom Endpoint.

`generic_model` and `openrouter_allow_fallbacks` are now ignored from the Sampler Selection popup and the custom show/hide logic. They are always displayed on API Type change for the respective endpoints.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
