### PR TITLE
feat: add gpt-5.3-codex to OpenAI Chat Completion models

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3019,6 +3019,9 @@
                             <div>
                                 <h4 data-i18n="OpenAI Model">OpenAI Model</h4>
                                 <select id="model_openai_select">
+                                    <optgroup label="GPT-5.3 Codex">
+                                        <option value="gpt-5.3-codex">gpt-5.3-codex</option>
+                                    </optgroup>
                                     <optgroup label="GPT-5.2">
                                         <option value="gpt-5.2">gpt-5.2</option>
                                         <option value="gpt-5.2-2025-12-11">gpt-5.2-2025-12-11</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -53,6 +53,7 @@
                         <option data-type="cohere" value="c4ai-aya-vision-8b">c4ai-aya-vision-8b</option>
                         <option data-type="cohere" value="c4ai-aya-vision-32b">c4ai-aya-vision-32b</option>
                         <option data-type="cohere" value="command-a-vision-07-2025">command-a-vision-07-2025</option>
+                        <option data-type="openai" value="gpt-5.3-codex">gpt-5.3-codex</option>
                         <option data-type="openai" value="gpt-5.2">gpt-5.2</option>
                         <option data-type="openai" value="gpt-5.2-2025-12-11">gpt-5.2-2025-12-11</option>
                         <option data-type="openai" value="gpt-5.2-chat-latest">gpt-5.2-chat-latest</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2854,7 +2854,7 @@ export async function createGenerationParameters(settings, model, type, messages
         if (/gpt-5-chat-latest/.test(model)) {
             delete generate_data.tools;
             delete generate_data.tool_choice;
-        } else if (/gpt-5.(1|2)/.test(model) && !/chat-latest/.test(model)) {
+        } else if (/gpt-5.(1|2|3)/.test(model) && !/chat-latest/.test(model)) {
             delete generate_data.frequency_penalty;
             delete generate_data.presence_penalty;
             delete generate_data.logit_bias;

--- a/src/constants.js
+++ b/src/constants.js
@@ -476,6 +476,7 @@ export const OPENAI_REASONING_EFFORT_MODELS = [
     'gpt-5.2',
     'gpt-5.2-2025-12-11',
     'gpt-5.2-chat-latest',
+    'gpt-5.3-codex',
 ];
 
 export const OPENAI_REASONING_EFFORT_MAP = {


### PR DESCRIPTION
Adds **gpt-5.3-codex** to the OpenAI Chat Completion source with thinking/reasoning support.

### Changes
- **public/index.html** – New `GPT-5.3 Codex` optgroup in the OpenAI model select dropdown.
- **public/scripts/extensions/caption/settings.html** – Added `gpt-5.3-codex` to the multimodal caption model list.
- **src/constants.js** – Added `gpt-5.3-codex` to `OPENAI_REASONING_EFFORT_MODELS` for thinking/reasoning effort support.
- **public/scripts/openai.js** – Updated the `gpt-5.x` regex from `/(1|2)/` to `/(1|2|3)/` so `gpt-5.3-codex` gets proper request parameter handling (same as gpt-5.1/5.2 models).

Existing gpt-5 infrastructure already covers vision support, verbosity, max context (400k), and `max_completion_tokens` substitution via broader `/gpt-5/` pattern matches.