### PR TITLE
Fix: Remove trailing space from [INST] in Impersonate mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -548,7 +548,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
             "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/core": "^0.22.12"
             }
@@ -1010,7 +1009,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
             "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/core": "1.6.0",
                 "@jimp/types": "1.6.0",
@@ -1042,7 +1040,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
             "integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1138,7 +1135,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
             "integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1175,7 +1171,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
             "integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12",
                 "tinycolor2": "^1.6.0"
@@ -1219,7 +1214,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
             "integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1307,7 +1301,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
             "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1320,7 +1313,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
             "integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1921,7 +1913,6 @@
             "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -2611,7 +2602,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3231,7 +3221,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -4563,7 +4552,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -8115,7 +8103,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -1982,7 +1982,7 @@
                                             </span>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="makersuite,vertexai,aimlapi,openrouter,claude,xai,electronhub,chutes,nanogpt">
+                                    <div class="range-block" data-source="makersuite,vertexai,aimlapi,openrouter,claude,electronhub,chutes,nanogpt">
                                         <label for="openai_enable_web_search" class="checkbox_label flexWrap widthFreeExpand">
                                             <input id="openai_enable_web_search" type="checkbox" />
                                             <span data-i18n="Enable web search">Enable web search</span>
@@ -3028,6 +3028,9 @@
                             <div>
                                 <h4 data-i18n="OpenAI Model">OpenAI Model</h4>
                                 <select id="model_openai_select">
+                                    <optgroup label="GPT-5.4">
+                                        <option value="gpt-5.4">gpt-5.4</option>
+                                    </optgroup>
                                     <optgroup label="GPT-5.3">
                                         <option value="gpt-5.3-chat-latest">gpt-5.3-chat-latest</option>
                                     </optgroup>
@@ -3553,6 +3556,11 @@
                             <div data-for="api_key_siliconflow" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'.">
                                 For privacy reasons, your API key will be hidden after you click 'Connect'.
                             </div>
+                            <h4 data-i18n="SiliconFlow Endpoint">SiliconFlow Endpoint</h4>
+                            <select id="siliconflow_endpoint">
+                                <option value="global" data-i18n="Global (siliconflow.com)">Global (siliconflow.com)</option>
+                                <option value="cn" data-i18n="China (siliconflow.cn)">China (siliconflow.cn)</option>
+                            </select>
                             <h4>SiliconFlow Model</h4>
                             <select id="model_siliconflow_select">
                                 <option value="" data-i18n="-- Connect to the API --">-- Connect to the API --</option>
@@ -3915,6 +3923,8 @@
                             </select>
                             <h4 data-i18n="Z.AI Model">Z.AI Model</h4>
                             <select id="model_zai_select">
+                                <option value="glm-5-turbo">glm-5-turbo</option>
+                                <option value="glm-5.1">glm-5.1</option>
                                 <option value="glm-5">glm-5</option>
                                 <option value="glm-4.7">glm-4.7</option>
                                 <option value="glm-4.7-flash">glm-4.7-flash</option>
@@ -4368,6 +4378,12 @@
                                     <div class="flexAuto" title="If a stop sequence is generated, everything past it will be removed from the output (inclusive)." data-i18n="[title]If a stop sequence is generated, everything past it will be removed from the output (inclusive).">
                                         <small data-i18n="Stop Sequence">Stop Sequence</small>
                                         <textarea id="instruct_stop_sequence" data-macros class="text_pole textarea_compact autoSetHeight"></textarea>
+                                    </div>
+                                </div>
+                                    <div class="flex-container">
+                                    <div class="flexAuto" title="Inserted as a last prompt line when impersonating. Falls back to User Prefix if empty." data-i18n="[title]Inserted as a last prompt line when impersonating. Falls back to User Prefix if empty.">
+                                        <small data-i18n="Impersonate Prefix">Impersonate Prefix</small>
+                                        <textarea id="instruct_impersonate_sequence" data-macros class="text_pole textarea_compact autoSetHeight"></textarea>
                                     </div>
                                 </div>
                                 <div class="flex-container">
@@ -5635,6 +5651,14 @@
                             <a href="#bg_chat_tab" data-i18n="Chat">Chat</a>
                         </li>
                         <div class="heading-controls">
+                            <button id="bg_group_add_to_folder_button" class="menu_button menu_button_icon" style="display:none;" data-i18n="[title]Add selected backgrounds to folder" title="Add selected backgrounds to folder">
+                                <i class="fa-solid fa-folder-tree"></i>
+                                <span data-i18n="Add to Folder">Add to Folder</span>
+                            </button>
+                            <button id="bg_selection_mode_button" class="menu_button menu_button_icon" data-i18n="[title]Select backgrounds for bulk folder actions" title="Select backgrounds for bulk folder actions">
+                                <i class="fa-solid fa-edit"></i>
+                                <span id="bg_group_select_count" style="display:none;"></span>
+                            </button>
                             <button id="bg_thumb_zoom_out" class="menu_button menu_button_icon" title="Make thumbnails smaller" data-i18n="[title]Make thumbnails smaller">
                                 <i class="fa-solid fa-minus"></i>
                             </button>
@@ -5650,6 +5674,11 @@
                                 <span data-i18n="Back">Back</span>
                             </button>
                             <span id="bg_current_folder_name" class="bg_current_folder_name"></span>
+                            <span class="expander"></span>
+                            <button id="bg_folder_remove_selected_button" class="menu_button menu_button_icon" style="display:none;" data-i18n="[title]Remove selected backgrounds from this folder" title="Remove selected backgrounds from this folder">
+                                <i class="fa-solid fa-folder-minus"></i>
+                                <span data-i18n="Remove from Folder">Remove from Folder</span>
+                            </button>
                         </div>
                         <div id="bg_folder_grid" class="bg_list bg_folder_grid"></div>
                         <div id="bg_menu_content" class="bg_list"></div>
@@ -5816,12 +5845,18 @@
                                     <div class="persona_controls_buttons_block buttons_block">
                                         <div id="persona_rename_button" class="menu_button fa-solid fa-pencil" title="Rename Persona" data-i18n="[title]Rename Persona"></div>
                                         <div id="sync_name_button" class="menu_button fa-solid fa-sync" title="Click to set user name for all messages" data-i18n="[title]Click to set user name for all messages"></div>
-                                        <div id="persona_lore_button" class="menu_button fa-solid fa-globe" title="Persona Lore&#10;Alt+Click to open the lorebook" data-i18n="[title]Persona Lore Alt+Click to open the lorebook"></div>
+                                        <div id="persona_lore_button" class="menu_button fa-solid fa-globe" title="Persona Lore&#10;&#10;Click to load&#10;Shift/Alt-click or long-press to open 'Link to Persona Lorebook' popup" data-i18n="[title]persona_lore_button_title"></div>
 
                                         <div id="persona_set_image_button" class="menu_button fa-solid fa-image" title="Change Persona Image" data-i18n="[title]Change Persona Image"></div>
                                         <div id="persona_duplicate_button" class="menu_button fa-solid fa-clone" title="Duplicate Persona" data-i18n="[title]Duplicate Persona"></div>
                                         <div id="persona_delete_button" class="menu_button fa-solid fa-skull red_button" title="Delete Persona" data-i18n="[title]Delete Persona"></div>
                                     </div>
+                                    <label class="flex1 height100p" for="persona-management-dropdown">
+                                        <select id="persona-management-dropdown" class="text_pole">
+                                            <option value="default" disabled selected data-i18n="More...">More...</option>
+                                            <option id="persona_lorebook_link" data-i18n="Link to Persona Lorebook">Link to Persona Lorebook</option>
+                                        </select>
+                                    </label>
                                 </div>
 
                                 <h4 class="flex-container alignItemsBaseline">
@@ -5987,8 +6022,8 @@
                                                 <div id="favorite_button" class="menu_button fa-solid fa-star" title="Add to Favorites" data-i18n="[title]Add to Favorites"></div>
                                                 <input type="hidden" id="fav_checkbox" name="fav" />
                                                 <div id="advanced_div" class="menu_button fa-solid fa-book " title="Advanced Definitions" data-i18n="[title]Advanced Definition"></div>
-                                                <div id="world_button" class="menu_button fa-solid fa-globe" title="Character Lore&#10;&#10;Click to load&#10;Shift-click to open 'Link to World Info' popup" data-i18n="[title]world_button_title"></div>
-                                                <div class="chat_lorebook_button menu_button fa-solid fa-passport" title="Chat Lore&#10;Alt+Click to open the lorebook" data-i18n="[title]Chat Lore Alt+Click to open the lorebook"></div>
+                                                <div id="world_button" class="menu_button fa-solid fa-globe" title="Character Lore&#10;&#10;Click to load&#10;Shift/Alt-click or long-press to open 'Link to World Info' popup" data-i18n="[title]world_button_title"></div>
+                                                <div class="chat_lorebook_button menu_button fa-solid fa-passport" title="Chat Lore&#10;&#10;Click to load&#10;Shift/Alt-click or long-press to open 'Link to Chat Lorebook' popup" data-i18n="[title]chat_lorebook_button_title"></div>
                                                 <div id="char_connections_button" class="menu_button fa-solid fa-face-smile" title="Connected Personas" data-i18n="[title]Connected Personas"></div>
                                                 <div id="export_button" class="menu_button fa-solid fa-file-export " title="Export and Download" data-i18n="[title]Export and Download"></div>
                                                 <!-- <div id="set_chat_character_settings" class="menu_button fa-solid fa-scroll" title="Set a chat scenario override"></div> -->
@@ -6139,8 +6174,14 @@
                                 <div id="group-metadata-controls" class="marginTopBot5">
                                     <div class="flex-container wide100p">
                                         <input id="rm_group_chat_name" class="text_pole flex1" type="text" name="chat_name" data-i18n="[placeholder]Chat Name (Optional)" placeholder="Chat Name (Optional)" />
-                                        <div class="chat_lorebook_button menu_button fa-solid fa-passport" title="Chat Lore" data-i18n="[title]Chat Lore"></div>
+                                        <div class="chat_lorebook_button menu_button fa-solid fa-passport" title="Chat Lore&#10;&#10;Click to load&#10;Shift/Alt-click or long-press to open 'Link to Chat Lorebook' popup" data-i18n="[title]chat_lorebook_button_title"></div>
                                     </div>
+                                    <label class="flex1 height100p" for="group-chat-lorebook-dropdown">
+                                        <select id="group-chat-lorebook-dropdown" class="text_pole">
+                                            <option value="default" disabled selected data-i18n="More...">More...</option>
+                                            <option id="group_chat_lorebook_link" data-i18n="Link to Chat Lorebook">Link to Chat Lorebook</option>
+                                        </select>
+                                    </label>
                                     <div id="group_tags_div" class="wide100p">
                                         <div class="tag_controls">
                                             <input id="groupTagInput" class="text_pole textarea_compact tag_input flex1 margin0" data-i18n="[placeholder]Search / Create Tags" placeholder="Search / Create tags" />
@@ -7331,6 +7372,7 @@
                                 <div title="Toggle media display style" class="mes_button mes_media_gallery fa-solid fa-photo-film" data-i18n="[title]Toggle media display style"></div>
                                 <div title="Toggle media display style" class="mes_button mes_media_list fa-solid fa-table-cells-large" data-i18n="[title]Toggle media display style"></div>
                                 <div title="Embed file or image" class="mes_button mes_embed fa-solid fa-paperclip" data-i18n="[title]Embed file or image"></div>
+                                <div title="Jump to swipe history" class="mes_button mes_swipe_picker fa-solid fa-bookmark" data-i18n="[title]Jump to swipe history" style="display: none;"></div>
                                 <div title="Create checkpoint" class="mes_button mes_create_bookmark fa-regular fa-solid fa-flag-checkered" data-i18n="[title]Create checkpoint"></div>
                                 <div title="Create branch" class="mes_button mes_create_branch fa-regular fa-code-branch" data-i18n="[title]Create Branch"></div>
                                 <div title="Copy" class="mes_button mes_copy fa-solid fa-copy " data-i18n="[title]Copy"></div>

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -45,6 +45,7 @@ const controls = [
     { id: 'instruct_names_behavior', property: 'names_behavior', isCheckbox: false },
     { id: 'instruct_system_same_as_user', property: 'system_same_as_user', isCheckbox: true, trigger: true },
     { id: 'instruct_sequences_as_stop_strings', property: 'sequences_as_stop_strings', isCheckbox: true },
+    { id: 'instruct_impersonate_sequence', property: 'impersonate_sequence', isCheckbox: false },
 ];
 
 /**
@@ -82,6 +83,7 @@ function migrateInstructModeSettings(settings) {
         sequences_as_stop_strings: true,
         story_string_prefix: '',
         story_string_suffix: '',
+        impersonate_sequence: '',
     };
 
     for (let key in defaults) {
@@ -597,14 +599,8 @@ export function formatInstructModePrompt(name, isImpersonate, promptBias, name1,
     function getSequence() {
         // User impersonation prompt
         if (isImpersonate) {
-            const seq = instruct.input_sequence || '';
-
-            // Remove trailing space after [INST] for impersonation to fix tokenization
-            if (seq.includes('[INST] ')) {
-                return seq.replace(/\[INST\]\s+$/, '[INST]');
-            }
-
-            return seq;
+            // Fall back to input_sequence if impersonate_sequence is not set
+            return instruct.impersonate_sequence || instruct.input_sequence;
         }
 
         // Neutral / system / quiet prompt
@@ -755,6 +751,12 @@ export function getInstructMacros(env) {
             key: 'instructLastInput|instructLastUserPrefix',
             value: power_user.instruct.last_input_sequence || power_user.instruct.input_sequence,
             enabled: power_user.instruct.enabled,
+        },
+        {
+            key: 'instructImpersonate',
+            value: power_user.instruct.impersonate_sequence || power_user.instruct.input_sequence,
+            enabled: power_user.instruct.enabled,
+        
         },
         // System prompt macros
         {

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -597,7 +597,14 @@ export function formatInstructModePrompt(name, isImpersonate, promptBias, name1,
     function getSequence() {
         // User impersonation prompt
         if (isImpersonate) {
-            return instruct.input_sequence;
+            const seq = instruct.input_sequence || '';
+
+            // Remove trailing space after [INST] for impersonation to fix tokenization
+            if (seq.includes('[INST] ')) {
+                return seq.replace(/\[INST\]\s+$/, '[INST]');
+            }
+
+            return seq;
         }
 
         // Neutral / system / quiet prompt

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -248,6 +248,7 @@ export const power_user = {
         bind_to_context: false,
         user_alignment_message: '',
         system_same_as_user: false,
+        impersonate_sequence: '',
         /** @deprecated Use output_suffix instead */
         separator_sequence: '',
         sequences_as_stop_strings: true,
@@ -286,9 +287,9 @@ export const power_user = {
         add_to_prompts: false,
         auto_expand: false,
         show_hidden: false,
-        prefix: '<think>\n',
-        suffix: '\n</think>',
-        separator: '\n\n',
+        prefix: '<think>',
+        suffix: '</think>',
+        separator: '\n',
         max_additions: 1,
     },
 


### PR DESCRIPTION
**Reason for change:** 
When using Mistral-style models (like M2411/M2407), the `input_sequence` usually requires a trailing space (e.g., `[INST] `). However, during Impersonation, the AI is expected to continue directly from the tag. If a trailing space exists, it forces the AI to start its response with a space, which often breaks Mistral's specific tokenization and causes degraded output.

 **What was done:** 
Modified the `getSequence` helper within `formatInstructModePrompt` to strip the trailing space from the `input_sequence` ONLY when `isImpersonate` is active and the sequence contains `[INST] `.

**How to test:** 
1. Set an Instruct preset with `[INST] ` as the input sequence.
2. Use a Mistral-family model.
3. Click "Impersonate".
4. Observe in the console/backend logs that the prompt now ends in `[INST]` instead of `[INST] `

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
