### PR TITLE
fix: skip system messages in OpenRouter cacheAtDepth calculation

### DIFF
--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1026,6 +1026,11 @@ export function cachingAtDepthForOpenRouterClaude(messages, cachingAtDepth, ttl)
 
         passedThePrefill = true;
 
+        // Skip system messages so they don't affect depth counting or receive cache breakpoints
+        if (messages[i].role === 'system') {
+            continue;
+        }
+
         if (messages[i].role !== previousRoleName) {
             if (depth === cachingAtDepth || depth === cachingAtDepth + 2) {
                 const content = messages[i].content;


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## What and why

Fixes #5227.

`cachingAtDepthForOpenRouterClaude` walks backward through messages counting depth by role switches. Unlike the Claude-native path (where `convertClaudeMessages` strips system messages before `cachingAtDepthForClaude` runs), the OpenRouter path retains `role: "system"` messages inline. These were counted as depth changes and could receive `cache_control` breakpoints.

This causes two problems:
- Depth calculation is wrong, so breakpoints land on the wrong messages
- OpenRouter hoists system messages (with their `cache_control`) into Claude's separate `system` parameter, which can push cached content below the minimum cache size threshold, preventing caching entirely

## What I did

Added a `continue` guard to skip system messages during the backward walk, making depth calculation consistent with the Claude-native code path. System prompt caching is unaffected since it is handled separately by `cachingSystemPromptForOpenRouter`.

## How to test

- Use OpenRouter with a Claude model and enable cacheAtDepth
- Use a prompt setup that injects system messages mid-conversation
- Verify in the server console that `cache_control` lands on user/assistant messages, not system messages