### PR TITLE
Fix AICC direct link import parsing

### DIFF
--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -589,7 +589,6 @@ function parseAICC(url) {
             const urlObj = new URL(url);
             // Split the path and remove empty strings caused by trailing slashes
             const parts = urlObj.pathname.split('/').filter(Boolean);
-            
             if (parts.length >= 2) {
                 // Always grab the last two segments (author/character)
                 return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -585,7 +585,7 @@ async function downloadAICCCharacter(id) {
  */
 function parseAICC(url) {
     try {
-        if (url.startsWith('http')) {
+        if (isValidUrl(url)) {
             const urlObj = new URL(url);
             // Split the path and remove empty strings caused by trailing slashes
             const parts = urlObj.pathname.split('/').filter(Boolean);

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -584,11 +584,25 @@ async function downloadAICCCharacter(id) {
  * @returns {string | null} AICC path
  */
 function parseAICC(url) {
-    const pattern = /^https?:\/\/aicharactercards\.com\/character-cards\/([^/]+)\/([^/]+)\/?$|([^/]+)\/([^/]+)$/;
-    const match = url.match(pattern);
-    if (match) {
-        // Match group 1 & 2 for full URL, 3 & 4 for relative path
-        return match[1] && match[2] ? `${match[1]}/${match[2]}` : `${match[3]}/${match[4]}`;
+    try {
+        if (url.startsWith('http')) {
+            const urlObj = new URL(url);
+            // Split the path and remove empty strings caused by trailing slashes
+            const parts = urlObj.pathname.split('/').filter(Boolean);
+            
+            if (parts.length >= 2) {
+                // Always grab the last two segments (author/character)
+                return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+            }
+        } else {
+            // Fallback for relative paths or raw "author/character" strings
+            const parts = url.split('/').filter(Boolean);
+            if (parts.length >= 2) {
+                return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+            }
+        }
+    } catch (e) {
+        console.error('Error parsing AICC URL:', e);
     }
     return null;
 }


### PR DESCRIPTION
Update parseAICC in src/endpoints/content-manager.js to dynamically extract the author and character name from the end of the URL path. This resolves a 404 import error caused by AICC adding category subfolders and changing their base URL structure from /character-cards/ to /charactercards/.

Iteration Summary
• Fix the AICC direct link importer in content-manager.js to allow users to paste full URLs again.
– The UUID import (AICC/author/card) worked correctly because it skipped the URL parsing logic entirely.
– The Bug: The direct link import threw a 404 because the hardcoded regex in parseAICC couldn't handle the new category subfolders (/anime-manga/) or the changed base path.
– The Fix: Replaced the rigid regex with a dynamic path segment extractor using the standard URL object. It now always grabs the final two directories (author and card name) regardless of the preceding folder structure.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
