### PR TITLE
feat(ui): add interface to manage message swipe history

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7359,6 +7359,7 @@
                                 <div title="Toggle media display style" class="mes_button mes_media_gallery fa-solid fa-photo-film" data-i18n="[title]Toggle media display style"></div>
                                 <div title="Toggle media display style" class="mes_button mes_media_list fa-solid fa-table-cells-large" data-i18n="[title]Toggle media display style"></div>
                                 <div title="Embed file or image" class="mes_button mes_embed fa-solid fa-paperclip" data-i18n="[title]Embed file or image"></div>
+                                <div title="Jump to swipe history" class="mes_button mes_swipe_picker fa-solid fa-bookmark" data-i18n="[title]Jump to swipe history" style="display: none;"></div>
                                 <div title="Create checkpoint" class="mes_button mes_create_bookmark fa-regular fa-solid fa-flag-checkered" data-i18n="[title]Create checkpoint"></div>
                                 <div title="Create branch" class="mes_button mes_create_branch fa-regular fa-code-branch" data-i18n="[title]Create Branch"></div>
                                 <div title="Copy" class="mes_button mes_copy fa-solid fa-copy " data-i18n="[title]Copy"></div>

--- a/public/script.js
+++ b/public/script.js
@@ -9053,43 +9053,6 @@ async function openSwipePicker(messageId) {
         return canJumpToSwipe || swipeId !== currentSwipeId;
     }
 
-    async function deleteSwipeFromPicker(swipeId) {
-        if (!canDeleteSwipeFromPicker(swipeId)) {
-            toastr.info(t`Cannot delete the currently displayed swipe on a historical message.`, t`Delete Swipe`);
-            return;
-        }
-
-        const nextSelectedSwipeId = swipeId < selectedSwipeId
-            ? selectedSwipeId - 1
-            : swipeId > selectedSwipeId
-                ? selectedSwipeId
-                : Math.min(selectedSwipeId, message.swipes.length - 2);
-
-        if (power_user.confirm_message_delete) {
-            const result = await callGenericPopup(t`Are you sure you want to delete swipe #${swipeId + 1}?`, POPUP_TYPE.CONFIRM, null, {
-                okButton: t`Delete Swipe`,
-                cancelButton: t`Cancel`,
-            });
-
-            if (result !== POPUP_RESULT.AFFIRMATIVE) {
-                return;
-            }
-        }
-
-        const newSwipeId = await deleteSwipe(swipeId, messageId);
-        if (!Number.isInteger(newSwipeId)) {
-            return;
-        }
-
-        selectedSwipeId = clamp(nextSelectedSwipeId, 0, message.swipes.length - 1);
-
-        if (swipeIdInput instanceof HTMLInputElement) {
-            swipeIdInput.max = String(message.swipes.length);
-        }
-
-        await renderSwipeList();
-    }
-
     async function renderSwipeList() {
         const swipeBlocks = [];
 
@@ -9142,7 +9105,35 @@ async function openSwipePicker(messageId) {
                         return;
                     }
 
-                    await deleteSwipeFromPicker(index);
+                    const nextSelectedSwipeId = index < selectedSwipeId
+                        ? selectedSwipeId - 1
+                        : index > selectedSwipeId
+                            ? selectedSwipeId
+                            : Math.min(selectedSwipeId, message.swipes.length - 2);
+
+                    if (power_user.confirm_message_delete) {
+                        const result = await callGenericPopup(t`Are you sure you want to delete swipe #${index + 1}?`, POPUP_TYPE.CONFIRM, null, {
+                            okButton: t`Delete Swipe`,
+                            cancelButton: t`Cancel`,
+                        });
+
+                        if (result !== POPUP_RESULT.AFFIRMATIVE) {
+                            return;
+                        }
+                    }
+
+                    const newSwipeId = await deleteSwipe(index, messageId);
+                    if (!Number.isInteger(newSwipeId)) {
+                        return;
+                    }
+
+                    selectedSwipeId = clamp(nextSelectedSwipeId, 0, message.swipes.length - 1);
+
+                    if (swipeIdInput instanceof HTMLInputElement) {
+                        swipeIdInput.max = String(message.swipes.length);
+                    }
+
+                    await renderSwipeList();
                 });
             template.find('.select_chat_block_filename').text(`#${index + 1}${index === Number(message.swipe_id ?? 0) ? ` ${t`[Current]`}` : ''}`);
             template.find('.chat_messages_date').text(sendDate);

--- a/public/script.js
+++ b/public/script.js
@@ -8925,7 +8925,178 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
 
     const swipeCounterText = formatSwipeCounter((message?.swipe_id + 1), message?.swipes?.length);
     const swipeCounter = messageElement.find('.swipes-counter');
-    swipeCounter.text(swipeCounterText).prop('hidden', false);
+    const swipePickerButton = messageElement.find('.mes_swipe_picker');
+    const canOpenSwipePicker = Boolean(message?.swipes?.length > 1 && mesId === chat.length - 1 && !message?.is_user);
+
+    swipeCounter
+        .text(swipeCounterText)
+        .prop('hidden', false)
+        .toggleClass('swipe-picker-enabled', canOpenSwipePicker);
+    swipePickerButton.toggle(canOpenSwipePicker);
+
+    if (canOpenSwipePicker) {
+        swipeCounter.attr({
+            tabindex: '0',
+            role: 'button',
+            title: t`Click to jump to a swipe`,
+        });
+    } else {
+        swipeCounter.removeAttr('tabindex role title');
+    }
+}
+
+/**
+ * Builds a compact label for the swipe picker.
+ * @param {string} text Swipe text
+ * @param {number} index Swipe index
+ * @param {number} currentSwipeId Currently selected swipe index
+ * @returns {string}
+ */
+function formatSwipePickerOption(text, index, currentSwipeId) {
+    const normalizedText = String(text ?? '').replace(/\s+/g, ' ').trim();
+    const preview = normalizedText.length > 80 ? `${normalizedText.slice(0, 80).trimEnd()}...` : normalizedText;
+    const label = preview || t`(empty swipe)`;
+    const currentLabel = index === currentSwipeId ? ` ${t`[Current]`}` : '';
+    return `#${index + 1}${currentLabel} ${label}`;
+}
+
+/**
+ * Opens a popup for jumping to a specific swipe on the last message.
+ * @param {number} messageId
+ * @returns {Promise<void>}
+ */
+async function openSwipePicker(messageId) {
+    const message = chat[messageId];
+
+    if (!message || !Array.isArray(message.swipes) || message.swipes.length <= 1) {
+        toastr.info(t`This message has no alternate swipes yet.`, t`Jump to Swipe`);
+        return;
+    }
+
+    if (!isSwipingAllowed() || !isMessageSwipeable(messageId, message)) {
+        toastr.warning(t`Swipes are not available right now.`, t`Jump to Swipe`);
+        return;
+    }
+
+    let selectedSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('flex-container', 'flexFlowColumn', 'flexNoGap', 'wide100p', 'flex1');
+
+    const description = document.createElement('div');
+    description.classList.add('m-b-1');
+    description.textContent = t`Select which swipe to show for the latest message.`;
+    wrapper.appendChild(description);
+
+    const searchInput = document.createElement('input');
+    searchInput.type = 'search';
+    searchInput.classList.add('text_pole', 'wide100p');
+    searchInput.placeholder = t`Search...`;
+    searchInput.autocomplete = 'off';
+    wrapper.appendChild(searchInput);
+
+    const listContainer = document.createElement('div');
+    listContainer.classList.add('swipe_picker_div', 'flex1');
+    wrapper.appendChild(listContainer);
+
+    /** @type {Popup} */
+    let popup;
+
+    function setSelectedSwipe(nextSwipeId) {
+        selectedSwipeId = clamp(Number(nextSwipeId), 0, message.swipes.length - 1);
+        listContainer.querySelectorAll('.swipe_picker_block').forEach((element) => {
+            const isSelected = Number(element.getAttribute('data-swipe-id')) === selectedSwipeId;
+            if (isSelected) {
+                element.setAttribute('highlight', 'true');
+            } else {
+                element.removeAttribute('highlight');
+            }
+        });
+    }
+
+    function renderSwipeList(searchQuery = '') {
+        const normalizedQuery = String(searchQuery ?? '').trim().toLowerCase();
+        const swipeBlocks = [];
+
+        for (let index = 0; index < message.swipes.length; index++) {
+            const swipeText = String(message.swipes[index] ?? '');
+            const swipeLabel = formatSwipePickerOption(swipeText, index, Number(message.swipe_id ?? 0));
+            if (normalizedQuery && !swipeLabel.toLowerCase().includes(normalizedQuery)) {
+                continue;
+            }
+
+            const template = $('#past_chat_template .select_chat_block_wrapper').clone();
+            const block = template.find('.select_chat_block');
+            block.removeClass('select_chat_block').addClass('swipe_picker_block');
+            const swipeInfo = Array.isArray(message.swipe_info) ? message.swipe_info[index] : null;
+            const sendDate = swipeInfo?.send_date ? timestampToMoment(swipeInfo.send_date).format('lll') : '';
+            const previewText = swipeText.replace(/\s+/g, ' ').trim();
+            const tokenCount = swipeInfo?.extra?.token_count;
+
+            block.attr({
+                file_name: `swipe-${index + 1}`,
+                'data-swipe-id': index,
+            });
+
+            template.find('.renameChatButton, .exportRawChatButton, .exportChatButton, .PastChat_cross').remove();
+            template.find('.select_chat_block_filename').text(`#${index + 1}${index === Number(message.swipe_id ?? 0) ? ` ${t`[Current]`}` : ''}`);
+            template.find('.chat_messages_date').text(sendDate);
+            template.find('.chat_file_size').text(previewText ? `${previewText.length} ${t`chars`}` : '');
+            template.find('.chat_messages_num').text(tokenCount ? `${tokenCount}t` : '');
+            template.find('.select_chat_block_mes').text(previewText || t`(empty swipe)`);
+
+            block.on('click', () => setSelectedSwipe(index));
+            block.on('dblclick', async () => {
+                setSelectedSwipe(index);
+                await popup.completeAffirmative();
+            });
+
+            swipeBlocks.push(template[0]);
+        }
+
+        listContainer.replaceChildren(...swipeBlocks);
+        setSelectedSwipe(selectedSwipeId);
+
+        if (swipeBlocks.length === 0) {
+            const empty = document.createElement('div');
+            empty.classList.add('textAlignCenter', 'opacity50p', 'padding10');
+            empty.textContent = t`No swipes match your search.`;
+            listContainer.replaceChildren(empty);
+        }
+    }
+
+    searchInput.addEventListener('input', function () {
+        renderSwipeList(this.value);
+    });
+
+    popup = new Popup(wrapper, POPUP_TYPE.CONFIRM, '', {
+        okButton: t`Go`,
+        cancelButton: t`Cancel`,
+        wider: true,
+        large: true,
+        allowVerticalScrolling: true,
+        onOpen: function () {
+            searchInput.focus();
+            searchInput.select();
+            renderSwipeList();
+        },
+    });
+
+    const popupResult = await popup.show();
+
+    if (popupResult !== POPUP_RESULT.AFFIRMATIVE) {
+        return;
+    }
+
+    const targetSwipeId = clamp(selectedSwipeId, 0, message.swipes.length - 1);
+    const currentSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
+
+    if (targetSwipeId === currentSwipeId) {
+        toastr.info(t`Already showing swipe #${targetSwipeId + 1}.`, t`Jump to Swipe`);
+        return;
+    }
+
+    const direction = targetSwipeId > currentSwipeId ? SWIPE_DIRECTION.RIGHT : SWIPE_DIRECTION.LEFT;
+    await swipe(null, direction, { source: SWIPE_SOURCE.SLASH_COMMAND, forceMesId: messageId, forceSwipeId: targetSwipeId });
 }
 
 /**
@@ -10881,6 +11052,22 @@ jQuery(async function () {
     //limit swiping to only last message clicks
     $(document).on('click', '.last_mes .swipe_right', async (e, data) => await swipe(e, SWIPE_DIRECTION.RIGHT, data));
     $(document).on('click', '.last_mes .swipe_left', async (e, data) => await swipe(e, SWIPE_DIRECTION.LEFT, data));
+    $(document).on('click', '.last_mes .swipes-counter.swipe-picker-enabled', async function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const mesId = Number($(this).closest('.mes').attr('mesid'));
+        await openSwipePicker(mesId);
+    });
+    $(document).on('keydown', '.last_mes .swipes-counter.swipe-picker-enabled', async function (e) {
+        if (e.key !== 'Enter' && e.key !== ' ') {
+            return;
+        }
+
+        e.preventDefault();
+        const mesId = Number($(this).closest('.mes').attr('mesid'));
+        await openSwipePicker(mesId);
+    });
 
     initCharacterSearch();
 
@@ -11544,6 +11731,14 @@ jQuery(async function () {
                 console.error('Failed to copy: ', err);
             }
         }
+    });
+
+    $(document).on('click', '.mes_swipe_picker', async function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const mesId = Number($(this).closest('.mes').attr('mesid'));
+        await openSwipePicker(mesId);
     });
 
     //********************

--- a/public/script.js
+++ b/public/script.js
@@ -9225,6 +9225,7 @@ export function refreshSwipeButtons(updateCounters = false, fade = true) {
             const isLastSwipe = (message?.swipes?.length ?? 1) - 1 <= (message?.swipe_id ?? 0);
             const hasSwipes = (message?.swipes?.length > 1);
             const overswipe = getOverswipeBehavior(messageId, message);
+            const swipePickerButton = $(div).find('.mes_swipe_picker');
 
             // Chevrons should always be shown on pristine greetings: https://github.com/SillyTavern/SillyTavern/pull/4712#issuecomment-3557893373
             const pristineGreeting = overswipe == OVERSWIPE_BEHAVIOR.PRISTINE_GREETING;
@@ -9238,12 +9239,14 @@ export function refreshSwipeButtons(updateCounters = false, fade = true) {
 
             //If there's only one swipe, the left arrow should not be shown.
             div.classList.toggle('swipes_visible', hasSwipes || pristineGreeting);
+            swipePickerButton.toggle(hasSwipes);
 
             //updateSwipeCounter does not need to be awaited, It can run a bit later.
             if (updateCounters) updateSwipeCounter(messageId, { message, messageElement: $(div) });
         } else {
             //Hide all messages that are not swipeable.
             div.classList.remove('swipes_visible', 'last_swipe');
+            $(div).find('.mes_swipe_picker').hide();
         }
     });
 }

--- a/public/script.js
+++ b/public/script.js
@@ -128,7 +128,6 @@ import {
 
 import {
     initBookmarks,
-    branchChat,
     showBookmarksButtons,
     updateBookmarkDisplay,
 } from './scripts/bookmarks.js';
@@ -287,6 +286,7 @@ import { MacroEngine } from './scripts/macros/engine/MacroEngine.js';
 import { addChatBackupsBrowser } from './scripts/chat-backups.js';
 import { onboardingExperimentalMacroEngine } from './scripts/macros/engine/MacroDiagnostics.js';
 import { compressRequest, setRequestCompressionConfig } from './scripts/request-compression.js';
+import { canJumpToSwipeForMessage, canOpenSwipePickerForMessage, initSwipePicker } from './scripts/swipe-picker.js';
 
 // API OBJECT FOR EXTERNAL WIRING
 globalThis.SillyTavern = {
@@ -733,6 +733,7 @@ async function firstLoadInit() {
     initDataMaid();
     initItemizedPrompts();
     initAccessibility();
+    initSwipePicker();
     addDebugFunctions();
     doDailyExtensionUpdatesCheck();
     await eventSource.emit(event_types.APP_INITIALIZED);
@@ -8951,357 +8952,6 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
 }
 
 /**
- * Returns whether a swipe picker can be opened for the message.
- * Unlike message swiping, this supports historical AI messages for inspection and branching.
- * @param {number} messageId
- * @returns {boolean}
- */
-function canOpenSwipePickerForMessage(messageId) {
-    const message = chat[messageId];
-
-    if (!message) {
-        return false;
-    }
-
-    if (ensureSwipes(message)) {
-        syncMesToSwipe(messageId);
-    }
-
-    return Boolean(
-        message?.swipes?.length > 1 &&
-        !message?.is_user &&
-        !(message?.extra?.isSmallSys) &&
-        !(message?.extra?.swipeable === false),
-    );
-}
-
-/**
- * Returns whether the picker can actively jump to a different swipe.
- * Historical AI messages can open the picker, but only the currently swipeable message may jump.
- * @param {number} messageId
- * @returns {boolean}
- */
-function canJumpToSwipeForMessage(messageId) {
-    const message = chat[messageId];
-    return canOpenSwipePickerForMessage(messageId) && isSwipingAllowed() && isMessageSwipeable(messageId, message);
-}
-
-/**
- * Opens a popup for viewing or jumping to a specific swipe on a message.
- * @param {number} messageId
- * @returns {Promise<void>}
- */
-async function openSwipePicker(messageId) {
-    const message = chat[messageId];
-
-    if (!canOpenSwipePickerForMessage(messageId)) {
-        toastr.info(t`This message has no alternate swipes yet.`, t`Jump to Swipe`);
-        return;
-    }
-
-    const canJumpToSwipe = canJumpToSwipeForMessage(messageId);
-    let selectedSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
-    const swipeIdInputId = `swipe_picker_id_${messageId}`;
-    const wrapper = document.createElement('div');
-    wrapper.classList.add('flex-container', 'flexFlowColumn', 'flexNoGap', 'wide100p', 'flex1', 'overflowHidden');
-
-    const header = document.createElement('div');
-    header.classList.add('swipe_picker_header', 'flex-container', 'alignItemsCenter', 'justifySpaceBetween', 'gap10px');
-
-    const description = document.createElement('h3');
-    description.classList.add('margin0', 'justifyLeft');
-    description.textContent = t`Swipe Selection`;
-    header.appendChild(description);
-    wrapper.appendChild(header);
-
-    const listContainer = document.createElement('div');
-    listContainer.classList.add('swipe_picker_div', 'flex1', 'marginTop10');
-    wrapper.appendChild(listContainer);
-
-    /** @type {Popup} */
-    let popup;
-    /** @type {HTMLInputElement} */
-    let swipeIdInput;
-    /** @type {number|null} */
-    let branchActionSwipeId = null;
-
-    function syncSwipeIdInput() {
-        if (swipeIdInput) {
-            swipeIdInput.value = String(selectedSwipeId + 1);
-        }
-    }
-
-    function setSelectedSwipe(nextSwipeId) {
-        selectedSwipeId = clamp(Number(nextSwipeId), 0, message.swipes.length - 1);
-        listContainer.querySelectorAll('.swipe_picker_block').forEach((element) => {
-            const isSelected = Number(element.getAttribute('data-swipe-id')) === selectedSwipeId;
-            if (isSelected) {
-                element.setAttribute('highlight', 'true');
-            } else {
-                element.removeAttribute('highlight');
-            }
-        });
-        syncSwipeIdInput();
-    }
-
-    function canDeleteSwipeFromPicker(swipeId) {
-        if ((message?.swipes?.length ?? 0) <= 1) {
-            return false;
-        }
-
-        const currentSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
-        return canJumpToSwipe || swipeId !== currentSwipeId;
-    }
-
-    async function renderSwipeList() {
-        const swipeBlocks = await Promise.all(message.swipes.map(async (swipe, index) => {
-            const swipeText = String(swipe ?? '');
-            const template = $('#past_chat_template .select_chat_block_wrapper').clone();
-            const block = template.find('.select_chat_block');
-            block.removeClass('select_chat_block').addClass('swipe_picker_block');
-            const branchButton = template.find('.exportRawChatButton');
-            const deleteButton = template.find('.PastChat_cross');
-            const swipeInfo = Array.isArray(message.swipe_info) ? message.swipe_info[index] : null;
-            const sendDate = swipeInfo?.send_date ? timestampToMoment(swipeInfo.send_date).format('lll') : '';
-            const previewText = swipeText.replace(/\s+/g, ' ').trim();
-            const tokenCount = swipeInfo?.extra?.token_count ?? await getTokenCountAsync(swipeText, 0);
-            const canDeleteSwipe = canDeleteSwipeFromPicker(index);
-            const swipeDetails = [];
-
-            if (previewText) {
-                swipeDetails.push(`${previewText.length} ${t`chars`}`);
-            }
-
-            if (tokenCount) {
-                swipeDetails.push(`${tokenCount}t`);
-            }
-
-            block.attr({
-                file_name: `swipe-${index + 1}`,
-                'data-swipe-id': index,
-            });
-
-            template.find('.renameChatButton, .exportChatButton').remove();
-            branchButton
-                .removeAttr('data-format')
-                .attr({
-                    title: t`Create Branch`,
-                    'data-i18n': '[title]Create Branch',
-                })
-                .removeClass('exportRawChatButton fa-solid fa-file-export')
-                .addClass('swipe_picker_branch mes_button fa-regular fa-code-branch')
-                .on('click', async (event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    setSelectedSwipe(index);
-                    branchActionSwipeId = index;
-                    await popup.completeCancelled();
-                });
-            deleteButton
-                .removeAttr('file_name')
-                .attr('aria-disabled', String(!canDeleteSwipe))
-                .removeClass('fa-skull')
-                .addClass('swipe_picker_delete fa-trash-can')
-                .toggleClass('hoverglow', canDeleteSwipe)
-                .toggleClass('disabled', !canDeleteSwipe)
-                .each(function () {
-                    if (canDeleteSwipe) {
-                        $(this)
-                            .attr({
-                                title: t`Delete Swipe`,
-                                'data-i18n': '[title]Delete Swipe',
-                            });
-                    } else {
-                        $(this)
-                            .removeAttr('title')
-                            .removeAttr('data-i18n');
-                    }
-                })
-                .off('click')
-                .on('click', async (event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-
-                    if (!canDeleteSwipe) {
-                        return;
-                    }
-
-                    const nextSelectedSwipeId = index < selectedSwipeId
-                        ? selectedSwipeId - 1
-                        : index > selectedSwipeId
-                            ? selectedSwipeId
-                            : Math.min(selectedSwipeId, message.swipes.length - 2);
-
-                    if (power_user.confirm_message_delete) {
-                        const result = await callGenericPopup(t`Are you sure you want to delete swipe #${index + 1}?`, POPUP_TYPE.CONFIRM, null, {
-                            okButton: t`Delete Swipe`,
-                            cancelButton: t`Cancel`,
-                        });
-
-                        if (result !== POPUP_RESULT.AFFIRMATIVE) {
-                            return;
-                        }
-                    }
-
-                    const newSwipeId = await deleteSwipe(index, messageId);
-                    if (!Number.isInteger(newSwipeId)) {
-                        return;
-                    }
-
-                    selectedSwipeId = clamp(nextSelectedSwipeId, 0, message.swipes.length - 1);
-
-                    if (swipeIdInput instanceof HTMLInputElement) {
-                        swipeIdInput.max = String(message.swipes.length);
-                    }
-
-                    await renderSwipeList();
-                });
-            template.find('.select_chat_block_filename').text(`#${index + 1}${index === Number(message.swipe_id ?? 0) ? ` ${t`[Current]`}` : ''}`);
-            template.find('.chat_messages_date').text(sendDate);
-            template.find('.chat_file_size').text(swipeDetails.length ? `(${swipeDetails[0]}${swipeDetails.length > 1 ? ',' : ')'}` : '');
-            template.find('.chat_messages_num').text(swipeDetails.length > 1 ? `${swipeDetails.slice(1).join(', ')})` : '');
-            template.find('.select_chat_block_mes').text(previewText || t`(empty swipe)`);
-
-            block.on('click', () => setSelectedSwipe(index));
-            block.on('dblclick', async () => {
-                if (!canJumpToSwipe) {
-                    return;
-                }
-
-                setSelectedSwipe(index);
-                await popup.completeAffirmative();
-            });
-
-            return template[0];
-        }));
-
-        listContainer.replaceChildren(...swipeBlocks);
-        setSelectedSwipe(selectedSwipeId);
-
-        if (swipeBlocks.length === 0) {
-            const empty = document.createElement('div');
-            empty.classList.add('textAlignCenter', 'opacity50p', 'padding10');
-            empty.textContent = t`No swipes available.`;
-            listContainer.replaceChildren(empty);
-        }
-    }
-
-    popup = new Popup(wrapper, POPUP_TYPE.CONFIRM, '', {
-        okButton: canJumpToSwipe ? t`Go` : false,
-        cancelButton: false,
-        customInputs: [{
-            id: swipeIdInputId,
-            label: t`Swipe ID`,
-            type: 'text',
-            defaultState: String(selectedSwipeId + 1),
-            tooltip: `1-${message.swipes.length}`,
-        }],
-        wider: true,
-        allowVerticalScrolling: true,
-        onOpen: function () {
-            if (swipeIdInput instanceof HTMLInputElement) {
-                swipeIdInput.focus();
-                swipeIdInput.select();
-            }
-        },
-        onClosing: function (popup) {
-            if (popup.result !== POPUP_RESULT.AFFIRMATIVE) {
-                return true;
-            }
-
-            const swipeIdInput = popup.dlg.querySelector(`#${swipeIdInputId}`);
-            const targetSwipeNumber = Number.parseInt(String(swipeIdInput instanceof HTMLInputElement ? swipeIdInput.value : '').trim(), 10);
-
-            if (!Number.isInteger(targetSwipeNumber) || targetSwipeNumber < 1 || targetSwipeNumber > message.swipes.length) {
-                toastr.warning(t`Enter a swipe ID between 1 and ${message.swipes.length}.`, t`Jump to Swipe`);
-                if (swipeIdInput instanceof HTMLInputElement) {
-                    swipeIdInput.focus();
-                    swipeIdInput.select();
-                }
-                return false;
-            }
-
-            setSelectedSwipe(targetSwipeNumber - 1);
-            return true;
-        },
-    });
-
-    popup.dlg.classList.add('swipe_picker_popup');
-    popup.closeButton.style.display = 'block';
-    popup.closeButton.classList.add('opacity50p', 'hoverglow', 'fontsize120p');
-    popup.closeButton.style.position = 'static';
-    popup.closeButton.style.top = 'auto';
-    popup.closeButton.style.right = 'auto';
-    popup.closeButton.style.width = 'auto';
-    popup.closeButton.style.height = 'auto';
-    popup.closeButton.style.padding = '0';
-    popup.closeButton.style.filter = 'none';
-    header.appendChild(popup.closeButton);
-
-    swipeIdInput = popup.dlg.querySelector(`#${swipeIdInputId}`);
-    const swipeIdLabel = popup.dlg.querySelector(`label[for="${swipeIdInputId}"]`);
-
-    if (swipeIdLabel instanceof HTMLLabelElement) {
-        swipeIdLabel.classList.add('flex-container', 'alignItemsCenter', 'justifyCenter', 'gap10px', 'margin0');
-        popup.buttonControls.insertBefore(swipeIdLabel, canJumpToSwipe ? popup.okButton : popup.buttonControls.firstChild);
-        popup.inputControls.style.display = 'none';
-    }
-
-    if (swipeIdInput instanceof HTMLInputElement) {
-        swipeIdInput.type = 'number';
-        swipeIdInput.min = '1';
-        swipeIdInput.max = String(message.swipes.length);
-        swipeIdInput.step = '1';
-        swipeIdInput.inputMode = 'numeric';
-        swipeIdInput.classList.add('flex1', 'width100px', 'textAlignCenter');
-        swipeIdInput.setAttribute('autofocus', '');
-        syncSwipeIdInput();
-
-        swipeIdInput.addEventListener('input', function () {
-            const nextSwipeId = Number.parseInt(this.value, 10);
-            if (!Number.isInteger(nextSwipeId) || nextSwipeId < 1 || nextSwipeId > message.swipes.length) {
-                return;
-            }
-
-            setSelectedSwipe(nextSwipeId - 1);
-            listContainer.querySelector(`.swipe_picker_block[data-swipe-id="${selectedSwipeId}"]`)?.scrollIntoView({ block: 'nearest' });
-        });
-
-        swipeIdInput.addEventListener('blur', function () {
-            syncSwipeIdInput();
-        });
-    }
-
-    await renderSwipeList();
-
-    const popupResult = await popup.show();
-
-    if (branchActionSwipeId !== null) {
-        await branchChat(messageId, { swipeId: branchActionSwipeId });
-        return;
-    }
-
-    if (popupResult !== POPUP_RESULT.AFFIRMATIVE) {
-        return;
-    }
-
-    if (!canJumpToSwipe) {
-        return;
-    }
-
-    const targetSwipeId = clamp(selectedSwipeId, 0, message.swipes.length - 1);
-    const currentSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
-
-    if (targetSwipeId === currentSwipeId) {
-        toastr.info(t`Already showing swipe #${targetSwipeId + 1}.`, t`Jump to Swipe`);
-        return;
-    }
-
-    const direction = targetSwipeId > currentSwipeId ? SWIPE_DIRECTION.RIGHT : SWIPE_DIRECTION.LEFT;
-    await swipe(null, direction, { source: SWIPE_SOURCE.SWIPE_PICKER, forceMesId: messageId, forceSwipeId: targetSwipeId });
-}
-
-/**
  * Returns true if messages are generally swipeable.
  * @returns {boolean}
  */
@@ -11279,23 +10929,6 @@ jQuery(async function () {
     //limit swiping to only last message clicks
     $(document).on('click', '.last_mes .swipe_right', async (e, data) => await swipe(e, SWIPE_DIRECTION.RIGHT, data));
     $(document).on('click', '.last_mes .swipe_left', async (e, data) => await swipe(e, SWIPE_DIRECTION.LEFT, data));
-    $(document).on('click', '.swipes-counter.swipe-picker-enabled', async function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-
-        const mesId = Number($(this).closest('.mes').attr('mesid'));
-        await openSwipePicker(mesId);
-    });
-    $(document).on('keydown', '.swipes-counter.swipe-picker-enabled', async function (e) {
-        if (e.key !== ' ') {
-            return;
-        }
-
-        e.preventDefault();
-        e.stopPropagation();
-        const mesId = Number($(this).closest('.mes').attr('mesid'));
-        await openSwipePicker(mesId);
-    });
 
     initCharacterSearch();
 
@@ -11959,14 +11592,6 @@ jQuery(async function () {
                 console.error('Failed to copy: ', err);
             }
         }
-    });
-
-    $(document).on('click', '.mes_swipe_picker', async function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-
-        const mesId = Number($(this).closest('.mes').attr('mesid'));
-        await openSwipePicker(mesId);
     });
 
     //********************

--- a/public/script.js
+++ b/public/script.js
@@ -8940,12 +8940,12 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
     swipeCounter
         .text(swipeCounterText)
         .prop('hidden', false)
-        .toggleClass('swipe-picker-enabled', canJumpToSwipe)
-        .toggleClass(INTERACTABLE_CONTROL_CLASS, canJumpToSwipe)
-        .attr('title', canJumpToSwipe ? t`Click to jump to a swipe` : null);
+        .toggleClass('swipe-picker-enabled', canOpenSwipePicker)
+        .toggleClass(INTERACTABLE_CONTROL_CLASS, canOpenSwipePicker)
+        .attr('title', canJumpToSwipe ? t`Click to jump to a swipe` : canOpenSwipePicker ? t`Click to view swipe history` : null);
     swipePickerButton.toggle(canOpenSwipePicker);
 
-    if (!canJumpToSwipe) {
+    if (!canOpenSwipePicker) {
         swipeCounter.removeAttr('tabindex');
     }
 }
@@ -8987,7 +8987,7 @@ function canJumpToSwipeForMessage(messageId) {
 }
 
 /**
- * Opens a popup for jumping to a specific swipe on the last message.
+ * Opens a popup for viewing or jumping to a specific swipe on a message.
  * @param {number} messageId
  * @returns {Promise<void>}
  */
@@ -9054,10 +9054,8 @@ async function openSwipePicker(messageId) {
     }
 
     async function renderSwipeList() {
-        const swipeBlocks = [];
-
-        for (let index = 0; index < message.swipes.length; index++) {
-            const swipeText = String(message.swipes[index] ?? '');
+        const swipeBlocks = await Promise.all(message.swipes.map(async (swipe, index) => {
+            const swipeText = String(swipe ?? '');
             const template = $('#past_chat_template .select_chat_block_wrapper').clone();
             const block = template.find('.select_chat_block');
             block.removeClass('select_chat_block').addClass('swipe_picker_block');
@@ -9068,6 +9066,15 @@ async function openSwipePicker(messageId) {
             const previewText = swipeText.replace(/\s+/g, ' ').trim();
             const tokenCount = swipeInfo?.extra?.token_count ?? await getTokenCountAsync(swipeText, 0);
             const canDeleteSwipe = canDeleteSwipeFromPicker(index);
+            const swipeDetails = [];
+
+            if (previewText) {
+                swipeDetails.push(`${previewText.length} ${t`chars`}`);
+            }
+
+            if (tokenCount) {
+                swipeDetails.push(`${tokenCount}t`);
+            }
 
             block.attr({
                 file_name: `swipe-${index + 1}`,
@@ -9137,8 +9144,8 @@ async function openSwipePicker(messageId) {
                 });
             template.find('.select_chat_block_filename').text(`#${index + 1}${index === Number(message.swipe_id ?? 0) ? ` ${t`[Current]`}` : ''}`);
             template.find('.chat_messages_date').text(sendDate);
-            template.find('.chat_file_size').text(previewText ? `${previewText.length} ${t`chars`}` : '');
-            template.find('.chat_messages_num').text(tokenCount ? `${tokenCount}t` : '');
+            template.find('.chat_file_size').text(swipeDetails.length ? `(${swipeDetails[0]}${swipeDetails.length > 1 ? ',' : ')'}` : '');
+            template.find('.chat_messages_num').text(swipeDetails.length > 1 ? `${swipeDetails.slice(1).join(', ')})` : '');
             template.find('.select_chat_block_mes').text(previewText || t`(empty swipe)`);
 
             block.on('click', () => setSelectedSwipe(index));
@@ -9151,8 +9158,8 @@ async function openSwipePicker(messageId) {
                 await popup.completeAffirmative();
             });
 
-            swipeBlocks.push(template[0]);
-        }
+            return template[0];
+        }));
 
         listContainer.replaceChildren(...swipeBlocks);
         setSelectedSwipe(selectedSwipeId);
@@ -9177,52 +9184,10 @@ async function openSwipePicker(messageId) {
         }],
         wider: true,
         allowVerticalScrolling: true,
-        onOpen: async function (popup) {
-            popup.dlg.classList.add('swipe_picker_popup');
-            await renderSwipeList();
-            popup.closeButton.style.display = 'block';
-            popup.closeButton.classList.add('opacity50p', 'hoverglow', 'fontsize120p');
-            popup.closeButton.style.position = 'static';
-            popup.closeButton.style.top = 'auto';
-            popup.closeButton.style.right = 'auto';
-            popup.closeButton.style.width = 'auto';
-            popup.closeButton.style.height = 'auto';
-            popup.closeButton.style.padding = '0';
-            popup.closeButton.style.filter = 'none';
-            header.appendChild(popup.closeButton);
-            swipeIdInput = popup.dlg.querySelector(`#${swipeIdInputId}`);
-            const swipeIdLabel = popup.dlg.querySelector(`label[for="${swipeIdInputId}"]`);
-
-            if (swipeIdLabel instanceof HTMLLabelElement) {
-                swipeIdLabel.classList.add('flex-container', 'alignItemsCenter', 'justifyCenter', 'gap10px', 'margin0');
-                popup.buttonControls.insertBefore(swipeIdLabel, canJumpToSwipe ? popup.okButton : popup.buttonControls.firstChild);
-                popup.inputControls.style.display = 'none';
-            }
-
+        onOpen: function () {
             if (swipeIdInput instanceof HTMLInputElement) {
-                swipeIdInput.type = 'number';
-                swipeIdInput.min = '1';
-                swipeIdInput.max = String(message.swipes.length);
-                swipeIdInput.step = '1';
-                swipeIdInput.inputMode = 'numeric';
-                swipeIdInput.classList.add('flex1', 'width100px', 'textAlignCenter');
-                syncSwipeIdInput();
                 swipeIdInput.focus();
                 swipeIdInput.select();
-
-                swipeIdInput.addEventListener('input', function () {
-                    const nextSwipeId = Number.parseInt(this.value, 10);
-                    if (!Number.isInteger(nextSwipeId) || nextSwipeId < 1 || nextSwipeId > message.swipes.length) {
-                        return;
-                    }
-
-                    setSelectedSwipe(nextSwipeId - 1);
-                    listContainer.querySelector(`.swipe_picker_block[data-swipe-id="${selectedSwipeId}"]`)?.scrollIntoView({ block: 'nearest' });
-                });
-
-                swipeIdInput.addEventListener('blur', function () {
-                    syncSwipeIdInput();
-                });
             }
         },
         onClosing: function (popup) {
@@ -9247,6 +9212,54 @@ async function openSwipePicker(messageId) {
         },
     });
 
+    popup.dlg.classList.add('swipe_picker_popup');
+    popup.closeButton.style.display = 'block';
+    popup.closeButton.classList.add('opacity50p', 'hoverglow', 'fontsize120p');
+    popup.closeButton.style.position = 'static';
+    popup.closeButton.style.top = 'auto';
+    popup.closeButton.style.right = 'auto';
+    popup.closeButton.style.width = 'auto';
+    popup.closeButton.style.height = 'auto';
+    popup.closeButton.style.padding = '0';
+    popup.closeButton.style.filter = 'none';
+    header.appendChild(popup.closeButton);
+
+    swipeIdInput = popup.dlg.querySelector(`#${swipeIdInputId}`);
+    const swipeIdLabel = popup.dlg.querySelector(`label[for="${swipeIdInputId}"]`);
+
+    if (swipeIdLabel instanceof HTMLLabelElement) {
+        swipeIdLabel.classList.add('flex-container', 'alignItemsCenter', 'justifyCenter', 'gap10px', 'margin0');
+        popup.buttonControls.insertBefore(swipeIdLabel, canJumpToSwipe ? popup.okButton : popup.buttonControls.firstChild);
+        popup.inputControls.style.display = 'none';
+    }
+
+    if (swipeIdInput instanceof HTMLInputElement) {
+        swipeIdInput.type = 'number';
+        swipeIdInput.min = '1';
+        swipeIdInput.max = String(message.swipes.length);
+        swipeIdInput.step = '1';
+        swipeIdInput.inputMode = 'numeric';
+        swipeIdInput.classList.add('flex1', 'width100px', 'textAlignCenter');
+        swipeIdInput.setAttribute('autofocus', '');
+        syncSwipeIdInput();
+
+        swipeIdInput.addEventListener('input', function () {
+            const nextSwipeId = Number.parseInt(this.value, 10);
+            if (!Number.isInteger(nextSwipeId) || nextSwipeId < 1 || nextSwipeId > message.swipes.length) {
+                return;
+            }
+
+            setSelectedSwipe(nextSwipeId - 1);
+            listContainer.querySelector(`.swipe_picker_block[data-swipe-id="${selectedSwipeId}"]`)?.scrollIntoView({ block: 'nearest' });
+        });
+
+        swipeIdInput.addEventListener('blur', function () {
+            syncSwipeIdInput();
+        });
+    }
+
+    await renderSwipeList();
+
     const popupResult = await popup.show();
 
     if (branchActionSwipeId !== null) {
@@ -9255,6 +9268,10 @@ async function openSwipePicker(messageId) {
     }
 
     if (popupResult !== POPUP_RESULT.AFFIRMATIVE) {
+        return;
+    }
+
+    if (!canJumpToSwipe) {
         return;
     }
 
@@ -11248,19 +11265,20 @@ jQuery(async function () {
     //limit swiping to only last message clicks
     $(document).on('click', '.last_mes .swipe_right', async (e, data) => await swipe(e, SWIPE_DIRECTION.RIGHT, data));
     $(document).on('click', '.last_mes .swipe_left', async (e, data) => await swipe(e, SWIPE_DIRECTION.LEFT, data));
-    $(document).on('click', '.last_mes .swipes-counter.swipe-picker-enabled', async function (e) {
+    $(document).on('click', '.swipes-counter.swipe-picker-enabled', async function (e) {
         e.preventDefault();
         e.stopPropagation();
 
         const mesId = Number($(this).closest('.mes').attr('mesid'));
         await openSwipePicker(mesId);
     });
-    $(document).on('keydown', '.last_mes .swipes-counter.swipe-picker-enabled', async function (e) {
+    $(document).on('keydown', '.swipes-counter.swipe-picker-enabled', async function (e) {
         if (e.key !== ' ') {
             return;
         }
 
         e.preventDefault();
+        e.stopPropagation();
         const mesId = Number($(this).closest('.mes').attr('mesid'));
         await openSwipePicker(mesId);
     });

--- a/public/script.js
+++ b/public/script.js
@@ -9019,7 +9019,7 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
         .prop('hidden', false)
         .toggleClass('swipe-picker-enabled', canOpenSwipePicker)
         .toggleClass(INTERACTABLE_CONTROL_CLASS, canOpenSwipePicker)
-        .attr('aria-role', canOpenSwipePicker ? 'button' : null)
+        .attr('role', canOpenSwipePicker ? 'button' : null)
         .attr('title', canJumpToSwipe ? t`Click to jump to a swipe` : canOpenSwipePicker ? t`Click to view swipe history` : null);
     swipePickerButton.toggle(canOpenSwipePicker);
 

--- a/public/script.js
+++ b/public/script.js
@@ -128,6 +128,7 @@ import {
 
 import {
     initBookmarks,
+    branchChat,
     showBookmarksButtons,
     updateBookmarkDisplay,
 } from './scripts/bookmarks.js';
@@ -7186,10 +7187,11 @@ export function saveChatDebounced() {
  * @param {object} [options.withMetadata] Additional metadata to save with the chat
  * @param {number} [options.mesId] The message ID to save the chat up to
  * @param {boolean} [options.force] Force the saving despite the integrity check result
+ * @param {ChatMessage[]} [options.chatData] Chat snapshot to save instead of the current in-memory chat
  *
  * @returns {Promise<void>}
  */
-export async function saveChat({ chatName, withMetadata, mesId, force = false } = {}) {
+export async function saveChat({ chatName, withMetadata, mesId, force = false, chatData = undefined } = {}) {
     if (selected_group) {
         toastr.error(t`Operation was aborted to prevent data corruption.`, t`saveChat called for a group chat`);
         throw new Error('saveChat called for a group chat');
@@ -7215,9 +7217,11 @@ export async function saveChat({ chatName, withMetadata, mesId, force = false } 
 
     characters[this_chid].date_last_chat = Date.now();
 
-    const trimmedChat = (mesId !== undefined && mesId >= 0 && mesId < chat.length)
-        ? chat.slice(0, Number(mesId) + 1)
-        : chat.slice();
+    const trimmedChat = Array.isArray(chatData)
+        ? chatData
+        : (mesId !== undefined && mesId >= 0 && mesId < chat.length)
+            ? chat.slice(0, Number(mesId) + 1)
+            : chat.slice();
 
     /** @type {ChatHeader} */
     const chatHeader = {
@@ -8926,15 +8930,16 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
     const swipeCounterText = formatSwipeCounter((message?.swipe_id + 1), message?.swipes?.length);
     const swipeCounter = messageElement.find('.swipes-counter');
     const swipePickerButton = messageElement.find('.mes_swipe_picker');
-    const canOpenSwipePicker = Boolean(message?.swipes?.length > 1 && mesId === chat.length - 1 && !message?.is_user);
+    const canOpenSwipePicker = canOpenSwipePickerForMessage(mesId, message);
+    const canJumpToSwipe = canJumpToSwipeForMessage(mesId, message);
 
     swipeCounter
         .text(swipeCounterText)
         .prop('hidden', false)
-        .toggleClass('swipe-picker-enabled', canOpenSwipePicker);
+        .toggleClass('swipe-picker-enabled', canJumpToSwipe);
     swipePickerButton.toggle(canOpenSwipePicker);
 
-    if (canOpenSwipePicker) {
+    if (canJumpToSwipe) {
         swipeCounter.attr({
             tabindex: '0',
             role: 'button',
@@ -8946,6 +8951,43 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
 }
 
 /**
+ * Returns whether a swipe picker can be opened for the message.
+ * Unlike message swiping, this supports historical AI messages for inspection and branching.
+ * @param {number} messageId
+ * @param {ChatMessage} [message=undefined]
+ * @returns {boolean}
+ */
+function canOpenSwipePickerForMessage(messageId, message = undefined) {
+    message ??= chat[messageId];
+
+    if (!message) {
+        return false;
+    }
+
+    if (ensureSwipes(message)) {
+        syncMesToSwipe(messageId);
+    }
+
+    return Boolean(
+        message?.swipes?.length > 1 &&
+        !message?.is_user &&
+        !(message?.extra?.isSmallSys) &&
+        !(message?.extra?.swipeable === false),
+    );
+}
+
+/**
+ * Returns whether the picker can actively jump to a different swipe.
+ * Historical AI messages can open the picker, but only the currently swipeable message may jump.
+ * @param {number} messageId
+ * @param {ChatMessage} [message=undefined]
+ * @returns {boolean}
+ */
+function canJumpToSwipeForMessage(messageId, message = undefined) {
+    return canOpenSwipePickerForMessage(messageId, message) && isSwipingAllowed() && isMessageSwipeable(messageId, message);
+}
+
+/**
  * Opens a popup for jumping to a specific swipe on the last message.
  * @param {number} messageId
  * @returns {Promise<void>}
@@ -8953,20 +8995,16 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
 async function openSwipePicker(messageId) {
     const message = chat[messageId];
 
-    if (!message || !Array.isArray(message.swipes) || message.swipes.length <= 1) {
+    if (!canOpenSwipePickerForMessage(messageId, message)) {
         toastr.info(t`This message has no alternate swipes yet.`, t`Jump to Swipe`);
         return;
     }
 
-    if (!isSwipingAllowed() || !isMessageSwipeable(messageId, message)) {
-        toastr.warning(t`Swipes are not available right now.`, t`Jump to Swipe`);
-        return;
-    }
-
+    const canJumpToSwipe = canJumpToSwipeForMessage(messageId, message);
     let selectedSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
     const swipeIdInputId = `swipe_picker_id_${messageId}`;
     const wrapper = document.createElement('div');
-    wrapper.classList.add('flex-container', 'flexFlowColumn', 'flexNoGap', 'wide100p', 'flex1', 'height100p', 'overflowHidden');
+    wrapper.classList.add('flex-container', 'flexFlowColumn', 'flexNoGap', 'wide100p', 'flex1', 'overflowHidden');
 
     const header = document.createElement('div');
     header.classList.add('swipe_picker_header', 'flex-container', 'alignItemsCenter', 'justifySpaceBetween', 'gap10px');
@@ -8985,6 +9023,8 @@ async function openSwipePicker(messageId) {
     let popup;
     /** @type {HTMLInputElement} */
     let swipeIdInput;
+    /** @type {number|null} */
+    let branchActionSwipeId = null;
 
     function syncSwipeIdInput() {
         if (swipeIdInput) {
@@ -9013,6 +9053,7 @@ async function openSwipePicker(messageId) {
             const template = $('#past_chat_template .select_chat_block_wrapper').clone();
             const block = template.find('.select_chat_block');
             block.removeClass('select_chat_block').addClass('swipe_picker_block');
+            const branchButton = template.find('.exportRawChatButton');
             const swipeInfo = Array.isArray(message.swipe_info) ? message.swipe_info[index] : null;
             const sendDate = swipeInfo?.send_date ? timestampToMoment(swipeInfo.send_date).format('lll') : '';
             const previewText = swipeText.replace(/\s+/g, ' ').trim();
@@ -9023,7 +9064,22 @@ async function openSwipePicker(messageId) {
                 'data-swipe-id': index,
             });
 
-            template.find('.renameChatButton, .exportRawChatButton, .exportChatButton, .PastChat_cross').remove();
+            template.find('.renameChatButton, .exportChatButton, .PastChat_cross').remove();
+            branchButton
+                .removeAttr('data-format')
+                .attr({
+                    title: t`Create Branch`,
+                    'data-i18n': '[title]Create Branch',
+                })
+                .removeClass('exportRawChatButton fa-solid fa-file-export')
+                .addClass('swipe_picker_branch mes_button fa-regular fa-code-branch')
+                .on('click', async (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    setSelectedSwipe(index);
+                    branchActionSwipeId = index;
+                    await popup.completeCancelled();
+                });
             template.find('.select_chat_block_filename').text(`#${index + 1}${index === Number(message.swipe_id ?? 0) ? ` ${t`[Current]`}` : ''}`);
             template.find('.chat_messages_date').text(sendDate);
             template.find('.chat_file_size').text(previewText ? `${previewText.length} ${t`chars`}` : '');
@@ -9032,6 +9088,10 @@ async function openSwipePicker(messageId) {
 
             block.on('click', () => setSelectedSwipe(index));
             block.on('dblclick', async () => {
+                if (!canJumpToSwipe) {
+                    return;
+                }
+
                 setSelectedSwipe(index);
                 await popup.completeAffirmative();
             });
@@ -9051,7 +9111,7 @@ async function openSwipePicker(messageId) {
     }
 
     popup = new Popup(wrapper, POPUP_TYPE.CONFIRM, '', {
-        okButton: t`Go`,
+        okButton: canJumpToSwipe ? t`Go` : false,
         cancelButton: false,
         customInputs: [{
             id: swipeIdInputId,
@@ -9061,9 +9121,9 @@ async function openSwipePicker(messageId) {
             tooltip: `1-${message.swipes.length}`,
         }],
         wider: true,
-        large: true,
         allowVerticalScrolling: true,
         onOpen: function (popup) {
+            popup.dlg.classList.add('swipe_picker_popup');
             renderSwipeList();
             popup.closeButton.style.display = 'block';
             popup.closeButton.classList.add('opacity50p', 'hoverglow', 'fontsize120p');
@@ -9080,7 +9140,7 @@ async function openSwipePicker(messageId) {
 
             if (swipeIdLabel instanceof HTMLLabelElement) {
                 swipeIdLabel.classList.add('flex-container', 'alignItemsCenter', 'justifyCenter', 'gap10px', 'margin0');
-                popup.buttonControls.insertBefore(swipeIdLabel, popup.okButton);
+                popup.buttonControls.insertBefore(swipeIdLabel, canJumpToSwipe ? popup.okButton : popup.buttonControls.firstChild);
                 popup.inputControls.style.display = 'none';
             }
 
@@ -9131,6 +9191,11 @@ async function openSwipePicker(messageId) {
     });
 
     const popupResult = await popup.show();
+
+    if (branchActionSwipeId !== null) {
+        await branchChat(messageId, { swipeId: branchActionSwipeId });
+        return;
+    }
 
     if (popupResult !== POPUP_RESULT.AFFIRMATIVE) {
         return;
@@ -9275,6 +9340,7 @@ export function refreshSwipeButtons(updateCounters = false, fade = true) {
             const hasSwipes = (message?.swipes?.length > 1);
             const overswipe = getOverswipeBehavior(messageId, message);
             const swipePickerButton = $(div).find('.mes_swipe_picker');
+            const canOpenSwipePicker = canOpenSwipePickerForMessage(messageId, message);
 
             // Chevrons should always be shown on pristine greetings: https://github.com/SillyTavern/SillyTavern/pull/4712#issuecomment-3557893373
             const pristineGreeting = overswipe == OVERSWIPE_BEHAVIOR.PRISTINE_GREETING;
@@ -9288,14 +9354,14 @@ export function refreshSwipeButtons(updateCounters = false, fade = true) {
 
             //If there's only one swipe, the left arrow should not be shown.
             div.classList.toggle('swipes_visible', hasSwipes || pristineGreeting);
-            swipePickerButton.toggle(hasSwipes);
+            swipePickerButton.toggle(canOpenSwipePicker);
 
             //updateSwipeCounter does not need to be awaited, It can run a bit later.
             if (updateCounters) updateSwipeCounter(messageId, { message, messageElement: $(div) });
         } else {
             //Hide all messages that are not swipeable.
             div.classList.remove('swipes_visible', 'last_swipe');
-            $(div).find('.mes_swipe_picker').hide();
+            $(div).find('.mes_swipe_picker').toggle(canOpenSwipePickerForMessage(messageId, message));
         }
     });
 }

--- a/public/script.js
+++ b/public/script.js
@@ -9044,7 +9044,7 @@ async function openSwipePicker(messageId) {
         syncSwipeIdInput();
     }
 
-    function renderSwipeList() {
+    async function renderSwipeList() {
         const swipeBlocks = [];
 
         for (let index = 0; index < message.swipes.length; index++) {
@@ -9056,7 +9056,7 @@ async function openSwipePicker(messageId) {
             const swipeInfo = Array.isArray(message.swipe_info) ? message.swipe_info[index] : null;
             const sendDate = swipeInfo?.send_date ? timestampToMoment(swipeInfo.send_date).format('lll') : '';
             const previewText = swipeText.replace(/\s+/g, ' ').trim();
-            const tokenCount = swipeInfo?.extra?.token_count;
+            const tokenCount = swipeInfo?.extra?.token_count ?? await getTokenCountAsync(swipeText, 0);
 
             block.attr({
                 file_name: `swipe-${index + 1}`,
@@ -9121,9 +9121,9 @@ async function openSwipePicker(messageId) {
         }],
         wider: true,
         allowVerticalScrolling: true,
-        onOpen: function (popup) {
+        onOpen: async function (popup) {
             popup.dlg.classList.add('swipe_picker_popup');
-            renderSwipeList();
+            await renderSwipeList();
             popup.closeButton.style.display = 'block';
             popup.closeButton.classList.add('opacity50p', 'hoverglow', 'fontsize120p');
             popup.closeButton.style.position = 'static';
@@ -9209,7 +9209,7 @@ async function openSwipePicker(messageId) {
     }
 
     const direction = targetSwipeId > currentSwipeId ? SWIPE_DIRECTION.RIGHT : SWIPE_DIRECTION.LEFT;
-    await swipe(null, direction, { source: SWIPE_SOURCE.SLASH_COMMAND, forceMesId: messageId, forceSwipeId: targetSwipeId });
+    await swipe(null, direction, { source: SWIPE_SOURCE.SWIPE_PICKER, forceMesId: messageId, forceSwipeId: targetSwipeId });
 }
 
 /**
@@ -9979,7 +9979,7 @@ function formatSwipeCounter(current, total) {
  * @param {SwipeEvent} event Event.
  * @param {SWIPE_DIRECTION} direction The direction to swipe.
  * @param {object} params Additional parameters.
- * @param {import('./scripts/constants.js').SWIPE_SOURCE} [params.source]  The source of the swipe event. null, 'keyboard', 'auto_swipe', 'back' or 'delete'.
+ * @param {import('./scripts/constants.js').SWIPE_SOURCE} [params.source]  The source of the swipe event.
  * @param {boolean} [params.repeated] Is the swipe event repeated.
  * @param {ChatMessage} [params.message=chat[chat.length - 1]] The chat message to swipe.
  * @param {number} [params.forceMesId] The message id to swipe.
@@ -10005,7 +10005,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
 
     const mesId = Number(forceMesId ?? event?.currentTarget?.closest('.mes')?.getAttribute('mesid') ?? messageIndex ?? chat.length - 1);
 
-    if ([SWIPE_SOURCE.DELETE, SWIPE_SOURCE.BACK, SWIPE_SOURCE.AUTO_SWIPE, SWIPE_SOURCE.SLASH_COMMAND].includes(source)) {
+    if ([SWIPE_SOURCE.DELETE, SWIPE_SOURCE.BACK, SWIPE_SOURCE.AUTO_SWIPE, SWIPE_SOURCE.SLASH_COMMAND, SWIPE_SOURCE.SWIPE_PICKER].includes(source)) {
         console.info(`The ${direction} swipe source on message #${mesId} is ${source}, Most checks have been bypassed. `);
     } else {
         //Only show an error if swipes are not hidden and a message is generating.
@@ -10465,7 +10465,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
  * Handles the swipe to the left event.
  * @param {SwipeEvent} [event] Event.
  * @param {object} params Additional parameters.
- * @param {import('./scripts/constants.js').SWIPE_SOURCE} [params.source]  The source of the swipe event. null, 'keyboard', 'auto_swipe', 'back' or 'delete'.
+ * @param {import('./scripts/constants.js').SWIPE_SOURCE} [params.source]  The source of the swipe event.
  * @param {boolean} [params.repeated] Is the swipe event repeated.
  * @param {object} [params.message] The chat message to swipe.
  */
@@ -10478,7 +10478,7 @@ export async function swipe_left(event, { source, repeated, message } = {}) {
  * Handles the swipe to the right event.
  * @param {SwipeEvent} [event] Event.
  * @param {object} params Additional parameters.
- * @param {import('./scripts/constants.js').SWIPE_SOURCE} [params.source] The source of the swipe event. null, 'keyboard', 'auto_swipe', 'back' or 'delete'.
+ * @param {import('./scripts/constants.js').SWIPE_SOURCE} [params.source] The source of the swipe event.
  * @param {boolean} [params.repeated] Is the swipe event repeated.
  * @param {object} [params.message] The chat message to swipe.
  */

--- a/public/script.js
+++ b/public/script.js
@@ -9269,6 +9269,7 @@ export async function deleteSwipe(swipeId = null, messageId = chat.length - 1) {
         if (messageId !== chat.length - 1) {
             await updateSwipeCounter(chat.length - 1);
         }
+        refreshSwipeButtons();
         saveChatDebounced();
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -6751,20 +6751,24 @@ export function syncMesToSwipe(messageId = null) {
  * If the swipe data is invalid in some way, this function will exit out without doing anything.
  * @param {number?} [messageId=null] - The ID of the message to sync with the swipe data. If no ID is given, the last message is used.
  * @param {number?} [swipeId=null] - The ID of the swipe to sync. If no ID is given, the current swipe ID in the message object is used.
+ * @param {ChatMessage?} [targetMessage=null] - The message object to sync instead of resolving one from `chat`.
  * @returns {boolean} Whether the swipe data was successfully synced to the message
  */
-export function syncSwipeToMes(messageId = null, swipeId = null) {
-    if (!chat.length) {
+export function syncSwipeToMes(messageId = null, swipeId = null, targetMessage = null) {
+    if (!targetMessage && !chat.length) {
         return false;
     }
 
-    const targetMessageId = messageId ?? chat.length - 1;
-    if (targetMessageId >= chat.length || targetMessageId < 0) {
-        console.warn(`[syncSwipeToMes] Invalid message ID: ${messageId}`);
-        return false;
+    if (!targetMessage) {
+        const targetMessageId = messageId ?? chat.length - 1;
+        if (targetMessageId >= chat.length || targetMessageId < 0) {
+            console.warn(`[syncSwipeToMes] Invalid message ID: ${messageId}`);
+            return false;
+        }
+
+        targetMessage = chat[targetMessageId];
     }
 
-    const targetMessage = chat[targetMessageId];
     if (!targetMessage) {
         return false;
     }
@@ -8930,8 +8934,8 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
     const swipeCounterText = formatSwipeCounter((message?.swipe_id + 1), message?.swipes?.length);
     const swipeCounter = messageElement.find('.swipes-counter');
     const swipePickerButton = messageElement.find('.mes_swipe_picker');
-    const canOpenSwipePicker = canOpenSwipePickerForMessage(mesId, message);
-    const canJumpToSwipe = canJumpToSwipeForMessage(mesId, message);
+    const canOpenSwipePicker = canOpenSwipePickerForMessage(mesId);
+    const canJumpToSwipe = canJumpToSwipeForMessage(mesId);
 
     swipeCounter
         .text(swipeCounterText)
@@ -8954,11 +8958,10 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
  * Returns whether a swipe picker can be opened for the message.
  * Unlike message swiping, this supports historical AI messages for inspection and branching.
  * @param {number} messageId
- * @param {ChatMessage} [message=undefined]
  * @returns {boolean}
  */
-function canOpenSwipePickerForMessage(messageId, message = undefined) {
-    message ??= chat[messageId];
+function canOpenSwipePickerForMessage(messageId) {
+    const message = chat[messageId];
 
     if (!message) {
         return false;
@@ -8980,11 +8983,11 @@ function canOpenSwipePickerForMessage(messageId, message = undefined) {
  * Returns whether the picker can actively jump to a different swipe.
  * Historical AI messages can open the picker, but only the currently swipeable message may jump.
  * @param {number} messageId
- * @param {ChatMessage} [message=undefined]
  * @returns {boolean}
  */
-function canJumpToSwipeForMessage(messageId, message = undefined) {
-    return canOpenSwipePickerForMessage(messageId, message) && isSwipingAllowed() && isMessageSwipeable(messageId, message);
+function canJumpToSwipeForMessage(messageId) {
+    const message = chat[messageId];
+    return canOpenSwipePickerForMessage(messageId) && isSwipingAllowed() && isMessageSwipeable(messageId, message);
 }
 
 /**
@@ -8995,12 +8998,12 @@ function canJumpToSwipeForMessage(messageId, message = undefined) {
 async function openSwipePicker(messageId) {
     const message = chat[messageId];
 
-    if (!canOpenSwipePickerForMessage(messageId, message)) {
+    if (!canOpenSwipePickerForMessage(messageId)) {
         toastr.info(t`This message has no alternate swipes yet.`, t`Jump to Swipe`);
         return;
     }
 
-    const canJumpToSwipe = canJumpToSwipeForMessage(messageId, message);
+    const canJumpToSwipe = canJumpToSwipeForMessage(messageId);
     let selectedSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
     const swipeIdInputId = `swipe_picker_id_${messageId}`;
     const wrapper = document.createElement('div');
@@ -9340,7 +9343,7 @@ export function refreshSwipeButtons(updateCounters = false, fade = true) {
             const hasSwipes = (message?.swipes?.length > 1);
             const overswipe = getOverswipeBehavior(messageId, message);
             const swipePickerButton = $(div).find('.mes_swipe_picker');
-            const canOpenSwipePicker = canOpenSwipePickerForMessage(messageId, message);
+            const canOpenSwipePicker = canOpenSwipePickerForMessage(messageId);
 
             // Chevrons should always be shown on pristine greetings: https://github.com/SillyTavern/SillyTavern/pull/4712#issuecomment-3557893373
             const pristineGreeting = overswipe == OVERSWIPE_BEHAVIOR.PRISTINE_GREETING;
@@ -9361,7 +9364,7 @@ export function refreshSwipeButtons(updateCounters = false, fade = true) {
         } else {
             //Hide all messages that are not swipeable.
             div.classList.remove('swipes_visible', 'last_swipe');
-            $(div).find('.mes_swipe_picker').toggle(canOpenSwipePickerForMessage(messageId, message));
+            $(div).find('.mes_swipe_picker').toggle(canOpenSwipePickerForMessage(messageId));
         }
     });
 }

--- a/public/script.js
+++ b/public/script.js
@@ -9099,10 +9099,24 @@ async function openSwipePicker(messageId) {
                 });
             deleteButton
                 .removeAttr('file_name')
-                .attr('title', canDeleteSwipe ? t`Delete Swipe` : t`Cannot delete the currently displayed swipe on historical messages`)
+                .attr('aria-disabled', String(!canDeleteSwipe))
                 .removeClass('fa-skull')
                 .addClass('swipe_picker_delete fa-trash-can')
+                .toggleClass('hoverglow', canDeleteSwipe)
                 .toggleClass('disabled', !canDeleteSwipe)
+                .each(function () {
+                    if (canDeleteSwipe) {
+                        $(this)
+                            .attr({
+                                title: t`Delete Swipe`,
+                                'data-i18n': '[title]Delete Swipe',
+                            });
+                    } else {
+                        $(this)
+                            .removeAttr('title')
+                            .removeAttr('data-i18n');
+                    }
+                })
                 .off('click')
                 .on('click', async (event) => {
                     event.preventDefault();

--- a/public/script.js
+++ b/public/script.js
@@ -8946,21 +8946,6 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
 }
 
 /**
- * Builds a compact label for the swipe picker.
- * @param {string} text Swipe text
- * @param {number} index Swipe index
- * @param {number} currentSwipeId Currently selected swipe index
- * @returns {string}
- */
-function formatSwipePickerOption(text, index, currentSwipeId) {
-    const normalizedText = String(text ?? '').replace(/\s+/g, ' ').trim();
-    const preview = normalizedText.length > 80 ? `${normalizedText.slice(0, 80).trimEnd()}...` : normalizedText;
-    const label = preview || t`(empty swipe)`;
-    const currentLabel = index === currentSwipeId ? ` ${t`[Current]`}` : '';
-    return `#${index + 1}${currentLabel} ${label}`;
-}
-
-/**
  * Opens a popup for jumping to a specific swipe on the last message.
  * @param {number} messageId
  * @returns {Promise<void>}
@@ -8979,27 +8964,33 @@ async function openSwipePicker(messageId) {
     }
 
     let selectedSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
+    const swipeIdInputId = `swipe_picker_id_${messageId}`;
     const wrapper = document.createElement('div');
-    wrapper.classList.add('flex-container', 'flexFlowColumn', 'flexNoGap', 'wide100p', 'flex1');
+    wrapper.classList.add('flex-container', 'flexFlowColumn', 'flexNoGap', 'wide100p', 'flex1', 'height100p', 'overflowHidden');
 
-    const description = document.createElement('div');
-    description.classList.add('m-b-1');
-    description.textContent = t`Select which swipe to show for the latest message.`;
-    wrapper.appendChild(description);
+    const header = document.createElement('div');
+    header.classList.add('swipe_picker_header', 'flex-container', 'alignItemsCenter', 'justifySpaceBetween', 'gap10px');
 
-    const searchInput = document.createElement('input');
-    searchInput.type = 'search';
-    searchInput.classList.add('text_pole', 'wide100p');
-    searchInput.placeholder = t`Search...`;
-    searchInput.autocomplete = 'off';
-    wrapper.appendChild(searchInput);
+    const description = document.createElement('h3');
+    description.classList.add('margin0', 'justifyLeft');
+    description.textContent = t`Swipe Selection`;
+    header.appendChild(description);
+    wrapper.appendChild(header);
 
     const listContainer = document.createElement('div');
-    listContainer.classList.add('swipe_picker_div', 'flex1');
+    listContainer.classList.add('swipe_picker_div', 'flex1', 'marginTop10');
     wrapper.appendChild(listContainer);
 
     /** @type {Popup} */
     let popup;
+    /** @type {HTMLInputElement} */
+    let swipeIdInput;
+
+    function syncSwipeIdInput() {
+        if (swipeIdInput) {
+            swipeIdInput.value = String(selectedSwipeId + 1);
+        }
+    }
 
     function setSelectedSwipe(nextSwipeId) {
         selectedSwipeId = clamp(Number(nextSwipeId), 0, message.swipes.length - 1);
@@ -9011,19 +9002,14 @@ async function openSwipePicker(messageId) {
                 element.removeAttribute('highlight');
             }
         });
+        syncSwipeIdInput();
     }
 
-    function renderSwipeList(searchQuery = '') {
-        const normalizedQuery = String(searchQuery ?? '').trim().toLowerCase();
+    function renderSwipeList() {
         const swipeBlocks = [];
 
         for (let index = 0; index < message.swipes.length; index++) {
             const swipeText = String(message.swipes[index] ?? '');
-            const swipeLabel = formatSwipePickerOption(swipeText, index, Number(message.swipe_id ?? 0));
-            if (normalizedQuery && !swipeLabel.toLowerCase().includes(normalizedQuery)) {
-                continue;
-            }
-
             const template = $('#past_chat_template .select_chat_block_wrapper').clone();
             const block = template.find('.select_chat_block');
             block.removeClass('select_chat_block').addClass('swipe_picker_block');
@@ -9059,25 +9045,88 @@ async function openSwipePicker(messageId) {
         if (swipeBlocks.length === 0) {
             const empty = document.createElement('div');
             empty.classList.add('textAlignCenter', 'opacity50p', 'padding10');
-            empty.textContent = t`No swipes match your search.`;
+            empty.textContent = t`No swipes available.`;
             listContainer.replaceChildren(empty);
         }
     }
 
-    searchInput.addEventListener('input', function () {
-        renderSwipeList(this.value);
-    });
-
     popup = new Popup(wrapper, POPUP_TYPE.CONFIRM, '', {
         okButton: t`Go`,
-        cancelButton: t`Cancel`,
+        cancelButton: false,
+        customInputs: [{
+            id: swipeIdInputId,
+            label: t`Swipe ID`,
+            type: 'text',
+            defaultState: String(selectedSwipeId + 1),
+            tooltip: `1-${message.swipes.length}`,
+        }],
         wider: true,
         large: true,
         allowVerticalScrolling: true,
-        onOpen: function () {
-            searchInput.focus();
-            searchInput.select();
+        onOpen: function (popup) {
             renderSwipeList();
+            popup.closeButton.style.display = 'block';
+            popup.closeButton.classList.add('opacity50p', 'hoverglow', 'fontsize120p');
+            popup.closeButton.style.position = 'static';
+            popup.closeButton.style.top = 'auto';
+            popup.closeButton.style.right = 'auto';
+            popup.closeButton.style.width = 'auto';
+            popup.closeButton.style.height = 'auto';
+            popup.closeButton.style.padding = '0';
+            popup.closeButton.style.filter = 'none';
+            header.appendChild(popup.closeButton);
+            swipeIdInput = popup.dlg.querySelector(`#${swipeIdInputId}`);
+            const swipeIdLabel = popup.dlg.querySelector(`label[for="${swipeIdInputId}"]`);
+
+            if (swipeIdLabel instanceof HTMLLabelElement) {
+                swipeIdLabel.classList.add('flex-container', 'alignItemsCenter', 'justifyCenter', 'gap10px', 'margin0');
+                popup.buttonControls.insertBefore(swipeIdLabel, popup.okButton);
+                popup.inputControls.style.display = 'none';
+            }
+
+            if (swipeIdInput instanceof HTMLInputElement) {
+                swipeIdInput.type = 'number';
+                swipeIdInput.min = '1';
+                swipeIdInput.max = String(message.swipes.length);
+                swipeIdInput.step = '1';
+                swipeIdInput.inputMode = 'numeric';
+                swipeIdInput.classList.add('flex1', 'width100px', 'textAlignCenter');
+                syncSwipeIdInput();
+
+                swipeIdInput.addEventListener('input', function () {
+                    const nextSwipeId = Number.parseInt(this.value, 10);
+                    if (!Number.isInteger(nextSwipeId) || nextSwipeId < 1 || nextSwipeId > message.swipes.length) {
+                        return;
+                    }
+
+                    setSelectedSwipe(nextSwipeId - 1);
+                    listContainer.querySelector(`.swipe_picker_block[data-swipe-id="${selectedSwipeId}"]`)?.scrollIntoView({ block: 'nearest' });
+                });
+
+                swipeIdInput.addEventListener('blur', function () {
+                    syncSwipeIdInput();
+                });
+            }
+        },
+        onClosing: function (popup) {
+            if (popup.result !== POPUP_RESULT.AFFIRMATIVE) {
+                return true;
+            }
+
+            const swipeIdInput = popup.dlg.querySelector(`#${swipeIdInputId}`);
+            const targetSwipeNumber = Number.parseInt(String(swipeIdInput instanceof HTMLInputElement ? swipeIdInput.value : '').trim(), 10);
+
+            if (!Number.isInteger(targetSwipeNumber) || targetSwipeNumber < 1 || targetSwipeNumber > message.swipes.length) {
+                toastr.warning(t`Enter a swipe ID between 1 and ${message.swipes.length}.`, t`Jump to Swipe`);
+                if (swipeIdInput instanceof HTMLInputElement) {
+                    swipeIdInput.focus();
+                    swipeIdInput.select();
+                }
+                return false;
+            }
+
+            setSelectedSwipe(targetSwipeNumber - 1);
+            return true;
         },
     });
 

--- a/public/script.js
+++ b/public/script.js
@@ -9019,6 +9019,7 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
         .prop('hidden', false)
         .toggleClass('swipe-picker-enabled', canOpenSwipePicker)
         .toggleClass(INTERACTABLE_CONTROL_CLASS, canOpenSwipePicker)
+        .attr('aria-role', canOpenSwipePicker ? 'button' : null)
         .attr('title', canJumpToSwipe ? t`Click to jump to a swipe` : canOpenSwipePicker ? t`Click to view swipe history` : null);
     swipePickerButton.toggle(canOpenSwipePicker);
 

--- a/public/script.js
+++ b/public/script.js
@@ -8940,17 +8940,13 @@ export async function updateSwipeCounter(mesId, { message = undefined, messageEl
     swipeCounter
         .text(swipeCounterText)
         .prop('hidden', false)
-        .toggleClass('swipe-picker-enabled', canJumpToSwipe);
+        .toggleClass('swipe-picker-enabled', canJumpToSwipe)
+        .toggleClass(INTERACTABLE_CONTROL_CLASS, canJumpToSwipe)
+        .attr('title', canJumpToSwipe ? t`Click to jump to a swipe` : null);
     swipePickerButton.toggle(canOpenSwipePicker);
 
-    if (canJumpToSwipe) {
-        swipeCounter.attr({
-            tabindex: '0',
-            role: 'button',
-            title: t`Click to jump to a swipe`,
-        });
-    } else {
-        swipeCounter.removeAttr('tabindex role title');
+    if (!canJumpToSwipe) {
+        swipeCounter.removeAttr('tabindex');
     }
 }
 
@@ -11181,7 +11177,7 @@ jQuery(async function () {
         await openSwipePicker(mesId);
     });
     $(document).on('keydown', '.last_mes .swipes-counter.swipe-picker-enabled', async function (e) {
-        if (e.key !== 'Enter' && e.key !== ' ') {
+        if (e.key !== ' ') {
             return;
         }
 

--- a/public/script.js
+++ b/public/script.js
@@ -9044,6 +9044,52 @@ async function openSwipePicker(messageId) {
         syncSwipeIdInput();
     }
 
+    function canDeleteSwipeFromPicker(swipeId) {
+        if ((message?.swipes?.length ?? 0) <= 1) {
+            return false;
+        }
+
+        const currentSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
+        return canJumpToSwipe || swipeId !== currentSwipeId;
+    }
+
+    async function deleteSwipeFromPicker(swipeId) {
+        if (!canDeleteSwipeFromPicker(swipeId)) {
+            toastr.info(t`Cannot delete the currently displayed swipe on a historical message.`, t`Delete Swipe`);
+            return;
+        }
+
+        const nextSelectedSwipeId = swipeId < selectedSwipeId
+            ? selectedSwipeId - 1
+            : swipeId > selectedSwipeId
+                ? selectedSwipeId
+                : Math.min(selectedSwipeId, message.swipes.length - 2);
+
+        if (power_user.confirm_message_delete) {
+            const result = await callGenericPopup(t`Are you sure you want to delete swipe #${swipeId + 1}?`, POPUP_TYPE.CONFIRM, null, {
+                okButton: t`Delete Swipe`,
+                cancelButton: t`Cancel`,
+            });
+
+            if (result !== POPUP_RESULT.AFFIRMATIVE) {
+                return;
+            }
+        }
+
+        const newSwipeId = await deleteSwipe(swipeId, messageId);
+        if (!Number.isInteger(newSwipeId)) {
+            return;
+        }
+
+        selectedSwipeId = clamp(nextSelectedSwipeId, 0, message.swipes.length - 1);
+
+        if (swipeIdInput instanceof HTMLInputElement) {
+            swipeIdInput.max = String(message.swipes.length);
+        }
+
+        await renderSwipeList();
+    }
+
     async function renderSwipeList() {
         const swipeBlocks = [];
 
@@ -9053,17 +9099,19 @@ async function openSwipePicker(messageId) {
             const block = template.find('.select_chat_block');
             block.removeClass('select_chat_block').addClass('swipe_picker_block');
             const branchButton = template.find('.exportRawChatButton');
+            const deleteButton = template.find('.PastChat_cross');
             const swipeInfo = Array.isArray(message.swipe_info) ? message.swipe_info[index] : null;
             const sendDate = swipeInfo?.send_date ? timestampToMoment(swipeInfo.send_date).format('lll') : '';
             const previewText = swipeText.replace(/\s+/g, ' ').trim();
             const tokenCount = swipeInfo?.extra?.token_count ?? await getTokenCountAsync(swipeText, 0);
+            const canDeleteSwipe = canDeleteSwipeFromPicker(index);
 
             block.attr({
                 file_name: `swipe-${index + 1}`,
                 'data-swipe-id': index,
             });
 
-            template.find('.renameChatButton, .exportChatButton, .PastChat_cross').remove();
+            template.find('.renameChatButton, .exportChatButton').remove();
             branchButton
                 .removeAttr('data-format')
                 .attr({
@@ -9078,6 +9126,23 @@ async function openSwipePicker(messageId) {
                     setSelectedSwipe(index);
                     branchActionSwipeId = index;
                     await popup.completeCancelled();
+                });
+            deleteButton
+                .removeAttr('file_name')
+                .attr('title', canDeleteSwipe ? t`Delete Swipe` : t`Cannot delete the currently displayed swipe on historical messages`)
+                .removeClass('fa-skull')
+                .addClass('swipe_picker_delete fa-trash-can')
+                .toggleClass('disabled', !canDeleteSwipe)
+                .off('click')
+                .on('click', async (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+
+                    if (!canDeleteSwipe) {
+                        return;
+                    }
+
+                    await deleteSwipeFromPicker(index);
                 });
             template.find('.select_chat_block_filename').text(`#${index + 1}${index === Number(message.swipe_id ?? 0) ? ` ${t`[Current]`}` : ''}`);
             template.find('.chat_messages_date').text(sendDate);
@@ -9151,6 +9216,8 @@ async function openSwipePicker(messageId) {
                 swipeIdInput.inputMode = 'numeric';
                 swipeIdInput.classList.add('flex1', 'width100px', 'textAlignCenter');
                 syncSwipeIdInput();
+                swipeIdInput.focus();
+                swipeIdInput.select();
 
                 swipeIdInput.addEventListener('input', function () {
                     const nextSwipeId = Number.parseInt(this.value, 10);
@@ -9394,9 +9461,12 @@ export function hideSwipeButtons({ hideCounters = false } = {}) {
  * @returns {Promise<number>|undefined} - The ID of the new swipe after deletion.
  */
 export async function deleteSwipe(swipeId = null, messageId = chat.length - 1) {
-    if (swipeId && (isNaN(swipeId) || swipeId < 0)) {
-        toastr.warning(t`Invalid swipe ID: ${swipeId + 1}`);
-        return;
+    if (swipeId != null) {
+        swipeId = Number(swipeId);
+        if (!Number.isInteger(swipeId) || swipeId < 0) {
+            toastr.warning(t`Invalid swipe ID.`);
+            return;
+        }
     }
 
     const message = chat[messageId];
@@ -9410,7 +9480,8 @@ export async function deleteSwipe(swipeId = null, messageId = chat.length - 1) {
         return;
     }
 
-    swipeId = swipeId ?? message.swipe_id;
+    swipeId = Number(swipeId ?? message.swipe_id);
+    const currentSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
 
     if (swipeId < 0 || swipeId >= message.swipes.length) {
         toastr.warning(t`Invalid swipe ID: ${swipeId + 1}`);
@@ -9423,17 +9494,34 @@ export async function deleteSwipe(swipeId = null, messageId = chat.length - 1) {
         message.swipe_info.splice(swipeId, 1);
     }
 
-    // Select the next swipe, or the one before if it was the last one
-    const newSwipeId = Math.min(swipeId, message.swipes.length - 1);
+    let newSwipeId;
+    if (swipeId < currentSwipeId) {
+        newSwipeId = currentSwipeId - 1;
+    } else if (swipeId > currentSwipeId) {
+        newSwipeId = currentSwipeId;
+    } else {
+        // Select the next swipe, or the one before if it was the last one.
+        newSwipeId = Math.min(swipeId, message.swipes.length - 1);
+    }
 
     chat_metadata.tainted = true;
 
     messageId = Number(messageId);
     swipeId = Number(swipeId);
+    message.swipe_id = newSwipeId;
     await eventSource.emit(event_types.MESSAGE_SWIPE_DELETED, { messageId, swipeId, newSwipeId });
-    let direction = (swipeId <= newSwipeId) ? SWIPE_DIRECTION.RIGHT : SWIPE_DIRECTION.LEFT;
-    //Animate swipe and swap dispayed message.
-    await swipe(null, direction, { source: SWIPE_SOURCE.DELETE, repeated: false, forceMesId: messageId, forceSwipeId: newSwipeId });
+
+    if (swipeId === currentSwipeId) {
+        const direction = (swipeId <= newSwipeId) ? SWIPE_DIRECTION.RIGHT : SWIPE_DIRECTION.LEFT;
+        // Animate swipe and swap displayed message when the currently visible swipe was deleted.
+        await swipe(null, direction, { source: SWIPE_SOURCE.DELETE, repeated: false, forceMesId: messageId, forceSwipeId: newSwipeId });
+    } else {
+        await updateSwipeCounter(messageId);
+        if (messageId !== chat.length - 1) {
+            await updateSwipeCounter(chat.length - 1);
+        }
+        saveChatDebounced();
+    }
 
     await saveChatConditional();
 

--- a/public/scripts/a11y.js
+++ b/public/scripts/a11y.js
@@ -3,6 +3,20 @@
  * Be careful what you import!
  */
 
+const MANAGED_ROLE_ATTRIBUTE = 'data-a11y-role';
+
+function setManagedRole(element, role) {
+    element.setAttribute('role', role);
+    element.setAttribute(MANAGED_ROLE_ATTRIBUTE, role);
+}
+
+function clearManagedRole(element) {
+    if (element.hasAttribute(MANAGED_ROLE_ATTRIBUTE)) {
+        element.removeAttribute('role');
+        element.removeAttribute(MANAGED_ROLE_ATTRIBUTE);
+    }
+}
+
 const buttonSelectors = [
     '.menu_button',
     '.right_menu_button',
@@ -14,6 +28,7 @@ const buttonSelectors = [
     '.character_select',
     '.tags .tag',
     '.jg-menu .jg-button',
+    '.swipes-counter.interactable',
     '.bg_example .mobile-only-menu-toggle',
     '.paginationjs-pages li a',
 ].join(', ');
@@ -61,25 +76,25 @@ const tabItemSelectors = [
 /** @type {Record<string, (element: Element) => void>} */
 const a11yRules = {
     [buttonSelectors]: (element) => {
-        element.setAttribute('role', 'button');
+        setManagedRole(element, 'button');
     },
     [listSelectors]: (element) => {
-        element.setAttribute('role', 'list');
+        setManagedRole(element, 'list');
     },
     [listItemSelectors]: (element) => {
-        element.setAttribute('role', 'listitem');
+        setManagedRole(element, 'listitem');
     },
     [toolbarSelectors]: (element) => {
-        element.setAttribute('role', 'toolbar');
+        setManagedRole(element, 'toolbar');
     },
     [tabListSelectors]: (element) => {
-        element.setAttribute('role', 'tablist');
+        setManagedRole(element, 'tablist');
     },
     [tabItemSelectors]: (element) => {
-        element.setAttribute('role', 'tab');
+        setManagedRole(element, 'tab');
     },
     '#toast-container .toast': (element) => {
-        element.setAttribute('role', 'status');
+        setManagedRole(element, 'status');
     },
 };
 
@@ -89,6 +104,11 @@ const a11yRules = {
  */
 function applyA11yRules(element) {
     try {
+        if (element.hasAttribute(MANAGED_ROLE_ATTRIBUTE)) {
+            clearManagedRole(element);
+        }
+        element.querySelectorAll(`[${MANAGED_ROLE_ATTRIBUTE}]`).forEach(clearManagedRole);
+
         for (const [selector, rule] of Object.entries(a11yRules)) {
             // Apply if the element directly matches the selector
             if (element.matches(selector)) {
@@ -116,12 +136,17 @@ function setAccessibilityObserver() {
                     }
                 }
             }
+            if (mutation.type === 'attributes' && mutation.target instanceof Element) {
+                applyA11yRules(mutation.target);
+            }
         }
     });
 
     observer.observe(document.body, {
         childList: true,
         subtree: true,
+        attributes: true,
+        attributeFilter: ['class'],
     });
 }
 

--- a/public/scripts/a11y.js
+++ b/public/scripts/a11y.js
@@ -3,20 +3,6 @@
  * Be careful what you import!
  */
 
-const MANAGED_ROLE_ATTRIBUTE = 'data-a11y-role';
-
-function setManagedRole(element, role) {
-    element.setAttribute('role', role);
-    element.setAttribute(MANAGED_ROLE_ATTRIBUTE, role);
-}
-
-function clearManagedRole(element) {
-    if (element.hasAttribute(MANAGED_ROLE_ATTRIBUTE)) {
-        element.removeAttribute('role');
-        element.removeAttribute(MANAGED_ROLE_ATTRIBUTE);
-    }
-}
-
 const buttonSelectors = [
     '.menu_button',
     '.right_menu_button',
@@ -28,7 +14,6 @@ const buttonSelectors = [
     '.character_select',
     '.tags .tag',
     '.jg-menu .jg-button',
-    '.swipes-counter.interactable',
     '.bg_example .mobile-only-menu-toggle',
     '.paginationjs-pages li a',
 ].join(', ');
@@ -76,25 +61,25 @@ const tabItemSelectors = [
 /** @type {Record<string, (element: Element) => void>} */
 const a11yRules = {
     [buttonSelectors]: (element) => {
-        setManagedRole(element, 'button');
+        element.setAttribute('role', 'button');
     },
     [listSelectors]: (element) => {
-        setManagedRole(element, 'list');
+        element.setAttribute('role', 'list');
     },
     [listItemSelectors]: (element) => {
-        setManagedRole(element, 'listitem');
+        element.setAttribute('role', 'listitem');
     },
     [toolbarSelectors]: (element) => {
-        setManagedRole(element, 'toolbar');
+        element.setAttribute('role', 'toolbar');
     },
     [tabListSelectors]: (element) => {
-        setManagedRole(element, 'tablist');
+        element.setAttribute('role', 'tablist');
     },
     [tabItemSelectors]: (element) => {
-        setManagedRole(element, 'tab');
+        element.setAttribute('role', 'tab');
     },
     '#toast-container .toast': (element) => {
-        setManagedRole(element, 'status');
+        element.setAttribute('role', 'status');
     },
 };
 
@@ -104,11 +89,6 @@ const a11yRules = {
  */
 function applyA11yRules(element) {
     try {
-        if (element.hasAttribute(MANAGED_ROLE_ATTRIBUTE)) {
-            clearManagedRole(element);
-        }
-        element.querySelectorAll(`[${MANAGED_ROLE_ATTRIBUTE}]`).forEach(clearManagedRole);
-
         for (const [selector, rule] of Object.entries(a11yRules)) {
             // Apply if the element directly matches the selector
             if (element.matches(selector)) {
@@ -136,17 +116,12 @@ function setAccessibilityObserver() {
                     }
                 }
             }
-            if (mutation.type === 'attributes' && mutation.target instanceof Element) {
-                applyA11yRules(mutation.target);
-            }
         }
     });
 
     observer.observe(document.body, {
         childList: true,
         subtree: true,
-        attributes: true,
-        attributeFilter: ['class'],
     });
 }
 

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -2,6 +2,7 @@ import {
     characters,
     saveChat,
     system_message_types,
+    syncSwipeToMes,
     this_chid,
     openCharacterChat,
     chat_metadata,
@@ -162,45 +163,6 @@ async function saveBookmarkMenu() {
 }
 
 /**
- * Applies a swipe from the message snapshot back onto the top-level message fields.
- * @param {ChatMessage} message
- * @param {number} swipeId
- * @returns {boolean}
- */
-function applySwipeToSnapshot(message, swipeId) {
-    if (!message || !Array.isArray(message.swipes) || typeof message.swipes[swipeId] !== 'string') {
-        return false;
-    }
-
-    message.swipe_id = swipeId;
-    message.mes = message.swipes[swipeId];
-
-    const swipeInfo = Array.isArray(message.swipe_info) ? message.swipe_info[swipeId] : null;
-    if (!swipeInfo || typeof swipeInfo !== 'object') {
-        return true;
-    }
-
-    if ('send_date' in swipeInfo) {
-        message.send_date = swipeInfo.send_date;
-    }
-
-    if ('gen_started' in swipeInfo) {
-        message.gen_started = swipeInfo.gen_started;
-    } else {
-        delete message.gen_started;
-    }
-
-    if ('gen_finished' in swipeInfo) {
-        message.gen_finished = swipeInfo.gen_finished;
-    } else {
-        delete message.gen_finished;
-    }
-
-    message.extra = typeof swipeInfo.extra === 'object' && swipeInfo.extra !== null ? structuredClone(swipeInfo.extra) : {};
-    return true;
-}
-
-/**
  * Builds the branch chat snapshot, optionally selecting a specific swipe for the target message.
  * @param {number} mesId
  * @param {number|null} swipeId
@@ -213,7 +175,7 @@ function getBranchChatSnapshot(mesId, swipeId = null) {
         return snapshot;
     }
 
-    if (!applySwipeToSnapshot(snapshot[mesId], swipeId)) {
+    if (!syncSwipeToMes(null, swipeId, snapshot[mesId])) {
         return null;
     }
 

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -165,10 +165,10 @@ async function saveBookmarkMenu() {
 /**
  * Builds the branch chat snapshot, optionally selecting a specific swipe for the target message.
  * @param {number} mesId
- * @param {number|null} swipeId
+ * @param {{swipeId?: number|null}} [options={}]
  * @returns {ChatMessage[]|null}
  */
-function getBranchChatSnapshot(mesId, swipeId = null) {
+function getBranchChatSnapshot(mesId, { swipeId = null } = {}) {
     const snapshot = structuredClone(chat.slice(0, Number(mesId) + 1));
 
     if (swipeId === null) {
@@ -219,7 +219,7 @@ export async function createBranch(mesId, { swipeId = null } = {}) {
         return;
     }
 
-    const branchChatSnapshot = getBranchChatSnapshot(mesId, selectedSwipeId);
+    const branchChatSnapshot = getBranchChatSnapshot(mesId, { swipeId: selectedSwipeId });
     if (!branchChatSnapshot) {
         toastr.warning('Could not prepare the selected swipe for branching.', 'Branch creation failed');
         return;

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -161,8 +161,67 @@ async function saveBookmarkMenu() {
     return await createNewBookmark(chat.length - 1);
 }
 
+/**
+ * Applies a swipe from the message snapshot back onto the top-level message fields.
+ * @param {ChatMessage} message
+ * @param {number} swipeId
+ * @returns {boolean}
+ */
+function applySwipeToSnapshot(message, swipeId) {
+    if (!message || !Array.isArray(message.swipes) || typeof message.swipes[swipeId] !== 'string') {
+        return false;
+    }
+
+    message.swipe_id = swipeId;
+    message.mes = message.swipes[swipeId];
+
+    const swipeInfo = Array.isArray(message.swipe_info) ? message.swipe_info[swipeId] : null;
+    if (!swipeInfo || typeof swipeInfo !== 'object') {
+        return true;
+    }
+
+    if ('send_date' in swipeInfo) {
+        message.send_date = swipeInfo.send_date;
+    }
+
+    if ('gen_started' in swipeInfo) {
+        message.gen_started = swipeInfo.gen_started;
+    } else {
+        delete message.gen_started;
+    }
+
+    if ('gen_finished' in swipeInfo) {
+        message.gen_finished = swipeInfo.gen_finished;
+    } else {
+        delete message.gen_finished;
+    }
+
+    message.extra = typeof swipeInfo.extra === 'object' && swipeInfo.extra !== null ? structuredClone(swipeInfo.extra) : {};
+    return true;
+}
+
+/**
+ * Builds the branch chat snapshot, optionally selecting a specific swipe for the target message.
+ * @param {number} mesId
+ * @param {number|null} swipeId
+ * @returns {ChatMessage[]|null}
+ */
+function getBranchChatSnapshot(mesId, swipeId = null) {
+    const snapshot = structuredClone(chat.slice(0, Number(mesId) + 1));
+
+    if (swipeId === null) {
+        return snapshot;
+    }
+
+    if (!applySwipeToSnapshot(snapshot[mesId], swipeId)) {
+        return null;
+    }
+
+    return snapshot;
+}
+
 // Export is used by Timelines extension. Do not remove.
-export async function createBranch(mesId) {
+export async function createBranch(mesId, { swipeId = null } = {}) {
     if (!chat.length) {
         toastr.warning('The chat is empty.', 'Branch creation failed');
         return;
@@ -176,6 +235,12 @@ export async function createBranch(mesId) {
     const lastMes = chat[mesId];
     const mainChatName = (getCurrentChatDetails()).sessionName;
     const newMetadata = { main_chat: mainChatName };
+    const selectedSwipeId = swipeId === null ? null : Number(swipeId);
+
+    if (selectedSwipeId !== null && (!Number.isInteger(selectedSwipeId) || selectedSwipeId < 0 || selectedSwipeId >= (lastMes?.swipes?.length ?? 0))) {
+        toastr.warning('Invalid swipe ID.', 'Branch creation failed');
+        return;
+    }
 
     function buildBranchName(name, i) {
         // Strip off existing suffixes, then build new name
@@ -192,10 +257,16 @@ export async function createBranch(mesId) {
         return;
     }
 
+    const branchChatSnapshot = getBranchChatSnapshot(mesId, selectedSwipeId);
+    if (!branchChatSnapshot) {
+        toastr.warning('Could not prepare the selected swipe for branching.', 'Branch creation failed');
+        return;
+    }
+
     if (selected_group) {
-        await saveGroupBookmarkChat(selected_group, name, newMetadata, mesId);
+        await saveGroupBookmarkChat(selected_group, name, newMetadata, mesId, branchChatSnapshot);
     } else {
-        await saveChat({ chatName: name, withMetadata: newMetadata, mesId });
+        await saveChat({ chatName: name, withMetadata: newMetadata, mesId, chatData: branchChatSnapshot });
     }
     // append to branches list if it exists
     // otherwise create it
@@ -410,15 +481,20 @@ export async function convertSoloToGroupChat() {
 /**
  * Creates a new branch from the message with the given ID
  * @param {number} mesId Message ID
+ * @param {{swipeId?: number|null}} [options={}] Branch options
  * @returns {Promise<string?>} Branch file name
  */
-export async function branchChat(mesId) {
+export async function branchChat(mesId, { swipeId = null } = {}) {
     if (this_chid === undefined && !selected_group) {
         toastr.info('No character selected.', 'Create Branch');
         return null;
     }
 
-    const fileName = await createBranch(mesId);
+    const fileName = await createBranch(mesId, { swipeId });
+    if (!fileName) {
+        return null;
+    }
+
     await saveItemizedPrompts(fileName);
 
     if (selected_group) {

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -176,6 +176,7 @@ export const SWIPE_SOURCE = {
     BACK: 'back',
     AUTO_SWIPE: 'auto_swipe',
     SLASH_COMMAND: 'slash_command',
+    SWIPE_PICKER: 'swipe_picker',
 };
 
 /**

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -2352,9 +2352,10 @@ export async function importGroupChat(formData, { refresh = true } = {}) {
  * @param {string} name Name of the chat to save
  * @param {ChatMetadata?} metadata New metadata to save with the chat
  * @param {number|undefined} mesId Optional message ID to trim the chat up to
+ * @param {ChatMessage[]|undefined} chatData Optional chat snapshot to save instead of the current in-memory chat
  * @returns {Promise<void>} Promise that resolves when the group chat is saved
  */
-export async function saveGroupBookmarkChat(groupId, name, metadata, mesId) {
+export async function saveGroupBookmarkChat(groupId, name, metadata, mesId, chatData = undefined) {
     const group = groups.find(x => x.id === groupId);
 
     if (!group) {
@@ -2371,9 +2372,11 @@ export async function saveGroupBookmarkChat(groupId, name, metadata, mesId) {
     };
 
     /** @type {ChatMessage[]} */
-    const trimmedChat = (mesId !== undefined && mesId >= 0 && mesId < chat.length)
-        ? chat.slice(0, Number(mesId) + 1)
-        : chat;
+    const trimmedChat = Array.isArray(chatData)
+        ? chatData
+        : (mesId !== undefined && mesId >= 0 && mesId < chat.length)
+            ? chat.slice(0, Number(mesId) + 1)
+            : chat;
 
     await editGroup(groupId, true, false);
 

--- a/public/scripts/keyboard.js
+++ b/public/scripts/keyboard.js
@@ -8,6 +8,7 @@ const interactableSelectors = [
     '.inline-drawer-icon', // Buttons/icons inside the drawer menus
     '.paginationjs-pages li a', // Pagination buttons
     '.group_select, .character_select, .bogus_folder_select', // Cards to select char, group or folder in character list and other places
+    '.swipe_picker_block', // Swipe picker entries in the swipe history popup
     '.avatar-container', // Persona list blocks
     '.tag .tag_remove', // Remove button in removable tags
     '.bg_example', // Background elements in the background menu

--- a/public/scripts/keyboard.js
+++ b/public/scripts/keyboard.js
@@ -21,6 +21,11 @@ const interactableSelectors = [
     '.select2_choice_clickable+span.select2-container .select2-selection__choice__display', // select2 control elements if they are meant to be clickable
     '.avatar_load_preview', // Char display avatar selection
     '.bg_tabs_list .bg_tab_button', // Background tabs
+    '.select_chat_block', // The blocks to select a past chat in the past chats menu
+    '.select_chat_block .exportRawChatButton', // Export raw chat button in the past chats menu
+    '.select_chat_block .exportChatButton', // Export chat button in the past chats menu
+    '.select_chat_block .PastChat_cross', // Delete chat button in the past chats menu
+    '.select_chat_block .renameChatButton', // The button to rename a past chat in the past chats menu
 ];
 
 if (CSS.supports('selector(:has(*))')) {

--- a/public/scripts/swipe-picker.js
+++ b/public/scripts/swipe-picker.js
@@ -101,6 +101,22 @@ async function openSwipePicker(messageId) {
         syncSwipeIdInput();
     }
 
+    function scrollToSelectedSwipe() {
+        const swipeBlock = listContainer.querySelector(`.swipe_picker_block[data-swipe-id="${selectedSwipeId}"]`);
+        if (swipeBlock instanceof HTMLElement) {
+            const scrollParent = swipeBlock.closest('.swipe_picker_div');
+            if (scrollParent instanceof HTMLElement) {
+                const blockRect = swipeBlock.getBoundingClientRect();
+                const parentRect = scrollParent.getBoundingClientRect();
+                if (blockRect.top < parentRect.top) {
+                    scrollParent.scrollTop -= (parentRect.top - blockRect.top) + 5;
+                } else if (blockRect.bottom > parentRect.bottom) {
+                    scrollParent.scrollTop += (blockRect.bottom - parentRect.bottom) + 5;
+                }
+            }
+        }
+    }
+
     function canDeleteSwipeFromPicker(swipeId) {
         if ((message?.swipes?.length ?? 0) <= 1) {
             return false;
@@ -256,6 +272,7 @@ async function openSwipePicker(messageId) {
         wider: true,
         allowVerticalScrolling: true,
         onOpen: function () {
+            scrollToSelectedSwipe();
             if (swipeIdInput instanceof HTMLInputElement) {
                 swipeIdInput.focus();
                 swipeIdInput.select();
@@ -321,7 +338,7 @@ async function openSwipePicker(messageId) {
             }
 
             setSelectedSwipe(nextSwipeId - 1);
-            listContainer.querySelector(`.swipe_picker_block[data-swipe-id="${selectedSwipeId}"]`)?.scrollIntoView({ block: 'nearest' });
+            scrollToSelectedSwipe();
         });
 
         swipeIdInput.addEventListener('blur', function () {

--- a/public/scripts/swipe-picker.js
+++ b/public/scripts/swipe-picker.js
@@ -1,0 +1,386 @@
+import { branchChat } from './bookmarks.js';
+import { SWIPE_DIRECTION, SWIPE_SOURCE } from './constants.js';
+import { t } from './i18n.js';
+import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from './popup.js';
+import { power_user } from './power-user.js';
+import { getTokenCountAsync } from './tokenizers.js';
+import { clamp, timestampToMoment } from './utils.js';
+import { chat, deleteSwipe, ensureSwipes, isMessageSwipeable, isSwipingAllowed, swipe, syncMesToSwipe } from '/script.js';
+
+/**
+ * Returns whether a swipe picker can be opened for the message.
+ * Unlike message swiping, this supports historical AI messages for inspection and branching.
+ * @param {number} messageId
+ * @returns {boolean}
+ */
+export function canOpenSwipePickerForMessage(messageId) {
+    const message = chat[messageId];
+
+    if (!message) {
+        return false;
+    }
+
+    if (ensureSwipes(message)) {
+        syncMesToSwipe(messageId);
+    }
+
+    return Boolean(
+        message?.swipes?.length > 1 &&
+        !message?.is_user &&
+        !(message?.extra?.isSmallSys) &&
+        !(message?.extra?.swipeable === false),
+    );
+}
+
+/**
+ * Returns whether the picker can actively jump to a different swipe.
+ * Historical AI messages can open the picker, but only the currently swipeable message may jump.
+ * @param {number} messageId
+ * @returns {boolean}
+ */
+export function canJumpToSwipeForMessage(messageId) {
+    const message = chat[messageId];
+    return canOpenSwipePickerForMessage(messageId) && isSwipingAllowed() && isMessageSwipeable(messageId, message);
+}
+
+/**
+ * Opens a popup for viewing or jumping to a specific swipe on a message.
+ * @param {number} messageId
+ * @returns {Promise<void>}
+ */
+async function openSwipePicker(messageId) {
+    const message = chat[messageId];
+
+    if (!canOpenSwipePickerForMessage(messageId)) {
+        toastr.info(t`This message has no alternate swipes yet.`, t`Jump to Swipe`);
+        return;
+    }
+
+    const canJumpToSwipe = canJumpToSwipeForMessage(messageId);
+    let selectedSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
+    const swipeIdInputId = `swipe_picker_id_${messageId}`;
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('flex-container', 'flexFlowColumn', 'flexNoGap', 'wide100p', 'flex1', 'overflowHidden');
+
+    const header = document.createElement('div');
+    header.classList.add('swipe_picker_header', 'flex-container', 'alignItemsCenter', 'justifySpaceBetween', 'gap10px');
+
+    const description = document.createElement('h3');
+    description.classList.add('margin0', 'justifyLeft');
+    description.textContent = t`Swipe Selection`;
+    header.appendChild(description);
+    wrapper.appendChild(header);
+
+    const listContainer = document.createElement('div');
+    listContainer.classList.add('swipe_picker_div', 'flex1', 'marginTop10');
+    wrapper.appendChild(listContainer);
+
+    /** @type {Popup} */
+    let popup;
+    /** @type {HTMLInputElement} */
+    let swipeIdInput;
+    /** @type {number|null} */
+    let branchActionSwipeId = null;
+
+    function syncSwipeIdInput() {
+        if (swipeIdInput) {
+            swipeIdInput.value = String(selectedSwipeId + 1);
+        }
+    }
+
+    function setSelectedSwipe(nextSwipeId) {
+        selectedSwipeId = clamp(Number(nextSwipeId), 0, message.swipes.length - 1);
+        listContainer.querySelectorAll('.swipe_picker_block').forEach((element) => {
+            const isSelected = Number(element.getAttribute('data-swipe-id')) === selectedSwipeId;
+            if (isSelected) {
+                element.setAttribute('highlight', 'true');
+            } else {
+                element.removeAttribute('highlight');
+            }
+        });
+        syncSwipeIdInput();
+    }
+
+    function canDeleteSwipeFromPicker(swipeId) {
+        if ((message?.swipes?.length ?? 0) <= 1) {
+            return false;
+        }
+
+        const currentSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
+        return canJumpToSwipe || swipeId !== currentSwipeId;
+    }
+
+    async function renderSwipeList() {
+        const swipeBlocks = await Promise.all(message.swipes.map(async (swipe, index) => {
+            const swipeText = String(swipe ?? '');
+            const template = $('#past_chat_template .select_chat_block_wrapper').clone();
+            const block = template.find('.select_chat_block');
+            block.removeClass('select_chat_block').addClass('swipe_picker_block');
+            const branchButton = template.find('.exportRawChatButton');
+            const deleteButton = template.find('.PastChat_cross');
+            const swipeInfo = Array.isArray(message.swipe_info) ? message.swipe_info[index] : null;
+            const sendDate = swipeInfo?.send_date ? timestampToMoment(swipeInfo.send_date).format('lll') : '';
+            const previewText = swipeText.replace(/\s+/g, ' ').trim();
+            const tokenCount = swipeInfo?.extra?.token_count ?? await getTokenCountAsync(swipeText, 0);
+            const canDeleteSwipe = canDeleteSwipeFromPicker(index);
+            const swipeDetails = [];
+
+            if (previewText) {
+                swipeDetails.push(`${previewText.length} ${t`chars`}`);
+            }
+
+            if (tokenCount) {
+                swipeDetails.push(`${tokenCount}t`);
+            }
+
+            block.attr({
+                file_name: `swipe-${index + 1}`,
+                'data-swipe-id': index,
+            });
+
+            template.find('.renameChatButton, .exportChatButton').remove();
+            branchButton
+                .removeAttr('data-format')
+                .attr({
+                    title: t`Create Branch`,
+                    'data-i18n': '[title]Create Branch',
+                })
+                .removeClass('exportRawChatButton fa-solid fa-file-export')
+                .addClass('swipe_picker_branch mes_button fa-regular fa-code-branch')
+                .on('click', async (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    setSelectedSwipe(index);
+                    branchActionSwipeId = index;
+                    await popup.completeCancelled();
+                });
+            deleteButton
+                .removeAttr('file_name')
+                .attr('aria-disabled', String(!canDeleteSwipe))
+                .removeClass('fa-skull')
+                .addClass('swipe_picker_delete fa-trash-can')
+                .toggleClass('hoverglow', canDeleteSwipe)
+                .toggleClass('disabled', !canDeleteSwipe)
+                .each(function () {
+                    if (canDeleteSwipe) {
+                        $(this)
+                            .attr({
+                                title: t`Delete Swipe`,
+                                'data-i18n': '[title]Delete Swipe',
+                            });
+                    } else {
+                        $(this)
+                            .removeAttr('title')
+                            .removeAttr('data-i18n');
+                    }
+                })
+                .off('click')
+                .on('click', async (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+
+                    if (!canDeleteSwipe) {
+                        return;
+                    }
+
+                    const nextSelectedSwipeId = index < selectedSwipeId
+                        ? selectedSwipeId - 1
+                        : index > selectedSwipeId
+                            ? selectedSwipeId
+                            : Math.min(selectedSwipeId, message.swipes.length - 2);
+
+                    if (power_user.confirm_message_delete) {
+                        const result = await callGenericPopup(t`Are you sure you want to delete swipe #${index + 1}?`, POPUP_TYPE.CONFIRM, null, {
+                            okButton: t`Delete Swipe`,
+                            cancelButton: t`Cancel`,
+                        });
+
+                        if (result !== POPUP_RESULT.AFFIRMATIVE) {
+                            return;
+                        }
+                    }
+
+                    const newSwipeId = await deleteSwipe(index, messageId);
+                    if (!Number.isInteger(newSwipeId)) {
+                        return;
+                    }
+
+                    selectedSwipeId = clamp(nextSelectedSwipeId, 0, message.swipes.length - 1);
+
+                    if (swipeIdInput instanceof HTMLInputElement) {
+                        swipeIdInput.max = String(message.swipes.length);
+                    }
+
+                    await renderSwipeList();
+                });
+            template.find('.select_chat_block_filename').text(`#${index + 1}${index === Number(message.swipe_id ?? 0) ? ` ${t`[Current]`}` : ''}`);
+            template.find('.chat_messages_date').text(sendDate);
+            template.find('.chat_file_size').text(swipeDetails.length ? `(${swipeDetails[0]}${swipeDetails.length > 1 ? ',' : ')'}` : '');
+            template.find('.chat_messages_num').text(swipeDetails.length > 1 ? `${swipeDetails.slice(1).join(', ')})` : '');
+            template.find('.select_chat_block_mes').text(previewText || t`(empty swipe)`);
+
+            block.on('click', () => setSelectedSwipe(index));
+            block.on('dblclick', async () => {
+                if (!canJumpToSwipe) {
+                    return;
+                }
+
+                setSelectedSwipe(index);
+                await popup.completeAffirmative();
+            });
+
+            return template[0];
+        }));
+
+        listContainer.replaceChildren(...swipeBlocks);
+        setSelectedSwipe(selectedSwipeId);
+
+        if (swipeBlocks.length === 0) {
+            const empty = document.createElement('div');
+            empty.classList.add('textAlignCenter', 'opacity50p', 'padding10');
+            empty.textContent = t`No swipes available.`;
+            listContainer.replaceChildren(empty);
+        }
+    }
+
+    popup = new Popup(wrapper, POPUP_TYPE.CONFIRM, '', {
+        okButton: canJumpToSwipe ? t`Go` : false,
+        cancelButton: false,
+        customInputs: [{
+            id: swipeIdInputId,
+            label: t`Swipe ID`,
+            type: 'text',
+            defaultState: String(selectedSwipeId + 1),
+            tooltip: `1-${message.swipes.length}`,
+        }],
+        wider: true,
+        allowVerticalScrolling: true,
+        onOpen: function () {
+            if (swipeIdInput instanceof HTMLInputElement) {
+                swipeIdInput.focus();
+                swipeIdInput.select();
+            }
+        },
+        onClosing: function (popup) {
+            if (popup.result !== POPUP_RESULT.AFFIRMATIVE) {
+                return true;
+            }
+
+            const swipeIdInput = popup.dlg.querySelector(`#${swipeIdInputId}`);
+            const targetSwipeNumber = Number.parseInt(String(swipeIdInput instanceof HTMLInputElement ? swipeIdInput.value : '').trim(), 10);
+
+            if (!Number.isInteger(targetSwipeNumber) || targetSwipeNumber < 1 || targetSwipeNumber > message.swipes.length) {
+                toastr.warning(t`Enter a swipe ID between 1 and ${message.swipes.length}.`, t`Jump to Swipe`);
+                if (swipeIdInput instanceof HTMLInputElement) {
+                    swipeIdInput.focus();
+                    swipeIdInput.select();
+                }
+                return false;
+            }
+
+            setSelectedSwipe(targetSwipeNumber - 1);
+            return true;
+        },
+    });
+
+    popup.dlg.classList.add('swipe_picker_popup');
+    popup.closeButton.style.display = 'block';
+    popup.closeButton.classList.add('opacity50p', 'hoverglow', 'fontsize120p');
+    popup.closeButton.style.position = 'static';
+    popup.closeButton.style.top = 'auto';
+    popup.closeButton.style.right = 'auto';
+    popup.closeButton.style.width = 'auto';
+    popup.closeButton.style.height = 'auto';
+    popup.closeButton.style.padding = '0';
+    popup.closeButton.style.filter = 'none';
+    header.appendChild(popup.closeButton);
+
+    swipeIdInput = popup.dlg.querySelector(`#${swipeIdInputId}`);
+    const swipeIdLabel = popup.dlg.querySelector(`label[for="${swipeIdInputId}"]`);
+
+    if (swipeIdLabel instanceof HTMLLabelElement) {
+        swipeIdLabel.classList.add('flex-container', 'alignItemsCenter', 'justifyCenter', 'gap10px', 'margin0');
+        popup.buttonControls.insertBefore(swipeIdLabel, canJumpToSwipe ? popup.okButton : popup.buttonControls.firstChild);
+        popup.inputControls.style.display = 'none';
+    }
+
+    if (swipeIdInput instanceof HTMLInputElement) {
+        swipeIdInput.type = 'number';
+        swipeIdInput.min = '1';
+        swipeIdInput.max = String(message.swipes.length);
+        swipeIdInput.step = '1';
+        swipeIdInput.inputMode = 'numeric';
+        swipeIdInput.classList.add('flex1', 'width100px', 'textAlignCenter');
+        swipeIdInput.setAttribute('autofocus', '');
+        syncSwipeIdInput();
+
+        swipeIdInput.addEventListener('input', function () {
+            const nextSwipeId = Number.parseInt(this.value, 10);
+            if (!Number.isInteger(nextSwipeId) || nextSwipeId < 1 || nextSwipeId > message.swipes.length) {
+                return;
+            }
+
+            setSelectedSwipe(nextSwipeId - 1);
+            listContainer.querySelector(`.swipe_picker_block[data-swipe-id="${selectedSwipeId}"]`)?.scrollIntoView({ block: 'nearest' });
+        });
+
+        swipeIdInput.addEventListener('blur', function () {
+            syncSwipeIdInput();
+        });
+    }
+
+    await renderSwipeList();
+
+    const popupResult = await popup.show();
+
+    if (branchActionSwipeId !== null) {
+        await branchChat(messageId, { swipeId: branchActionSwipeId });
+        return;
+    }
+
+    if (popupResult !== POPUP_RESULT.AFFIRMATIVE) {
+        return;
+    }
+
+    if (!canJumpToSwipe) {
+        return;
+    }
+
+    const targetSwipeId = clamp(selectedSwipeId, 0, message.swipes.length - 1);
+    const currentSwipeId = clamp(Number(message.swipe_id ?? 0), 0, message.swipes.length - 1);
+
+    if (targetSwipeId === currentSwipeId) {
+        toastr.info(t`Already showing swipe #${targetSwipeId + 1}.`, t`Jump to Swipe`);
+        return;
+    }
+
+    const direction = targetSwipeId > currentSwipeId ? SWIPE_DIRECTION.RIGHT : SWIPE_DIRECTION.LEFT;
+    await swipe(null, direction, { source: SWIPE_SOURCE.SWIPE_PICKER, forceMesId: messageId, forceSwipeId: targetSwipeId });
+}
+
+export function initSwipePicker() {
+    $(document).on('click', '.swipes-counter.swipe-picker-enabled', async function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const mesId = Number($(this).closest('.mes').attr('mesid'));
+        await openSwipePicker(mesId);
+    });
+    $(document).on('keydown', '.swipes-counter.swipe-picker-enabled', async function (e) {
+        if (e.key !== ' ') {
+            return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+        const mesId = Number($(this).closest('.mes').attr('mesid'));
+        await openSwipePicker(mesId);
+    });
+    $(document).on('click', '.mes_swipe_picker', async function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const mesId = Number($(this).closest('.mes').attr('mesid'));
+        await openSwipePicker(mesId);
+    });
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1296,6 +1296,14 @@ body .panelControlBar {
     border-bottom: 1px solid var(--SmartThemeBorderColor);
 }
 
+.swipe_picker_popup .popup-body,
+.swipe_picker_popup .popup-content {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+}
+
 
 body.swipeAllMessages .mes:not(.last_mes) .swipes-counter {
     /* Avoid expensive DOM queries */

--- a/public/style.css
+++ b/public/style.css
@@ -4828,6 +4828,11 @@ h5 {
     animation: infinite-spinning 1s ease-out 0s infinite normal;
 }
 
+.swipe_picker_delete.disabled {
+    cursor: not-allowed;
+    opacity: 0.2;
+}
+
 #export_character_div {
     display: grid;
     grid-template-columns: 340px auto;

--- a/public/style.css
+++ b/public/style.css
@@ -4829,8 +4829,17 @@ h5 {
 }
 
 .swipe_picker_delete.disabled {
-    cursor: not-allowed;
+    cursor: default !important;
     opacity: 0.2;
+}
+
+.swipe_picker_delete.disabled:hover {
+    cursor: default !important;
+    color: inherit;
+    filter: none;
+    -webkit-animation: none;
+    animation: none;
+    opacity: 0.2 !important;
 }
 
 #export_character_div {

--- a/public/style.css
+++ b/public/style.css
@@ -1291,9 +1291,7 @@ body .panelControlBar {
     position: sticky;
     top: 0;
     z-index: 1;
-    padding-bottom: 10px;
     background-color: var(--SmartThemeBlurTintColor);
-    border-bottom: 1px solid var(--SmartThemeBorderColor);
 }
 
 .swipe_picker_popup .popup-body,

--- a/public/style.css
+++ b/public/style.css
@@ -1287,12 +1287,13 @@ body .panelControlBar {
     opacity: 0.7;
 }
 
-.swipe_picker_div {
-    padding: 0;
-    margin-top: 10px;
-    min-height: 0;
-    height: 100%;
-    overflow-y: auto;
+.swipe_picker_header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding-bottom: 10px;
+    background-color: var(--SmartThemeBlurTintColor);
+    border-bottom: 1px solid var(--SmartThemeBorderColor);
 }
 
 
@@ -4738,13 +4739,15 @@ h5 {
     cursor: pointer;
 }
 
-#select_chat_div {
+#select_chat_div,
+.swipe_picker_div {
     padding: 0;
     height: 100%;
     overflow-y: auto;
 }
 
-#select_chat_div hr {
+#select_chat_div hr,
+.swipe_picker_div hr {
     margin: 0;
 }
 
@@ -4752,7 +4755,8 @@ h5 {
     cursor: pointer;
 }
 
-.select_chat_block {
+.select_chat_block,
+.swipe_picker_block {
     border-radius: 5px;
     margin-top: 5px;
     border: 1px solid var(--SmartThemeBorderColor);
@@ -4771,10 +4775,6 @@ h5 {
 
 .swipe_picker_block {
     cursor: pointer;
-    border-radius: 5px;
-    margin-top: 5px;
-    border: 1px solid var(--SmartThemeBorderColor);
-    padding: 5px 7px;
 }
 
 .select_chat_block .avatar {

--- a/public/style.css
+++ b/public/style.css
@@ -4783,6 +4783,8 @@ h5 {
 
 .swipe_picker_block {
     cursor: pointer;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .select_chat_block .avatar {
@@ -4821,7 +4823,7 @@ h5 {
 }
 
 
-.PastChat_cross:hover {
+.PastChat_cross:not(.disabled):hover {
     color: red;
     filter: drop-shadow(0 0 2px red);
     -webkit-animation: infinite-spinning 1s ease-out 0s infinite normal;

--- a/public/style.css
+++ b/public/style.css
@@ -1278,6 +1278,23 @@ body .panelControlBar {
     pointer-events: auto;
 }
 
+.swipes-counter.swipe-picker-enabled {
+    cursor: pointer;
+}
+
+.swipes-counter.swipe-picker-enabled:hover,
+.swipes-counter.swipe-picker-enabled:focus-visible {
+    opacity: 0.7;
+}
+
+.swipe_picker_div {
+    padding: 0;
+    margin-top: 10px;
+    min-height: 0;
+    height: 100%;
+    overflow-y: auto;
+}
+
 
 body.swipeAllMessages .mes:not(.last_mes) .swipes-counter {
     /* Avoid expensive DOM queries */
@@ -4742,12 +4759,22 @@ h5 {
     padding: 5px 7px;
 }
 
-.select_chat_block:hover {
+.select_chat_block:hover,
+.swipe_picker_block:hover {
     background-color: var(--white30a);
 }
 
-.select_chat_block[highlight] {
+.select_chat_block[highlight],
+.swipe_picker_block[highlight] {
     background-color: var(--cobalt30a);
+}
+
+.swipe_picker_block {
+    cursor: pointer;
+    border-radius: 5px;
+    margin-top: 5px;
+    border: 1px solid var(--SmartThemeBorderColor);
+    padding: 5px 7px;
 }
 
 .select_chat_block .avatar {

--- a/public/style.css
+++ b/public/style.css
@@ -1291,7 +1291,6 @@ body .panelControlBar {
     position: sticky;
     top: 0;
     z-index: 1;
-    background-color: var(--SmartThemeBlurTintColor);
 }
 
 .swipe_picker_popup .popup-body,


### PR DESCRIPTION
## About

This PR aims to optimize multi-swipe navigation within the Chat page of SillyTavern by introducing a UI similar to the chat file manager. This makes it easier for users to browse previous swipes and quickly jump to a specific one.

I added event listeners to the UI (roughly in the toolbar area) and the swipe indicator. Clicking these areas will now open the swipe navigator.

## How to Use

Click these areas to open the UI:

<img width="857" height="331" alt="image" src="https://github.com/user-attachments/assets/558a5700-364a-4300-a405-003c1a827d57" />

Select the entry you want to jump to, then click `Go` to navigate to the corresponding historical message.

<img width="683" height="857" alt="image" src="https://github.com/user-attachments/assets/7e67e443-5cf0-4857-9eaa-61316cb2aede" />

As shown in the image above.

<img width="952" height="88" alt="image" src="https://github.com/user-attachments/assets/94304ee5-02ad-4aa9-9269-9f4c1a15701c" />


---

video here：

[20260317_005754.webm](https://github.com/user-attachments/assets/3e513fc1-22d2-4813-981e-42a9f3d7288f)


## What did I change?

I extended swipe navigation directly in the frontend chat UI.

More specifically, I hooked into the existing refresh flow (`updateSwipeCounter()` and `refreshSwipeButtons()`) and added swipe picker visibility handling there. The picker entry is only shown when:

- the message is the last one,
- it is not a user message,
- and it has multiple swipes.

This avoids introducing a separate state source.

I also implemented `openSwipePicker(messageId)`, reusing the existing `Popup` component and the current `swipe(..., { forceMesId, forceSwipeId })` flow. The picker builds a swipe history list from the current message's `swipes` and `swipe_info`.

Each item shows:

- swipe index,
- timestamp,
- preview text,
- and token information when available.

Selection still goes through the existing swipe pipeline, so there is no duplicated save logic, no separate rendering branch, and no extra animation handling.

For access, I added a new `mes_swipe_picker` button in the message action area and also made the latest message's swipe counter clickable through event delegation.

I intentionally did not reuse the chat file manager's behavioral class names. Instead, I introduced a separate `swipe_picker_block` class to avoid triggering the existing global `.select_chat_block` chat-switch listener.

Visually, the picker is aligned with the chat history manager by reusing shared list styling and common utility classes where possible, while keeping its behavior isolated.

The popup was further refined by:

- removing the default search field,
- pinning the `Swipe Selection` title at the top,
- adding a `Swipe ID` input next to the `Go` action for direct navigation,
- and replacing the bottom cancel action with a header-level close button styled to match the chat history manager.


## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
