### PR TITLE
Support for isomorphic-git as an alternative git backend, part 1

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -250,6 +250,12 @@ extensions:
     speechToText: Xenova/whisper-small
     textToSpeech: Xenova/speecht5_tts
 
+# Git backend for plugin/extension repository operations.
+# - Use "auto" to prefer system git, falling back to the integrated backend
+# - Use "system" to force system backend, use "builtin" to force integrated backend
+git:
+  backend: auto
+
 # Additional model tokenizers can be downloaded on demand.
 # Disabling will fallback to another locally available tokenizer.
 enableDownloadableTokenizers: true

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -252,7 +252,8 @@ extensions:
 
 # Git backend for plugin/extension repository operations.
 # - Use "auto" to prefer system git, falling back to the integrated backend
-# - Use "system" to force system backend, use "builtin" to force integrated backend
+# - Use "system" to force system backend
+# - Use "builtin" to force integrated backend
 git:
   backend: auto
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -548,6 +548,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
             "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/core": "^0.22.12"
             }
@@ -1009,6 +1010,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
             "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/core": "1.6.0",
                 "@jimp/types": "1.6.0",
@@ -1040,6 +1042,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
             "integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1135,6 +1138,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
             "integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1171,6 +1175,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
             "integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12",
                 "tinycolor2": "^1.6.0"
@@ -1214,6 +1219,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
             "integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1301,6 +1307,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
             "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1313,6 +1320,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
             "integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1913,6 +1921,7 @@
             "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -2602,6 +2611,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3233,6 +3243,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -4564,6 +4575,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -8135,6 +8147,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
                 "ip-regex": "^5.0.0",
                 "ipaddr.js": "^2.2.0",
                 "is-docker": "^3.0.0",
+                "isomorphic-git": "^1.36.3",
                 "localforage": "^1.10.0",
                 "lodash": "^4.17.21",
                 "mime-types": "^3.0.2",
@@ -547,7 +548,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
             "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/core": "^0.22.12"
             }
@@ -1009,7 +1009,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
             "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/core": "1.6.0",
                 "@jimp/types": "1.6.0",
@@ -1041,7 +1040,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
             "integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1137,7 +1135,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
             "integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1174,7 +1171,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
             "integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12",
                 "tinycolor2": "^1.6.0"
@@ -1218,7 +1214,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
             "integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1306,7 +1301,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
             "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1319,7 +1313,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
             "integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1920,7 +1913,6 @@
             "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -2610,7 +2602,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2994,11 +2985,32 @@
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
             "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
         },
+        "node_modules/async-lock": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+            "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+            "license": "MIT"
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/await-to-js": {
             "version": "3.0.0",
@@ -3221,7 +3233,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -3344,6 +3355,24 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.0",
+                "es-define-property": "^1.0.0",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -3495,6 +3524,12 @@
             "engines": {
                 "node": ">=6.0"
             }
+        },
+        "node_modules/clean-git-ref": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+            "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+            "license": "Apache-2.0"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -4121,6 +4156,23 @@
                 "node": ">=10"
             }
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/define-lazy-prop": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -4180,6 +4232,12 @@
             "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
             "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
             "license": "Apache-2.0"
+        },
+        "node_modules/diff3": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+            "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+            "license": "MIT"
         },
         "node_modules/digest-fetch": {
             "version": "1.3.0",
@@ -4506,7 +4564,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -5161,6 +5218,21 @@
                 }
             }
         },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/foreground-child": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -5586,6 +5658,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/has-symbols": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -5839,7 +5923,6 @@
             "version": "5.2.4",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
             "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -5967,6 +6050,18 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "license": "MIT"
         },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-docker": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -6069,6 +6164,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "license": "MIT",
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-wsl": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
@@ -6124,6 +6234,88 @@
                 "encoding": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/isomorphic-git": {
+            "version": "1.37.2",
+            "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.2.tgz",
+            "integrity": "sha512-HCQBBKmXIMPdHgYGstSBNp6MNmVcMQBbUqJF8xfywFmlpNseO4KKex59YlXqNxhRxmv3fUZwvNWvMyOdc1VvhA==",
+            "license": "MIT",
+            "dependencies": {
+                "async-lock": "^1.4.1",
+                "clean-git-ref": "^2.0.1",
+                "crc-32": "^1.2.0",
+                "diff3": "0.0.3",
+                "ignore": "^5.1.4",
+                "minimisted": "^2.0.0",
+                "pako": "^1.0.10",
+                "pify": "^4.0.1",
+                "readable-stream": "^4.0.0",
+                "sha.js": "^2.4.12",
+                "simple-get": "^4.0.1"
+            },
+            "bin": {
+                "isogit": "cli.cjs"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/isomorphic-git/node_modules/crc-32": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+            "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+            "license": "Apache-2.0",
+            "bin": {
+                "crc32": "bin/crc32.njs"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/isomorphic-git/node_modules/readable-stream": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+            "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/isomorphic-git/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/isomorphic-git/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/jackspeak": {
@@ -6621,6 +6813,15 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minimisted": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+            "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.5"
             }
         },
         "node_modules/minipass": {
@@ -7320,6 +7521,15 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/pify": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/platform": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
@@ -7348,6 +7558,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.19.0"
+            }
+        },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/prelude-ls": {
@@ -7916,7 +8135,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -8028,11 +8246,68 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
             "license": "ISC"
+        },
+        "node_modules/sha.js": {
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+            "license": "(MIT AND BSD-3-Clause)",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
+            },
+            "bin": {
+                "sha.js": "bin.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/sha.js/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -8202,6 +8477,51 @@
                 "@jimp/plugins": "^0.22.12",
                 "@jimp/types": "^0.22.12",
                 "regenerator-runtime": "^0.13.3"
+            }
+        },
+        "node_modules/simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/simple-get": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decompress-response": "^6.0.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
             }
         },
         "node_modules/simple-git": {
@@ -8628,6 +8948,46 @@
             "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
             "license": "MIT"
         },
+        "node_modules/to-buffer": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+            "license": "MIT",
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/to-buffer/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "license": "MIT"
+        },
+        "node_modules/to-buffer/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8774,6 +9134,20 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/typedarray": {
@@ -9122,6 +9496,27 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/wordwrap": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "ip-matching": "^2.1.2",
         "ip-regex": "^5.0.0",
         "ipaddr.js": "^2.2.0",
+        "isomorphic-git": "^1.36.3",
         "is-docker": "^3.0.0",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",

--- a/plugins.js
+++ b/plugins.js
@@ -9,11 +9,13 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import { default as git, CheckRepoActions } from 'simple-git';
+import { createGitClient } from './src/git/client.js';
 import { color } from './src/util.js';
 
 const __dirname = import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
 process.chdir(__dirname);
 const pluginsPath = './plugins';
+const gitBackend = process.env.SILLYTAVERN_GIT_BACKEND || 'auto';
 
 const command = process.argv[2];
 
@@ -87,7 +89,7 @@ async function installPlugin(pluginName) {
             return console.log(color.yellow(`Directory already exists at ${pluginPath}`));
         }
 
-        await git().clone(pluginName, pluginPath, { '--depth': 1 });
+        await createGitClient({ backend: gitBackend }).clone(pluginName, pluginPath, { depth: 1 });
         console.log(`Plugin ${color.green(pluginName)} installed to ${color.cyan(pluginPath)}`);
     } catch (error) {
         console.error(color.red(`Failed to install plugin ${pluginName}`), error);

--- a/src/endpoints/extensions.js
+++ b/src/endpoints/extensions.js
@@ -6,6 +6,10 @@ import sanitize from 'sanitize-filename';
 import { CheckRepoActions, default as simpleGit } from 'simple-git';
 
 import { PUBLIC_DIRECTORIES } from '../constants.js';
+import { getConfigValue } from '../util.js';
+import { createGitClient } from '../git/client.js';
+
+const gitBackend = getConfigValue('git.backend', 'auto');
 
 /**
  * @type {Partial<import('simple-git').SimpleGitOptions>}
@@ -76,8 +80,7 @@ router.post('/install', async (request, response) => {
     }
 
     try {
-        // No timeout for cloning, as it may take a while depending on the repo size
-        const git = simpleGit();
+        const git = createGitClient({ backend: gitBackend });
 
         // make sure the third-party directory exists
         if (!fs.existsSync(path.join(request.user.directories.extensions))) {
@@ -102,9 +105,9 @@ router.post('/install', async (request, response) => {
             return response.status(409).send(`Directory already exists at ${extensionPath}`);
         }
 
-        const cloneOptions = { '--depth': 1 };
+        const cloneOptions = { depth: 1 };
         if (branch) {
-            cloneOptions['--branch'] = branch;
+            cloneOptions.branch = branch;
         }
         await git.clone(url, extensionPath, cloneOptions);
         console.info(`Extension has been cloned to ${extensionPath} from ${url} at ${branch || '(default)'} branch`);

--- a/src/git/client.js
+++ b/src/git/client.js
@@ -1,0 +1,138 @@
+import fs from 'node:fs';
+
+import { sync as commandExistsSync } from 'command-exists';
+import git from 'isomorphic-git';
+import http from 'isomorphic-git/http/node';
+import simpleGit from 'simple-git';
+
+/** @type {{ AUTO: 'auto', SYSTEM: 'system', BUILTIN: 'builtin' }} */
+export const GIT_BACKENDS = {
+    AUTO: 'auto',
+    SYSTEM: 'system',
+    BUILTIN: 'builtin',
+};
+
+/**
+ * @param {string | undefined | null} preferredBackend
+ * @returns {'system' | 'builtin'}
+ */
+function resolveBackend(preferredBackend) {
+    const normalized = typeof preferredBackend === 'string' ? preferredBackend.trim().toLowerCase() : GIT_BACKENDS.AUTO;
+    const backend = normalized === GIT_BACKENDS.SYSTEM
+        ? GIT_BACKENDS.SYSTEM
+        : normalized === GIT_BACKENDS.BUILTIN
+            ? GIT_BACKENDS.BUILTIN
+            : GIT_BACKENDS.AUTO;
+    const systemGitAvailable = commandExistsSync('git');
+
+    if (backend === GIT_BACKENDS.SYSTEM && !systemGitAvailable) {
+        throw new Error('System git backend is configured, but no git binary was found in PATH.');
+    }
+
+    if (backend === GIT_BACKENDS.SYSTEM || (backend === GIT_BACKENDS.AUTO && systemGitAvailable)) {
+        return GIT_BACKENDS.SYSTEM;
+    }
+
+    return GIT_BACKENDS.BUILTIN;
+}
+
+/**
+ * @typedef {object} GitCloneOptions
+ * @property {number} [depth]
+ * @property {string} [branch]
+ */
+
+const SUPPORTED_CLONE_OPTIONS = new Set(['depth', 'branch']);
+
+/**
+ * @param {GitCloneOptions} [options]
+ * @returns {{ depth?: number, branch?: string }}
+ */
+function normalizeCloneOptions(options = {}) {
+    for (const key of Object.keys(options)) {
+        if (!SUPPORTED_CLONE_OPTIONS.has(key)) {
+            throw new Error(`Unsupported clone option: ${key}`);
+        }
+    }
+    return { depth: options.depth, branch: options.branch };
+}
+
+/**
+ * @typedef {object} GitClient
+ * @property {'system' | 'builtin'} backend
+ * @property {(url: string, localPath: string, options?: GitCloneOptions) => Promise<void>} clone
+ */
+
+/**
+ * @param {{ backend?: string }} [options]
+ * @returns {GitClient}
+ */
+export function createGitClient(options = {}) {
+    const backend = resolveBackend(options.backend);
+    if (backend === GIT_BACKENDS.SYSTEM) {
+        return new SimpleGitClient();
+    }
+
+    return new IsomorphicGitClient();
+}
+
+/**
+ * @implements {GitClient}
+ */
+class SimpleGitClient {
+    constructor() {
+        this.backend = GIT_BACKENDS.SYSTEM;
+        this.git = simpleGit();
+    }
+
+    /**
+     * @param {string} url
+     * @param {string} localPath
+     * @param {GitCloneOptions} [options]
+     * @returns {Promise<void>}
+     */
+    async clone(url, localPath, options = {}) {
+        const { depth, branch } = normalizeCloneOptions(options);
+        /** @type {Record<string, any>} */
+        const cloneOptions = {};
+
+        if (depth !== undefined) {
+            cloneOptions['--depth'] = depth;
+        }
+
+        if (branch) {
+            cloneOptions['--branch'] = branch;
+        }
+
+        await this.git.clone(url, localPath, cloneOptions);
+    }
+}
+
+/**
+ * @implements {GitClient}
+ */
+class IsomorphicGitClient {
+    constructor() {
+        this.backend = GIT_BACKENDS.BUILTIN;
+    }
+
+    /**
+     * @param {string} url
+     * @param {string} localPath
+     * @param {GitCloneOptions} [options]
+     * @returns {Promise<void>}
+     */
+    async clone(url, localPath, options = {}) {
+        const { depth, branch } = normalizeCloneOptions(options);
+
+        await git.clone({
+            fs,
+            http,
+            dir: localPath,
+            url,
+            depth,
+            ref: branch,
+            singleBranch: depth !== undefined || Boolean(branch),
+        });
+    }
+}


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Implementation of an adapter for isomorphic-git support. This allows using git features in deployments where the system git binary is not available.

Adapter selects git backend between simple-git and isomorphic-git based on a toggle in config.yaml, as discussed in https://github.com/SillyTavern/SillyTavern/issues/5209

plugins.js doesn't have access to config.yaml, so an env variable is used instead.

Only clone is implemented in this PR to keep size small per contribution guidelines, rest of operations still use simple-git directly and to be ported in future PRs.

How to test:
- Set git.backend: builtin in config.yaml and install an extension
- Set git.backend: system and install an extension
- run node plugins install [plugin-url]
- run SILLYTAVERN_GIT_BACKEND=builtin node plugins install [plugin-url]