### PR TITLE
Add Claude native compaction support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2205,6 +2205,33 @@
                                             <span>Prefills won't work when function calling is enabled and any tools are registered.</span>
                                         </div>
                                     </div>
+                                    <div class="range-block" data-source="claude">
+                                        <label for="claude_compact_enabled" class="checkbox_label widthFreeExpand">
+                                            <input id="claude_compact_enabled" type="checkbox" />
+                                            <span>Enable Claude auto-compact</span>
+                                        </label>
+                                        <div class="toggle-description justifyLeft marginBot5">
+                                            Configure Anthropic `context_management` with the native `compact_20260112` edit.
+                                            Returned compaction blocks are round-tripped on later Claude requests. Anthropic currently requires the trigger to be at least `50000`.
+                                        </div>
+                                        <div class="wide100p marginBot5">
+                                            <div class="flex-container alignItemsCenter">
+                                                <span>Compact Instructions</span>
+                                                <i class="editor_maximize fa-solid fa-maximize right_menu_button" data-for="claude_compact_instructions" title="Expand the editor" data-i18n="[title]Expand the editor"></i>
+                                            </div>
+                                            <textarea id="claude_compact_instructions" class="text_pole textarea_compact autoSetHeight" rows="3" placeholder="Optional extra instructions for Claude's compaction summary."></textarea>
+                                        </div>
+                                        <div class="flex-container flexnowrap flexGap10 wide100p marginBot5">
+                                            <label for="claude_compact_trigger_value" class="wide100p">
+                                                <span>Compact Trigger Tokens</span>
+                                                <input id="claude_compact_trigger_value" class="text_pole" type="number" min="50000" step="1" />
+                                            </label>
+                                        </div>
+                                        <label for="claude_compact_pause_after_compaction" class="checkbox_label widthFreeExpand">
+                                            <input id="claude_compact_pause_after_compaction" type="checkbox" />
+                                            <span>Pause after compaction</span>
+                                        </label>
+                                    </div>
                                 </div>
                                 <div class="range-block m-t-1" data-source="openai,aimlapi,openrouter,custom,electronhub,azure_openai,chutes">
                                     <div id="logit_bias_openai" class="range-block-title openai_restorable" data-i18n="Logit Bias">

--- a/public/script.js
+++ b/public/script.js
@@ -3452,6 +3452,8 @@ class StreamingProcessor {
         this.images = [];
         /** @type {string?} */
         this.reasoningSignature = null;
+        /** @type {{type: 'compaction', content: string | null}[]} */
+        this.compactionBlocks = [];
     }
 
     /**
@@ -3651,6 +3653,16 @@ class StreamingProcessor {
             message.extra.reasoning_signature = this.reasoningSignature;
         }
 
+        const compactionBlocks = sanitizeClaudeCompactionBlocks(this.compactionBlocks);
+        if (compactionBlocks.length > 0) {
+            message.extra = message.extra || {};
+            message.extra.claude_compaction_blocks = structuredClone(compactionBlocks);
+        } else if (message.extra?.claude_compaction_blocks) {
+            delete message.extra.claude_compaction_blocks;
+        }
+
+        syncMesToSwipe(messageId);
+
         this.markUIGenStopped();
 
         if (this.type !== 'impersonate') {
@@ -3746,6 +3758,7 @@ class StreamingProcessor {
                 this.reasoningHandler.updateReasoning(this.messageId, state?.reasoning);
                 this.images = state?.images ?? [];
                 this.reasoningSignature = state?.signature ?? null;
+                this.compactionBlocks = sanitizeClaudeCompactionBlocks(state?.claudeCompactionBlocks);
                 await eventSource.emit(event_types.STREAM_TOKEN_RECEIVED, text);
                 await sw.tick(async () => await this.onProgressStreaming(this.messageId, this.continueMessage + text));
             }
@@ -5325,6 +5338,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         let title = extractTitleFromData(data);
         let reasoning = extractReasoningFromData(data);
         let imageUrls = extractImagesFromData(data);
+        const compactionBlocks = extractCompactionBlocksFromData(data);
         const reasoningSignature = extractReasoningSignatureFromData(data);
         kobold_horde_model = title;
 
@@ -5367,9 +5381,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         } else {
             // Without streaming we'll be having a full message on continuation. Treat it as a last chunk.
             if (originalType !== 'continue') {
-                ({ type, getMessage } = await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature }));
+                ({ type, getMessage } = await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, compactionBlocks }));
             } else {
-                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, title, swipes, reasoning, imageUrls, reasoningSignature }));
+                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, compactionBlocks }));
             }
 
             // This relies on `saveReply` having been called to add the message to the chat, so it must be last.
@@ -6038,6 +6052,44 @@ function extractImagesFromData(data, { mainApi = null, chatCompletionSource = nu
 }
 
 /**
+ * Sanitizes Claude compaction blocks for storage and round-tripping.
+ * @param {unknown} blocks Candidate compaction blocks
+ * @returns {{type: 'compaction', content: string | null}[]} Sanitized compaction blocks
+ */
+function sanitizeClaudeCompactionBlocks(blocks) {
+    if (!Array.isArray(blocks)) {
+        return [];
+    }
+
+    return blocks
+        .filter(block => block?.type === 'compaction' && (block.content === null || (typeof block.content === 'string' && block.content.length > 0)))
+        .map(block => ({
+            type: 'compaction',
+            content: block.content === null ? null : String(block.content),
+        }));
+}
+
+/**
+ * Extracts Claude compaction blocks from the response data.
+ * @param {object} data Response data
+ * @param {object} [options] Extraction options
+ * @param {string} [options.mainApi] Main API to use
+ * @param {string} [options.chatCompletionSource] Chat completion source
+ * @returns {{type: 'compaction', content: string | null}[]} Extracted compaction blocks or empty array
+ */
+function extractCompactionBlocksFromData(data, { mainApi = null, chatCompletionSource = null } = {}) {
+    switch (mainApi ?? main_api) {
+        case 'openai':
+            if ((chatCompletionSource ?? oai_settings.chat_completion_source) === chat_completion_sources.CLAUDE) {
+                return sanitizeClaudeCompactionBlocks(data?.content);
+            }
+            break;
+    }
+
+    return [];
+}
+
+/**
  * parseAndSaveLogprobs receives the full data response for a non-streaming
  * generation, parses logprobs for all tokens in the message, and saves them
  * to the currently active message.
@@ -6436,16 +6488,17 @@ async function processImageAttachment(message, { imageUrls }) {
  * @property {string} [reasoning] Message reasoning
  * @property {string[]} [imageUrls] Links to images
  * @property {string?} [reasoningSignature] Encrypted signature of the reasoning text
+ * @property {{type: 'compaction', content: string | null}[]} [compactionBlocks] Claude compaction blocks
  *
  * @typedef {object} SaveReplyResult
  * @property {string} type Type of generation
  * @property {string} getMessage Generated message
  */
-export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrls = [], reasoningSignature = null }) {
+export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrls = [], reasoningSignature = null, compactionBlocks = [] }) {
     // Backward compatibility
     if (arguments.length > 1 && typeof arguments[0] !== 'object') {
         console.trace('saveReply called with positional arguments. Please use an object instead.');
-        [type, getMessage, fromStreaming, title, swipes, reasoning, imageUrls, reasoningSignature] = arguments;
+        [type, getMessage, fromStreaming, title, swipes, reasoning, imageUrls, reasoningSignature, compactionBlocks] = arguments;
     }
 
     const lastMessage = chat[chat.length - 1];
@@ -6468,6 +6521,19 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         reasoning = '';
     }
 
+    const applyCompactionBlocks = (message) => {
+        if (!message.extra || typeof message.extra !== 'object') {
+            message.extra = {};
+        }
+
+        const sanitizedCompactionBlocks = sanitizeClaudeCompactionBlocks(compactionBlocks);
+        if (sanitizedCompactionBlocks.length > 0) {
+            message.extra.claude_compaction_blocks = structuredClone(sanitizedCompactionBlocks);
+        } else {
+            delete message.extra.claude_compaction_blocks;
+        }
+    };
+
     let oldMessage = '';
     const generationFinished = new Date();
     if (type === 'swipe') {
@@ -6484,6 +6550,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
             lastMessage.extra.reasoning = reasoning;
             lastMessage.extra.reasoning_duration = null;
             lastMessage.extra.reasoning_signature = reasoningSignature;
+            applyCompactionBlocks(lastMessage);
             await processImageAttachment(lastMessage, { imageUrls });
             if (power_user.message_token_count_enabled) {
                 const tokenCountText = (reasoning || '') + lastMessage.mes;
@@ -6509,6 +6576,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.extra.reasoning = reasoning;
         lastMessage.extra.reasoning_duration = null;
         lastMessage.extra.reasoning_signature = reasoningSignature;
+        applyCompactionBlocks(lastMessage);
         await processImageAttachment(lastMessage, { imageUrls });
         if (power_user.message_token_count_enabled) {
             const tokenCountText = (reasoning || '') + lastMessage.mes;
@@ -6530,6 +6598,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.extra.model = getGeneratingModel();
         lastMessage.extra.reasoning += reasoning;
         lastMessage.extra.reasoning_signature = reasoningSignature;
+        applyCompactionBlocks(lastMessage);
         await processImageAttachment(lastMessage, { imageUrls });
         // We don't know if the reasoning duration extended, so we don't update it here on purpose.
         if (power_user.message_token_count_enabled) {
@@ -6553,6 +6622,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         newMessage.extra.reasoning = reasoning;
         newMessage.extra.reasoning_duration = null;
         newMessage.extra.reasoning_signature = reasoningSignature;
+        applyCompactionBlocks(newMessage);
         if (power_user.trim_spaces) {
             getMessage = getMessage.trim();
         }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -231,6 +231,9 @@ const openrouter_middleout_types = {
     OFF: 'off',
 };
 
+const DEFAULT_CLAUDE_COMPACT_TRIGGER_VALUE = 150000;
+const MIN_CLAUDE_COMPACT_TRIGGER_VALUE = 50000;
+
 export const reasoning_effort_types = {
     auto: 'auto',
     low: 'low',
@@ -353,6 +356,10 @@ export const settingsToUpdate = {
     proxy_password: ['#openai_proxy_password', 'proxy_password', false, true],
     assistant_prefill: ['#claude_assistant_prefill', 'assistant_prefill', false, false],
     assistant_impersonation: ['#claude_assistant_impersonation', 'assistant_impersonation', false, false],
+    claude_compact_enabled: ['#claude_compact_enabled', 'claude_compact_enabled', true, false],
+    claude_compact_instructions: ['#claude_compact_instructions', 'claude_compact_instructions', false, false],
+    claude_compact_pause_after_compaction: ['#claude_compact_pause_after_compaction', 'claude_compact_pause_after_compaction', true, false],
+    claude_compact_trigger_value: ['#claude_compact_trigger_value', 'claude_compact_trigger_value', false, false],
     use_sysprompt: ['#use_sysprompt', 'use_sysprompt', true, false],
     vertexai_auth_mode: ['#vertexai_auth_mode', 'vertexai_auth_mode', false, true],
     vertexai_region: ['#vertexai_region', 'vertexai_region', false, true],
@@ -457,6 +464,10 @@ const default_settings = {
     proxy_password: '',
     assistant_prefill: '',
     assistant_impersonation: '',
+    claude_compact_enabled: false,
+    claude_compact_instructions: '',
+    claude_compact_pause_after_compaction: false,
+    claude_compact_trigger_value: DEFAULT_CLAUDE_COMPACT_TRIGGER_VALUE,
     use_sysprompt: false,
     vertexai_auth_mode: 'express',
     vertexai_region: 'us-central1',
@@ -499,6 +510,19 @@ export let openai_settings;
 
 /** @type {import('./PromptManager.js').PromptManager} */
 export let promptManager = null;
+
+function sanitizeClaudeCompactionBlocks(blocks) {
+    if (!Array.isArray(blocks)) {
+        return [];
+    }
+
+    return blocks
+        .filter(block => block?.type === 'compaction' && (block.content === null || (typeof block.content === 'string' && block.content.length > 0)))
+        .map(block => ({
+            type: 'compaction',
+            content: block.content === null ? null : String(block.content),
+        }));
+}
 
 async function validateReverseProxy() {
     if (!oai_settings.reverse_proxy) {
@@ -592,6 +616,9 @@ function setOpenAIMessages(chat) {
         const isSameModel = originApi === currentApi && originModel === currentModel;
         const signature = isSameModel ? chat[j]?.extra?.reasoning_signature : null;
         const reasoning = isSameModel ? String(chat[j]?.extra?.reasoning ?? '') : '';
+        const compactionBlocks = oai_settings.chat_completion_source === chat_completion_sources.CLAUDE
+            ? sanitizeClaudeCompactionBlocks(chat[j]?.extra?.claude_compaction_blocks)
+            : [];
 
         // Remove reasoning metadata from invocations if the API/model don't match
         if (Array.isArray(invocations) && invocations.length > 0) {
@@ -605,7 +632,18 @@ function setOpenAIMessages(chat) {
             });
         }
 
-        messages[i] = { 'role': role, 'content': content, name: name, 'media': media, 'mediaDisplay': mediaDisplay, 'mediaIndex': mediaIndex, 'invocations': invocations, 'signature': signature, 'reasoning': reasoning };
+        messages[i] = {
+            'role': role,
+            'content': content,
+            name: name,
+            'media': media,
+            'mediaDisplay': mediaDisplay,
+            'mediaIndex': mediaIndex,
+            'invocations': invocations,
+            'signature': signature,
+            'reasoning': reasoning,
+            ...(compactionBlocks.length > 0 ? { compactionBlocks } : {}),
+        };
         j++;
     }
 
@@ -954,6 +992,26 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
             if (chatPrompt.mediaDisplay === MEDIA_DISPLAY.GALLERY) {
                 const media = chatPrompt.media[chatPrompt.mediaIndex];
                 await inlineMediaAttachment(media);
+            }
+        }
+
+        const compactionBlocks = sanitizeClaudeCompactionBlocks(chatPrompt.compactionBlocks);
+        if (chatMessage.role === 'assistant' && compactionBlocks.length > 0) {
+            const content = Array.isArray(chatMessage.content)
+                ? chatMessage.content
+                : (typeof chatMessage.content === 'string' && chatMessage.content.length > 0
+                    ? [{ type: 'text', text: chatMessage.content }]
+                    : []);
+            chatMessage.content = content;
+            content.unshift(...compactionBlocks.map(block => ({ type: 'compaction', content: block.content })));
+
+            const compactionText = compactionBlocks
+                .filter(block => typeof block.content === 'string')
+                .map(block => block.content)
+                .join('\n\n');
+
+            if (compactionText.length > 0) {
+                chatMessage.tokens += await tokenHandler.countAsync({ role: chatMessage.role, content: compactionText });
             }
         }
 
@@ -2510,6 +2568,39 @@ function getVerbosity(settings = null) {
     return settings.verbosity;
 }
 
+function normalizeClaudeCompactTriggerValue(value) {
+    const parsedValue = Number.parseInt(String(value ?? ''), 10);
+    if (!Number.isInteger(parsedValue)) {
+        return DEFAULT_CLAUDE_COMPACT_TRIGGER_VALUE;
+    }
+
+    return Math.max(parsedValue, MIN_CLAUDE_COMPACT_TRIGGER_VALUE);
+}
+
+function getClaudeContextManagement(settings = null) {
+    settings = settings ?? oai_settings;
+
+    if (!settings.claude_compact_enabled) {
+        return undefined;
+    }
+
+    const edit = {
+        type: 'compact_20260112',
+        pause_after_compaction: !!settings.claude_compact_pause_after_compaction,
+        trigger: {
+            type: 'input_tokens',
+            value: normalizeClaudeCompactTriggerValue(settings.claude_compact_trigger_value),
+        },
+    };
+
+    const instructions = substituteParams(String(settings.claude_compact_instructions ?? '')).trim();
+    if (instructions.length > 0) {
+        edit.instructions = instructions;
+    }
+
+    return { edits: [edit] };
+}
+
 /**
  * Build the generation parameter object for an OAI request.
  * @param {ChatCompletionSettings} settings Initial chat completion settings
@@ -2688,6 +2779,10 @@ export async function createGenerationParameters(settings, model, type, messages
         generate_data.top_k = Number(settings.top_k_openai);
         generate_data.use_sysprompt = settings.use_sysprompt;
         generate_data.stop = getCustomStoppingStrings(); // Claude shouldn't have limits on stop strings.
+        const contextManagement = getClaudeContextManagement(settings);
+        if (contextManagement) {
+            generate_data.context_management = contextManagement;
+        }
         // Don't add a prefill on quiet gens (summarization) and when using continue prefill.
         if (type !== 'quiet' && !(type === 'continue' && settings.continue_prefill)) {
             generate_data.assistant_prefill = type === 'impersonate'
@@ -2920,7 +3015,7 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
             let text = '';
             const swipes = [];
             const toolCalls = [];
-            const state = { reasoning: '', images: [], signature: '', toolSignatures: {} };
+            const state = { reasoning: '', images: [], signature: '', toolSignatures: {}, claudeCompactionBlocks: [] };
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) return;
@@ -2979,6 +3074,32 @@ export function getStreamingReply(data, state, { chatCompletionSource = null, ov
     const show_thoughts = overrideShowThoughts ?? oai_settings.show_thoughts;
 
     if (chat_completion_source === chat_completion_sources.CLAUDE) {
+        if (Array.isArray(state.claudeCompactionBlocks)) {
+            const index = Number.isInteger(data?.index) ? data.index : state.claudeCompactionBlocks.length;
+
+            if (data?.content_block?.type === 'compaction') {
+                state.claudeCompactionBlocks[index] = {
+                    type: 'compaction',
+                    content: data.content_block.content === null
+                        ? null
+                        : typeof data.content_block.content === 'string'
+                            ? data.content_block.content
+                            : '',
+                };
+            }
+
+            if (data?.delta?.type === 'compaction_delta') {
+                const block = state.claudeCompactionBlocks[index] ?? { type: 'compaction', content: '' };
+                if (block.content === null) {
+                    block.content = '';
+                }
+                if (typeof data.delta.content === 'string') {
+                    block.content += data.delta.content;
+                }
+                state.claudeCompactionBlocks[index] = block;
+            }
+        }
+
         if (show_thoughts) {
             state.reasoning += data?.delta?.thinking || '';
         }
@@ -6607,6 +6728,33 @@ export function initOpenAI() {
 
     $('#claude_assistant_impersonation').on('input', function () {
         oai_settings.assistant_impersonation = String($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#claude_compact_enabled').on('input', function () {
+        oai_settings.claude_compact_enabled = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#claude_compact_instructions').on('input', function () {
+        oai_settings.claude_compact_instructions = String($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#claude_compact_pause_after_compaction').on('input', function () {
+        oai_settings.claude_compact_pause_after_compaction = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#claude_compact_trigger_value').on('input', function () {
+        oai_settings.claude_compact_trigger_value = String($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#claude_compact_trigger_value').on('change', function () {
+        const normalizedValue = normalizeClaudeCompactTriggerValue($(this).val());
+        $(this).val(normalizedValue);
+        oai_settings.claude_compact_trigger_value = String(normalizedValue);
         saveSettingsDebounced();
     });
 

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -290,6 +290,23 @@ async function sendClaudeRequest(request, response) {
             requestBody.tools = [...webSearchTool, ...(requestBody.tools || [])];
         }
 
+        const hasCompactionBlocks = requestBody.messages.some(message =>
+            Array.isArray(message?.content) && message.content.some(block => block?.type === 'compaction'));
+        const hasCompactEdit = Array.isArray(request.body.context_management?.edits)
+            && request.body.context_management.edits.some(edit => edit?.type === 'compact_20260112');
+
+        if (request.body.context_management && typeof request.body.context_management === 'object') {
+            requestBody.context_management = request.body.context_management;
+        }
+
+        if (requestBody.context_management || hasCompactionBlocks) {
+            betaHeaders.push('context-management-2025-06-27');
+        }
+
+        if (hasCompactEdit || hasCompactionBlocks) {
+            betaHeaders.push('compact-2026-01-12');
+        }
+
         if (cachingAtDepth !== -1) {
             cachingAtDepthForClaude(convertedPrompt.messages, cachingAtDepth, cacheTTL);
         }
@@ -380,7 +397,7 @@ async function sendClaudeRequest(request, response) {
 
             /** @type {any} */
             const generateResponseJson = await generateResponse.json();
-            const responseText = generateResponseJson?.content?.[0]?.text || '';
+            const responseText = generateResponseJson?.content?.filter(part => part?.type === 'text')?.map(part => part.text)?.join('\n\n') || '';
             console.debug('Claude response:', generateResponseJson);
 
             // Wrap it back to OAI format + save the original content


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Summary

Adds native Anthropic Claude compaction support to the Claude chat completion source.

This PR:
- adds Claude compact settings for `instructions`, `pause_after_compaction`, and `trigger.value`
- sends `context_management.edits = [{ type: "compact_20260112", ... }]` for Claude requests
- automatically adds the `compact-2026-01-12` beta header when native compaction is used
- clamps the trigger to Anthropic's current minimum of `50000`
- preserves returned Claude `compaction` blocks from streaming and non-streaming responses
- round-trips preserved `compaction` blocks on later Claude requests

## Why

Anthropic's native compaction flow currently requires two extra constraints that are easy to miss:
- `anthropic-beta` must include `compact-2026-01-12`
- `context_management.edits[].trigger.value` must be at least `50000`

Without those, requests fail upstream.

Once Anthropic starts returning `compaction` blocks with `stop_reason: "compaction"`, SillyTavern also needs to preserve and resend those blocks on later Claude turns.

## Testing

Tested locally with:
- `node --check public/scripts/openai.js`
- `node --check public/script.js`
- `node --check src/endpoints/backends/chat-completions.js`
- `npm run lint -- public/scripts/openai.js public/script.js src/endpoints/backends/chat-completions.js`

I also verified the Anthropic API behavior directly against `https://api.anthropic.com/v1/messages`:
- requests fail without `compact-2026-01-12`
- requests fail when `trigger.value < 50000`
- requests succeed and return native `compaction` / `compaction_delta` blocks when both conditions are met
