### PR TITLE
fix(users): ensure directory exists for cookie secret

### DIFF
--- a/src/users.js
+++ b/src/users.js
@@ -530,6 +530,7 @@ export async function initUserStorage(dataRoot) {
  */
 export function getCookieSecret(dataRoot) {
     const cookieSecretPath = path.join(dataRoot, COOKIE_SECRET_PATH);
+    fs.mkdirSync(path.dirname(cookieSecretPath), { recursive: true });
 
     if (fs.existsSync(cookieSecretPath)) {
         const stat = fs.statSync(cookieSecretPath);


### PR DESCRIPTION
## Description

This is a minor change. It originated when I wanted to reset my SillyTavern installation. I ran `rm -rf data/` and restarted the server, but it subsequently crashed with an error. This PR provides a minimal fix for this issue, ensuring robustness when restarting the server after the `data` directory has been deleted.

Root cause:
 `getCookieSecret()` writes the cookie secret with `write-file-atomic`, which requires the parent directory to exist. If `dataRoot` is missing, startup crashes with `ENOENT`.



```
~/data/workspace/SillyTavern staging*
❯ node ./server.js
Node version: v24.11.0. Running in undefined environment. Server directory: /home/awaae001/data/workspace/SillyTavern
Using config path: ./config.yaml
Cookie secret is missing from data root. Generating a new one...
A critical error has occurred while starting the server: Error: ENOENT: no such file or directory, open 'data/cookie-secret.txt.1968077911'
    at Object.openSync (node:fs:560:18)
    at writeFileSync (/home/awaae001/data/workspace/SillyTavern/node_modules/.pnpm/write-file-atomic@5.0.1/node_modules/write-file-atomic/lib/index.js:216:13)
    at getCookieSecret (file:///home/awaae001/data/workspace/SillyTavern/src/users.js:550:5)
    at file:///home/awaae001/data/workspace/SillyTavern/src/server-main.js:153:13
    at ModuleJob.run (node:internal/modules/esm/module_job:377:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:691:26)
    at async file:///home/awaae001/data/workspace/SillyTavern/server.js:14:5 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'data/cookie-secret.txt.1968077911'
}
```

## How to reproduce:
- Backup your `data` folder.
- Delete the folder directly.
- Restart SillyTavern.

## What I did
- I modified `src/users.js` to recreate the `data` folder if it detects that it does not exist.
- I believe this acts as a fallback to prevent startup failures and unnecessary panic (I was personally a bit lost when it happened).
## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
