### PR TITLE
Add branch navigation UI, visual graph, and persist branch metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7352,7 +7352,7 @@
                                 <div title="Copy" class="mes_button mes_copy fa-solid fa-copy " data-i18n="[title]Copy"></div>
                             </div>
                             <div data-tooltip="Click to open checkpoint chat&#10;Shift+Click to replace the existing checkpoint with a new one" class="mes_button mes_bookmark fa-solid fa-flag" data-i18n="[data-tooltip]Open checkpoint chat&#10;Shift+Click to replace the existing checkpoint with a new one"></div>
-                            <div data-tooltip="Click to view branch chats" class="mes_button mes_branches fa-solid fa-code-branch" data-i18n="[data-tooltip]Click to view branch chats"></div>
+                            <div title="View branch chats" class="mes_button mes_branches fa-solid fa-code-branch" data-i18n="[title]View branch chats"></div>
                             <div title="Edit" class="mes_button mes_edit fa-solid fa-pencil " data-i18n="[title]Edit"></div>
                         </div>
                         <div class="mes_edit_buttons">

--- a/public/index.html
+++ b/public/index.html
@@ -7352,6 +7352,7 @@
                                 <div title="Copy" class="mes_button mes_copy fa-solid fa-copy " data-i18n="[title]Copy"></div>
                             </div>
                             <div data-tooltip="Click to open checkpoint chat&#10;Shift+Click to replace the existing checkpoint with a new one" class="mes_button mes_bookmark fa-solid fa-flag" data-i18n="[data-tooltip]Open checkpoint chat&#10;Shift+Click to replace the existing checkpoint with a new one"></div>
+                            <div data-tooltip="Click to view branch chats" class="mes_button mes_branches fa-solid fa-code-branch" data-i18n="[data-tooltip]Click to view branch chats"></div>
                             <div title="Edit" class="mes_button mes_edit fa-solid fa-pencil " data-i18n="[title]Edit"></div>
                         </div>
                         <div class="mes_edit_buttons">
@@ -8076,6 +8077,10 @@
             <a id="option_back_to_main">
                 <i class="fa-lg fa-solid fa-left-long"></i>
                 <span data-i18n="Back to parent chat">Back to parent chat</span>
+            </a>
+            <a id="option_branch_graph">
+                <i class="fa-lg fa-solid fa-diagram-project"></i>
+                <span data-i18n="Branch graph">Branch graph</span>
             </a>
             <a id="option_new_bookmark">
                 <i class="fa-lg fa-solid fa-flag"></i>

--- a/public/script.js
+++ b/public/script.js
@@ -130,6 +130,7 @@ import {
     initBookmarks,
     showBookmarksButtons,
     updateBookmarkDisplay,
+    updateBranchMetadataAfterRename,
 } from './scripts/bookmarks.js';
 
 import {
@@ -10452,6 +10453,8 @@ export async function renameGroupOrCharacterChat({ characterId, groupId, oldFile
             $('#selected_chat_pole').val(characters[characterId].chat);
             await createOrEditCharacter();
         }
+
+        await updateBranchMetadataAfterRename(oldFileName, newFileName);
 
         if (currentChatId) {
             await reloadCurrentChat();

--- a/public/script.js
+++ b/public/script.js
@@ -2521,6 +2521,7 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
     const timestamp = momentDate.isValid() ? momentDate.format('LL LT') : '';
     const messageHTML = getMessageTextHTML(mes, { messageId });
     const bookmarkLink = mes?.extra?.bookmark_link;
+    const hasBranches = Array.isArray(mes?.extra?.branches) && mes.extra.branches.length > 0;
     const tokenCount = mes.extra?.token_count;
     const { timerValue, timerTitle } = formatGenerationTimer(mes.gen_started, mes.gen_finished, mes.extra?.token_count, mes.extra?.reasoning_duration, mes.extra?.time_to_first_token);
 
@@ -2531,6 +2532,7 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
         'is_user': mes.is_user,
         'is_system': !!mes.is_system,
         'bookmark_link': bookmarkLink,
+        'has_branches': hasBranches ? 'true' : '',
         'force_avatar': !!mes.force_avatar,
         'timestamp': timestamp,
         // ...(type ?? { type }),

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -27,7 +27,7 @@ import {
 } from './group-chats.js';
 import { hideLoader, showLoader } from './loader.js';
 import { getLastMessageId } from './macros.js';
-import { Popup, POPUP_TYPE } from './popup.js';
+import { Popup, POPUP_TYPE, POPUP_RESULT } from './popup.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { commonEnumProviders } from './slash-commands/SlashCommandCommonEnumsProvider.js';
@@ -36,6 +36,10 @@ import { createTagMapFromList } from './tags.js';
 import { renderTemplateAsync } from './templates.js';
 import { compressRequest } from './request-compression.js';
 import { t } from './i18n.js';
+import {
+    showBranchGraph as showBranchGraphModule,
+    updateBranchMetadataAfterRename,
+} from './branch-graph.js';
 
 import {
     getUniqueName,
@@ -741,32 +745,31 @@ async function showBranchList(mesId) {
             },
         });
 
-        // Add click handlers to the branch items (use one-time handler to avoid duplicates)
-        const handleBranchClick = async function () {
-            const fileName = $(this).attr('data-file-name');
-            if (!fileName) return;
+        const result = await popup.show();
 
-            try {
-                showLoader();
-                // Close the popup
-                popup.completeAffirmative();
+        // If user cancelled or closed the popup, do nothing
+        // Note: result can be 0 (first item), so we need to check for null/undefined or negative button explicitly
+        if (result === POPUP_RESULT.CANCELLED || result === null || result === undefined) {
+            return;
+        }
 
-                // Remove the event handler to prevent memory leaks
-                $(document).off('click', '.branch-list-item', handleBranchClick);
+        // Get the selected branch by index
+        const selectedBranch = branches[result];
+        if (!selectedBranch) {
+            console.error('Invalid branch selection:', result);
+            return;
+        }
 
-                if (selected_group) {
-                    await openGroupChat(selected_group, fileName);
-                } else {
-                    await openCharacterChat(fileName);
-                }
-            } finally {
-                await hideLoader();
+        try {
+            showLoader();
+            if (selected_group) {
+                await openGroupChat(selected_group, selectedBranch.file_name);
+            } else {
+                await openCharacterChat(selectedBranch.file_name);
             }
-        };
-
-        $(document).on('click', '.branch-list-item', handleBranchClick);
-
-        await popup.show();
+        } finally {
+            await hideLoader();
+        }
     } catch (error) {
         console.error('Error showing branch list:', error);
         toastr.error('Failed to load branch list. Please try again.', 'Error');
@@ -778,481 +781,12 @@ async function showBranchList(mesId) {
 /**
  * Builds a tree of all related chats (parents and children) and displays it in a graph.
  */
-/**
- * Fetches chat metadata including parent and branch information.
- * @param {string} chatName Chat filename (without .jsonl)
- * @returns {Promise<{main_chat: string, branches: string[], messages: any[]}|null>}
- */
-async function fetchChatMetadata(chatName) {
-    try {
-        const metaResponse = await fetch('/api/chats/get', {
-            method: 'POST',
-            headers: getRequestHeaders(),
-            body: JSON.stringify({
-                ch_name: selected_group ? null : characters[this_chid]?.name,
-                file_name: chatName,
-                avatar_url: selected_group ? null : characters[this_chid]?.avatar,
-            }),
-        });
-
-        if (!metaResponse.ok) {
-            return null;
-        }
-
-        const chatData = await metaResponse.json();
-
-        let chat_metadata = null;
-        let messages = [];
-
-        if (Array.isArray(chatData)) {
-            if (chatData.length > 0) {
-                chat_metadata = chatData[0].chat_metadata;
-                messages = chatData.slice(1);
-            }
-        } else {
-            chat_metadata = chatData.chat_metadata;
-            messages = chatData.chat || [];
-        }
-
-        const branches = [];
-
-        if (Array.isArray(messages)) {
-            for (const message of messages) {
-                if (message?.extra?.branches && Array.isArray(message.extra.branches)) {
-                    branches.push(...message.extra.branches);
-                }
-            }
-        }
-
-        return {
-            main_chat: chat_metadata?.main_chat,
-            branches: [...new Set(branches)],
-            messages: messages,
-        };
-    } catch (err) {
-        console.error('[BranchMetadata] Error fetching metadata for', chatName, ':', err);
-        return null;
-    }
-}
-
-/**
- * Traverses the branch tree starting from a chat to collect all related chats.
- * @param {string} startChatName Starting chat filename
- * @param {Map<string, any>} chatMap Map of all available chats
- * @returns {Promise<{relatedChats: Set<string>, metadataCache: Map<string, any>}>}
- */
-async function traverseBranchTree(startChatName, chatMap) {
-    const relatedChats = new Set([startChatName]);
-    const metadataCache = new Map();
-
-    // Find root by going up the parent chain
-    let rootChatName = startChatName;
-    let current = startChatName;
-    const visited = new Set();
-
-    while (current && !visited.has(current)) {
-        visited.add(current);
-        relatedChats.add(current);
-
-        const metadata = await fetchChatMetadata(current);
-        if (metadata) {
-            metadataCache.set(current, metadata);
-            const parent = metadata.main_chat;
-
-            if (parent && chatMap.has(parent)) {
-                rootChatName = parent;
-                current = parent;
-            } else {
-                break;
-            }
-        } else {
-            break;
-        }
-    }
-
-    // Traverse down from root to collect all children
-    async function collectChildren(chatName, visitedInPath = new Set()) {
-        if (visitedInPath.has(chatName)) {
-            return;
-        }
-
-        visitedInPath.add(chatName);
-
-        if (!metadataCache.has(chatName)) {
-            const metadata = await fetchChatMetadata(chatName);
-            if (metadata) {
-                metadataCache.set(chatName, metadata);
-            }
-        }
-
-        const metadata = metadataCache.get(chatName);
-
-        if (metadata?.branches) {
-            for (const branchName of metadata.branches) {
-                if (chatMap.has(branchName) && !relatedChats.has(branchName)) {
-                    relatedChats.add(branchName);
-                    await collectChildren(branchName, new Set(visitedInPath));
-                }
-            }
-        }
-    }
-
-    await collectChildren(rootChatName);
-
-    return { relatedChats, metadataCache };
-}
-
-/**
- * Updates branch metadata across the branch tree after a chat is renamed.
- * @param {string} oldFileName Old chat filename (without .jsonl)
- * @param {string} newFileName New chat filename (without .jsonl)
- */
-export async function updateBranchMetadataAfterRename(oldFileName, newFileName) {
-    try {
-        // Fetch all chats to build the chat map
-        const response = await fetch('/api/chats/search', {
-            method: 'POST',
-            headers: getRequestHeaders(),
-            body: JSON.stringify({
-                query: '',
-                avatar_url: selected_group ? null : characters[this_chid]?.avatar,
-                group_id: selected_group || null,
-            }),
-        });
-
-        if (!response.ok) {
-            console.error('Failed to fetch chat list for branch metadata update');
-            return;
-        }
-
-        const allChats = await response.json();
-        const chatMap = new Map(allChats.map(chat => [chat.file_name, chat]));
-
-        // Use the new filename to traverse the tree (since the file has already been renamed)
-        if (!chatMap.has(newFileName)) {
-            console.warn(`Renamed chat ${newFileName} not found in chat list`);
-            return;
-        }
-
-        const { relatedChats, metadataCache } = await traverseBranchTree(newFileName, chatMap);
-
-        // Update branch references in all related chats
-        for (const chatName of relatedChats) {
-            const metadata = metadataCache.get(chatName);
-            if (!metadata?.messages) {
-                continue;
-            }
-
-            let hadChanges = false;
-
-            for (const message of metadata.messages) {
-                if (message?.extra?.branches && Array.isArray(message.extra.branches)) {
-                    const branchIndex = message.extra.branches.indexOf(oldFileName);
-                    if (branchIndex !== -1) {
-                        message.extra.branches[branchIndex] = newFileName;
-                        hadChanges = true;
-                    }
-                }
-            }
-
-            if (hadChanges) {
-                // Reconstruct the full chat data with header
-                const chatHeader = {
-                    chat_metadata: metadataCache.get(chatName)?.main_chat ? { main_chat: metadataCache.get(chatName).main_chat } : {},
-                    user_name: 'unused',
-                    character_name: 'unused',
-                };
-
-                if (selected_group) {
-                    const saveChatRequest = await compressRequest({
-                        method: 'POST',
-                        headers: getRequestHeaders(),
-                        body: JSON.stringify({ id: chatName, chat: [chatHeader, ...metadata.messages] }),
-                    });
-                    const saveChatResponse = await fetch('/api/chats/group/save', saveChatRequest);
-
-                    if (!saveChatResponse.ok) {
-                        console.error(`Failed to update branch metadata in group chat: ${chatName}`);
-                    } else {
-                        console.log(`Updated branch metadata in group chat: ${chatName}`);
-                    }
-                } else {
-                    const saveChatRequest = await compressRequest({
-                        method: 'POST',
-                        headers: getRequestHeaders(),
-                        body: JSON.stringify({
-                            ch_name: characters[this_chid]?.name,
-                            file_name: chatName,
-                            chat: [chatHeader, ...metadata.messages],
-                            avatar_url: characters[this_chid]?.avatar,
-                        }),
-                    });
-                    const saveChatResponse = await fetch('/api/chats/save', saveChatRequest);
-
-                    if (!saveChatResponse.ok) {
-                        console.error(`Failed to update branch metadata in chat: ${chatName}`);
-                    } else {
-                        console.log(`Updated branch metadata in chat: ${chatName}`);
-                    }
-                }
-            }
-        }
-    } catch (error) {
-        console.error('Error updating branch metadata after rename:', error);
-    }
-}
-
 async function showBranchGraph() {
-    try {
-        showLoader();
-
-        const currentChatName = (getCurrentChatDetails()).sessionName;
-
-        if (!currentChatName) {
-            toastr.info('Please open a chat first.', 'No chat loaded');
-            return;
-        }
-
-        // Fetch all chats to get basic info
-        const response = await fetch('/api/chats/search', {
-            method: 'POST',
-            headers: getRequestHeaders(),
-            body: JSON.stringify({
-                query: '',
-                avatar_url: selected_group ? null : characters[this_chid]?.avatar,
-                group_id: selected_group || null,
-            }),
-        });
-
-        if (!response.ok) {
-            throw new Error('Failed to fetch chat list');
-        }
-
-        const allChats = await response.json();
-        const chatMap = new Map(allChats.map(chat => [chat.file_name, chat]));
-
-        // Use the shared traversal function
-        const { relatedChats, metadataCache } = await traverseBranchTree(currentChatName, chatMap);
-
-        // Find root chat
-        let rootChatName = currentChatName;
-        for (const chatName of relatedChats) {
-            const metadata = metadataCache.get(chatName);
-            if (metadata && !metadata.main_chat) {
-                rootChatName = chatName;
-                break;
-            }
-        }
-
-        // Build tree structure
-        function buildTree(chatName, depth = 0) {
-            const chat = chatMap.get(chatName);
-            if (!chat) {
-                return null;
-            }
-
-            const metadata = metadataCache.get(chatName);
-            const children = (metadata?.branches || [])
-                .filter(childName => chatMap.has(childName))
-                .map(childName => buildTree(childName, depth + 1))
-                .filter(Boolean);
-
-            return {
-                name: chatName,
-                chat: chat,
-                children: children,
-                depth: depth,
-            };
-        }
-
-        const tree = buildTree(rootChatName);
-
-        if (!tree) {
-            toastr.error('Failed to build branch graph.', 'Error');
-            return;
-        }
-
-        // Remove duplicate nodes from the tree (keep first occurrence only)
-        function removeDuplicates(node, seen = new Set()) {
-            if (seen.has(node.name)) {
-                return null;
-            }
-            seen.add(node.name);
-
-            // Recursively process children, sharing the same seen set
-            // so a node only appears once across the entire tree
-            node.children = node.children
-                .map(child => removeDuplicates(child, seen))
-                .filter(Boolean);
-
-            return node;
-        }
-
-        const cleanTree = removeDuplicates(tree);
-
-        // Calculate layout positions for each node
-        function calculateLayout(node, depth = 0, leftOffset = 0) {
-            // Calculate width needed for this subtree
-            function getSubtreeWidth(n) {
-                if (n.children.length === 0) return 1;
-                return n.children.reduce((sum, child) => sum + getSubtreeWidth(child), 0);
-            }
-
-            const subtreeWidth = getSubtreeWidth(node);
-
-            // Position this node
-            node.layout = {
-                depth: depth,
-                leftOffset: leftOffset,
-                width: subtreeWidth,
-                x: leftOffset + (subtreeWidth - 1) / 2, // Center position
-            };
-
-            // Position children
-            let childOffset = leftOffset;
-            for (const child of node.children) {
-                calculateLayout(child, depth + 1, childOffset);
-                childOffset += getSubtreeWidth(child);
-            }
-
-            return node;
-        }
-
-        calculateLayout(cleanTree);
-
-        // Organize nodes by depth level with proper positioning
-        function organizeByLevelsWithLayout(node, levels = []) {
-            if (!levels[node.layout.depth]) {
-                levels[node.layout.depth] = [];
-            }
-            levels[node.layout.depth].push(node);
-
-            for (const child of node.children) {
-                organizeByLevelsWithLayout(child, levels);
-            }
-
-            return levels;
-        }
-
-        const levels = organizeByLevelsWithLayout(cleanTree);
-
-        // Prepare data for template
-        const nodeWidth = 280;
-        const nodeHeight = 120;
-        const horizontalGap = 20;
-        const verticalGap = 60;
-
-        const maxWidth = Math.max(...levels.map(level =>
-            Math.max(...level.map(node => node.layout.x)),
-        )) + 1;
-
-        const totalWidth = maxWidth * (nodeWidth + horizontalGap);
-        const totalHeight = levels.length * (nodeHeight + verticalGap);
-
-        const lines = [];
-        const nodes = [];
-
-        // Collect connection lines
-        for (const level of levels) {
-            for (const node of level) {
-                const parentX = node.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
-                const parentY = node.layout.depth * (nodeHeight + verticalGap) + nodeHeight;
-
-                for (const child of node.children) {
-                    const childX = child.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
-                    const childY = child.layout.depth * (nodeHeight + verticalGap);
-
-                    lines.push({ x1: parentX, y1: parentY, x2: childX, y2: childY });
-                }
-            }
-        }
-
-        // Collect nodes
-        for (const level of levels) {
-            for (const node of level) {
-                const isCurrentChat = node.name === currentChatName;
-                const momentDate = timestampToMoment(node.chat.last_mes);
-                const formattedDate = momentDate.isValid() ? momentDate.format('lll') : 'Unknown date';
-                const messageCount = node.chat.message_count || 0;
-                const preview = node.chat.preview_message || '(No messages)';
-
-                const x = node.layout.x * (nodeWidth + horizontalGap);
-                const y = node.layout.depth * (nodeHeight + verticalGap);
-
-                nodes.push({
-                    name: node.name,
-                    isCurrentChat,
-                    formattedDate,
-                    messageCount,
-                    preview,
-                    x,
-                    y,
-                    width: nodeWidth,
-                });
-            }
-        }
-
-        const graphHTML = await renderTemplateAsync('branchGraph', { totalWidth, totalHeight, lines, nodes });
-
-        // Show the popup with large size
-        const popup = new Popup(graphHTML, POPUP_TYPE.TEXT, '', {
-            okButton: false,
-            cancelButton: 'Close',
-            wide: true,
-            large: true,
-            onOpen: () => {
-                // Use .text() to safely set content after popup is in DOM (like "Manage chat files" does)
-                $('.branch-graph-node').each(function () {
-                    const nodeIndex = parseInt($(this).attr('data-node-index'));
-                    const node = nodes[nodeIndex];
-                    $(this).attr('data-file-name', node.name);
-                    $(this).find('.branch-node-name-text').text(node.name);
-                    $(this).find('.branch-node-preview-text').text(node.preview);
-                });
-            },
-            onClose: () => {
-                // Clean up event handler when popup closes
-                $(document).off('click', '.branch-graph-node', handleNodeClick);
-            },
-        });
-
-        // Add click handlers to the nodes
-        const handleNodeClick = async function () {
-            const fileName = $(this).attr('data-file-name');
-            if (!fileName || fileName === currentChatName) return;
-
-            // Close the popup FIRST
-            popup.completeAffirmative();
-
-            // Remove the event handler
-            $(document).off('click', '.branch-graph-node', handleNodeClick);
-
-            try {
-                showLoader();
-                // Save current chat before switching
-                await saveChatConditional();
-
-                if (selected_group) {
-                    await openGroupChat(selected_group, fileName);
-                } else {
-                    await openCharacterChat(fileName);
-                }
-            } finally {
-                await hideLoader();
-            }
-        };
-
-        $(document).on('click', '.branch-graph-node', handleNodeClick);
-
-        // Show and wait for popup to complete
-        await popup.show();
-    } catch (error) {
-        console.error('[BranchGraph] Error showing branch graph:', error);
-        toastr.error('Failed to load branch graph. Please try again.', 'Error');
-    } finally {
-        await hideLoader();
-    }
+    await showBranchGraphModule();
 }
+
+// Re-export for backward compatibility
+export { updateBranchMetadataAfterRename };
 
 export function initBookmarks() {
     $('#option_new_bookmark').on('click', saveBookmarkMenu);

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -196,7 +196,22 @@ export async function createBranch(mesId) {
     if (selected_group) {
         await saveGroupBookmarkChat(selected_group, name, newMetadata, mesId);
     } else {
+        // Temporarily strip branches from messages so the branch chat
+        // doesn't inherit the parent's branch references in its .jsonl file
+        const branchBackups = [];
+        for (let i = 0; i <= mesId; i++) {
+            if (chat[i]?.extra?.branches) {
+                branchBackups.push({ index: i, branches: chat[i].extra.branches });
+                delete chat[i].extra.branches;
+            }
+        }
+
         await saveChat({ chatName: name, withMetadata: newMetadata, mesId });
+
+        // Restore branches on the in-memory messages
+        for (const { index, branches } of branchBackups) {
+            chat[index].extra.branches = branches;
+        }
     }
     // append to branches list if it exists
     // otherwise create it
@@ -928,16 +943,17 @@ async function showBranchGraph() {
             return;
         }
 
-        // Remove duplicate nodes from the tree
+        // Remove duplicate nodes from the tree (keep first occurrence only)
         function removeDuplicates(node, seen = new Set()) {
             if (seen.has(node.name)) {
                 return null;
             }
             seen.add(node.name);
 
-            // Recursively process children
+            // Recursively process children, sharing the same seen set
+            // so a node only appears once across the entire tree
             node.children = node.children
-                .map(child => removeDuplicates(child, new Set(seen)))
+                .map(child => removeDuplicates(child, seen))
                 .filter(Boolean);
 
             return node;

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -699,7 +699,7 @@ async function showBranchList(mesId) {
         if (branchChats.length === 0) {
             const result = await Popup.show.confirm(
                 'All branch chats appear to have been deleted.',
-                'Would you like to clean up the branch metadata from this message?'
+                'Would you like to clean up the branch metadata from this message?',
             );
             if (result) {
                 // Clean up the branch metadata
@@ -731,7 +731,7 @@ async function showBranchList(mesId) {
             cancelButton: 'Close',
             onOpen: () => {
                 // Use .text() to safely set content after popup is in DOM (like "Manage chat files" does)
-                $('.branch-list-item').each(function() {
+                $('.branch-list-item').each(function () {
                     const branchIndex = parseInt($(this).attr('data-branch-index'));
                     const branch = branches[branchIndex];
                     $(this).attr('data-file-name', branch.file_name);
@@ -778,6 +778,230 @@ async function showBranchList(mesId) {
 /**
  * Builds a tree of all related chats (parents and children) and displays it in a graph.
  */
+/**
+ * Fetches chat metadata including parent and branch information.
+ * @param {string} chatName Chat filename (without .jsonl)
+ * @returns {Promise<{main_chat: string, branches: string[], messages: any[]}|null>}
+ */
+async function fetchChatMetadata(chatName) {
+    try {
+        const metaResponse = await fetch('/api/chats/get', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                ch_name: selected_group ? null : characters[this_chid]?.name,
+                file_name: chatName,
+                avatar_url: selected_group ? null : characters[this_chid]?.avatar,
+            }),
+        });
+
+        if (!metaResponse.ok) {
+            return null;
+        }
+
+        const chatData = await metaResponse.json();
+
+        let chat_metadata = null;
+        let messages = [];
+
+        if (Array.isArray(chatData)) {
+            if (chatData.length > 0) {
+                chat_metadata = chatData[0].chat_metadata;
+                messages = chatData.slice(1);
+            }
+        } else {
+            chat_metadata = chatData.chat_metadata;
+            messages = chatData.chat || [];
+        }
+
+        const branches = [];
+
+        if (Array.isArray(messages)) {
+            for (const message of messages) {
+                if (message?.extra?.branches && Array.isArray(message.extra.branches)) {
+                    branches.push(...message.extra.branches);
+                }
+            }
+        }
+
+        return {
+            main_chat: chat_metadata?.main_chat,
+            branches: [...new Set(branches)],
+            messages: messages,
+        };
+    } catch (err) {
+        console.error('[BranchMetadata] Error fetching metadata for', chatName, ':', err);
+        return null;
+    }
+}
+
+/**
+ * Traverses the branch tree starting from a chat to collect all related chats.
+ * @param {string} startChatName Starting chat filename
+ * @param {Map<string, any>} chatMap Map of all available chats
+ * @returns {Promise<{relatedChats: Set<string>, metadataCache: Map<string, any>}>}
+ */
+async function traverseBranchTree(startChatName, chatMap) {
+    const relatedChats = new Set([startChatName]);
+    const metadataCache = new Map();
+
+    // Find root by going up the parent chain
+    let rootChatName = startChatName;
+    let current = startChatName;
+    const visited = new Set();
+
+    while (current && !visited.has(current)) {
+        visited.add(current);
+        relatedChats.add(current);
+
+        const metadata = await fetchChatMetadata(current);
+        if (metadata) {
+            metadataCache.set(current, metadata);
+            const parent = metadata.main_chat;
+
+            if (parent && chatMap.has(parent)) {
+                rootChatName = parent;
+                current = parent;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    // Traverse down from root to collect all children
+    async function collectChildren(chatName, visitedInPath = new Set()) {
+        if (visitedInPath.has(chatName)) {
+            return;
+        }
+
+        visitedInPath.add(chatName);
+
+        if (!metadataCache.has(chatName)) {
+            const metadata = await fetchChatMetadata(chatName);
+            if (metadata) {
+                metadataCache.set(chatName, metadata);
+            }
+        }
+
+        const metadata = metadataCache.get(chatName);
+
+        if (metadata?.branches) {
+            for (const branchName of metadata.branches) {
+                if (chatMap.has(branchName) && !relatedChats.has(branchName)) {
+                    relatedChats.add(branchName);
+                    await collectChildren(branchName, new Set(visitedInPath));
+                }
+            }
+        }
+    }
+
+    await collectChildren(rootChatName);
+
+    return { relatedChats, metadataCache };
+}
+
+/**
+ * Updates branch metadata across the branch tree after a chat is renamed.
+ * @param {string} oldFileName Old chat filename (without .jsonl)
+ * @param {string} newFileName New chat filename (without .jsonl)
+ */
+export async function updateBranchMetadataAfterRename(oldFileName, newFileName) {
+    try {
+        // Fetch all chats to build the chat map
+        const response = await fetch('/api/chats/search', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                query: '',
+                avatar_url: selected_group ? null : characters[this_chid]?.avatar,
+                group_id: selected_group || null,
+            }),
+        });
+
+        if (!response.ok) {
+            console.error('Failed to fetch chat list for branch metadata update');
+            return;
+        }
+
+        const allChats = await response.json();
+        const chatMap = new Map(allChats.map(chat => [chat.file_name, chat]));
+
+        // Use the new filename to traverse the tree (since the file has already been renamed)
+        if (!chatMap.has(newFileName)) {
+            console.warn(`Renamed chat ${newFileName} not found in chat list`);
+            return;
+        }
+
+        const { relatedChats, metadataCache } = await traverseBranchTree(newFileName, chatMap);
+
+        // Update branch references in all related chats
+        for (const chatName of relatedChats) {
+            const metadata = metadataCache.get(chatName);
+            if (!metadata?.messages) {
+                continue;
+            }
+
+            let hadChanges = false;
+
+            for (const message of metadata.messages) {
+                if (message?.extra?.branches && Array.isArray(message.extra.branches)) {
+                    const branchIndex = message.extra.branches.indexOf(oldFileName);
+                    if (branchIndex !== -1) {
+                        message.extra.branches[branchIndex] = newFileName;
+                        hadChanges = true;
+                    }
+                }
+            }
+
+            if (hadChanges) {
+                // Reconstruct the full chat data with header
+                const chatHeader = {
+                    chat_metadata: metadataCache.get(chatName)?.main_chat ? { main_chat: metadataCache.get(chatName).main_chat } : {},
+                    user_name: 'unused',
+                    character_name: 'unused',
+                };
+
+                if (selected_group) {
+                    const saveChatRequest = await compressRequest({
+                        method: 'POST',
+                        headers: getRequestHeaders(),
+                        body: JSON.stringify({ id: chatName, chat: [chatHeader, ...metadata.messages] }),
+                    });
+                    const saveChatResponse = await fetch('/api/chats/group/save', saveChatRequest);
+
+                    if (!saveChatResponse.ok) {
+                        console.error(`Failed to update branch metadata in group chat: ${chatName}`);
+                    } else {
+                        console.log(`Updated branch metadata in group chat: ${chatName}`);
+                    }
+                } else {
+                    const saveChatRequest = await compressRequest({
+                        method: 'POST',
+                        headers: getRequestHeaders(),
+                        body: JSON.stringify({
+                            ch_name: characters[this_chid]?.name,
+                            file_name: chatName,
+                            chat: [chatHeader, ...metadata.messages],
+                            avatar_url: characters[this_chid]?.avatar,
+                        }),
+                    });
+                    const saveChatResponse = await fetch('/api/chats/save', saveChatRequest);
+
+                    if (!saveChatResponse.ok) {
+                        console.error(`Failed to update branch metadata in chat: ${chatName}`);
+                    } else {
+                        console.log(`Updated branch metadata in chat: ${chatName}`);
+                    }
+                }
+            }
+        }
+    } catch (error) {
+        console.error('Error updating branch metadata after rename:', error);
+    }
+}
+
 async function showBranchGraph() {
     try {
         showLoader();
@@ -807,124 +1031,18 @@ async function showBranchGraph() {
         const allChats = await response.json();
         const chatMap = new Map(allChats.map(chat => [chat.file_name, chat]));
 
-        // Helper to fetch chat metadata (parent and branches)
-        async function fetchChatMetadata(chatName) {
-            try {
-                const metaResponse = await fetch('/api/chats/get', {
-                    method: 'POST',
-                    headers: getRequestHeaders(),
-                    body: JSON.stringify({
-                        ch_name: selected_group ? null : characters[this_chid]?.name,
-                        file_name: chatName,
-                        avatar_url: selected_group ? null : characters[this_chid]?.avatar,
-                    }),
-                });
+        // Use the shared traversal function
+        const { relatedChats, metadataCache } = await traverseBranchTree(currentChatName, chatMap);
 
-                if (!metaResponse.ok) {
-                    return null;
-                }
-
-                const chatData = await metaResponse.json();
-
-                // The API returns an array where the first element is metadata + user/character names
-                // and the rest are messages
-                let chat_metadata = null;
-                let messages = [];
-
-                if (Array.isArray(chatData)) {
-                    if (chatData.length > 0) {
-                        // First line contains chat_metadata
-                        chat_metadata = chatData[0].chat_metadata;
-                        // Rest are messages
-                        messages = chatData.slice(1);
-                    }
-                } else {
-                    // Fallback for different API response format
-                    chat_metadata = chatData.chat_metadata;
-                    messages = chatData.chat || [];
-                }
-
-                const branches = [];
-
-                // Extract branches from all messages
-                if (Array.isArray(messages)) {
-                    for (const message of messages) {
-                        if (message?.extra?.branches && Array.isArray(message.extra.branches)) {
-                            branches.push(...message.extra.branches);
-                        }
-                    }
-                }
-
-                const metadata = {
-                    main_chat: chat_metadata?.main_chat,
-                    branches: [...new Set(branches)], // Remove duplicates
-                };
-
-                return metadata;
-            } catch (err) {
-                console.error('[BranchGraph] Error fetching metadata for', chatName, ':', err);
-                return null;
-            }
-        }
-
-        // Traverse to find root and collect all related chats
-        const relatedChats = new Set([currentChatName]);
-        const metadataCache = new Map();
-
-        // Find root by going up the parent chain
+        // Find root chat
         let rootChatName = currentChatName;
-        let current = currentChatName;
-        const visited = new Set();
-
-        while (current && !visited.has(current)) {
-            visited.add(current);
-            relatedChats.add(current);
-
-            const metadata = await fetchChatMetadata(current);
-            if (metadata) {
-                metadataCache.set(current, metadata);
-                const parent = metadata.main_chat;
-
-                if (parent && chatMap.has(parent)) {
-                    rootChatName = parent;
-                    current = parent;
-                } else {
-                    break;
-                }
-            } else {
+        for (const chatName of relatedChats) {
+            const metadata = metadataCache.get(chatName);
+            if (metadata && !metadata.main_chat) {
+                rootChatName = chatName;
                 break;
             }
         }
-
-        // Now traverse down from root to collect all children
-        async function collectChildren(chatName, visitedInPath = new Set()) {
-            // Prevent circular references
-            if (visitedInPath.has(chatName)) {
-                return;
-            }
-
-            visitedInPath.add(chatName);
-
-            if (!metadataCache.has(chatName)) {
-                const metadata = await fetchChatMetadata(chatName);
-                if (metadata) {
-                    metadataCache.set(chatName, metadata);
-                }
-            }
-
-            const metadata = metadataCache.get(chatName);
-
-            if (metadata?.branches) {
-                for (const branchName of metadata.branches) {
-                    if (chatMap.has(branchName) && !relatedChats.has(branchName)) {
-                        relatedChats.add(branchName);
-                        await collectChildren(branchName, new Set(visitedInPath));
-                    }
-                }
-            }
-        }
-
-        await collectChildren(rootChatName);
 
         // Build tree structure
         function buildTree(chatName, depth = 0) {
@@ -1084,7 +1202,7 @@ async function showBranchGraph() {
             large: true,
             onOpen: () => {
                 // Use .text() to safely set content after popup is in DOM (like "Manage chat files" does)
-                $('.branch-graph-node').each(function() {
+                $('.branch-graph-node').each(function () {
                     const nodeIndex = parseInt($(this).attr('data-node-index'));
                     const node = nodes[nodeIndex];
                     $(this).attr('data-file-name', node.name);

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -712,28 +712,34 @@ async function showBranchList(mesId) {
         // Sort by last message date (most recent first)
         branchChats.sort((a, b) => sortMoments(timestampToMoment(a.last_mes), timestampToMoment(b.last_mes)));
 
-        // Build the HTML for the branch list
-        let branchListHTML = '<div class="branch-list">';
-        for (const branch of branchChats) {
+        // Prepare data for template (don't escape - we'll use .text() to set content safely)
+        const branches = branchChats.map(branch => {
             const momentDate = timestampToMoment(branch.last_mes);
-            const formattedDate = momentDate.isValid() ? momentDate.format('lll') : 'Unknown date';
-            const preview = branch.preview_message || '(No messages)';
-            const messageCount = branch.message_count || 0;
+            return {
+                file_name: branch.file_name,
+                formattedDate: momentDate.isValid() ? momentDate.format('lll') : 'Unknown date',
+                preview: branch.preview_message || '(No messages)',
+                message_count: branch.message_count || 0,
+            };
+        });
 
-            branchListHTML += `
-                <div class="branch-list-item" data-file-name="${branch.file_name}">
-                    <div class="branch-list-item-header">
-                        <span class="branch-list-item-name"><i class="fa-solid fa-code-branch"></i> ${branch.file_name}</span>
-                        <small class="branch-list-item-date">${formattedDate}</small>
-                    </div>
-                    <div class="branch-list-item-preview">${messageCount} messages • ${preview}</div>
-                </div>
-            `;
-        }
-        branchListHTML += '</div>';
+        const branchListHTML = await renderTemplateAsync('branchList', { branches });
 
         // Show the popup
-        const popup = new Popup(branchListHTML, POPUP_TYPE.TEXT, '', { okButton: false, cancelButton: 'Close' });
+        const popup = new Popup(branchListHTML, POPUP_TYPE.TEXT, '', {
+            okButton: false,
+            cancelButton: 'Close',
+            onOpen: () => {
+                // Use .text() to safely set content after popup is in DOM (like "Manage chat files" does)
+                $('.branch-list-item').each(function() {
+                    const branchIndex = parseInt($(this).attr('data-branch-index'));
+                    const branch = branches[branchIndex];
+                    $(this).attr('data-file-name', branch.file_name);
+                    $(this).find('.branch-name-text').text(branch.file_name);
+                    $(this).find('.branch-preview-text').text(branch.preview);
+                });
+            },
+        });
 
         // Add click handlers to the branch items (use one-time handler to avoid duplicates)
         const handleBranchClick = async function () {
@@ -1012,81 +1018,63 @@ async function showBranchGraph() {
 
         const levels = organizeByLevelsWithLayout(cleanTree);
 
-        // Render the tree as HTML with proper alignment and connections
-        function renderGraph(levels) {
-            const nodeWidth = 280;
-            const nodeHeight = 120;
-            const horizontalGap = 20;
-            const verticalGap = 60;
+        // Prepare data for template
+        const nodeWidth = 280;
+        const nodeHeight = 120;
+        const horizontalGap = 20;
+        const verticalGap = 60;
 
-            // Calculate total width needed
-            const maxWidth = Math.max(...levels.map(level =>
-                Math.max(...level.map(node => node.layout.x)),
-            )) + 1;
+        const maxWidth = Math.max(...levels.map(level =>
+            Math.max(...level.map(node => node.layout.x)),
+        )) + 1;
 
-            const totalWidth = maxWidth * (nodeWidth + horizontalGap);
-            const totalHeight = levels.length * (nodeHeight + verticalGap);
+        const totalWidth = maxWidth * (nodeWidth + horizontalGap);
+        const totalHeight = levels.length * (nodeHeight + verticalGap);
 
-            // Create a single container with relative positioning
-            let html = `<div style="position: relative; width: ${totalWidth}px; height: ${totalHeight}px;">`;
+        const lines = [];
+        const nodes = [];
 
-            // Draw SVG with connection lines (relative positioned, not absolute)
-            html += `<svg width="${totalWidth}" height="${totalHeight}" style="position: absolute; top: 0; left: 0; pointer-events: none;">`;
+        // Collect connection lines
+        for (const level of levels) {
+            for (const node of level) {
+                const parentX = node.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
+                const parentY = node.layout.depth * (nodeHeight + verticalGap) + nodeHeight;
 
-            // Draw connection lines
-            for (const level of levels) {
-                for (const node of level) {
-                    const parentX = node.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
-                    const parentY = node.layout.depth * (nodeHeight + verticalGap) + nodeHeight;
+                for (const child of node.children) {
+                    const childX = child.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
+                    const childY = child.layout.depth * (nodeHeight + verticalGap);
 
-                    for (const child of node.children) {
-                        const childX = child.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
-                        const childY = child.layout.depth * (nodeHeight + verticalGap);
-
-                        // Draw line from parent to child
-                        html += `<line x1="${parentX}" y1="${parentY}" x2="${childX}" y2="${childY}"
-                                 stroke="var(--SmartThemeBorderColor)" stroke-width="2"/>`;
-                    }
+                    lines.push({ x1: parentX, y1: parentY, x2: childX, y2: childY });
                 }
             }
-
-            html += '</svg>';
-
-            // Render nodes as HTML elements positioned absolutely within the same container
-            for (const level of levels) {
-                for (const node of level) {
-                    const isCurrentChat = node.name === currentChatName;
-                    const momentDate = timestampToMoment(node.chat.last_mes);
-                    const formattedDate = momentDate.isValid() ? momentDate.format('lll') : 'Unknown date';
-                    const messageCount = node.chat.message_count || 0;
-                    const preview = node.chat.preview_message || '(No messages)';
-
-                    const x = node.layout.x * (nodeWidth + horizontalGap);
-                    const y = node.layout.depth * (nodeHeight + verticalGap);
-
-                    html += `
-                        <div class="branch-graph-node ${isCurrentChat ? 'current-chat' : ''}"
-                             data-file-name="${node.name}"
-                             style="position: absolute; left: ${x}px; top: ${y}px; width: ${nodeWidth}px;">
-                            <div class="branch-graph-node-name">
-                                <i class="fa-solid fa-${isCurrentChat ? 'circle-dot' : 'circle'}"></i>
-                                ${node.name}
-                            </div>
-                            <div class="branch-graph-node-info">
-                                ${messageCount} messages • ${formattedDate}
-                            </div>
-                            <div class="branch-graph-node-preview">${preview}</div>
-                        </div>
-                    `;
-                }
-            }
-
-            html += '</div>';
-
-            return html;
         }
 
-        const graphHTML = `<div class="branch-graph-container">${renderGraph(levels)}</div>`;
+        // Collect nodes
+        for (const level of levels) {
+            for (const node of level) {
+                const isCurrentChat = node.name === currentChatName;
+                const momentDate = timestampToMoment(node.chat.last_mes);
+                const formattedDate = momentDate.isValid() ? momentDate.format('lll') : 'Unknown date';
+                const messageCount = node.chat.message_count || 0;
+                const preview = node.chat.preview_message || '(No messages)';
+
+                const x = node.layout.x * (nodeWidth + horizontalGap);
+                const y = node.layout.depth * (nodeHeight + verticalGap);
+
+                nodes.push({
+                    name: node.name,
+                    isCurrentChat,
+                    formattedDate,
+                    messageCount,
+                    preview,
+                    x,
+                    y,
+                    width: nodeWidth,
+                });
+            }
+        }
+
+        const graphHTML = await renderTemplateAsync('branchGraph', { totalWidth, totalHeight, lines, nodes });
 
         // Show the popup with large size
         const popup = new Popup(graphHTML, POPUP_TYPE.TEXT, '', {
@@ -1094,6 +1082,16 @@ async function showBranchGraph() {
             cancelButton: 'Close',
             wide: true,
             large: true,
+            onOpen: () => {
+                // Use .text() to safely set content after popup is in DOM (like "Manage chat files" does)
+                $('.branch-graph-node').each(function() {
+                    const nodeIndex = parseInt($(this).attr('data-node-index'));
+                    const node = nodes[nodeIndex];
+                    $(this).attr('data-file-name', node.name);
+                    $(this).find('.branch-node-name-text').text(node.name);
+                    $(this).find('.branch-node-preview-text').text(node.preview);
+                });
+            },
             onClose: () => {
                 // Clean up event handler when popup closes
                 $(document).off('click', '.branch-graph-node', handleNodeClick);

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -666,7 +666,7 @@ function registerBookmarksSlashCommands() {
 async function showBranchList(mesId) {
     const message = chat[mesId];
     if (!message?.extra?.branches || !Array.isArray(message.extra.branches) || message.extra.branches.length === 0) {
-        await Popup.show.text('No branches found', 'This message has no branch chats.');
+        toastr.info('This message has no branch chats.', 'No branches found');
         return;
     }
 
@@ -696,7 +696,15 @@ async function showBranchList(mesId) {
         const branchChats = allChats.filter(chat => branchNames.includes(chat.file_name));
 
         if (branchChats.length === 0) {
-            await Popup.show.text('No branches found', 'All branch chats appear to have been deleted.');
+            const result = await Popup.show.confirm(
+                'All branch chats appear to have been deleted.',
+                'Would you like to clean up the branch metadata from this message?'
+            );
+            if (result) {
+                // Clean up the branch metadata
+                delete message.extra.branches;
+                await saveChatConditional();
+            }
             return;
         }
 
@@ -758,7 +766,7 @@ async function showBranchList(mesId) {
         await popup.show();
     } catch (error) {
         console.error('Error showing branch list:', error);
-        await Popup.show.text('Error', 'Failed to load branch list. Please try again.');
+        toastr.error('Failed to load branch list. Please try again.', 'Error');
     } finally {
         await hideLoader();
     }
@@ -774,7 +782,7 @@ async function showBranchGraph() {
         const currentChatName = (getCurrentChatDetails()).sessionName;
 
         if (!currentChatName) {
-            await Popup.show.text('No chat loaded', 'Please open a chat first.');
+            toastr.info('Please open a chat first.', 'No chat loaded');
             return;
         }
 
@@ -939,7 +947,7 @@ async function showBranchGraph() {
         const tree = buildTree(rootChatName);
 
         if (!tree) {
-            await Popup.show.text('Error', 'Failed to build branch graph.');
+            toastr.error('Failed to build branch graph.', 'Error');
             return;
         }
 
@@ -1127,7 +1135,7 @@ async function showBranchGraph() {
         await popup.show();
     } catch (error) {
         console.error('[BranchGraph] Error showing branch graph:', error);
-        await Popup.show.text('Error', 'Failed to load branch graph. Please try again.');
+        toastr.error('Failed to load branch graph. Please try again.', 'Error');
     } finally {
         await hideLoader();
     }

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -27,7 +27,7 @@ import {
 } from './group-chats.js';
 import { hideLoader, showLoader } from './loader.js';
 import { getLastMessageId } from './macros.js';
-import { Popup } from './popup.js';
+import { Popup, POPUP_TYPE } from './popup.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { commonEnumProviders } from './slash-commands/SlashCommandCommonEnumsProvider.js';
@@ -40,6 +40,7 @@ import { t } from './i18n.js';
 import {
     getUniqueName,
     isTrueBoolean,
+    timestampToMoment,
 } from './utils.js';
 
 const bookmarkNameToken = 'Checkpoint #';
@@ -419,6 +420,10 @@ export async function branchChat(mesId) {
     }
 
     const fileName = await createBranch(mesId);
+
+    // Save the parent chat to persist the branches array
+    await saveChatConditional();
+
     await saveItemizedPrompts(fileName);
 
     if (selected_group) {
@@ -639,10 +644,484 @@ function registerBookmarksSlashCommands() {
     }));
 }
 
+/**
+ * Shows a popup with a list of branch chats for a given message.
+ * @param {number} mesId - The message ID that has branches
+ */
+async function showBranchList(mesId) {
+    const message = chat[mesId];
+    if (!message?.extra?.branches || !Array.isArray(message.extra.branches) || message.extra.branches.length === 0) {
+        await Popup.show.text('No branches found', 'This message has no branch chats.');
+        return;
+    }
+
+    const branchNames = message.extra.branches;
+
+    try {
+        showLoader();
+
+        // Fetch all chats to get info about the branches
+        const response = await fetch('/api/chats/search', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                query: '',
+                avatar_url: selected_group ? null : characters[this_chid]?.avatar,
+                group_id: selected_group || null,
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error('Failed to fetch chat list');
+        }
+
+        const allChats = await response.json();
+
+        // Filter to only the branches we care about
+        const branchChats = allChats.filter(chat => branchNames.includes(chat.file_name));
+
+        if (branchChats.length === 0) {
+            await Popup.show.text('No branches found', 'All branch chats appear to have been deleted.');
+            return;
+        }
+
+        // Sort by last message date (most recent first)
+        branchChats.sort((a, b) => {
+            const momentA = timestampToMoment(a.last_mes);
+            const momentB = timestampToMoment(b.last_mes);
+            return momentB.valueOf() - momentA.valueOf();
+        });
+
+        // Build the HTML for the branch list
+        let branchListHTML = '<div class="branch-list">';
+        for (const branch of branchChats) {
+            const momentDate = timestampToMoment(branch.last_mes);
+            const formattedDate = momentDate.isValid() ? momentDate.format('lll') : 'Unknown date';
+            const preview = branch.preview_message || '(No messages)';
+            const messageCount = branch.message_count || 0;
+
+            branchListHTML += `
+                <div class="branch-list-item" data-file-name="${branch.file_name}">
+                    <div class="branch-list-item-header">
+                        <span class="branch-list-item-name"><i class="fa-solid fa-code-branch"></i> ${branch.file_name}</span>
+                        <small class="branch-list-item-date">${formattedDate}</small>
+                    </div>
+                    <div class="branch-list-item-preview">${messageCount} messages • ${preview}</div>
+                </div>
+            `;
+        }
+        branchListHTML += '</div>';
+
+        // Show the popup
+        const popup = new Popup(branchListHTML, POPUP_TYPE.TEXT, '', { okButton: false, cancelButton: 'Close' });
+
+        // Add click handlers to the branch items (use one-time handler to avoid duplicates)
+        const handleBranchClick = async function () {
+            const fileName = $(this).attr('data-file-name');
+            if (!fileName) return;
+
+            try {
+                showLoader();
+                // Close the popup
+                popup.completeAffirmative();
+
+                // Remove the event handler to prevent memory leaks
+                $(document).off('click', '.branch-list-item', handleBranchClick);
+
+                if (selected_group) {
+                    await openGroupChat(selected_group, fileName);
+                } else {
+                    await openCharacterChat(fileName);
+                }
+            } finally {
+                await hideLoader();
+            }
+        };
+
+        $(document).on('click', '.branch-list-item', handleBranchClick);
+
+        await popup.show();
+    } catch (error) {
+        console.error('Error showing branch list:', error);
+        await Popup.show.text('Error', 'Failed to load branch list. Please try again.');
+    } finally {
+        await hideLoader();
+    }
+}
+
+/**
+ * Builds a tree of all related chats (parents and children) and displays it in a graph.
+ */
+async function showBranchGraph() {
+    try {
+        showLoader();
+
+        const currentChatName = (getCurrentChatDetails()).sessionName;
+
+        if (!currentChatName) {
+            await Popup.show.text('No chat loaded', 'Please open a chat first.');
+            return;
+        }
+
+        // Fetch all chats to get basic info
+        const response = await fetch('/api/chats/search', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                query: '',
+                avatar_url: selected_group ? null : characters[this_chid]?.avatar,
+                group_id: selected_group || null,
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error('Failed to fetch chat list');
+        }
+
+        const allChats = await response.json();
+        const chatMap = new Map(allChats.map(chat => [chat.file_name, chat]));
+
+        // Helper to fetch chat metadata (parent and branches)
+        async function fetchChatMetadata(chatName) {
+            try {
+                const metaResponse = await fetch('/api/chats/get', {
+                    method: 'POST',
+                    headers: getRequestHeaders(),
+                    body: JSON.stringify({
+                        ch_name: selected_group ? null : characters[this_chid]?.name,
+                        file_name: chatName,
+                        avatar_url: selected_group ? null : characters[this_chid]?.avatar,
+                    }),
+                });
+
+                if (!metaResponse.ok) {
+                    return null;
+                }
+
+                const chatData = await metaResponse.json();
+
+                // The API returns an array where the first element is metadata + user/character names
+                // and the rest are messages
+                let chat_metadata = null;
+                let messages = [];
+
+                if (Array.isArray(chatData)) {
+                    if (chatData.length > 0) {
+                        // First line contains chat_metadata
+                        chat_metadata = chatData[0].chat_metadata;
+                        // Rest are messages
+                        messages = chatData.slice(1);
+                    }
+                } else {
+                    // Fallback for different API response format
+                    chat_metadata = chatData.chat_metadata;
+                    messages = chatData.chat || [];
+                }
+
+                const branches = [];
+
+                // Extract branches from all messages
+                if (Array.isArray(messages)) {
+                    for (const message of messages) {
+                        if (message?.extra?.branches && Array.isArray(message.extra.branches)) {
+                            branches.push(...message.extra.branches);
+                        }
+                    }
+                }
+
+                const metadata = {
+                    main_chat: chat_metadata?.main_chat,
+                    branches: [...new Set(branches)], // Remove duplicates
+                };
+
+                return metadata;
+            } catch (err) {
+                console.error('[BranchGraph] Error fetching metadata for', chatName, ':', err);
+                return null;
+            }
+        }
+
+        // Traverse to find root and collect all related chats
+        const relatedChats = new Set([currentChatName]);
+        const metadataCache = new Map();
+
+        // Find root by going up the parent chain
+        let rootChatName = currentChatName;
+        let current = currentChatName;
+        const visited = new Set();
+
+        while (current && !visited.has(current)) {
+            visited.add(current);
+            relatedChats.add(current);
+
+            const metadata = await fetchChatMetadata(current);
+            if (metadata) {
+                metadataCache.set(current, metadata);
+                const parent = metadata.main_chat;
+
+                if (parent && chatMap.has(parent)) {
+                    rootChatName = parent;
+                    current = parent;
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Now traverse down from root to collect all children
+        async function collectChildren(chatName, visitedInPath = new Set()) {
+            // Prevent circular references
+            if (visitedInPath.has(chatName)) {
+                return;
+            }
+
+            visitedInPath.add(chatName);
+
+            if (!metadataCache.has(chatName)) {
+                const metadata = await fetchChatMetadata(chatName);
+                if (metadata) {
+                    metadataCache.set(chatName, metadata);
+                }
+            }
+
+            const metadata = metadataCache.get(chatName);
+
+            if (metadata?.branches) {
+                for (const branchName of metadata.branches) {
+                    if (chatMap.has(branchName) && !relatedChats.has(branchName)) {
+                        relatedChats.add(branchName);
+                        await collectChildren(branchName, new Set(visitedInPath));
+                    }
+                }
+            }
+        }
+
+        await collectChildren(rootChatName);
+
+        // Build tree structure
+        function buildTree(chatName, depth = 0) {
+            const chat = chatMap.get(chatName);
+            if (!chat) {
+                return null;
+            }
+
+            const metadata = metadataCache.get(chatName);
+            const children = (metadata?.branches || [])
+                .filter(childName => chatMap.has(childName))
+                .map(childName => buildTree(childName, depth + 1))
+                .filter(Boolean);
+
+            return {
+                name: chatName,
+                chat: chat,
+                children: children,
+                depth: depth,
+            };
+        }
+
+        const tree = buildTree(rootChatName);
+
+        if (!tree) {
+            await Popup.show.text('Error', 'Failed to build branch graph.');
+            return;
+        }
+
+        // Remove duplicate nodes from the tree
+        function removeDuplicates(node, seen = new Set()) {
+            if (seen.has(node.name)) {
+                return null;
+            }
+            seen.add(node.name);
+
+            // Recursively process children
+            node.children = node.children
+                .map(child => removeDuplicates(child, new Set(seen)))
+                .filter(Boolean);
+
+            return node;
+        }
+
+        const cleanTree = removeDuplicates(tree);
+
+        // Calculate layout positions for each node
+        function calculateLayout(node, depth = 0, leftOffset = 0) {
+            // Calculate width needed for this subtree
+            function getSubtreeWidth(n) {
+                if (n.children.length === 0) return 1;
+                return n.children.reduce((sum, child) => sum + getSubtreeWidth(child), 0);
+            }
+
+            const subtreeWidth = getSubtreeWidth(node);
+
+            // Position this node
+            node.layout = {
+                depth: depth,
+                leftOffset: leftOffset,
+                width: subtreeWidth,
+                x: leftOffset + (subtreeWidth - 1) / 2, // Center position
+            };
+
+            // Position children
+            let childOffset = leftOffset;
+            for (const child of node.children) {
+                calculateLayout(child, depth + 1, childOffset);
+                childOffset += getSubtreeWidth(child);
+            }
+
+            return node;
+        }
+
+        calculateLayout(cleanTree);
+
+        // Organize nodes by depth level with proper positioning
+        function organizeByLevelsWithLayout(node, levels = []) {
+            if (!levels[node.layout.depth]) {
+                levels[node.layout.depth] = [];
+            }
+            levels[node.layout.depth].push(node);
+
+            for (const child of node.children) {
+                organizeByLevelsWithLayout(child, levels);
+            }
+
+            return levels;
+        }
+
+        const levels = organizeByLevelsWithLayout(cleanTree);
+
+        // Render the tree as HTML with proper alignment and connections
+        function renderGraph(levels) {
+            const nodeWidth = 280;
+            const nodeHeight = 120;
+            const horizontalGap = 20;
+            const verticalGap = 60;
+
+            // Calculate total width needed
+            const maxWidth = Math.max(...levels.map(level =>
+                Math.max(...level.map(node => node.layout.x)),
+            )) + 1;
+
+            const totalWidth = maxWidth * (nodeWidth + horizontalGap);
+            const totalHeight = levels.length * (nodeHeight + verticalGap);
+
+            // Create a single container with relative positioning
+            let html = `<div style="position: relative; width: ${totalWidth}px; height: ${totalHeight}px;">`;
+
+            // Draw SVG with connection lines (relative positioned, not absolute)
+            html += `<svg width="${totalWidth}" height="${totalHeight}" style="position: absolute; top: 0; left: 0; pointer-events: none;">`;
+
+            // Draw connection lines
+            for (const level of levels) {
+                for (const node of level) {
+                    const parentX = node.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
+                    const parentY = node.layout.depth * (nodeHeight + verticalGap) + nodeHeight;
+
+                    for (const child of node.children) {
+                        const childX = child.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
+                        const childY = child.layout.depth * (nodeHeight + verticalGap);
+
+                        // Draw line from parent to child
+                        html += `<line x1="${parentX}" y1="${parentY}" x2="${childX}" y2="${childY}"
+                                 stroke="var(--SmartThemeBorderColor)" stroke-width="2"/>`;
+                    }
+                }
+            }
+
+            html += '</svg>';
+
+            // Render nodes as HTML elements positioned absolutely within the same container
+            for (const level of levels) {
+                for (const node of level) {
+                    const isCurrentChat = node.name === currentChatName;
+                    const momentDate = timestampToMoment(node.chat.last_mes);
+                    const formattedDate = momentDate.isValid() ? momentDate.format('lll') : 'Unknown date';
+                    const messageCount = node.chat.message_count || 0;
+                    const preview = node.chat.preview_message || '(No messages)';
+
+                    const x = node.layout.x * (nodeWidth + horizontalGap);
+                    const y = node.layout.depth * (nodeHeight + verticalGap);
+
+                    html += `
+                        <div class="branch-graph-node ${isCurrentChat ? 'current-chat' : ''}"
+                             data-file-name="${node.name}"
+                             style="position: absolute; left: ${x}px; top: ${y}px; width: ${nodeWidth}px;">
+                            <div class="branch-graph-node-name">
+                                <i class="fa-solid fa-${isCurrentChat ? 'circle-dot' : 'circle'}"></i>
+                                ${node.name}
+                            </div>
+                            <div class="branch-graph-node-info">
+                                ${messageCount} messages • ${formattedDate}
+                            </div>
+                            <div class="branch-graph-node-preview">${preview}</div>
+                        </div>
+                    `;
+                }
+            }
+
+            html += '</div>';
+
+            return html;
+        }
+
+        const graphHTML = `<div class="branch-graph-container">${renderGraph(levels)}</div>`;
+
+        // Show the popup with large size
+        const popup = new Popup(graphHTML, POPUP_TYPE.TEXT, '', {
+            okButton: false,
+            cancelButton: 'Close',
+            wide: true,
+            large: true,
+            onClose: () => {
+                // Clean up event handler when popup closes
+                $(document).off('click', '.branch-graph-node', handleNodeClick);
+            },
+        });
+
+        // Add click handlers to the nodes
+        const handleNodeClick = async function () {
+            const fileName = $(this).attr('data-file-name');
+            if (!fileName || fileName === currentChatName) return;
+
+            // Close the popup FIRST
+            popup.completeAffirmative();
+
+            // Remove the event handler
+            $(document).off('click', '.branch-graph-node', handleNodeClick);
+
+            try {
+                showLoader();
+                // Save current chat before switching
+                await saveChatConditional();
+
+                if (selected_group) {
+                    await openGroupChat(selected_group, fileName);
+                } else {
+                    await openCharacterChat(fileName);
+                }
+            } finally {
+                await hideLoader();
+            }
+        };
+
+        $(document).on('click', '.branch-graph-node', handleNodeClick);
+
+        // Show and wait for popup to complete
+        await popup.show();
+    } catch (error) {
+        console.error('[BranchGraph] Error showing branch graph:', error);
+        await Popup.show.text('Error', 'Failed to load branch graph. Please try again.');
+    } finally {
+        await hideLoader();
+    }
+}
+
 export function initBookmarks() {
     $('#option_new_bookmark').on('click', saveBookmarkMenu);
     $('#option_back_to_main').on('click', backToMainChat);
     $('#option_convert_to_group').on('click', convertSoloToGroupChat);
+    $('#option_branch_graph').on('click', showBranchGraph);
 
     $(document).on('click', '.select_chat_block, .mes_bookmark', async function (e) {
         // If shift is held down, we are not following the bookmark, but creating a new one
@@ -686,6 +1165,13 @@ export function initBookmarks() {
         const mesId = $(this).closest('.mes').attr('mesid');
         if (mesId !== undefined) {
             await branchChat(Number(mesId));
+        }
+    });
+
+    $(document).on('click', '.mes_branches', async function () {
+        const mesId = $(this).closest('.mes').attr('mesid');
+        if (mesId !== undefined) {
+            await showBranchList(Number(mesId));
         }
     });
 

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -40,6 +40,7 @@ import { t } from './i18n.js';
 import {
     getUniqueName,
     isTrueBoolean,
+    sortMoments,
     timestampToMoment,
 } from './utils.js';
 
@@ -709,11 +710,7 @@ async function showBranchList(mesId) {
         }
 
         // Sort by last message date (most recent first)
-        branchChats.sort((a, b) => {
-            const momentA = timestampToMoment(a.last_mes);
-            const momentB = timestampToMoment(b.last_mes);
-            return momentB.valueOf() - momentA.valueOf();
-        });
+        branchChats.sort((a, b) => sortMoments(timestampToMoment(a.last_mes), timestampToMoment(b.last_mes)));
 
         // Build the HTML for the branch list
         let branchListHTML = '<div class="branch-list">';

--- a/public/scripts/branch-graph.js
+++ b/public/scripts/branch-graph.js
@@ -28,14 +28,24 @@ import { compressRequest } from './request-compression.js';
  */
 export async function fetchChatMetadata(chatName) {
     try {
-        const metaResponse = await fetch('/api/chats/get', {
+        const request = selected_group
+            ? {
+                url: '/api/chats/group/get',
+                body: { id: chatName },
+            }
+            : {
+                url: '/api/chats/get',
+                body: {
+                    ch_name: characters[this_chid]?.name,
+                    file_name: chatName,
+                    avatar_url: characters[this_chid]?.avatar,
+                },
+            };
+
+        const metaResponse = await fetch(request.url, {
             method: 'POST',
             headers: getRequestHeaders(),
-            body: JSON.stringify({
-                ch_name: selected_group ? null : characters[this_chid]?.name,
-                file_name: chatName,
-                avatar_url: selected_group ? null : characters[this_chid]?.avatar,
-            }),
+            body: JSON.stringify(request.body),
         });
 
         if (!metaResponse.ok) {
@@ -82,7 +92,7 @@ export async function fetchChatMetadata(chatName) {
  * Traverses the branch tree starting from a chat to collect all related chats.
  * @param {string} startChatName Starting chat filename
  * @param {Map<string, any>} chatMap Map of all available chats
- * @returns {Promise<{relatedChats: Set<string>, metadataCache: Map<string, any>}>}
+ * @returns {Promise<{relatedChats: Set<string>, metadataCache: Map<string, any>, rootChatName: string}>}
  */
 export async function traverseBranchTree(startChatName, chatMap) {
     const relatedChats = new Set([startChatName]);
@@ -142,7 +152,7 @@ export async function traverseBranchTree(startChatName, chatMap) {
 
     await collectChildren(rootChatName);
 
-    return { relatedChats, metadataCache };
+    return { relatedChats, metadataCache, rootChatName };
 }
 
 /**
@@ -583,17 +593,7 @@ export async function showBranchGraph() {
         }
 
         const chatMap = await fetchAllChats();
-        const { relatedChats, metadataCache } = await traverseBranchTree(currentChatName, chatMap);
-
-        // Find root chat
-        let rootChatName = currentChatName;
-        for (const chatName of relatedChats) {
-            const metadata = metadataCache.get(chatName);
-            if (metadata && !metadata.main_chat) {
-                rootChatName = chatName;
-                break;
-            }
-        }
+        const { relatedChats, metadataCache, rootChatName } = await traverseBranchTree(currentChatName, chatMap);
 
         const tree = buildTree(rootChatName, chatMap, metadataCache);
 

--- a/public/scripts/branch-graph.js
+++ b/public/scripts/branch-graph.js
@@ -297,7 +297,12 @@ export async function updateBranchMetadataAfterRename(oldFileName, newFileName) 
                 continue;
             }
 
-            const hadChanges = updateBranchReferencesInMessages(metadata.messages, oldFileName, newFileName);
+            let hadChanges = updateBranchReferencesInMessages(metadata.messages, oldFileName, newFileName);
+
+            if (metadata.main_chat === oldFileName) {
+                metadata.main_chat = newFileName;
+                hadChanges = true;
+            }
 
             if (hadChanges) {
                 const chatData = constructChatData(metadata);
@@ -508,6 +513,8 @@ async function showGraphPopup(graphData) {
     const { totalWidth, totalHeight, lines, nodes } = graphData;
     const graphHTML = await renderTemplateAsync('branchGraph', { totalWidth, totalHeight, lines, nodes });
 
+    let selectedName = null;
+
     const popup = new Popup(graphHTML, POPUP_TYPE.TEXT, '', {
         okButton: false,
         cancelButton: 'Close',
@@ -520,25 +527,24 @@ async function showGraphPopup(graphData) {
                 $(this).attr('data-file-name', node.name);
                 $(this).find('.branch-node-name-text').text(node.name);
                 $(this).find('.branch-node-preview-text').text(node.preview);
+
+                if (!node.isCurrentChat) {
+                    $(this).on('click', () => {
+                        selectedName = node.name;
+                        popup.completeAffirmative();
+                    });
+                }
             });
         },
     });
 
     const result = await popup.show();
 
-    // If user cancelled or closed the popup, do nothing
-    // Note: result can be 0 (first item), so we need to check for null/undefined explicitly
-    if (result === POPUP_RESULT.CANCELLED || result === null || result === undefined) {
+    if (result !== POPUP_RESULT.AFFIRMATIVE || !selectedName) {
         return null;
     }
 
-    const selectedNode = nodes[result];
-    if (!selectedNode) {
-        console.error('Invalid node selection:', result);
-        return null;
-    }
-
-    return selectedNode.name;
+    return selectedName;
 }
 
 /**
@@ -602,7 +608,7 @@ export async function showBranchGraph() {
 
         const selectedChatName = await showGraphPopup(graphData);
 
-        if (selectedChatName) {
+        if (selectedChatName && selectedChatName !== currentChatName) {
             await switchToChat(selectedChatName);
         }
     } catch (error) {

--- a/public/scripts/branch-graph.js
+++ b/public/scripts/branch-graph.js
@@ -521,6 +521,7 @@ async function showGraphPopup(graphData) {
         wide: true,
         large: true,
         onOpen: () => {
+            popup.dlg.classList.add('branch-graph-popup');
             $('.branch-graph-node').each(function () {
                 const nodeIndex = parseInt($(this).attr('data-node-index'));
                 const node = nodes[nodeIndex];

--- a/public/scripts/branch-graph.js
+++ b/public/scripts/branch-graph.js
@@ -1,0 +1,614 @@
+/**
+ * Branch Graph Module
+ * Handles visualization and navigation of chat branch trees
+ */
+
+import {
+    characters,
+    this_chid,
+    openCharacterChat,
+    getRequestHeaders,
+    saveChatConditional,
+    getCurrentChatDetails,
+} from '../script.js';
+import {
+    openGroupChat,
+    selected_group,
+} from './group-chats.js';
+import { hideLoader, showLoader } from './loader.js';
+import { Popup, POPUP_TYPE, POPUP_RESULT } from './popup.js';
+import { renderTemplateAsync } from './templates.js';
+import { timestampToMoment } from './utils.js';
+import { compressRequest } from './request-compression.js';
+
+/**
+ * Fetches chat metadata including parent and branch information.
+ * @param {string} chatName Chat filename (without .jsonl)
+ * @returns {Promise<{main_chat: string, branches: string[], messages: any[]}|null>}
+ */
+export async function fetchChatMetadata(chatName) {
+    try {
+        const metaResponse = await fetch('/api/chats/get', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                ch_name: selected_group ? null : characters[this_chid]?.name,
+                file_name: chatName,
+                avatar_url: selected_group ? null : characters[this_chid]?.avatar,
+            }),
+        });
+
+        if (!metaResponse.ok) {
+            return null;
+        }
+
+        const chatData = await metaResponse.json();
+
+        let chat_metadata_obj = null;
+        let messages = [];
+
+        if (Array.isArray(chatData)) {
+            if (chatData.length > 0) {
+                chat_metadata_obj = chatData[0].chat_metadata;
+                messages = chatData.slice(1);
+            }
+        } else {
+            chat_metadata_obj = chatData.chat_metadata;
+            messages = chatData.chat || [];
+        }
+
+        const branches = [];
+
+        if (Array.isArray(messages)) {
+            for (const message of messages) {
+                if (message?.extra?.branches && Array.isArray(message.extra.branches)) {
+                    branches.push(...message.extra.branches);
+                }
+            }
+        }
+
+        return {
+            main_chat: chat_metadata_obj?.main_chat,
+            branches: [...new Set(branches)],
+            messages: messages,
+        };
+    } catch (err) {
+        console.error('[BranchMetadata] Error fetching metadata for', chatName, ':', err);
+        return null;
+    }
+}
+
+/**
+ * Traverses the branch tree starting from a chat to collect all related chats.
+ * @param {string} startChatName Starting chat filename
+ * @param {Map<string, any>} chatMap Map of all available chats
+ * @returns {Promise<{relatedChats: Set<string>, metadataCache: Map<string, any>}>}
+ */
+export async function traverseBranchTree(startChatName, chatMap) {
+    const relatedChats = new Set([startChatName]);
+    const metadataCache = new Map();
+
+    // Find root by going up the parent chain
+    let rootChatName = startChatName;
+    let current = startChatName;
+    const visited = new Set();
+
+    while (current && !visited.has(current)) {
+        visited.add(current);
+        relatedChats.add(current);
+
+        const metadata = await fetchChatMetadata(current);
+        if (metadata) {
+            metadataCache.set(current, metadata);
+            const parent = metadata.main_chat;
+
+            if (parent && chatMap.has(parent)) {
+                rootChatName = parent;
+                current = parent;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    // Traverse down from root to collect all children
+    async function collectChildren(chatName, visitedInPath = new Set()) {
+        if (visitedInPath.has(chatName)) {
+            return;
+        }
+
+        visitedInPath.add(chatName);
+
+        if (!metadataCache.has(chatName)) {
+            const metadata = await fetchChatMetadata(chatName);
+            if (metadata) {
+                metadataCache.set(chatName, metadata);
+            }
+        }
+
+        const metadata = metadataCache.get(chatName);
+
+        if (metadata?.branches) {
+            for (const branchName of metadata.branches) {
+                if (chatMap.has(branchName) && !relatedChats.has(branchName)) {
+                    relatedChats.add(branchName);
+                    await collectChildren(branchName, new Set(visitedInPath));
+                }
+            }
+        }
+    }
+
+    await collectChildren(rootChatName);
+
+    return { relatedChats, metadataCache };
+}
+
+/**
+ * Updates branch references in a message's metadata
+ * @param {Object} message Message object
+ * @param {string} oldFileName Old filename to replace
+ * @param {string} newFileName New filename to use
+ * @returns {boolean} True if changes were made
+ */
+function updateBranchReferencesInMessage(message, oldFileName, newFileName) {
+    if (!message?.extra?.branches || !Array.isArray(message.extra.branches)) {
+        return false;
+    }
+
+    const branchIndex = message.extra.branches.indexOf(oldFileName);
+    if (branchIndex !== -1) {
+        message.extra.branches[branchIndex] = newFileName;
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Updates branch references in all messages of a chat
+ * @param {Array} messages Array of message objects
+ * @param {string} oldFileName Old filename to replace
+ * @param {string} newFileName New filename to use
+ * @returns {boolean} True if any changes were made
+ */
+function updateBranchReferencesInMessages(messages, oldFileName, newFileName) {
+    let hadChanges = false;
+
+    for (const message of messages) {
+        if (updateBranchReferencesInMessage(message, oldFileName, newFileName)) {
+            hadChanges = true;
+        }
+    }
+
+    return hadChanges;
+}
+
+/**
+ * Constructs chat data with header for saving
+ * @param {Object} metadata Chat metadata
+ * @returns {Array} Chat data array with header
+ */
+function constructChatData(metadata) {
+    const chatHeader = {
+        chat_metadata: metadata.main_chat ? { main_chat: metadata.main_chat } : {},
+        user_name: 'unused',
+        character_name: 'unused',
+    };
+
+    return [chatHeader, ...metadata.messages];
+}
+
+/**
+ * Saves updated chat data for a group chat
+ * @param {string} chatName Chat filename
+ * @param {Array} chatData Chat data to save
+ * @returns {Promise<boolean>} True if successful
+ */
+async function saveGroupChat(chatName, chatData) {
+    try {
+        const saveChatRequest = await compressRequest({
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({ id: chatName, chat: chatData }),
+        });
+        const saveChatResponse = await fetch('/api/chats/group/save', saveChatRequest);
+
+        if (!saveChatResponse.ok) {
+            console.error(`Failed to update branch metadata in group chat: ${chatName}`);
+            return false;
+        }
+
+        console.log(`Updated branch metadata in group chat: ${chatName}`);
+        return true;
+    } catch (error) {
+        console.error(`Error saving group chat ${chatName}:`, error);
+        return false;
+    }
+}
+
+/**
+ * Saves updated chat data for a character chat
+ * @param {string} chatName Chat filename
+ * @param {Array} chatData Chat data to save
+ * @returns {Promise<boolean>} True if successful
+ */
+async function saveCharacterChat(chatName, chatData) {
+    try {
+        const saveChatRequest = await compressRequest({
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                ch_name: characters[this_chid]?.name,
+                file_name: chatName,
+                chat: chatData,
+                avatar_url: characters[this_chid]?.avatar,
+            }),
+        });
+        const saveChatResponse = await fetch('/api/chats/save', saveChatRequest);
+
+        if (!saveChatResponse.ok) {
+            console.error(`Failed to update branch metadata in chat: ${chatName}`);
+            return false;
+        }
+
+        console.log(`Updated branch metadata in chat: ${chatName}`);
+        return true;
+    } catch (error) {
+        console.error(`Error saving character chat ${chatName}:`, error);
+        return false;
+    }
+}
+
+/**
+ * Saves chat data (group or character)
+ * @param {string} chatName Chat filename
+ * @param {Array} chatData Chat data to save
+ * @returns {Promise<boolean>} True if successful
+ */
+async function saveChat(chatName, chatData) {
+    if (selected_group) {
+        return await saveGroupChat(chatName, chatData);
+    } else {
+        return await saveCharacterChat(chatName, chatData);
+    }
+}
+
+/**
+ * Updates branch metadata across the branch tree after a chat is renamed.
+ * @param {string} oldFileName Old chat filename (without .jsonl)
+ * @param {string} newFileName New chat filename (without .jsonl)
+ */
+export async function updateBranchMetadataAfterRename(oldFileName, newFileName) {
+    try {
+        const chatMap = await fetchAllChats();
+
+        if (!chatMap.has(newFileName)) {
+            console.warn(`Renamed chat ${newFileName} not found in chat list`);
+            return;
+        }
+
+        const { relatedChats, metadataCache } = await traverseBranchTree(newFileName, chatMap);
+
+        for (const chatName of relatedChats) {
+            const metadata = metadataCache.get(chatName);
+            if (!metadata?.messages) {
+                continue;
+            }
+
+            const hadChanges = updateBranchReferencesInMessages(metadata.messages, oldFileName, newFileName);
+
+            if (hadChanges) {
+                const chatData = constructChatData(metadata);
+                await saveChat(chatName, chatData);
+            }
+        }
+    } catch (error) {
+        console.error('Error updating branch metadata after rename:', error);
+    }
+}
+
+/**
+ * Fetches all chats for the current character or group
+ * @returns {Promise<Map<string, any>>} Map of chat filename to chat data
+ */
+async function fetchAllChats() {
+    const response = await fetch('/api/chats/search', {
+        method: 'POST',
+        headers: getRequestHeaders(),
+        body: JSON.stringify({
+            query: '',
+            avatar_url: selected_group ? null : characters[this_chid]?.avatar,
+            group_id: selected_group || null,
+        }),
+    });
+
+    if (!response.ok) {
+        throw new Error('Failed to fetch chat list');
+    }
+
+    const allChats = await response.json();
+    return new Map(allChats.map(chat => [chat.file_name, chat]));
+}
+
+/**
+ * Builds a tree structure from the branch data
+ * @param {string} chatName Root chat name
+ * @param {Map<string, any>} chatMap Map of all chats
+ * @param {Map<string, any>} metadataCache Cached metadata
+ * @param {number} depth Current depth in tree
+ * @returns {Object|null} Tree node or null
+ */
+function buildTree(chatName, chatMap, metadataCache, depth = 0) {
+    const chat = chatMap.get(chatName);
+    if (!chat) {
+        return null;
+    }
+
+    const metadata = metadataCache.get(chatName);
+    const children = (metadata?.branches || [])
+        .filter(childName => chatMap.has(childName))
+        .map(childName => buildTree(childName, chatMap, metadataCache, depth + 1))
+        .filter(Boolean);
+
+    return {
+        name: chatName,
+        chat: chat,
+        children: children,
+        depth: depth,
+    };
+}
+
+/**
+ * Removes duplicate nodes from the tree (keeps first occurrence only)
+ * @param {Object} node Tree node
+ * @param {Set<string>} seen Set of seen node names
+ * @returns {Object|null} Cleaned node or null
+ */
+function removeDuplicates(node, seen = new Set()) {
+    if (seen.has(node.name)) {
+        return null;
+    }
+    seen.add(node.name);
+
+    node.children = node.children
+        .map(child => removeDuplicates(child, seen))
+        .filter(Boolean);
+
+    return node;
+}
+
+/**
+ * Calculates the width needed for a subtree
+ * @param {Object} node Tree node
+ * @returns {number} Width in node units
+ */
+function getSubtreeWidth(node) {
+    if (node.children.length === 0) return 1;
+    return node.children.reduce((sum, child) => sum + getSubtreeWidth(child), 0);
+}
+
+/**
+ * Calculates layout positions for each node in the tree
+ * @param {Object} node Tree node
+ * @param {number} depth Current depth
+ * @param {number} leftOffset Left offset position
+ * @returns {Object} Node with layout information
+ */
+function calculateLayout(node, depth = 0, leftOffset = 0) {
+    const subtreeWidth = getSubtreeWidth(node);
+
+    node.layout = {
+        depth: depth,
+        leftOffset: leftOffset,
+        width: subtreeWidth,
+        x: leftOffset + (subtreeWidth - 1) / 2,
+    };
+
+    let childOffset = leftOffset;
+    for (const child of node.children) {
+        calculateLayout(child, depth + 1, childOffset);
+        childOffset += getSubtreeWidth(child);
+    }
+
+    return node;
+}
+
+/**
+ * Organizes nodes by depth level
+ * @param {Object} node Tree node
+ * @param {Array<Array>} levels Array of levels
+ * @returns {Array<Array>} Organized levels
+ */
+function organizeByLevels(node, levels = []) {
+    if (!levels[node.layout.depth]) {
+        levels[node.layout.depth] = [];
+    }
+    levels[node.layout.depth].push(node);
+
+    for (const child of node.children) {
+        organizeByLevels(child, levels);
+    }
+
+    return levels;
+}
+
+/**
+ * Prepares graph data for rendering
+ * @param {Array<Array>} levels Organized node levels
+ * @param {string} currentChatName Current chat filename
+ * @returns {Object} Graph data with lines and nodes
+ */
+function prepareGraphData(levels, currentChatName) {
+    const nodeWidth = 280;
+    const nodeHeight = 120;
+    const horizontalGap = 20;
+    const verticalGap = 60;
+
+    const maxWidth = Math.max(...levels.map(level =>
+        Math.max(...level.map(node => node.layout.x)),
+    )) + 1;
+
+    const totalWidth = maxWidth * (nodeWidth + horizontalGap);
+    const totalHeight = levels.length * (nodeHeight + verticalGap);
+
+    const lines = [];
+    const nodes = [];
+
+    // Collect connection lines
+    for (const level of levels) {
+        for (const node of level) {
+            const parentX = node.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
+            const parentY = node.layout.depth * (nodeHeight + verticalGap) + nodeHeight;
+
+            for (const child of node.children) {
+                const childX = child.layout.x * (nodeWidth + horizontalGap) + nodeWidth / 2;
+                const childY = child.layout.depth * (nodeHeight + verticalGap);
+
+                lines.push({ x1: parentX, y1: parentY, x2: childX, y2: childY });
+            }
+        }
+    }
+
+    // Collect nodes
+    for (const level of levels) {
+        for (const node of level) {
+            const isCurrentChat = node.name === currentChatName;
+            const momentDate = timestampToMoment(node.chat.last_mes);
+            const formattedDate = momentDate.isValid() ? momentDate.format('lll') : 'Unknown date';
+            const messageCount = node.chat.message_count || 0;
+            const preview = node.chat.preview_message || '(No messages)';
+
+            const x = node.layout.x * (nodeWidth + horizontalGap);
+            const y = node.layout.depth * (nodeHeight + verticalGap);
+
+            nodes.push({
+                name: node.name,
+                isCurrentChat,
+                formattedDate,
+                messageCount,
+                preview,
+                x,
+                y,
+                width: nodeWidth,
+            });
+        }
+    }
+
+    return { totalWidth, totalHeight, lines, nodes };
+}
+
+/**
+ * Shows the branch graph popup and handles user interaction
+ * @param {Object} graphData Graph data with lines and nodes
+ * @returns {Promise<string|null>} Selected chat filename or null
+ */
+async function showGraphPopup(graphData) {
+    const { totalWidth, totalHeight, lines, nodes } = graphData;
+    const graphHTML = await renderTemplateAsync('branchGraph', { totalWidth, totalHeight, lines, nodes });
+
+    const popup = new Popup(graphHTML, POPUP_TYPE.TEXT, '', {
+        okButton: false,
+        cancelButton: 'Close',
+        wide: true,
+        large: true,
+        onOpen: () => {
+            $('.branch-graph-node').each(function () {
+                const nodeIndex = parseInt($(this).attr('data-node-index'));
+                const node = nodes[nodeIndex];
+                $(this).attr('data-file-name', node.name);
+                $(this).find('.branch-node-name-text').text(node.name);
+                $(this).find('.branch-node-preview-text').text(node.preview);
+            });
+        },
+    });
+
+    const result = await popup.show();
+
+    // If user cancelled or closed the popup, do nothing
+    // Note: result can be 0 (first item), so we need to check for null/undefined explicitly
+    if (result === POPUP_RESULT.CANCELLED || result === null || result === undefined) {
+        return null;
+    }
+
+    const selectedNode = nodes[result];
+    if (!selectedNode) {
+        console.error('Invalid node selection:', result);
+        return null;
+    }
+
+    return selectedNode.name;
+}
+
+/**
+ * Switches to the selected chat
+ * @param {string} chatFileName Chat filename to switch to
+ */
+async function switchToChat(chatFileName) {
+    try {
+        showLoader();
+        await saveChatConditional();
+
+        if (selected_group) {
+            await openGroupChat(selected_group, chatFileName);
+        } else {
+            await openCharacterChat(chatFileName);
+        }
+    } finally {
+        await hideLoader();
+    }
+}
+
+/**
+ * Main function to show the branch graph
+ * Displays a visual tree of all related chats and allows navigation
+ */
+export async function showBranchGraph() {
+    try {
+        showLoader();
+
+        const currentChatName = (getCurrentChatDetails()).sessionName;
+
+        if (!currentChatName) {
+            toastr.info('Please open a chat first.', 'No chat loaded');
+            return;
+        }
+
+        const chatMap = await fetchAllChats();
+        const { relatedChats, metadataCache } = await traverseBranchTree(currentChatName, chatMap);
+
+        // Find root chat
+        let rootChatName = currentChatName;
+        for (const chatName of relatedChats) {
+            const metadata = metadataCache.get(chatName);
+            if (metadata && !metadata.main_chat) {
+                rootChatName = chatName;
+                break;
+            }
+        }
+
+        const tree = buildTree(rootChatName, chatMap, metadataCache);
+
+        if (!tree) {
+            toastr.error('Failed to build branch graph.', 'Error');
+            return;
+        }
+
+        const cleanTree = removeDuplicates(tree);
+        calculateLayout(cleanTree);
+        const levels = organizeByLevels(cleanTree);
+        const graphData = prepareGraphData(levels, currentChatName);
+
+        const selectedChatName = await showGraphPopup(graphData);
+
+        if (selectedChatName) {
+            await switchToChat(selectedChatName);
+        }
+    } catch (error) {
+        console.error('[BranchGraph] Error showing branch graph:', error);
+        toastr.error('Failed to load branch graph. Please try again.', 'Error');
+    } finally {
+        await hideLoader();
+    }
+}

--- a/public/scripts/templates/branchGraph.html
+++ b/public/scripts/templates/branchGraph.html
@@ -1,0 +1,24 @@
+<div class="branch-graph-container">
+    <div style="position: relative; width: {{totalWidth}}px; height: {{totalHeight}}px;">
+        <svg width="{{totalWidth}}" height="{{totalHeight}}" style="position: absolute; top: 0; left: 0; pointer-events: none;">
+            {{#each lines}}
+            <line x1="{{x1}}" y1="{{y1}}" x2="{{x2}}" y2="{{y2}}" stroke="rgba(255, 255, 255, 0.3)" stroke-width="2"/>
+            {{/each}}
+        </svg>
+        {{#each nodes}}
+        <div class="branch-graph-node {{#if isCurrentChat}}current-chat{{/if}}"
+             data-file-name=""
+             data-node-index="{{@index}}"
+             style="position: absolute; left: {{x}}px; top: {{y}}px; width: {{width}}px;">
+            <div class="branch-graph-node-name">
+                <i class="fa-solid fa-{{#if isCurrentChat}}circle-dot{{else}}circle{{/if}}"></i>
+                <span class="branch-node-name-text"></span>
+            </div>
+            <div class="branch-graph-node-info">
+                {{messageCount}} messages • {{formattedDate}}
+            </div>
+            <div class="branch-graph-node-preview branch-node-preview-text"></div>
+        </div>
+        {{/each}}
+    </div>
+</div>

--- a/public/scripts/templates/branchGraph.html
+++ b/public/scripts/templates/branchGraph.html
@@ -9,6 +9,7 @@
         <div class="branch-graph-node {{#if isCurrentChat}}current-chat{{/if}}"
              data-file-name=""
              data-node-index="{{@index}}"
+             {{#unless isCurrentChat}}data-result="{{@index}}"{{/unless}}
              style="position: absolute; left: {{x}}px; top: {{y}}px; width: {{width}}px;">
             <div class="branch-graph-node-name">
                 <i class="fa-solid fa-{{#if isCurrentChat}}circle-dot{{else}}circle{{/if}}"></i>

--- a/public/scripts/templates/branchGraph.html
+++ b/public/scripts/templates/branchGraph.html
@@ -9,7 +9,6 @@
         <div class="branch-graph-node {{#if isCurrentChat}}current-chat{{/if}}"
              data-file-name=""
              data-node-index="{{@index}}"
-             {{#unless isCurrentChat}}data-result="{{@index}}"{{/unless}}
              style="position: absolute; left: {{x}}px; top: {{y}}px; width: {{width}}px;">
             <div class="branch-graph-node-name">
                 <i class="fa-solid fa-{{#if isCurrentChat}}circle-dot{{else}}circle{{/if}}"></i>

--- a/public/scripts/templates/branchList.html
+++ b/public/scripts/templates/branchList.html
@@ -1,6 +1,6 @@
 <div class="branch-list">
     {{#each branches}}
-    <div class="branch-list-item" data-file-name="" data-branch-index="{{@index}}">
+    <div class="branch-list-item" data-file-name="" data-branch-index="{{@index}}" data-result="{{@index}}">
         <div class="branch-list-item-header">
             <span class="branch-list-item-name"><i class="fa-solid fa-code-branch"></i> <span class="branch-name-text"></span></span>
             <small class="branch-list-item-date">{{formattedDate}}</small>

--- a/public/scripts/templates/branchList.html
+++ b/public/scripts/templates/branchList.html
@@ -1,0 +1,11 @@
+<div class="branch-list">
+    {{#each branches}}
+    <div class="branch-list-item" data-file-name="" data-branch-index="{{@index}}">
+        <div class="branch-list-item-header">
+            <span class="branch-list-item-name"><i class="fa-solid fa-code-branch"></i> <span class="branch-name-text"></span></span>
+            <small class="branch-list-item-date">{{formattedDate}}</small>
+        </div>
+        <div class="branch-list-item-preview">{{message_count}} messages • <span class="branch-preview-text"></span></div>
+    </div>
+    {{/each}}
+</div>

--- a/public/style.css
+++ b/public/style.css
@@ -3683,11 +3683,6 @@ grammarly-extension {
     max-width: 90dvw !important;
 }
 
-.large_dialogue_popup:has(.branch-graph-container) {
-    width: 90vw !important;
-    width: 90dvw !important;
-}
-
 .wide_dialogue_popup {
     /* FIXME: Chrome 129 broke max-height for aspect-ratio sized elements */
     /* aspect-ratio: 1 / 1; */
@@ -4537,7 +4532,8 @@ input[type="range"]::-webkit-slider-thumb {
     overflow: auto;
     max-width: 100%;
     max-height: 100%;
-    width: fit-content;
+    width: 90vw;
+    width: 90dvw;
     height: fit-content;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -4543,7 +4543,7 @@ input[type="range"]::-webkit-slider-thumb {
 
 .branch-graph-node {
     padding: 12px 16px;
-    border: 2px solid var(--SmartThemeBorderColor);
+    border: 2px solid rgba(255, 255, 255, 0.3);
     border-radius: 8px;
     cursor: pointer;
     transition: all 0.2s;
@@ -4581,7 +4581,7 @@ input[type="range"]::-webkit-slider-thumb {
     color: var(--grey70);
     margin-top: 6px;
     padding-top: 6px;
-    border-top: 1px solid var(--SmartThemeBorderColor);
+    border-top: 1px solid rgba(255, 255, 255, 0.2);
     overflow: hidden;
     text-overflow: ellipsis;
     display: -webkit-box;

--- a/public/style.css
+++ b/public/style.css
@@ -3683,6 +3683,11 @@ grammarly-extension {
     max-width: 90dvw !important;
 }
 
+.large_dialogue_popup:has(.branch-graph-container) {
+    width: 90vw !important;
+    width: 90dvw !important;
+}
+
 .wide_dialogue_popup {
     /* FIXME: Chrome 129 broke max-height for aspect-ratio sized elements */
     /* aspect-ratio: 1 / 1; */
@@ -4474,6 +4479,116 @@ input[type="range"]::-webkit-slider-thumb {
 
 .mes:not([bookmark_link='']) .mes_create_bookmark {
     display: none;
+}
+
+.mes_branches {
+    display: none;
+}
+
+.mes:not([has_branches='']) .mes_branches {
+    display: inline-block;
+}
+
+.branch-list {
+    max-height: 400px;
+    overflow-y: auto;
+    min-width: 300px;
+}
+
+.branch-list-item {
+    padding: 10px;
+    margin-bottom: 8px;
+    border: 1px solid var(--SmartThemeBorderColor);
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.branch-list-item:hover {
+    background-color: var(--black30a);
+}
+
+.branch-list-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+.branch-list-item-name {
+    font-weight: bold;
+    margin-right: 10px;
+}
+
+.branch-list-item-date {
+    color: var(--grey70);
+    font-size: 0.9em;
+}
+
+.branch-list-item-preview {
+    color: var(--grey70);
+    font-size: 0.9em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.branch-graph-container {
+    overflow: auto;
+    max-width: 100%;
+    max-height: 100%;
+    width: fit-content;
+    height: fit-content;
+}
+
+.branch-graph-node {
+    padding: 12px 16px;
+    border: 2px solid var(--SmartThemeBorderColor);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s;
+    background-color: var(--SmartThemeBlurTintColor);
+    position: relative;
+    z-index: 1;
+}
+
+.branch-graph-node:hover {
+    background-color: var(--black30a);
+    border-color: var(--SmartThemeBodyColor);
+    z-index: 2;
+}
+
+.branch-graph-node.current-chat {
+    border-color: var(--SmartThemeQuoteColor);
+    background-color: var(--black30a);
+    font-weight: bold;
+}
+
+.branch-graph-node-name {
+    font-size: 0.95em;
+    margin-bottom: 6px;
+    word-wrap: break-word;
+}
+
+.branch-graph-node-info {
+    font-size: 0.8em;
+    color: var(--grey70);
+    margin-bottom: 4px;
+}
+
+.branch-graph-node-preview {
+    font-size: 0.75em;
+    color: var(--grey70);
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid var(--SmartThemeBorderColor);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    line-height: 1.3em;
+    max-height: 2.6em;
 }
 
 .mes_edit_buttons {

--- a/public/style.css
+++ b/public/style.css
@@ -4528,12 +4528,16 @@ input[type="range"]::-webkit-slider-thumb {
     white-space: nowrap;
 }
 
+.branch-graph-popup {
+    width: 90vw !important;
+    width: 90dvw !important;
+}
+
 .branch-graph-container {
     overflow: auto;
     max-width: 100%;
     max-height: 100%;
-    width: 90vw;
-    width: 90dvw;
+    width: fit-content;
     height: fit-content;
 }
 


### PR DESCRIPTION
Implements a comprehensive branch navigation system for chat branches, addressing the lack of UI to navigate from parent chats to their child branches.

Features:
- Branch indicator button on messages that have child branches
- Click to view list of branches with metadata (date, message count, preview)
- "Branch graph" menu option to visualize entire branch tree structure
- Interactive graph with proper parent-child alignment and connection lines
- Click any node in graph to navigate to that branch

Data changes:
- Parent chat now saves immediately when creating a branch, ensuring the branches array in message extra data is persisted to the .jsonl file
- Previously, branch references could be lost if the parent chat was not saved after branch creation

Technical details:
- Added mes_branches button following the same pattern as mes_bookmark
- Tree traversal: walks up parent chain to root, then collects descendants
- Layout algorithm with centered parent-child positioning
- SVG connection lines within scrollable container
- Proper event handler cleanup to prevent memory leaks
- Branch graph popup scoped to 90vw width without affecting other popups

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
