### PR TITLE
Add base64 avatar support for JanitorAI imports

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -891,17 +891,11 @@ async function importFromJson(uploadPath, { request }, preservedFileName) {
         const pngName = preservedFileName || getPngName(jsonData.data?.name || jsonData.name, request.user.directories);
 
         // Check if avatar is embedded as base64 (JanitorAI, Perchance, etc)
-        let avatarPath = DEFAULT_AVATAR_PATH;
-        let tempAvatarPath = null;
+        let avatarInput = DEFAULT_AVATAR_PATH;
         if (jsonData.data?.extensions?.avatar_base64) {
             console.info('Using embedded base64 avatar from extensions');
             const base64Data = jsonData.data.extensions.avatar_base64.split(',')[1] || jsonData.data.extensions.avatar_base64;
-            const avatarBuffer = Buffer.from(base64Data, 'base64');
-
-            // Write temporary avatar file
-            tempAvatarPath = path.join(process.cwd(), 'temp_avatar.png');
-            fs.writeFileSync(tempAvatarPath, avatarBuffer);
-            avatarPath = tempAvatarPath;
+            avatarInput = Buffer.from(base64Data, 'base64');
 
             // Clean up extensions to avoid bloating the character JSON
             delete jsonData.data.extensions.avatar_base64;
@@ -909,20 +903,8 @@ async function importFromJson(uploadPath, { request }, preservedFileName) {
 
         // Stringify AFTER removing avatar_base64
         const char = JSON.stringify(jsonData);
-
-        try {
-            const result = await writeCharacterData(avatarPath, char, pngName, request);
-            return result ? pngName : '';
-        } finally {
-            // Always clean up temp avatar file, even if writeCharacterData throws
-            if (tempAvatarPath && fs.existsSync(tempAvatarPath)) {
-                try {
-                    fs.unlinkSync(tempAvatarPath);
-                } catch (unlinkError) {
-                    console.warn('Failed to clean up temp avatar file:', unlinkError.message);
-                }
-            }
-        }
+        const result = await writeCharacterData(avatarInput, char, pngName, request);
+        return result ? pngName : '';
     } else if (jsonData.name !== undefined) {
         console.info('Importing from v1 json');
         jsonData.name = sanitize(jsonData.name);

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -889,9 +889,40 @@ async function importFromJson(uploadPath, { request }, preservedFileName) {
         jsonData = readFromV2(jsonData);
         jsonData.create_date = new Date().toISOString();
         const pngName = preservedFileName || getPngName(jsonData.data?.name || jsonData.name, request.user.directories);
+
+        // Check if avatar is embedded as base64 (JanitorAI, Perchance, etc)
+        let avatarPath = DEFAULT_AVATAR_PATH;
+        let tempAvatarPath = null;
+        if (jsonData.data?.extensions?.avatar_base64) {
+            console.info('Using embedded base64 avatar from extensions');
+            const base64Data = jsonData.data.extensions.avatar_base64.split(',')[1] || jsonData.data.extensions.avatar_base64;
+            const avatarBuffer = Buffer.from(base64Data, 'base64');
+
+            // Write temporary avatar file
+            tempAvatarPath = path.join(process.cwd(), 'temp_avatar.png');
+            fs.writeFileSync(tempAvatarPath, avatarBuffer);
+            avatarPath = tempAvatarPath;
+
+            // Clean up extensions to avoid bloating the character JSON
+            delete jsonData.data.extensions.avatar_base64;
+        }
+
+        // Stringify AFTER removing avatar_base64
         const char = JSON.stringify(jsonData);
-        const result = await writeCharacterData(DEFAULT_AVATAR_PATH, char, pngName, request);
-        return result ? pngName : '';
+
+        try {
+            const result = await writeCharacterData(avatarPath, char, pngName, request);
+            return result ? pngName : '';
+        } finally {
+            // Always clean up temp avatar file, even if writeCharacterData throws
+            if (tempAvatarPath && fs.existsSync(tempAvatarPath)) {
+                try {
+                    fs.unlinkSync(tempAvatarPath);
+                } catch (unlinkError) {
+                    console.warn('Failed to clean up temp avatar file:', unlinkError.message);
+                }
+            }
+        }
     } else if (jsonData.name !== undefined) {
         console.info('Importing from v1 json');
         jsonData.name = sanitize(jsonData.name);


### PR DESCRIPTION
- Process avatar_base64 from JSON extensions in importFromJson()
- Convert base64 to temporary PNG file
- Embed avatar in character card
- Clean up after processing

Enables any JSON import to include base64-encoded avatars.
Related: JanitorAI bookmarklet (PR #5199) uses this, but works for all import sources.


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
