### PR TITLE
feature(openai-compatible): forward reasoning_effort and verbosity for custom source

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2322,15 +2322,15 @@ router.post('/generate', async function (request, response) {
             return response.status(400).send({ error: true });
         }
 
-        // A few of OpenAIs reasoning models support reasoning effort
+        // OpenAI keeps the model allowlist, custom OpenAI-compatible endpoints always receive reasoning effort.
         if (request.body.reasoning_effort && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.OPENAI].includes(request.body.chat_completion_source)) {
-            if (OPENAI_REASONING_EFFORT_MODELS.includes(request.body.model)) {
+            if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM || OPENAI_REASONING_EFFORT_MODELS.includes(request.body.model)) {
                 bodyParams['reasoning_effort'] = OPENAI_REASONING_EFFORT_MAP[request.body.reasoning_effort] ?? request.body.reasoning_effort;
             }
         }
 
         if (request.body.verbosity && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.OPENAI].includes(request.body.chat_completion_source)) {
-            if (OPENAI_VERBOSITY_MODELS.test(request.body.model)) {
+            if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM || OPENAI_VERBOSITY_MODELS.test(request.body.model)) {
                 bodyParams['verbosity'] = request.body.verbosity;
             }
         }


### PR DESCRIPTION
## Summary
For `CUSTOM` OpenAI-compatible chat-completions requests, forward `reasoning_effort` and `verbosity` without OpenAI model allowlist gating as GPT-4 is desperated.

This is intended for custom gateways that map OpenAI-compatible parameters into downstream protocol controls (e.g. Claude/Gemini conversion layers).

## What Changed
- File: `src/endpoints/backends/chat-completions.js`
- For `CHAT_COMPLETION_SOURCES.CUSTOM`:
  - `reasoning_effort` is now forwarded regardless of `OPENAI_REASONING_EFFORT_MODELS`.
  - `verbosity` is now forwarded regardless of `OPENAI_VERBOSITY_MODELS`.
- For `CHAT_COMPLETION_SOURCES.OPENAI`:
  - Existing model-gated behavior is preserved.

## Notes
- `include_reasoning` is **not** forwarded as a custom OpenAI-compatible request parameter.

## Validation
- `node --check src/endpoints/backends/chat-completions.js` passes.
- Request assembly path confirms `CUSTOM` sends `reasoning_effort` / `verbosity` as expected.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
