### PR TITLE
feat: Add ModelsLab TTS provider

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -37,6 +37,7 @@ import { MiniMaxTtsProvider } from './minimax.js';
 import { ElectronHubTtsProvider } from './electronhub.js';
 import { ChutesTtsProvider } from './chutes.js';
 import { VolcengineTtsProvider } from './volcengine.js';
+import { ModelsLabTtsProvider } from './modelslab.js';
 import { applyLocale, t } from '/scripts/i18n.js';
 
 const UPDATE_INTERVAL = 1000;
@@ -149,6 +150,7 @@ const ttsProviders = {
     VITS: VITSTtsProvider,
     XTTSv2: XTTSTtsProvider,
     Volcengine: VolcengineTtsProvider,
+    ModelsLab: ModelsLabTtsProvider,
 };
 let ttsProvider;
 let ttsProviderName;

--- a/public/scripts/extensions/tts/modelslab.js
+++ b/public/scripts/extensions/tts/modelslab.js
@@ -1,0 +1,186 @@
+import { event_types, eventSource, getRequestHeaders } from '../../../script.js';
+import { SECRET_KEYS, secret_state } from '../../secrets.js';
+import { getPreviewString, saveTtsProviderSettings } from './index.js';
+
+export { ModelsLabTtsProvider };
+
+class ModelsLabTtsProvider {
+    settings;
+    voices = [];
+    separator = ' . ';
+
+    audioElement = document.createElement('audio');
+
+    defaultSettings = {
+        voiceMap: {},
+        voice_id: 'madison',
+        language: 'american english',
+        speed: 1,
+        emotion: false,
+    };
+
+    get settingsHtml() {
+        let html = `
+        <div class="flex-container alignItemsCenter">
+            <div class="flex1">ModelsLab TTS API</div>
+            <div id="modelslab_tts_key" class="menu_button menu_button_icon manage-api-keys" data-key="${SECRET_KEYS.MODELSLAB_TTS}">
+                <i class="fa-solid fa-key"></i>
+                <span>API Key</span>
+            </div>
+        </div>
+        <label for="modelslab_voice_id">Voice ID:</label>
+        <input id="modelslab_voice_id" type="text" class="text_pole" maxlength="500" value="${this.defaultSettings.voice_id}" placeholder="e.g. madison"/>
+        <label for="modelslab_language">Language:</label>
+        <select id="modelslab_language" class="text_pole">
+            <option value="american english">American English</option>
+            <option value="british english">British English</option>
+            <option value="spanish">Spanish</option>
+            <option value="french">French</option>
+            <option value="japanese">Japanese</option>
+            <option value="mandarin chinese">Mandarin Chinese</option>
+            <option value="hindi">Hindi</option>
+            <option value="italian">Italian</option>
+            <option value="brazilian portuguese">Brazilian Portuguese</option>
+        </select>
+        <label for="modelslab_tts_speed">Speed: <span id="modelslab_tts_speed_output">1</span></label>
+        <input type="range" id="modelslab_tts_speed" value="1" min="0.5" max="2" step="0.1">
+        <label>
+            <input type="checkbox" id="modelslab_emotion">
+            Enable Emotion Tags (English only)
+        </label>
+        <small>Supported tags: &lt;laugh&gt;, &lt;sigh&gt;, &lt;chuckle&gt;, &lt;cough&gt;, &lt;sniffle&gt;, &lt;groan&gt;, &lt;yawn&gt;, &lt;gasp&gt;</small>`;
+        return html;
+    }
+
+    constructor() {
+        this.handler = async function (/** @type {string} */ key) {
+            if (key !== SECRET_KEYS.MODELSLAB_TTS) return;
+            $('#modelslab_tts_key').toggleClass('success', !!secret_state[SECRET_KEYS.MODELSLAB_TTS]);
+        }.bind(this);
+    }
+
+    dispose() {
+        [event_types.SECRET_WRITTEN, event_types.SECRET_DELETED, event_types.SECRET_ROTATED].forEach(event => {
+            eventSource.removeListener(event, this.handler);
+        });
+    }
+
+    async loadSettings(settings) {
+        if (Object.keys(settings).length === 0) {
+            Object.assign(settings, this.defaultSettings);
+        }
+
+        this.settings = settings;
+
+        if (!this.settings.voiceMap) {
+            this.settings.voiceMap = {};
+        }
+
+        $('#modelslab_voice_id').val(this.settings.voice_id || this.defaultSettings.voice_id);
+        $('#modelslab_language').val(this.settings.language || this.defaultSettings.language);
+        $('#modelslab_tts_speed').val(this.settings.speed || 1);
+        $('#modelslab_tts_speed_output').text(this.settings.speed || 1);
+        $('#modelslab_emotion').prop('checked', !!this.settings.emotion);
+
+        $('#modelslab_voice_id').on('input', () => this.onSettingsChange());
+        $('#modelslab_language').on('change', () => this.onSettingsChange());
+        $('#modelslab_tts_speed').on('input', () => {
+            $('#modelslab_tts_speed_output').text($('#modelslab_tts_speed').val());
+            this.onSettingsChange();
+        });
+        $('#modelslab_emotion').on('change', () => this.onSettingsChange());
+
+        $('#modelslab_tts_key').toggleClass('success', !!secret_state[SECRET_KEYS.MODELSLAB_TTS]);
+        [event_types.SECRET_WRITTEN, event_types.SECRET_DELETED, event_types.SECRET_ROTATED].forEach(event => {
+            eventSource.on(event, this.handler);
+        });
+
+        await this.checkReady();
+    }
+
+    onSettingsChange() {
+        this.settings.voice_id = String($('#modelslab_voice_id').val());
+        this.settings.language = String($('#modelslab_language').val());
+        this.settings.speed = parseFloat(String($('#modelslab_tts_speed').val()));
+        this.settings.emotion = $('#modelslab_emotion').is(':checked');
+        saveTtsProviderSettings();
+    }
+
+    async checkReady() {
+        await this.fetchTtsVoiceObjects();
+    }
+
+    async onRefreshClick() {
+        return await this.checkReady();
+    }
+
+    async getVoice(voiceName) {
+        if (this.voices.length === 0) {
+            this.voices = await this.fetchTtsVoiceObjects();
+        }
+        const match = this.voices.find(v => v.name === voiceName || v.voice_id === voiceName);
+        if (!match) {
+            throw `TTS Voice name ${voiceName} not found`;
+        }
+        return match;
+    }
+
+    async generateTts(text, voiceId) {
+        return await this.fetchTtsGeneration(text, voiceId);
+    }
+
+    async fetchTtsVoiceObjects() {
+        // Static voice list — ModelsLab does not have a voice listing endpoint
+        this.voices = [
+            { name: 'madison', voice_id: 'madison', lang: 'en-US', preview_url: false },
+            { name: 'leigh', voice_id: 'leigh', lang: 'en-US', preview_url: false },
+            { name: 'diana', voice_id: 'diana', lang: 'en-US', preview_url: false },
+            { name: 'amy', voice_id: 'amy', lang: 'en-US', preview_url: false },
+            { name: 'emma', voice_id: 'emma', lang: 'en-US', preview_url: false },
+            { name: 'john', voice_id: 'john', lang: 'en-US', preview_url: false },
+            { name: 'james', voice_id: 'james', lang: 'en-US', preview_url: false },
+            { name: 'david', voice_id: 'david', lang: 'en-US', preview_url: false },
+            { name: 'ryan', voice_id: 'ryan', lang: 'en-US', preview_url: false },
+            { name: 'adam', voice_id: 'adam', lang: 'en-US', preview_url: false },
+        ];
+        return this.voices;
+    }
+
+    async previewTtsVoice(voiceId) {
+        this.audioElement.pause();
+        this.audioElement.currentTime = 0;
+        const voice = await this.getVoice(voiceId);
+        const text = getPreviewString(voice.lang);
+        const response = await this.generateTts(text, voiceId);
+        const audio = await response.blob();
+        const url = URL.createObjectURL(audio);
+        this.audioElement.src = url;
+        this.audioElement.onended = () => URL.revokeObjectURL(url);
+        this.audioElement.play();
+    }
+
+    async fetchTtsGeneration(text, voiceId) {
+        if (!secret_state[SECRET_KEYS.MODELSLAB_TTS]) {
+            throw new Error('ModelsLab API key is not set');
+        }
+
+        const response = await fetch('/api/modelslab/generate-voice', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                text: text,
+                voice_id: voiceId || this.settings.voice_id,
+                language: this.settings.language,
+                speed: this.settings.speed,
+                emotion: this.settings.emotion,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`ModelsLab TTS failed: ${error}`);
+        }
+
+        return response;
+    }
+}

--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -76,6 +76,7 @@ export const SECRET_KEYS = {
     POLLINATIONS: 'api_key_pollinations',
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
+    MODELSLAB_TTS: 'api_key_modelslab_tts',
 };
 
 const FRIENDLY_NAMES = {
@@ -140,6 +141,7 @@ const FRIENDLY_NAMES = {
     [SECRET_KEYS.POLLINATIONS]: 'Pollinations',
     [SECRET_KEYS.VOLCENGINE_APP_ID]: 'Volcengine App ID',
     [SECRET_KEYS.VOLCENGINE_ACCESS_KEY]: 'Volcengine Access Key',
+    [SECRET_KEYS.MODELSLAB_TTS]: 'ModelsLab TTS',
 };
 
 const INPUT_MAP = {

--- a/src/endpoints/modelslab.js
+++ b/src/endpoints/modelslab.js
@@ -1,0 +1,118 @@
+import express from 'express';
+import fetch from 'node-fetch';
+import { readSecret, SECRET_KEYS } from './secrets.js';
+
+export const router = express.Router();
+
+const MODELSLAB_TTS_URL = 'https://modelslab.com/api/v6/voice/text_to_speech';
+const MODELSLAB_FETCH_URL = 'https://modelslab.com/api/v6/voice/fetch';
+const MAX_POLL_ATTEMPTS = 10;
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * Poll ModelsLab fetch endpoint until audio is ready.
+ * @param {string} apiKey ModelsLab API key
+ * @param {string|number} taskId Task ID returned by the generation request
+ * @returns {Promise<string>} URL of the generated audio
+ */
+async function pollForAudio(apiKey, taskId) {
+    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+        await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+
+        const fetchResponse = await fetch(MODELSLAB_FETCH_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ key: apiKey, request_id: String(taskId) }),
+        });
+
+        if (!fetchResponse.ok) {
+            throw new Error(`ModelsLab fetch failed: HTTP ${fetchResponse.status}`);
+        }
+
+        const fetchData = await fetchResponse.json();
+
+        if (fetchData.status === 'success' && fetchData.output && fetchData.output.length > 0) {
+            return fetchData.output[0];
+        }
+
+        if (fetchData.status === 'failed' || fetchData.status === 'error') {
+            throw new Error(`ModelsLab TTS failed: ${fetchData.message || 'Unknown error'}`);
+        }
+
+        // status === 'processing' → keep polling
+    }
+
+    throw new Error('ModelsLab TTS timed out waiting for audio');
+}
+
+router.post('/generate-voice', async (request, response) => {
+    try {
+        const { text, voice_id, language, speed, emotion } = request.body;
+
+        const apiKey = readSecret(request.user.directories, SECRET_KEYS.MODELSLAB_TTS);
+
+        if (!apiKey) {
+            return response.status(401).json({ error: 'ModelsLab API key not configured' });
+        }
+
+        if (!text) {
+            return response.status(400).json({ error: 'Missing required parameter: text' });
+        }
+
+        // ModelsLab TTS has a 2500 char limit
+        const prompt = text.length > 2500 ? text.substring(0, 2500) : text;
+
+        const requestBody = {
+            key: apiKey,
+            prompt: prompt,
+            voice_id: voice_id || 'madison',
+            language: language || 'american english',
+            speed: Number(speed) || 1,
+            emotion: Boolean(emotion),
+        };
+
+        console.debug('ModelsLab TTS: Generating audio', { voice_id, language, speed });
+
+        const apiResponse = await fetch(MODELSLAB_TTS_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody),
+        });
+
+        if (!apiResponse.ok) {
+            const errorText = await apiResponse.text();
+            console.error('ModelsLab TTS API error:', errorText);
+            return response.status(apiResponse.status).json({ error: `ModelsLab API error: ${errorText}` });
+        }
+
+        const data = await apiResponse.json();
+
+        let audioUrl;
+
+        if (data.status === 'success' && data.output && data.output.length > 0) {
+            audioUrl = data.output[0];
+        } else if (data.status === 'processing' && data.id) {
+            // Async generation — poll until ready
+            audioUrl = await pollForAudio(apiKey, data.id);
+        } else {
+            const errorMsg = data.message || JSON.stringify(data);
+            console.error('ModelsLab TTS unexpected response:', data);
+            return response.status(500).json({ error: `Unexpected ModelsLab response: ${errorMsg}` });
+        }
+
+        // Proxy the audio file back to the client
+        const audioResponse = await fetch(audioUrl);
+
+        if (!audioResponse.ok) {
+            return response.status(500).json({ error: 'Failed to download generated audio from ModelsLab' });
+        }
+
+        const contentType = audioResponse.headers.get('content-type') || 'audio/mpeg';
+        response.setHeader('Content-Type', contentType);
+        audioResponse.body.pipe(response);
+
+    } catch (error) {
+        console.error('ModelsLab TTS error:', error);
+        response.status(500).json({ error: error.message });
+    }
+});

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -69,6 +69,7 @@ export const SECRET_KEYS = {
     POLLINATIONS: 'api_key_pollinations',
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
+    MODELSLAB_TTS: 'api_key_modelslab_tts',
 };
 
 /**

--- a/src/server-startup.js
+++ b/src/server-startup.js
@@ -50,6 +50,7 @@ import { router as dataMaidRouter } from './endpoints/data-maid.js';
 import { router as backupsRouter } from './endpoints/backups.js';
 import { router as imageMetadataRouter } from './endpoints/image-metadata.js';
 import { router as volcengineRouter } from './endpoints/volcengine.js';
+import { router as modelslabRouter } from './endpoints/modelslab.js';
 
 /**
  * @typedef {object} ServerStartupResult
@@ -178,6 +179,7 @@ export function setupPrivateEndpoints(app) {
     app.use('/api/azure', azureRouter);
     app.use('/api/volcengine', volcengineRouter);
     app.use('/api/minimax', minimaxRouter);
+    app.use('/api/modelslab', modelslabRouter);
     app.use('/api/data-maid', dataMaidRouter);
     app.use('/api/backups', backupsRouter);
     app.use('/api/image-metadata', imageMetadataRouter);


### PR DESCRIPTION
## Summary

Rebased and refreshed PR from the previous attempt. Adds ModelsLab as a TTS provider.

## Files changed

- `public/scripts/extensions/tts/modelslab.js` - Frontend provider
- `src/endpoints/modelslab.js` - Backend endpoint
- `public/scripts/secrets.js` - API key registration  
- `public/scripts/extensions/tts/index.js` - Provider registration
- `src/server-startup.js` - Route registration
- `src/endpoints/secrets.js` - Backend secret registration