### PR TITLE
Add Cloudflare bypass modal for JanitorAI imports

### DIFF
--- a/public/scripts/templates/janitorCloudflareBypass.html
+++ b/public/scripts/templates/janitorCloudflareBypass.html
@@ -1,0 +1,191 @@
+<div class="janitor-cloudflare-bypass">
+    <h3>
+        <i class="fa-solid fa-shield-halved"></i>
+        JanitorAI Import Blocked by Cloudflare
+    </h3>
+
+    <div class="alert alert-warning marginTopBot10">
+        <i class="fa-solid fa-triangle-exclamation"></i>
+        <strong>Why is this happening?</strong>
+        <p>JanitorAI uses Cloudflare Bot Fight Mode which blocks server-side requests.
+        Don't worry - you can still import this character using your browser!</p>
+    </div>
+
+    <div class="instruction-section">
+        <h4><i class="fa-solid fa-1"></i> Open the Character Page</h4>
+        <p>Click the button below to open the character page in a new tab:</p>
+        <a href="{{url}}" target="_blank" class="menu_button menu_button_icon margin10">
+            <i class="fa-solid fa-external-link-alt"></i>
+            Open Character Page
+        </a>
+    </div>
+
+    <div class="instruction-section">
+        <h4><i class="fa-solid fa-2"></i> Run the Extraction Code</h4>
+        <p>On the character page:</p>
+        <ol>
+            <li>Press <kbd>F12</kbd> to open browser console (Developer Tools)</li>
+            <li>Click the <strong>Console</strong> tab</li>
+            <li>Copy the code below and paste it into the console</li>
+            <li>Press <kbd>Enter</kbd> to run it</li>
+        </ol>
+
+        <div class="code-container margin10" style="position: relative;">
+            <button id="copy-bookmarklet-btn" class="menu_button menu_button_icon fa-solid fa-copy"
+                    title="Copy to clipboard" style="position: absolute; top: 5px; right: 5px; z-index: 10;">
+            </button>
+            <pre id="bookmarklet-code" class="code-block" style="white-space: pre-wrap; word-break: break-all; padding-right: 50px;">{{{bookmarklet}}}</pre>
+        </div>
+
+        <small class="text-muted">
+            <i class="fa-solid fa-circle-info"></i>
+            The code will automatically download a JSON file containing the character data.
+        </small>
+    </div>
+
+    <div class="instruction-section">
+        <h4><i class="fa-solid fa-3"></i> Import the Downloaded File</h4>
+        <p>After the JSON file downloads:</p>
+        <ol>
+            <li>Go to <strong>Character Management</strong> in SillyTavern</li>
+            <li>Click <strong>Import Character from File</strong></li>
+            <li>Select the downloaded <code>.json</code> file</li>
+        </ol>
+
+        <div class="margin10">
+            <p><strong>Or drag and drop the file here:</strong></p>
+            <div id="janitor-drop-zone" style="
+                border: 2px dashed var(--SmartThemeBorderColor);
+                border-radius: 10px;
+                padding: 30px;
+                text-align: center;
+                background: var(--black30a);
+                cursor: pointer;
+            ">
+                <i class="fa-solid fa-file-arrow-up fa-3x"></i>
+                <p>Drag & drop the downloaded JSON file here<br>or click to browse</p>
+            </div>
+            <input type="file" id="janitor-file-input" accept=".json" style="display: none;">
+        </div>
+    </div>
+
+    <details class="marginTopBot10">
+        <summary style="cursor: pointer; user-select: none;"><i class="fa-solid fa-circle-question"></i> Troubleshooting</summary>
+        <div class="margin10">
+            <p><strong>Code doesn't work?</strong></p>
+            <ul>
+                <li>Make sure you're on the correct character page</li>
+                <li>Try refreshing the page and running the code again</li>
+                <li>Check the console for error messages</li>
+            </ul>
+
+            <p><strong>Still having issues?</strong></p>
+            <ul>
+                <li>Press <kbd>Ctrl+U</kbd> to view page source</li>
+                <li>Press <kbd>Ctrl+F</kbd> and search for <code>window.mbxM.push</code></li>
+                <li>If you can't find it, JanitorAI may have changed their website structure</li>
+            </ul>
+        </div>
+    </details>
+</div>
+
+<style>
+.janitor-cloudflare-bypass h3 {
+    margin-top: 0;
+}
+
+.janitor-cloudflare-bypass h3 i {
+    color: var(--SmartThemeQuoteColor);
+    margin-right: 10px;
+}
+
+.janitor-cloudflare-bypass .alert {
+    padding: 15px;
+    border-radius: 8px;
+    background: #fff3cd;
+    color: #856404;
+    border: 1px solid #ffeaa7;
+}
+
+.chakra-ui-dark .janitor-cloudflare-bypass .alert,
+[data-theme=dark] .janitor-cloudflare-bypass .alert {
+    background: rgba(255, 193, 7, 0.2);
+    color: #ffc107;
+    border-color: rgba(255, 193, 7, 0.3);
+}
+
+.janitor-cloudflare-bypass .instruction-section {
+    margin: 20px 0;
+    padding: 15px;
+    background: var(--black10a);
+    border-radius: 8px;
+    border-left: 3px solid var(--SmartThemeQuoteColor);
+}
+
+.janitor-cloudflare-bypass .instruction-section h4 {
+    margin-top: 0;
+    color: var(--SmartThemeQuoteColor);
+}
+
+.janitor-cloudflare-bypass .instruction-section h4 i {
+    margin-right: 8px;
+}
+
+.janitor-cloudflare-bypass .code-container {
+    position: relative;
+    background: var(--black50a);
+    border: 1px solid var(--SmartThemeBorderColor);
+    border-radius: 5px;
+    padding: 10px;
+}
+
+.janitor-cloudflare-bypass .code-block {
+    max-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-family: 'Courier New', monospace;
+    font-size: 12px;
+    margin: 0;
+    padding: 5px;
+    background: transparent;
+}
+
+.janitor-cloudflare-bypass kbd {
+    background: var(--black50a);
+    border: 1px solid var(--SmartThemeBorderColor);
+    border-radius: 3px;
+    padding: 2px 6px;
+    font-family: monospace;
+    font-size: 0.9em;
+}
+
+.janitor-cloudflare-bypass code {
+    background: var(--black30a);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: monospace;
+}
+
+.janitor-cloudflare-bypass ol {
+    padding-left: 25px;
+}
+
+.janitor-cloudflare-bypass ol li {
+    margin: 8px 0;
+}
+
+.janitor-cloudflare-bypass #janitor-drop-zone:hover {
+    background: var(--black50a);
+    border-color: var(--SmartThemeQuoteColor);
+}
+
+.code-container {
+    position: relative;
+}
+
+.code-block {
+    max-height: 300px;
+    overflow-y: auto;
+}
+</style>

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2310,7 +2310,6 @@ export function highlightRegex(regexStr) {
                 flags: new RegExp('(?<=\\/)([gimsuy]*)$', 'g'),  // Match trailing flags
                 delimiters: new RegExp('^\\/|(?<![\\\\<])\\/', 'g'),  // Match leading or trailing delimiters
             };
-
         } catch (error) {
             return {
                 brackets: new RegExp('(\\\\)?\\[.*?\\]', 'g'),  // Non-escaped square brackets

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2866,6 +2866,23 @@ export async function importFromExternalUrl(url, { preserveFileName = null } = {
     }
 
     if (!request.ok) {
+        console.log('[Frontend] Error response - Status:', request.status);
+        console.log('[Frontend] Content-Type header:', request.headers.get('Content-Type'));
+
+        // Check if this is a Cloudflare block error
+        const contentType = request.headers.get('Content-Type');
+        if (contentType && contentType.includes('application/json')) {
+            try {
+                const errorData = await request.json();
+                if (errorData.error === 'cloudflare_block') {
+                    // Show special Cloudflare bypass modal
+                    await showCloudflareBypassModal(errorData);
+                    return;
+                }
+            } catch (e) {
+                // Not JSON, fall through to normal error handling
+            }
+        }
         toastr.info(request.statusText, 'Custom content import failed');
         console.error('Custom content import failed', request.status, request.statusText);
         return;
@@ -2893,6 +2910,106 @@ export async function importFromExternalUrl(url, { preserveFileName = null } = {
             toastr.warning('Unknown content type');
             console.error('Unknown content type', customContentType);
             break;
+    }
+}
+
+/**
+ * Shows a modal with instructions to bypass Cloudflare protection for JanitorAI.
+ * @param {Object} errorData Error data from the server
+ * @param {string} errorData.uuid Character UUID
+ * @param {string} errorData.url Character page URL
+ * @param {string} errorData.bookmarklet Bookmarklet code
+ */
+async function showCloudflareBypassModal(errorData) {
+    try {
+        const { renderTemplateAsync } = await import('./templates.js');
+        const { callGenericPopup, POPUP_TYPE } = await import('./popup.js');
+        const { processDroppedFiles } = await import('../script.js');
+
+        const html = await renderTemplateAsync('janitorCloudflareBypass', errorData);
+
+        // Show the popup (don't await yet, we need to set up handlers first)
+        const popupPromise = callGenericPopup(html, POPUP_TYPE.TEXT, '', {
+            wide: true,
+            large: true,
+            allowVerticalScrolling: true,
+            okButton: 'Close',
+        });
+
+        // Wait for popup to be in DOM
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // Set up copy button handler
+        const copyBtn = document.getElementById('copy-bookmarklet-btn');
+        const codeBlock = document.getElementById('bookmarklet-code');
+        if (copyBtn && codeBlock) {
+            copyBtn.addEventListener('click', () => {
+                const code = codeBlock.textContent;
+                if (code) {
+                    navigator.clipboard.writeText(code).then(() => {
+                        toastr.success('Code copied to clipboard!');
+                    }).catch(err => {
+                        console.error('Failed to copy:', err);
+                        toastr.error('Failed to copy code. Please select and copy manually.');
+                    });
+                }
+            });
+        }
+
+        // Set up drag & drop zone
+        const dropZone = document.getElementById('janitor-drop-zone');
+        const fileInput = document.getElementById('janitor-file-input');
+
+        if (dropZone && fileInput) {
+            dropZone.addEventListener('click', () => {
+                fileInput.click();
+            });
+
+            dropZone.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                dropZone.style.borderColor = 'var(--SmartThemeQuoteColor)';
+                dropZone.style.background = 'var(--black50a)';
+            });
+
+            dropZone.addEventListener('dragleave', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                dropZone.style.borderColor = 'var(--SmartThemeBorderColor)';
+                dropZone.style.background = 'var(--black30a)';
+            });
+
+            dropZone.addEventListener('drop', async (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                dropZone.style.borderColor = 'var(--SmartThemeBorderColor)';
+                dropZone.style.background = 'var(--black30a)';
+
+                const files = Array.from(e.dataTransfer?.files || []).filter(f => f.name.endsWith('.json'));
+                if (files.length > 0) {
+                    // Close the modal
+                    $('#dialogue_popup_cancel').trigger('click');
+                    // Import the files
+                    await processDroppedFiles(files);
+                }
+            });
+
+            fileInput.addEventListener('change', async (e) => {
+                const files = Array.from(e.target?.files || []);
+                if (files.length > 0) {
+                    // Close the modal
+                    $('#dialogue_popup_cancel').trigger('click');
+                    // Import the files
+                    await processDroppedFiles(files);
+                }
+            });
+        }
+
+        // Now await the popup result
+        await popupPromise;
+    } catch (error) {
+        console.error('[Frontend] Error showing Cloudflare bypass modal:', error);
+        toastr.error('Failed to show modal. Check console for details.');
     }
 }
 

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2310,6 +2310,7 @@ export function highlightRegex(regexStr) {
                 flags: new RegExp('(?<=\\/)([gimsuy]*)$', 'g'),  // Match trailing flags
                 delimiters: new RegExp('^\\/|(?<![\\\\<])\\/', 'g'),  // Match leading or trailing delimiters
             };
+
         } catch (error) {
             return {
                 brackets: new RegExp('(\\\\)?\\[.*?\\]', 'g'),  // Non-escaped square brackets
@@ -2922,6 +2923,13 @@ export async function importFromExternalUrl(url, { preserveFileName = null } = {
  */
 async function showCloudflareBypassModal(errorData) {
     try {
+        // Validate errorData
+        if (!errorData?.url || !errorData?.bookmarklet) {
+            console.error('Invalid errorData for Cloudflare bypass modal:', errorData);
+            toastr.error('Failed to show Cloudflare bypass instructions. Missing required data.');
+            return;
+        }
+
         const { renderTemplateAsync } = await import('./templates.js');
         const { callGenericPopup, POPUP_TYPE } = await import('./popup.js');
         const { processDroppedFiles } = await import('../script.js');
@@ -2990,7 +2998,12 @@ async function showCloudflareBypassModal(errorData) {
                     // Close the modal
                     $('#dialogue_popup_cancel').trigger('click');
                     // Import the files
-                    await processDroppedFiles(files);
+                    try {
+                        await processDroppedFiles(files);
+                    } catch (err) {
+                        console.error('Error processing dropped files:', err);
+                        toastr.error('Failed to import character file.');
+                    }
                 }
             });
 
@@ -3000,7 +3013,12 @@ async function showCloudflareBypassModal(errorData) {
                     // Close the modal
                     $('#dialogue_popup_cancel').trigger('click');
                     // Import the files
-                    await processDroppedFiles(files);
+                    try {
+                        await processDroppedFiles(files);
+                    } catch (err) {
+                        console.error('Error processing selected files:', err);
+                        toastr.error('Failed to import character file.');
+                    }
                 }
             });
         }


### PR DESCRIPTION
- Detect JSON error responses with cloudflare_block flag
- Display modal with bookmarklet instructions
- Copy-to-clipboard functionality
- Drag-drop file import zone
- Auto-import downloaded JSON files
- User-friendly troubleshooting guide

Related PRs:
- Part 1: #5199 (Backend detection - **Required, merge first**)
- Enhancement: #5200 (Avatar base64 - Optional)
Depends on #5199 to receive `cloudflare_block` errors.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
