### PR TITLE
feat: Add Avian as Chat Completion provider

### DIFF
--- a/public/img/avian.svg
+++ b/public/img/avian.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <circle cx="64" cy="64" r="60" fill="#2563EB"/>
+  <text x="64" y="82" font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="bold" fill="white" text-anchor="middle">A</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -3713,10 +3713,6 @@
                             <div>
                                 <h4 data-i18n="Avian Model">Avian Model</h4>
                                 <select id="model_avian_select">
-                                    <option value="deepseek/deepseek-v3.2">deepseek/deepseek-v3.2</option>
-                                    <option value="moonshotai/kimi-k2.5">moonshotai/kimi-k2.5</option>
-                                    <option value="z-ai/glm-5">z-ai/glm-5</option>
-                                    <option value="minimax/minimax-m2.5">minimax/minimax-m2.5</option>
                                 </select>
                             </div>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -697,7 +697,7 @@
                                         </span>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai">
+                                <div class="range-block" data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai,avian">
                                     <div class="range-block-title" data-i18n="Temperature">
                                         Temperature
                                     </div>
@@ -710,7 +710,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai">
+                                <div class="range-block" data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai,avian">
                                     <div class="range-block-title" data-i18n="Frequency Penalty">
                                         Frequency Penalty
                                     </div>
@@ -723,7 +723,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai">
+                                <div class="range-block" data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai,avian">
                                     <div class="range-block-title" data-i18n="Presence Penalty">
                                         Presence Penalty
                                     </div>
@@ -749,7 +749,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai">
+                                <div class="range-block" data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai,avian">
                                     <div class="range-block-title" data-i18n="Top P">
                                         Top P
                                     </div>
@@ -2000,7 +2000,7 @@
                                             </b>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="openai,cohere,mistralai,custom,claude,aimlapi,openrouter,groq,siliconflow,minimax,deepseek,makersuite,vertexai,ai21,xai,pollinations,moonshot,fireworks,cometapi,electronhub,chutes,azure_openai,zai,nanogpt,workers_ai">
+                                    <div class="range-block" data-source="openai,cohere,mistralai,custom,claude,aimlapi,openrouter,groq,siliconflow,minimax,deepseek,makersuite,vertexai,ai21,xai,pollinations,moonshot,fireworks,cometapi,electronhub,chutes,azure_openai,zai,nanogpt,workers_ai,avian">
                                         <label for="openai_function_calling" class="checkbox_label flexWrap widthFreeExpand">
                                             <input id="openai_function_calling" type="checkbox" />
                                             <span data-i18n="Enable function calling">Enable function calling</span>
@@ -2138,7 +2138,7 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="deepseek,aimlapi,openrouter,custom,claude,xai,makersuite,vertexai,pollinations,moonshot,mistralai,fireworks,cometapi,electronhub,chutes,azure_openai,nanogpt,zai,workers_ai">
+                                    <div class="range-block" data-source="deepseek,aimlapi,openrouter,custom,claude,xai,makersuite,vertexai,pollinations,moonshot,mistralai,fireworks,cometapi,electronhub,chutes,azure_openai,nanogpt,zai,workers_ai,avian">
                                         <label for="openai_show_thoughts" class="checkbox_label widthFreeExpand">
                                             <input id="openai_show_thoughts" type="checkbox" />
                                             <span data-i18n="Request model reasoning">Request model reasoning</span>
@@ -2927,6 +2927,7 @@
                             <optgroup>
                                 <option value="ai21">AI21</option>
                                 <option value="aimlapi">AI/ML API</option>
+                                <option value="avian">Avian</option>
                                 <option value="azure_openai">Azure OpenAI</option>
                                 <option value="chutes">Chutes</option>
                                 <option value="claude">Claude</option>
@@ -2952,7 +2953,7 @@
                                 <option value="zai">Z.AI (GLM)</option>
                             </optgroup>
                         </select>
-                        <div class="inline-drawer wide100p" data-source="openai,claude,mistralai,makersuite,vertexai,deepseek,xai,zai,moonshot">
+                        <div class="inline-drawer wide100p" data-source="openai,claude,mistralai,makersuite,vertexai,deepseek,xai,zai,moonshot,avian">
                             <div class="inline-drawer-toggle inline-drawer-header">
                                 <b data-i18n="Reverse Proxy">Reverse Proxy</b>
                                 <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
@@ -3016,7 +3017,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div id="ReverseProxyWarningMessage" data-source="openai,claude,mistralai,makersuite,vertexai,deepseek,xai,zai,moonshot">
+                        <div id="ReverseProxyWarningMessage" data-source="openai,claude,mistralai,makersuite,vertexai,deepseek,xai,zai,moonshot,avian">
                             <div class="reverse_proxy_warning">
                                 <b>
                                     <div data-i18n="Using a proxy that you're not running yourself is a risk to your data privacy.">
@@ -3697,6 +3698,25 @@
                                 <h4 data-i18n="DeepSeek Model">DeepSeek Model</h4>
                                 <select id="model_deepseek_select">
                                     <option value="" data-i18n="-- Connect to the API --">-- Connect to the API --</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div id="avian_form" data-source="avian">
+                            <h4><a href="https://avian.io" target="_blank" rel="noopener noreferrer" data-i18n="Avian API Key">Avian API Key</a></h4>
+                            <div class="flex-container">
+                                <input id="api_key_avian" name="api_key_avian" class="text_pole flex1" value="" type="text" autocomplete="off">
+                                <div title="Manage API keys" data-i18n="[title]Manage API keys" class="menu_button fa-solid fa-key fa-fw manage-api-keys" data-key="api_key_avian"></div>
+                            </div>
+                            <div data-for="api_key_avian" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'.">
+                                For privacy reasons, your API key will be hidden after you click 'Connect'.
+                            </div>
+                            <div>
+                                <h4 data-i18n="Avian Model">Avian Model</h4>
+                                <select id="model_avian_select">
+                                    <option value="deepseek/deepseek-v3.2">deepseek/deepseek-v3.2</option>
+                                    <option value="moonshotai/kimi-k2.5">moonshotai/kimi-k2.5</option>
+                                    <option value="z-ai/glm-5">z-ai/glm-5</option>
+                                    <option value="minimax/minimax-m2.5">minimax/minimax-m2.5</option>
                                 </select>
                             </div>
                         </div>

--- a/public/script.js
+++ b/public/script.js
@@ -6352,6 +6352,7 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
                 case chat_completion_sources.CHUTES:
                 case chat_completion_sources.AZURE_OPENAI:
                 case chat_completion_sources.ZAI:
+                case chat_completion_sources.AVIAN:
                 default:
                     result = tryParse(text);
                     if (!result && returnInvalidJson) {

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -411,6 +411,7 @@ function RA_autoconnect(PrevApi) {
                     || (secret_state[SECRET_KEYS.MINIMAX] && oai_settings.chat_completion_source == chat_completion_sources.MINIMAX)
                     || (isValidUrl(oai_settings.custom_url) && oai_settings.chat_completion_source == chat_completion_sources.CUSTOM)
                     || (secret_state[SECRET_KEYS.AZURE_OPENAI] && oai_settings.chat_completion_source == chat_completion_sources.AZURE_OPENAI)
+                    || (secret_state[SECRET_KEYS.AVIAN] && oai_settings.chat_completion_source == chat_completion_sources.AVIAN)
                 ) {
                     $('#api_button_openai').trigger('click');
                 }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -201,6 +201,7 @@ export const chat_completion_sources = {
     SILICONFLOW: 'siliconflow',
     WORKERS_AI: 'workers_ai',
     MINIMAX: 'minimax',
+    AVIAN: 'avian',
 };
 
 const character_names_behavior = {
@@ -339,6 +340,7 @@ export const settingsToUpdate = {
     nanogpt_provider: ['#nanogpt_provider', 'nanogpt_provider', false, true],
     nanogpt_payg_override: ['#nanogpt_payg_override', 'nanogpt_payg_override', true, true],
     deepseek_model: ['#model_deepseek_select', 'deepseek_model', false, true],
+    avian_model: ['#model_avian_select', 'avian_model', false, true],
     aimlapi_model: ['#model_aimlapi_select', 'aimlapi_model', false, true],
     xai_model: ['#model_xai_select', 'xai_model', false, true],
     pollinations_model: ['#model_pollinations_select', 'pollinations_model', false, true],
@@ -456,6 +458,7 @@ const default_settings = {
     nanogpt_provider: '',
     nanogpt_payg_override: false,
     deepseek_model: 'deepseek-v4-flash',
+    avian_model: 'deepseek/deepseek-v3.2',
     aimlapi_model: 'chatgpt-4o-latest',
     xai_model: 'grok-3-beta',
     pollinations_model: 'openai',
@@ -1757,6 +1760,8 @@ export function getChatCompletionModel(settings = null) {
             return settings.nanogpt_model;
         case chat_completion_sources.DEEPSEEK:
             return settings.deepseek_model;
+        case chat_completion_sources.AVIAN:
+            return settings.avian_model;
         case chat_completion_sources.AIMLAPI:
             return settings.aimlapi_model;
         case chat_completion_sources.XAI:
@@ -2214,6 +2219,24 @@ function saveModelList(data) {
         }
 
         $('#model_deepseek_select').val(oai_settings.deepseek_model).trigger('change');
+    }
+
+    if (oai_settings.chat_completion_source == chat_completion_sources.AVIAN) {
+        $('#model_avian_select').empty();
+        model_list.forEach((model) => {
+            $('#model_avian_select').append(
+                $('<option>', {
+                    value: model.id,
+                    text: model.id,
+                }));
+        });
+
+        const selectedModel = model_list.find(model => model.id === oai_settings.avian_model);
+        if (model_list.length > 0 && (!selectedModel || !oai_settings.avian_model)) {
+            oai_settings.avian_model = model_list[0].id;
+        }
+
+        $('#model_avian_select').val(oai_settings.avian_model).trigger('change');
     }
 
     if (oai_settings.chat_completion_source === chat_completion_sources.POLLINATIONS) {
@@ -2728,6 +2751,7 @@ export async function createGenerationParameters(settings, model, type, messages
         chat_completion_sources.XAI,
         chat_completion_sources.ZAI,
         chat_completion_sources.MOONSHOT,
+        chat_completion_sources.AVIAN,
     ];
 
     // Sources that support logprobs
@@ -3259,7 +3283,7 @@ export function getStreamingReply(data, state, { chatCompletionSource = null, ov
             }
         });
         return data.choices?.[0]?.delta?.content ?? data.choices?.[0]?.message?.content ?? data.choices?.[0]?.text ?? '';
-    } else if ([chat_completion_sources.CUSTOM, chat_completion_sources.POLLINATIONS, chat_completion_sources.AIMLAPI, chat_completion_sources.MOONSHOT, chat_completion_sources.COMETAPI, chat_completion_sources.ELECTRONHUB, chat_completion_sources.NANOGPT, chat_completion_sources.ZAI, chat_completion_sources.SILICONFLOW, chat_completion_sources.CHUTES, chat_completion_sources.WORKERS_AI, chat_completion_sources.FIREWORKS].includes(chat_completion_source)) {
+    } else if ([chat_completion_sources.CUSTOM, chat_completion_sources.POLLINATIONS, chat_completion_sources.AIMLAPI, chat_completion_sources.MOONSHOT, chat_completion_sources.COMETAPI, chat_completion_sources.ELECTRONHUB, chat_completion_sources.NANOGPT, chat_completion_sources.ZAI, chat_completion_sources.SILICONFLOW, chat_completion_sources.CHUTES, chat_completion_sources.WORKERS_AI, chat_completion_sources.FIREWORKS, chat_completion_sources.AVIAN].includes(chat_completion_source)) {
         if (show_thoughts) {
             state.reasoning +=
                 data.choices?.filter(x => x?.delta?.reasoning_content)?.[0]?.delta?.reasoning_content ??
@@ -4473,6 +4497,7 @@ async function getStatusOpen() {
         chat_completion_sources.XAI,
         chat_completion_sources.ZAI,
         chat_completion_sources.MOONSHOT,
+        chat_completion_sources.AVIAN,
     ];
     if (oai_settings.reverse_proxy && validateProxySources.includes(oai_settings.chat_completion_source)) {
         await validateReverseProxy();
@@ -5586,6 +5611,16 @@ async function onModelChange() {
         oai_settings.deepseek_model = value;
     }
 
+    if ($(this).is('#model_avian_select')) {
+        if (!value) {
+            console.debug('Null Avian model selected. Ignoring.');
+            return;
+        }
+
+        console.log('Avian model changed to', value);
+        oai_settings.avian_model = value;
+    }
+
     if (value && $(this).is('#model_custom_select')) {
         console.log('Custom model changed to', value);
         oai_settings.custom_model = value;
@@ -5875,6 +5910,20 @@ async function onModelChange() {
         $('#temp_openai').attr('max', workersAiMaxTemp).val(oai_settings.temp_openai).trigger('input');
     }
 
+    if (oai_settings.chat_completion_source === chat_completion_sources.AVIAN) {
+        if (oai_settings.max_context_unlocked) {
+            $('#openai_max_context').attr('max', unlocked_max);
+        } else if (oai_settings.avian_model === 'minimax/minimax-m2.5') {
+            $('#openai_max_context').attr('max', max_2mil);
+        } else {
+            $('#openai_max_context').attr('max', max_200k);
+        }
+
+        oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
+        $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
+        $('#temp_openai').attr('max', oai_max_temp).val(oai_settings.temp_openai).trigger('input');
+    }
+
     if (oai_settings.chat_completion_source === chat_completion_sources.COMETAPI) {
         $('#openai_max_context').attr('max', oai_settings.max_context_unlocked ? unlocked_max : max_128k);
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
@@ -6024,6 +6073,7 @@ async function onConnectButtonClick(e) {
         [chat_completion_sources.ELECTRONHUB]: { key: SECRET_KEYS.ELECTRONHUB, selector: '#api_key_electronhub', proxy: false },
         [chat_completion_sources.NANOGPT]: { key: SECRET_KEYS.NANOGPT, selector: '#api_key_nanogpt', proxy: false },
         [chat_completion_sources.DEEPSEEK]: { key: SECRET_KEYS.DEEPSEEK, selector: '#api_key_deepseek', proxy: true },
+        [chat_completion_sources.AVIAN]: { key: SECRET_KEYS.AVIAN, selector: '#api_key_avian', proxy: true },
         [chat_completion_sources.XAI]: { key: SECRET_KEYS.XAI, selector: '#api_key_xai', proxy: true },
         [chat_completion_sources.AIMLAPI]: { key: SECRET_KEYS.AIMLAPI, selector: '#api_key_aimlapi', proxy: false },
         [chat_completion_sources.MOONSHOT]: { key: SECRET_KEYS.MOONSHOT, selector: '#api_key_moonshot', proxy: true },
@@ -6110,6 +6160,8 @@ function toggleChatCompletionForms() {
         $('#model_custom_select').trigger('change');
     } else if (oai_settings.chat_completion_source == chat_completion_sources.DEEPSEEK) {
         $('#model_deepseek_select').trigger('change');
+    } else if (oai_settings.chat_completion_source == chat_completion_sources.AVIAN) {
+        $('#model_avian_select').trigger('change');
     } else if (oai_settings.chat_completion_source == chat_completion_sources.AIMLAPI) {
         $('#model_aimlapi_select').trigger('change');
     } else if (oai_settings.chat_completion_source == chat_completion_sources.XAI) {
@@ -7334,6 +7386,7 @@ export function initOpenAI() {
     $('#model_electronhub_select').on('change', onModelChange);
     $('#model_nanogpt_select').on('change', onModelChange);
     $('#model_deepseek_select').on('change', onModelChange);
+    $('#model_avian_select').on('change', onModelChange);
     $('#model_aimlapi_select').on('change', onModelChange);
     $('#model_custom_select').on('change', onModelChange);
     $('#model_xai_select').on('change', onModelChange);

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -155,6 +155,7 @@ export function extractReasoningFromData(data, {
                 case chat_completion_sources.ZAI:
                 case chat_completion_sources.WORKERS_AI:
                 case chat_completion_sources.FIREWORKS:
+                case chat_completion_sources.AVIAN:
                 case chat_completion_sources.CUSTOM: {
                     return data?.choices?.[0]?.message?.reasoning_content
                         ?? data?.choices?.[0]?.message?.reasoning

--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -79,6 +79,7 @@ export const SECRET_KEYS = {
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
     WORKERS_AI: 'api_key_workers_ai',
+    AVIAN: 'api_key_avian',
 };
 
 const FRIENDLY_NAMES = {
@@ -144,6 +145,7 @@ const FRIENDLY_NAMES = {
     [SECRET_KEYS.VOLCENGINE_APP_ID]: 'Volcengine App ID',
     [SECRET_KEYS.VOLCENGINE_ACCESS_KEY]: 'Volcengine Access Key',
     [SECRET_KEYS.WORKERS_AI]: 'Cloudflare Workers AI',
+    [SECRET_KEYS.AVIAN]: 'Avian',
 };
 
 const INPUT_MAP = {
@@ -189,6 +191,7 @@ const INPUT_MAP = {
     [SECRET_KEYS.MINIMAX]: '#api_key_minimax',
     [SECRET_KEYS.POLLINATIONS]: '#api_key_pollinations',
     [SECRET_KEYS.WORKERS_AI]: '#api_key_workers_ai',
+    [SECRET_KEYS.AVIAN]: '#api_key_avian',
 };
 
 const getLabel = () => moment().format('L LT');

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -6267,6 +6267,7 @@ function getModelOptions(quiet) {
         { id: 'model_electronhub_select', api: 'openai', type: chat_completion_sources.ELECTRONHUB },
         { id: 'model_nanogpt_select', api: 'openai', type: chat_completion_sources.NANOGPT },
         { id: 'model_deepseek_select', api: 'openai', type: chat_completion_sources.DEEPSEEK },
+        { id: 'model_avian_select', api: 'openai', type: chat_completion_sources.AVIAN },
         { id: 'model_aimlapi_select', api: 'openai', type: chat_completion_sources.AIMLAPI },
         { id: 'model_xai_select', api: 'openai', type: chat_completion_sources.XAI },
         { id: 'model_pollinations_select', api: 'openai', type: chat_completion_sources.POLLINATIONS },

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -597,6 +597,10 @@ export function getTokenizerModel() {
         return deepseekTokenizer;
     }
 
+    if (oai_settings.chat_completion_source == chat_completion_sources.AVIAN) {
+        return turboTokenizer;
+    }
+
     // And for OpenRouter (if not a site model, then it's impossible to determine the tokenizer)
     if (main_api == 'openai' && oai_settings.chat_completion_source == chat_completion_sources.OPENROUTER && oai_settings.openrouter_model ||
         main_api == 'textgenerationwebui' && textgen_settings.type === textgen_types.OPENROUTER && textgen_settings.openrouter_model) {

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -674,6 +674,7 @@ export class ToolManager {
             chat_completion_sources.NANOGPT,
             chat_completion_sources.WORKERS_AI,
             chat_completion_sources.MINIMAX,
+            chat_completion_sources.AVIAN,
         ];
         return supportedSources.includes(settings.chat_completion_source);
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -211,6 +211,7 @@ export const CHAT_COMPLETION_SOURCES = {
     SILICONFLOW: 'siliconflow',
     MINIMAX: 'minimax',
     WORKERS_AI: 'workers_ai',
+    AVIAN: 'avian',
 };
 
 /**

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -96,6 +96,7 @@ const API_SILICONFLOW = 'https://api.siliconflow.com/v1';
 const API_SILICONFLOW_CN = 'https://api.siliconflow.cn/v1';
 const API_MINIMAX = 'https://api.minimax.io/v1';
 const API_MINIMAX_CN = 'https://api.minimaxi.com/v1';
+const API_AVIAN = 'https://api.avian.io/v1';
 const API_OPENROUTER = 'https://openrouter.ai/api/v1';
 const API_WORKERS_AI = 'https://api.cloudflare.com/client/v4/accounts';
 
@@ -1165,6 +1166,96 @@ async function sendDeepSeekRequest(request, response) {
 }
 
 /**
+ * Sends a request to Avian API.
+ * @param {express.Request} request Express request
+ * @param {express.Response} response Express response
+ */
+async function sendAvianRequest(request, response) {
+    const apiUrl = new URL(request.body.reverse_proxy || API_AVIAN).toString();
+    const apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.AVIAN);
+
+    if (!apiKey && !request.body.reverse_proxy) {
+        console.warn('Avian API key is missing.');
+        return response.status(400).send({ error: true });
+    }
+
+    const controller = new AbortController();
+    request.socket.removeAllListeners('close');
+    request.socket.on('close', function () {
+        controller.abort();
+    });
+
+    try {
+        let bodyParams = {};
+
+        if (Array.isArray(request.body.tools) && request.body.tools.length > 0) {
+            bodyParams['tools'] = request.body.tools;
+            bodyParams['tool_choice'] = request.body.tool_choice;
+        }
+
+        if (request.body.json_schema) {
+            bodyParams.response_format = {
+                type: 'json_object',
+            };
+            const message = {
+                role: 'user',
+                content: `JSON schema for the response:\n${JSON.stringify(request.body.json_schema.value, null, 4)}`,
+            };
+            request.body.messages.push(message);
+        }
+
+        const requestBody = {
+            'messages': request.body.messages,
+            'model': request.body.model,
+            'temperature': request.body.temperature,
+            'max_tokens': request.body.max_tokens,
+            'stream': request.body.stream,
+            'presence_penalty': request.body.presence_penalty,
+            'frequency_penalty': request.body.frequency_penalty,
+            'top_p': request.body.top_p,
+            'stop': request.body.stop,
+            'seed': request.body.seed,
+            ...bodyParams,
+        };
+
+        const config = {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + apiKey,
+            },
+            body: JSON.stringify(requestBody),
+            signal: controller.signal,
+        };
+
+        console.debug('Avian request:', requestBody);
+
+        const generateResponse = await fetch(apiUrl + '/chat/completions', config);
+
+        if (request.body.stream) {
+            forwardFetchResponse(generateResponse, response);
+        } else {
+            if (!generateResponse.ok) {
+                const errorText = await generateResponse.text();
+                console.warn(`Avian API returned error: ${generateResponse.status} ${generateResponse.statusText} ${errorText}`);
+                const errorJson = tryParse(errorText) ?? { error: true };
+                return response.status(500).send(errorJson);
+            }
+            const generateResponseJson = await generateResponse.json();
+            console.debug('Avian response:', generateResponseJson);
+            return response.send(generateResponseJson);
+        }
+    } catch (error) {
+        console.error('Error communicating with Avian API: ', error);
+        if (!response.headersSent) {
+            response.send({ error: true });
+        } else {
+            response.end();
+        }
+    }
+}
+
+/**
  * Sends a request to XAI API.
  * @param {express.Request} request Express request
  * @param {express.Response} response Express response
@@ -1812,6 +1903,10 @@ router.post('/status', async function (request, statusResponse) {
             apiUrl = new URL(request.body.reverse_proxy || API_DEEPSEEK.replace('/beta', '')).toString();
             apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.DEEPSEEK, request.body.secret_id);
             headers = {};
+        } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.AVIAN) {
+            apiUrl = new URL(request.body.reverse_proxy || API_AVIAN).toString();
+            apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.AVIAN);
+            headers = {};
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.XAI) {
             apiUrl = new URL(request.body.reverse_proxy || API_XAI).toString();
             apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.XAI, request.body.secret_id);
@@ -2264,6 +2359,7 @@ router.post('/generate', async function (request, response) {
             case CHAT_COMPLETION_SOURCES.MISTRALAI: return await sendMistralAIRequest(request, response);
             case CHAT_COMPLETION_SOURCES.COHERE: return await sendCohereRequest(request, response);
             case CHAT_COMPLETION_SOURCES.DEEPSEEK: return await sendDeepSeekRequest(request, response);
+            case CHAT_COMPLETION_SOURCES.AVIAN: return await sendAvianRequest(request, response);
             case CHAT_COMPLETION_SOURCES.AIMLAPI: return await sendAimlapiRequest(request, response);
             case CHAT_COMPLETION_SOURCES.XAI: return await sendXaiRequest(request, response);
             case CHAT_COMPLETION_SOURCES.CHUTES: return await sendChutesRequest(request, response);

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1166,96 +1166,6 @@ async function sendDeepSeekRequest(request, response) {
 }
 
 /**
- * Sends a request to Avian API.
- * @param {express.Request} request Express request
- * @param {express.Response} response Express response
- */
-async function sendAvianRequest(request, response) {
-    const apiUrl = new URL(request.body.reverse_proxy || API_AVIAN).toString();
-    const apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.AVIAN);
-
-    if (!apiKey && !request.body.reverse_proxy) {
-        console.warn('Avian API key is missing.');
-        return response.status(400).send({ error: true });
-    }
-
-    const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
-
-    try {
-        let bodyParams = {};
-
-        if (Array.isArray(request.body.tools) && request.body.tools.length > 0) {
-            bodyParams['tools'] = request.body.tools;
-            bodyParams['tool_choice'] = request.body.tool_choice;
-        }
-
-        if (request.body.json_schema) {
-            bodyParams.response_format = {
-                type: 'json_object',
-            };
-            const message = {
-                role: 'user',
-                content: `JSON schema for the response:\n${JSON.stringify(request.body.json_schema.value, null, 4)}`,
-            };
-            request.body.messages.push(message);
-        }
-
-        const requestBody = {
-            'messages': request.body.messages,
-            'model': request.body.model,
-            'temperature': request.body.temperature,
-            'max_tokens': request.body.max_tokens,
-            'stream': request.body.stream,
-            'presence_penalty': request.body.presence_penalty,
-            'frequency_penalty': request.body.frequency_penalty,
-            'top_p': request.body.top_p,
-            'stop': request.body.stop,
-            'seed': request.body.seed,
-            ...bodyParams,
-        };
-
-        const config = {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer ' + apiKey,
-            },
-            body: JSON.stringify(requestBody),
-            signal: controller.signal,
-        };
-
-        console.debug('Avian request:', requestBody);
-
-        const generateResponse = await fetch(apiUrl + '/chat/completions', config);
-
-        if (request.body.stream) {
-            forwardFetchResponse(generateResponse, response);
-        } else {
-            if (!generateResponse.ok) {
-                const errorText = await generateResponse.text();
-                console.warn(`Avian API returned error: ${generateResponse.status} ${generateResponse.statusText} ${errorText}`);
-                const errorJson = tryParse(errorText) ?? { error: true };
-                return response.status(500).send(errorJson);
-            }
-            const generateResponseJson = await generateResponse.json();
-            console.debug('Avian response:', generateResponseJson);
-            return response.send(generateResponseJson);
-        }
-    } catch (error) {
-        console.error('Error communicating with Avian API: ', error);
-        if (!response.headersSent) {
-            response.send({ error: true });
-        } else {
-            response.end();
-        }
-    }
-}
-
-/**
  * Sends a request to XAI API.
  * @param {express.Request} request Express request
  * @param {express.Response} response Express response
@@ -2359,7 +2269,6 @@ router.post('/generate', async function (request, response) {
             case CHAT_COMPLETION_SOURCES.MISTRALAI: return await sendMistralAIRequest(request, response);
             case CHAT_COMPLETION_SOURCES.COHERE: return await sendCohereRequest(request, response);
             case CHAT_COMPLETION_SOURCES.DEEPSEEK: return await sendDeepSeekRequest(request, response);
-            case CHAT_COMPLETION_SOURCES.AVIAN: return await sendAvianRequest(request, response);
             case CHAT_COMPLETION_SOURCES.AIMLAPI: return await sendAimlapiRequest(request, response);
             case CHAT_COMPLETION_SOURCES.XAI: return await sendXaiRequest(request, response);
             case CHAT_COMPLETION_SOURCES.CHUTES: return await sendChutesRequest(request, response);
@@ -2664,6 +2573,14 @@ router.post('/generate', async function (request, response) {
                 ? API_SILICONFLOW_CN : API_SILICONFLOW;
             apiUrl = defaultApiUrl;
             apiKey = readSecret(request.user.directories, SECRET_KEYS.SILICONFLOW, request.body.secret_id);
+            headers = {};
+            bodyParams = {};
+            if (request.body.json_schema) {
+                setJsonObjectFormat(bodyParams, request.body.messages, request.body.json_schema);
+            }
+        } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.AVIAN) {
+            apiUrl = new URL(request.body.reverse_proxy || API_AVIAN).toString();
+            apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.AVIAN);
             headers = {};
             bodyParams = {};
             if (request.body.json_schema) {

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -70,6 +70,7 @@ export const SECRET_KEYS = {
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
     WORKERS_AI: 'api_key_workers_ai',
+    AVIAN: 'api_key_avian',
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds [Avian](https://avian.io) as a first-class Chat Completion source, following the same patterns used by existing OpenAI-compatible providers (DeepSeek, xAI, Moonshot, etc.).

- **API Base URL**: `https://api.avian.io/v1`
- **Auth**: Bearer token (API key)
- **Compatibility**: OpenAI-compatible (chat completions, streaming, function calling)
- **Models available**:
  - `deepseek/deepseek-v3.2` — 164K context, 65K output
  - `moonshotai/kimi-k2.5` — 131K context, 8K output
  - `z-ai/glm-5` — 131K context, 16K output
  - `minimax/minimax-m2.5` — 1M context, 1M output

## Changes

**Backend** (`src/`):
- `constants.js` — Add `AVIAN` to `CHAT_COMPLETION_SOURCES`
- `endpoints/secrets.js` — Add `api_key_avian` to `SECRET_KEYS`
- `endpoints/backends/chat-completions.js` — Add `API_AVIAN` URL, `sendAvianRequest()` handler, model list endpoint, and generate dispatch

**Frontend** (`public/`):
- `scripts/openai.js` — Add to source enum, settings mapping, defaults, model list population, model change handler, context size logic, streaming reply extraction, proxy support, connect handler, and event registration
- `scripts/secrets.js` — Add secret key, friendly name, and input mapping
- `scripts/tokenizers.js` — Add tokenizer fallback
- `scripts/tool-calling.js` — Add to supported tool-calling sources
- `scripts/reasoning.js` — Add to reasoning extraction
- `scripts/slash-commands.js` — Add to model selector list
- `scripts/RossAscends-mods.js` — Add to auto-connect logic
- `script.js` — Add to tool result extraction
- `index.html` — Add dropdown option, API key form with model selector, and include in data-source attributes for temperature, frequency/presence penalty, top_p, function calling, reasoning, and reverse proxy panels

## Test plan

- [ ] Select Avian from Chat Completion Source dropdown
- [ ] Enter API key and click Connect — model list should populate from `/v1/models`
- [ ] Select a model and send a message — should receive a response
- [ ] Test streaming mode — tokens should appear incrementally
- [ ] Test function calling with an Avian model
- [ ] Verify reverse proxy support works with a custom endpoint URL

cc @Cohee1207 @RossAscends @Wolfsblvt