### PR TITLE
Add gallery argument to /imagine command

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -3371,7 +3371,7 @@ async function sendGenerationRequest(generationType, prompt, additionalNegativeP
         return;
     }
 
-    const filename = `${characterName}_${humanizedDateTime()}`;
+    const filename = characterName ? `${characterName}_${humanizedDateTime()}` : humanizedDateTime();
     const base64Image = await saveBase64AsFile(result.data, characterName, filename, result.format);
     callback
         ? await callback(prompt, base64Image, generationType, additionalNegativePrefix, initiator, prefixedPrompt, result.format)

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2974,6 +2974,10 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         callback = () => { };
     }
 
+    if (isFalseBoolean(args?.gallery)) {
+        characterName = '';
+    }
+
     const dimensions = setTypeSpecificDimensions(generationType);
     const abortController = new AbortController();
     const stopButton = document.getElementById('sd_stop_gen');
@@ -5373,6 +5377,9 @@ jQuery(async () => {
             new SlashCommandNamedArgument(
                 'quiet', 'whether to post the generated image to chat', [ARGUMENT_TYPE.BOOLEAN], false, false, 'false',
             ),
+            new SlashCommandNamedArgument(
+                'gallery', 'whether to save the generated image to the character gallery', [ARGUMENT_TYPE.BOOLEAN], false, false, 'true',
+            ),
             SlashCommandNamedArgument.fromProps({
                 name: 'negative',
                 description: 'negative prompt prefix',
@@ -5555,7 +5562,7 @@ jQuery(async () => {
         ],
         helpString: `
             <div>
-                Requests to generate an image and posts it to chat (unless <code>quiet=true</code> argument is specified).
+                Requests to generate an image and posts it to chat (unless <code>quiet=true</code> argument is specified). The image is saved to the character gallery by default; use <code>gallery=false</code> to skip saving.
             </div>
             <div>
                 Supported arguments: <code>${Object.values(triggerWords).flat().join(', ')}</code>.

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2952,7 +2952,7 @@ async function generatePicture(initiator, args, trigger, message, callback) {
     const quietPrompt = getQuietPrompt(generationType, trigger);
     const context = getContext();
 
-    const characterName = context.groupId
+    let characterName = context.groupId
         ? context.groups[Object.keys(context.groups).filter(x => context.groups[x].id === context.groupId)[0]]?.id?.toString()
         : context.characters[context.characterId]?.name;
 

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -5562,7 +5562,7 @@ jQuery(async () => {
         ],
         helpString: `
             <div>
-                Requests to generate an image and posts it to chat (unless <code>quiet=true</code> argument is specified). The image is saved to the character gallery by default; use <code>gallery=false</code> to skip saving.
+                Requests to generate an image and posts it to chat (unless <code>quiet=true</code> argument is specified). The image is saved to the character gallery by default; use <code>gallery=false</code> to save to the root of the user images directory.
             </div>
             <div>
                 Supported arguments: <code>${Object.values(triggerWords).flat().join(', ')}</code>.


### PR DESCRIPTION
## Summary
- Adds a `gallery` named argument (default: `true`) to the `/imagine` slash command
- When `gallery=false`, the generated image is saved to the generic images directory instead of the character-specific gallery folder, while still returning a usable image URL
- Useful for extensions that manage their own image display (e.g. inline in chat messages) and don't need gallery copies

## Details

Currently, `/imagine` unconditionally saves generated images to the character's gallery via `saveBase64AsFile` with the character name as subfolder. The `quiet=true` argument suppresses posting to chat but does not affect gallery saving.

This adds a `gallery` argument that, when set to `false`, passes an empty character name to `sendGenerationRequest`, causing the image to be saved to the root `userImages/` directory instead of `userImages/{characterName}/`. The image URL is still returned normally via `result.pipe`.

The change is minimal (3 additions to a single file) and fully backward-compatible — existing behavior is unchanged since `gallery` defaults to `true`.

## Test plan
- [ ] Verify `/imagine apple tree` still saves to character gallery (default behavior)
- [ ] Verify `/imagine gallery=false apple tree` generates an image and returns a URL but does not save to the character gallery
- [ ] Verify `/imagine quiet=true gallery=false apple tree` works with both flags combined

🤖 Generated with [Claude Code](https://claude.com/claude-code)