### PR TITLE
add Slash commands regenerate and swipe

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9691,7 +9691,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
 
     const mesId = Number(forceMesId ?? event?.currentTarget?.closest('.mes')?.getAttribute('mesid') ?? messageIndex ?? chat.length - 1);
 
-    if (source === SWIPE_SOURCE.DELETE || source === SWIPE_SOURCE.BACK || source === SWIPE_SOURCE.AUTO_SWIPE) {
+    if ([SWIPE_SOURCE.DELETE, SWIPE_SOURCE.BACK, SWIPE_SOURCE.AUTO_SWIPE, SWIPE_SOURCE.SLASH_COMMAND].includes(source)) {
         console.info(`The ${direction} swipe source on message #${mesId} is ${source}, Most checks have been bypassed. `);
     } else {
         //Only show an error if swipes are not hidden and a message is generating.

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -175,6 +175,7 @@ export const SWIPE_SOURCE = {
     KEYBOARD: 'keyboard',
     BACK: 'back',
     AUTO_SWIPE: 'auto_swipe',
+    SLASH_COMMAND: 'slash_command',
 };
 
 /**

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -183,7 +183,7 @@ async function regenerateGroup() {
 
     const abortController = new AbortController();
     setExternalAbortController(abortController);
-    generateGroupWrapper(false, 'normal', { signal: abortController.signal });
+    return generateGroupWrapper(false, 'normal', { signal: abortController.signal });
 }
 
 /**

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -50,6 +50,7 @@ import {
     showMoreMessages,
     stopGeneration,
     substituteParams,
+    swipe_right,
     syncMesToSwipe,
     system_avatar,
     system_message_types,
@@ -62,7 +63,7 @@ import { getMessageTimeStamp, isMobile } from './RossAscends-mods.js';
 import { hideChatMessageRange } from './chats.js';
 import { getContext, saveMetadataDebounced } from './extensions.js';
 import { getRegexedString, regex_placement } from './extensions/regex/engine.js';
-import { findGroupMemberId, groups, is_group_generating, openGroupById, resetSelectedGroup, saveGroupChat, selected_group, getGroupMembers } from './group-chats.js';
+import { findGroupMemberId, groups, is_group_generating, openGroupById, regenerateGroup, resetSelectedGroup, saveGroupChat, selected_group, getGroupMembers } from './group-chats.js';
 import { chat_completion_sources, oai_settings, promptManager, ZAI_ENDPOINT } from './openai.js';
 import { user_avatar } from './personas.js';
 import { addEphemeralStoppingString, chat_styles, context_presets, flushEphemeralStoppingStrings, playMessageSound, power_user } from './power-user.js';
@@ -1129,6 +1130,51 @@ export function initDefaultSlashCommands() {
                     ${t`Continues the chat with the provided prompt and waits for the generation to finish.`}
                 </li>
             </ul>
+        </div>
+    `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'regenerate',
+        callback: regenerateChatCallback,
+        aliases: ['regen'],
+        namedArgumentList: [
+            new SlashCommandNamedArgument(
+                'await',
+                t`Whether to await for the regeneration before proceeding`,
+                [ARGUMENT_TYPE.BOOLEAN],
+                false,
+                false,
+                'false',
+            ),
+        ],
+        helpString: `
+        <div>
+            ${t`Regenerates the latest reply in the chat.`}
+        </div>
+        <div>
+            ${t`If <code>await=true</code> named argument is passed, the command will await for the regeneration before proceeding.`}
+        </div>
+    `,
+    }));
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'swipe',
+        callback: swipeChatCallback,
+        namedArgumentList: [
+            new SlashCommandNamedArgument(
+                'await',
+                t`Whether to await for the swipe action before proceeding`,
+                [ARGUMENT_TYPE.BOOLEAN],
+                false,
+                false,
+                'false',
+            ),
+        ],
+        helpString: `
+        <div>
+            ${t`Swipes right on the latest reply. If the next swipe doesn't exist yet, it may generate one depending on overswipe settings.`}
+        </div>
+        <div>
+            ${t`If <code>await=true</code> named argument is passed, the command will await for the swipe action before proceeding.`}
         </div>
     `,
     }));
@@ -4533,6 +4579,63 @@ async function continueChatCallback(args, prompt) {
 
     if (shouldAwait) {
         await outerPromise;
+    }
+
+    return '';
+}
+
+async function regenerateChatCallback(args) {
+    const shouldAwait = isTrueBoolean(args?.await);
+
+    const outerPromise = new Promise((outerResolve) => setTimeout(async () => {
+        try {
+            await waitUntilCondition(() => !is_send_press && !is_group_generating, 10000, 100);
+        } catch {
+            console.warn('Timeout waiting for generation unlock');
+            toastr.warning(t`Cannot run /regenerate command while the reply is being generated.`);
+            outerResolve(Promise.resolve(''));
+            return '';
+        }
+
+        if (selected_group) {
+            outerResolve(Promise.resolve(regenerateGroup()));
+            return '';
+        }
+
+        outerResolve(new Promise(innerResolve => setTimeout(() => {
+            innerResolve(Generate('regenerate'));
+        }, 1)));
+        return '';
+    }, 1));
+
+    if (shouldAwait) {
+        const innerPromise = await outerPromise;
+        await innerPromise;
+    }
+
+    return '';
+}
+
+async function swipeChatCallback(args) {
+    const shouldAwait = isTrueBoolean(args?.await);
+
+    const outerPromise = new Promise((outerResolve) => setTimeout(async () => {
+        try {
+            await waitUntilCondition(() => !is_send_press && !is_group_generating, 10000, 100);
+        } catch {
+            console.warn('Timeout waiting for generation unlock');
+            toastr.warning(t`Cannot run /swipe command while the reply is being generated.`);
+            outerResolve(Promise.resolve(''));
+            return '';
+        }
+
+        outerResolve(Promise.resolve(swipe_right(null, { repeated: false })));
+        return '';
+    }, 1));
+
+    if (shouldAwait) {
+        const innerPromise = await outerPromise;
+        await innerPromise;
     }
 
     return '';

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -48,9 +48,9 @@ import {
     setCharacterName,
     setExtensionPrompt,
     showMoreMessages,
+    swipe,
     stopGeneration,
     substituteParams,
-    swipe_right,
     syncMesToSwipe,
     system_avatar,
     system_message_types,
@@ -91,7 +91,7 @@ import { SlashCommandScope } from './slash-commands/SlashCommandScope.js';
 import { t } from './i18n.js';
 import { kai_settings } from './kai-settings.js';
 import { instruct_presets, selectContextPreset, selectInstructPreset } from './instruct-mode.js';
-import { debounce_timeout } from './constants.js';
+import { debounce_timeout, SWIPE_DIRECTION } from './constants.js';
 export {
     executeSlashCommands, executeSlashCommandsWithOptions, getSlashCommandsHelp, registerSlashCommand,
 };
@@ -1161,6 +1161,21 @@ export function initDefaultSlashCommands() {
         callback: swipeChatCallback,
         namedArgumentList: [
             new SlashCommandNamedArgument(
+                'direction',
+                t`Swipe direction`,
+                [ARGUMENT_TYPE.STRING],
+                false,
+                false,
+                SWIPE_DIRECTION.RIGHT,
+                [
+                    new SlashCommandEnumValue(SWIPE_DIRECTION.RIGHT, t`Swipe to the next reply`, enumTypes.enum, enumIcons.default),
+                    new SlashCommandEnumValue(SWIPE_DIRECTION.LEFT, t`Swipe to the previous reply`, enumTypes.enum, enumIcons.default),
+                ],
+                [],
+                null,
+                true,
+            ),
+            new SlashCommandNamedArgument(
                 'await',
                 t`Whether to await for the swipe action before proceeding`,
                 [ARGUMENT_TYPE.BOOLEAN],
@@ -1171,7 +1186,7 @@ export function initDefaultSlashCommands() {
         ],
         helpString: `
         <div>
-            ${t`Swipes right on the latest reply. If the next swipe doesn't exist yet, it may generate one depending on overswipe settings.`}
+            ${t`Swipes the latest reply. Defaults to <code>direction=right</code>; use <code>direction=left</code> to go to the previous reply. If no next swipe exists, behavior depends on message context.`}
         </div>
         <div>
             ${t`If <code>await=true</code> named argument is passed, the command will await for the swipe action before proceeding.`}
@@ -4618,6 +4633,7 @@ async function regenerateChatCallback(args) {
 
 async function swipeChatCallback(args) {
     const shouldAwait = isTrueBoolean(args?.await);
+    const direction = args?.direction === SWIPE_DIRECTION.LEFT ? SWIPE_DIRECTION.LEFT : SWIPE_DIRECTION.RIGHT;
 
     const outerPromise = new Promise((outerResolve) => setTimeout(async () => {
         try {
@@ -4629,7 +4645,7 @@ async function swipeChatCallback(args) {
             return '';
         }
 
-        outerResolve(Promise.resolve(swipe_right(null, { repeated: false })));
+        outerResolve(Promise.resolve(swipe(null, direction, { repeated: false })));
         return '';
     }, 1));
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -91,7 +91,7 @@ import { SlashCommandScope } from './slash-commands/SlashCommandScope.js';
 import { t } from './i18n.js';
 import { kai_settings } from './kai-settings.js';
 import { instruct_presets, selectContextPreset, selectInstructPreset } from './instruct-mode.js';
-import { debounce_timeout, SWIPE_DIRECTION } from './constants.js';
+import { debounce_timeout, SWIPE_DIRECTION, SWIPE_SOURCE } from './constants.js';
 export {
     executeSlashCommands, executeSlashCommandsWithOptions, getSlashCommandsHelp, registerSlashCommand,
 };
@@ -4645,7 +4645,7 @@ async function swipeChatCallback(args) {
             return '';
         }
 
-        outerResolve(Promise.resolve(swipe(null, direction, { repeated: false })));
+        outerResolve(Promise.resolve(swipe(null, direction, { source: SWIPE_SOURCE.SLASH_COMMAND, repeated: false })));
         return '';
     }, 1));
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Fixes https://github.com/SillyTavern/SillyTavern/issues/4252

Added /swipe and /generate to the command
![2026-03-04 at 18 37](https://github.com/user-attachments/assets/a04134fc-333a-43a9-b13b-35ceaf5cbbe9)
![2026-03-04 at 18 38](https://github.com/user-attachments/assets/945e1ac5-fcf4-4ce8-8273-71ca2f7c5d96)

Regenerate command handles 1:1 chat or group chat case 


