### PR TITLE
Use string byte length for token guesstimation

### DIFF
--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -162,7 +162,8 @@ let tokenCache = {};
  * @returns {number} Token count.
  */
 export function guesstimate(str) {
-    return Math.ceil(str.length / CHARACTERS_PER_TOKEN_RATIO);
+    const encodedString = new TextEncoder().encode(str);
+    return Math.ceil(encodedString.byteLength / CHARACTERS_PER_TOKEN_RATIO);
 }
 
 async function loadTokenCache() {

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -7,8 +7,9 @@ import { getStringHash } from './utils.js';
 import { kai_flags, kai_settings } from './kai-settings.js';
 import { textgen_types, textgenerationwebui_settings as textgen_settings, getTextGenServer, getTextGenModel } from './textgen-settings.js';
 import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, openRouterModels } from './textgen-models.js';
+export { BYTES_PER_TOKEN as CHARACTERS_PER_TOKEN_RATIO };
 
-export const CHARACTERS_PER_TOKEN_RATIO = 3.35;
+export const BYTES_PER_TOKEN = 3.35;
 export const TOKENIZER_WARNING_KEY = 'tokenizationWarningShown';
 export const TOKENIZER_SUPPORTED_KEY = 'tokenizationSupported';
 
@@ -152,6 +153,7 @@ const TOKENIZER_URLS = {
     },
 };
 
+const textEncoder = new TextEncoder();
 const objectStore = localforage.createInstance({ name: 'SillyTavern_ChatCompletions' });
 
 let tokenCache = {};
@@ -162,8 +164,8 @@ let tokenCache = {};
  * @returns {number} Token count.
  */
 export function guesstimate(str) {
-    const encodedString = new TextEncoder().encode(str);
-    return Math.ceil(encodedString.byteLength / CHARACTERS_PER_TOKEN_RATIO);
+    const byteLength = textEncoder.encode(str).length;
+    return Math.ceil(byteLength / BYTES_PER_TOKEN);
 }
 
 async function loadTokenCache() {

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -57,7 +57,7 @@ export const TEXT_COMPLETION_MODELS = [
     'code-search-ada-code-001',
 ];
 
-const CHARS_PER_TOKEN = 3.35;
+const BYTES_PER_TOKEN = 3.35;
 const IS_DOWNLOAD_ALLOWED = getConfigValue('enableDownloadableTokenizers', true, 'boolean');
 const gunzip = promisify(zlib.gunzip);
 
@@ -67,8 +67,8 @@ const gunzip = promisify(zlib.gunzip);
  * @returns {number} Token count.
  */
 function guesstimate(str) {
-    const encodedString = new TextEncoder().encode(str);
-    return Math.ceil(encodedString.byteLength / CHARS_PER_TOKEN);
+    const byteLength = Buffer.byteLength(str, 'utf8');
+    return Math.ceil(byteLength / BYTES_PER_TOKEN);
 }
 
 /**

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -62,6 +62,16 @@ const IS_DOWNLOAD_ALLOWED = getConfigValue('enableDownloadableTokenizers', true,
 const gunzip = promisify(zlib.gunzip);
 
 /**
+ * Guesstimates the token count for a string.
+ * @param {string} str String to tokenize.
+ * @returns {number} Token count.
+ */
+function guesstimate(str) {
+    const encodedString = new TextEncoder().encode(str);
+    return Math.ceil(encodedString.byteLength / CHARS_PER_TOKEN);
+}
+
+/**
  * Gets a path to the tokenizer model. Downloads the model if it's a URL.
  * @param {string} model Model URL or path
  * @param {string|undefined} fallbackModel Fallback model path
@@ -361,7 +371,7 @@ async function countSentencepieceTokens(tokenizer, text) {
     if (!instance) {
         return {
             ids: [],
-            count: Math.ceil(text.length / CHARS_PER_TOKEN),
+            count: guesstimate(text),
         };
     }
 
@@ -540,7 +550,7 @@ export function countWebTokenizerTokens(tokenizer, messages) {
 
     // Fallback to strlen estimation
     if (!tokenizer) {
-        return Math.ceil(convertedPrompt.length / CHARS_PER_TOKEN);
+        return guesstimate(convertedPrompt);
     }
 
     const count = tokenizer.encode(convertedPrompt).length;
@@ -1021,7 +1031,7 @@ router.post('/openai/count', async function (req, res) {
     } catch (error) {
         console.error('An error counting tokens, using fallback estimation method', error);
         const jsonBody = JSON.stringify(req.body);
-        const num_tokens = Math.ceil(jsonBody.length / CHARS_PER_TOKEN);
+        const num_tokens = guesstimate(jsonBody);
         res.send({ 'token_count': num_tokens });
     }
 });


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

This will allow to more accurately predict tokens for non-English texts by using the byte length of a string in a UTF-8 encoding instead of a number of code points. An average Chinese text is 3 bytes per one character, which nicely translates into ~1 token instead of ~0.33 tokens.

## Comparison table

> Using a default fallback (gpt-3.5 tokenizer for comparison)

| Language  | Text                                                                                                                                                                  | Guesstimate (old)  | Guesstimate (new)   | GPT-3.5 tokenizer |
| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------------ | ------------------- | ----------------- |
| Arabic    | `يولد جميع الناس أحراراً ومتساوين في الكرامة والحقوق. وهم قد وهبوا العقل والوجدان وعليهم أن يعاملوا بعضهم بعضاً بروح الإخاء.‭` | 37 | 68                  | 91 |
| Chinese   | `人人生而自由，在尊严和权利上一律平等。他们赋有理性和良心，并应以兄弟关系的精神相对待。` | 13 | 39 | 50 |
| Ukrainian | `Всі люди народжуються вільними і рівними у своїй гідності та правах. Вони наділені розумом і совістю і повинні діяти у відношенні один до одного в дусі братерства.` | 49 | 89  | 94      |
| Korean    | `모든 인간은 태어날 때부터 자유로우며 그 존엄과 권리에 있어 동등하다. 인간은 천부적으로 이성과 양심을 부여받았으며 서로 형제애의 정신으로 행동하여야 한다.`                                                | 26 | 66 | 85 |

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
