### PR TITLE
docs: Add community Mac one-click installer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 LLM Frontend for Power Users
 
+## Installation
+
+Visit the official documentation for platform-specific guides:
+
+- **Windows:** https://docs.sillytavern.app/installation/windows/
+- **macOS & Linux:** https://docs.sillytavern.app/installation/linuxmacos/
+- **Docker:** https://docs.sillytavern.app/installation/docker/
+
+### macOS Quick Start (Community Tool)
+
+For macOS users, we have a community-maintained one-click installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Crystaria/sillytavern-mac-installer/main/install.sh | bash
+```
+
+**Features:**
+- Full auto-installation (Homebrew, Git, Node.js)
+- Detailed setup guide: https://github.com/Crystaria/sillytavern-mac-installer
+- Optimized for users in China (npm mirror)
+
+*This is a community tool and not officially supported by SillyTavern.*
+
+---
+
 ## Resources
 
 - GitHub: <https://github.com/SillyTavern/SillyTavern>


### PR DESCRIPTION
## Summary

This PR adds a link to the community-maintained Mac one-click installer in the README.

## Why

- Helps Mac users quickly find the installer
- Reduces installation barriers for beginners
- Complements the official documentation

## What

Added an "Installation" section with:
- Links to official documentation
- macOS Quick Start using community installer
- Clear disclaimer that it is community-maintained

## Repository

https://github.com/Crystaria/sillytavern-mac-installer

---

Thanks for considering! 🦞