### PR TITLE
Remove xAI web search capability

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1982,7 +1982,7 @@
                                             </span>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="makersuite,vertexai,aimlapi,openrouter,claude,xai,electronhub,chutes,nanogpt">
+                                    <div class="range-block" data-source="makersuite,vertexai,aimlapi,openrouter,claude,electronhub,chutes,nanogpt">
                                         <label for="openai_enable_web_search" class="checkbox_label flexWrap widthFreeExpand">
                                             <input id="openai_enable_web_search" type="checkbox" />
                                             <span data-i18n="Enable web search">Enable web search</span>

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1154,17 +1154,6 @@ async function sendXaiRequest(request, response) {
             bodyParams['reasoning_effort'] = request.body.reasoning_effort === 'high' ? 'high' : 'low';
         }
 
-        if (request.body.enable_web_search) {
-            bodyParams['search_parameters'] = {
-                mode: 'on',
-                sources: [
-                    { type: 'web', safe_search: false },
-                    { type: 'news', safe_search: false },
-                    { type: 'x' },
-                ],
-            };
-        }
-
         if (request.body.json_schema) {
             bodyParams['response_format'] = {
                 type: 'json_schema',


### PR DESCRIPTION
This effectively reverts 3487302.
The web search tool is now exclusive for their Responses API (like all other tools) and it returns the following error:
```
{"error":"Live search is deprecated. Please switch to the Agent Tools API: https://docs.x.ai/docs/guides/tools/overview"}
```

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
