### PR TITLE
fix: prioritize UI memory content for {{summary}} macro resolution

### DIFF
--- a/public/scripts/extensions/memory/index.js
+++ b/public/scripts/extensions/memory/index.js
@@ -1109,8 +1109,8 @@ jQuery(async function () {
 
     const summaryMacroHandler = () => {
         // Checking content of the UI summary box first
-        const uiSummary = $('#memory_contents').val().toString().trim();
-        if (uiSummary.length > 0) {
+        const uiSummary = $('#memory_contents').val().toString();
+        if (uiSummary.trim().length > 0) {
             return uiSummary;
         }
         // Fallback to scanning the chat for the latest summary if the UI summary box is empty

--- a/public/scripts/extensions/memory/index.js
+++ b/public/scripts/extensions/memory/index.js
@@ -1111,7 +1111,15 @@ jQuery(async function () {
         macros.register('summary', {
             category: MacroCategory.CHAT,
             description: 'Returns the latest memory/summary from the current chat.',
-            handler: () => getLatestMemoryFromChat(getContext().chat),
+            handler: () => {
+                // Checking content of the UI summary box first
+                const uiSummary = $('#memory_contents').val();
+                if (uiSummary && uiSummary.trim() !== '') {
+                    return uiSummary;
+                }
+                // Fallback to scanning the chat for the latest summary if the UI summary box is empty
+                return getLatestMemoryFromChat(getContext().chat);
+            },
         });
     } else {
         // TODO: Remove this when the experimental macro engine is replacing the old macro engine

--- a/public/scripts/extensions/memory/index.js
+++ b/public/scripts/extensions/memory/index.js
@@ -1107,24 +1107,25 @@ jQuery(async function () {
         returns: ARGUMENT_TYPE.STRING,
     }));
 
+    const summaryMacroHandler = () => {
+        // Checking content of the UI summary box first
+        const uiSummary = $('#memory_contents').val().toString().trim();
+        if (uiSummary.length > 0) {
+            return uiSummary;
+        }
+        // Fallback to scanning the chat for the latest summary if the UI summary box is empty
+        return getLatestMemoryFromChat(getContext().chat);
+    };
     if (power_user.experimental_macro_engine) {
         macros.register('summary', {
             category: MacroCategory.CHAT,
             description: 'Returns the latest memory/summary from the current chat.',
-            handler: () => {
-                // Checking content of the UI summary box first
-                const uiSummary = $('#memory_contents').val();
-                if (uiSummary && uiSummary.trim() !== '') {
-                    return uiSummary;
-                }
-                // Fallback to scanning the chat for the latest summary if the UI summary box is empty
-                return getLatestMemoryFromChat(getContext().chat);
-            },
+            handler: () => summaryMacroHandler(),
         });
     } else {
         // TODO: Remove this when the experimental macro engine is replacing the old macro engine
         MacrosParser.registerMacro('summary',
-            () => getLatestMemoryFromChat(getContext().chat),
+            () => summaryMacroHandler(),
             'Returns the latest memory/summary from the current chat.');
     }
 });


### PR DESCRIPTION
**Description:**
I’ve encountered a scenario where the `{{summary}}` macro returns an empty string at the very start of a chat when "None (not injected)" is selected in the memory settings, despite a summary being present in the `Current summary` UI box.

The current macro resolution relies on `getLatestMemoryFromChat`, which scans the chat history for saved `extra.memory`. This works perfectly once the conversation is established or when other `Injection Position` options are active, but it fails on the first turn because no message history exists to host that metadata.

This PR improves this "cold start" behavior by updating the macro registration handler to check the `#memory_contents` UI field before falling back to the history-based search. This allows the macro to resolve immediately if a summary has been entered manually, even before the first history-based summary is generated.

**Changes:**
- Updated the `macros.register('summary', ...)` handler in `public/scripts/extensions/memory/index.js`.
- The handler now prioritizes `$('#memory_contents').val()` to capture the current UI state.

**Why this is useful:**
Users utilizing custom prompt templates (e.g., `<past_events>{{summary}}</past_events>`) with "None (not injected)" selected currently lose summary data on the first turn. This change ensures the macro remains populated as long as there is an active summary in the UI, regardless of the chat's initialization state.

Please check. Thanks! 🤘

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
