### PR TITLE
Fix NanoGPT prompt caching for anthropic/claude-* model IDs

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2241,7 +2241,7 @@ router.post('/generate', async function (request, response) {
                 bodyParams['reasoning'] = { effort: effort };
             }
 
-            const isClaude = /^claude-/.test(request.body.model);
+            const isClaude = /(?:^|\/)claude[-_]/.test(request.body.model);
             if (enableSystemPromptCache && isClaude) {
                 bodyParams['cache_control'] = {
                     'enabled': true,


### PR DESCRIPTION
Summary
  NanoGPT can expose Claude models as anthropic/claude-*. In the NanoGPT chat-completions path, prompt caching is only enabled when model matches /^claude-/, so prefixed Claude
  IDs never receive cache_control.

  Change
  - Update NanoGPT Claude detection from:
    - /^claude-/
  - To:
    - /(?:^|\/)claude[-_]/
  This preserves existing behavior for claude-* and adds support for anthropic/claude-* (and claude_ variants).

  Why
  Without this, users selecting anthropic/claude-* models via NanoGPT silently lose prompt caching even when claude.enableSystemPromptCache is enabled.

  File changed
  - src/endpoints/backends/chat-completions.js