### PR TITLE
Feat/Export SlashCommandEnumValue for extensions through getContext

### DIFF
--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -90,6 +90,7 @@ import { ScraperManager } from './scrapers.js';
 import { executeSlashCommands, executeSlashCommandsWithOptions, registerSlashCommand } from './slash-commands.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
+import { SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { tag_map, tags, importTags } from './tags.js';
 import { getTextGenServer, textgenerationwebui_settings } from './textgen-settings.js';
@@ -159,6 +160,7 @@ export function getContext() {
         SlashCommand,
         SlashCommandArgument,
         SlashCommandNamedArgument,
+        SlashCommandEnumValue,
         ARGUMENT_TYPE,
         executeSlashCommandsWithOptions,
         /** @deprecated Use SlashCommandParser.addCommandObject() instead */


### PR DESCRIPTION
## Change
- Exports `SlashCommandEnumValue` so extensions can fetch it from `SillyTavern.getContext()`

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
