### PR TITLE
Guard `isValidImageUrl` against nullish `avatar_url` inputs (#5172)

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -857,7 +857,7 @@ function updateGroupAvatar(group) {
  */
 function isValidImageUrl(url) {
     // check if empty dict
-    if (Object.keys(url).length === 0) {
+    if (!url || Object.keys(url).length === 0) {
         return false;
     }
     return isDataURL(url) || (url && (url.startsWith('user') || url.startsWith('/user')));


### PR DESCRIPTION
* Initial plan

* fix: guard isValidImageUrl against nullish input



---------

<!-- Put X in the box below to confirm -->

## Checklist:

- [ ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
