### PR TITLE
Bug Fix: SD Text -> Image huggingface inference API

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -23,7 +23,7 @@ We have a [Documentation website](https://docs.sillytavern.app/) to answer most 
 
 SillyTavern (or ST for short) is a locally installed user interface that allows you to interact with text generation LLMs, image generation engines, and TTS voice models.
 
-Beginning in February 2023 as a fork of TavernAI 1.2.8, SillyTavern now has over 200 contributors and 2 years of independent development under its belt, and continues to serve as a leading software for savvy AI hobbyists.
+Beginning in February 2023 as a fork of TavernAI 1.2.8, SillyTavern now has over 300 contributors and 3 years of independent development under its belt, and continues to serve as a leading software for savvy AI hobbyists.
 
 ## Our Vision
 

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -1893,7 +1893,7 @@ async function loadModels() {
             models = await loadStabilityModels();
             break;
         case sources.huggingface:
-            models = [{ value: '', text: t`<Enter Model ID above>` }];
+            models = [{ value: '', text: t`<Model ID Preselected Above>` }];
             break;
         case sources.chutes:
             models = await loadChutesModels();
@@ -4255,6 +4255,8 @@ async function generateHuggingFaceImage(prompt, signal) {
         body: JSON.stringify({
             model: extension_settings.sd.huggingface_model_id,
             prompt: prompt,
+            width: extension_settings.sd.width,
+            height: extension_settings.sd.height
         }),
     });
 

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -113,7 +113,7 @@
             <div data-sd-source="huggingface">
                 <i data-i18n="Hint: Save an API key in the Hugging Face (Text Completion) API settings to use it here.">Hint: Save an API key in the Hugging Face (Text Completion) API settings to use it here.</i>
                 <label for="sd_huggingface_model_id" data-i18n="Model ID">Model ID</label>
-                <input id="sd_huggingface_model_id" type="text" class="text_pole"  data-i18n="[placeholder]e.g. black-forest-labs/FLUX.1-dev" placeholder="e.g. black-forest-labs/FLUX.1-dev" value="" />
+                <input id="sd_huggingface_model_id" type="text" class="text_pole"  data-i18n="[placeholder]e.g. black-forest-labs/FLUX.1-dev" placeholder="e.g. black-forest-labs/FLUX.1-dev" value="stabilityai/stable-diffusion-xl-base-1.0" disabled/>
             </div>
             <div data-sd-source="chutes">
                 <i data-i18n="Hint: Save an API key in the Chutes (Chat Completion) API settings to use it here.">Hint: Save an API key in the Chutes (Chat Completion) API settings to use it here.</i>

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -1136,26 +1136,40 @@ huggingface.post('/generate', async (request, response) => {
 
         console.debug('Hugging Face request:', request.body);
 
-        const result = await fetch(`https://api-inference.huggingface.co/models/${request.body.model}`, {
-            method: 'POST',
-            body: JSON.stringify({
-                inputs: request.body.prompt,
-            }),
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${key}`,
-            },
-        });
+        const result = await fetch('https://router.huggingface.co/nscale/v1/images/generations',
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${key}`
+                },
+                method: 'POST',
+                body: JSON.stringify({
+                    response_format: "b64_json",
+                    prompt: request.body.prompt,
+                    model: request.body.model,
+                    width: request.body.width,
+                    height: request.body.height
+                })
+            }
+        );
+
+        const json = await result.json();
 
         if (!result.ok) {
-            console.warn('Hugging Face returned an error.');
-            return response.sendStatus(500);
+            console.warn('Hugging Face returned an error:', result.statusText, json?.error);
+
+            return response.sendStatus(500).send(json?.error);
         }
 
-        const buffer = await result.arrayBuffer();
-        return response.send({
-            image: Buffer.from(buffer).toString('base64'),
-        });
+        const image = json?.data?.[0]?.b64_json;
+
+        if (!image) {
+            console.warn('No image returned from Hugging Face.')
+            return response.sendStatus(500).send('No image returned from Hugging Face.');
+        }
+
+        return response.send({ image });
+
     } catch (error) {
         console.error(error);
         return response.sendStatus(500);


### PR DESCRIPTION
Bug Fix: Refactored SD text -> image for huggingface inference api using new endpoint and altered HTML / JS frontend to limit model ID as per inference API limitations while passing the width / height options which weren't passed before.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
