### PR TITLE
Add gpt-5.3-chat-latest model support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3028,6 +3028,9 @@
                             <div>
                                 <h4 data-i18n="OpenAI Model">OpenAI Model</h4>
                                 <select id="model_openai_select">
+                                    <optgroup label="GPT-5.3">
+                                        <option value="gpt-5.3-chat-latest">gpt-5.3-chat-latest</option>
+                                    </optgroup>
                                     <optgroup label="GPT-5.2">
                                         <option value="gpt-5.2">gpt-5.2</option>
                                         <option value="gpt-5.2-2025-12-11">gpt-5.2-2025-12-11</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -53,6 +53,7 @@
                         <option data-type="cohere" value="c4ai-aya-vision-8b">c4ai-aya-vision-8b</option>
                         <option data-type="cohere" value="c4ai-aya-vision-32b">c4ai-aya-vision-32b</option>
                         <option data-type="cohere" value="command-a-vision-07-2025">command-a-vision-07-2025</option>
+                        <option data-type="openai" value="gpt-5.3-chat-latest">gpt-5.3-chat-latest</option>
                         <option data-type="openai" value="gpt-5.2">gpt-5.2</option>
                         <option data-type="openai" value="gpt-5.2-2025-12-11">gpt-5.2-2025-12-11</option>
                         <option data-type="openai" value="gpt-5.2-chat-latest">gpt-5.2-chat-latest</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2859,7 +2859,7 @@ export async function createGenerationParameters(settings, model, type, messages
         if (/gpt-5-chat-latest/.test(model)) {
             delete generate_data.tools;
             delete generate_data.tool_choice;
-        } else if (/gpt-5.(1|2|3)/.test(model) && !/chat-latest/.test(model)) {
+        } else if (/gpt-5\.(1|2|3)/.test(model) && !/chat-latest/.test(model)) {
             delete generate_data.frequency_penalty;
             delete generate_data.presence_penalty;
             delete generate_data.logit_bias;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2859,7 +2859,7 @@ export async function createGenerationParameters(settings, model, type, messages
         if (/gpt-5-chat-latest/.test(model)) {
             delete generate_data.tools;
             delete generate_data.tool_choice;
-        } else if (/gpt-5.(1|2)/.test(model) && !/chat-latest/.test(model)) {
+        } else if (/gpt-5.(1|2|3)/.test(model) && !/chat-latest/.test(model)) {
             delete generate_data.frequency_penalty;
             delete generate_data.presence_penalty;
             delete generate_data.logit_bias;

--- a/src/constants.js
+++ b/src/constants.js
@@ -476,10 +476,19 @@ export const OPENAI_REASONING_EFFORT_MODELS = [
     'gpt-5.2',
     'gpt-5.2-2025-12-11',
     'gpt-5.2-chat-latest',
+    'gpt-5.3-chat-latest',
 ];
 
 export const OPENAI_REASONING_EFFORT_MAP = {
     min: 'minimal',
+};
+
+/**
+ * Models that only accept a single fixed reasoning effort value.
+ * @type {Record<string, string>}
+ */
+export const OPENAI_FIXED_REASONING_EFFORT = {
+    'gpt-5.3-chat-latest': 'medium',
 };
 
 export const NANOGPT_REASONING_EFFORT_MAP = {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -11,6 +11,7 @@ import {
     CHAT_COMPLETION_SOURCES,
     GEMINI_SAFETY,
     NANOGPT_REASONING_EFFORT_MAP,
+    OPENAI_FIXED_REASONING_EFFORT,
     OPENAI_REASONING_EFFORT_MAP,
     OPENAI_REASONING_EFFORT_MODELS,
     OPENAI_VERBOSITY_MODELS,
@@ -1597,7 +1598,7 @@ async function sendAzureOpenAIRequest(request, response) {
 
     // Do not send reasoning effort to models which do not support it
     apiRequestBody['reasoning_effort'] = OPENAI_REASONING_EFFORT_MODELS.includes(request.body.model)
-        ? OPENAI_REASONING_EFFORT_MAP[request.body.reasoning_effort] ?? request.body.reasoning_effort
+        ? OPENAI_FIXED_REASONING_EFFORT[request.body.model] ?? OPENAI_REASONING_EFFORT_MAP[request.body.reasoning_effort] ?? request.body.reasoning_effort
         : undefined;
 
     const controller = new AbortController();
@@ -2326,7 +2327,7 @@ router.post('/generate', async function (request, response) {
         // A few of OpenAIs reasoning models support reasoning effort
         if (request.body.reasoning_effort && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.OPENAI].includes(request.body.chat_completion_source)) {
             if (OPENAI_REASONING_EFFORT_MODELS.includes(request.body.model)) {
-                bodyParams['reasoning_effort'] = OPENAI_REASONING_EFFORT_MAP[request.body.reasoning_effort] ?? request.body.reasoning_effort;
+                bodyParams['reasoning_effort'] = OPENAI_FIXED_REASONING_EFFORT[request.body.model] ?? OPENAI_REASONING_EFFORT_MAP[request.body.reasoning_effort] ?? request.body.reasoning_effort;
             }
         }
 


### PR DESCRIPTION
Adds support for gpt-5.3-chat-latest. Adds to OpenAI model dropdown, captioning model list, OPENAI_REASONING_EFFORT_MODELS, and introduces OPENAI_FIXED_REASONING_EFFORT to clamp effort to medium (the only accepted value). Updates frontend gpt-5.x regex.