### PR TITLE
feat: add finalizeIntermediaryMessage for streaming tool call chains

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5253,6 +5253,13 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 const hasToolCalls = ToolManager.hasToolCalls(streamingProcessor.toolCalls);
                 const shouldDeleteMessage = type !== 'swipe' && ['', '...'].includes(lastMessage?.mes) && !lastMessage?.extra?.reasoning && ['', '...'].includes(streamingProcessor?.result);
                 hasToolCalls && shouldDeleteMessage && await deleteLastMessage();
+                // Finalize the streamed text message before tool invocation so that
+                // MESSAGE_RECEIVED and CHARACTER_MESSAGE_RENDERED fire for it.
+                // Without this, extensions (TTS, bridges, etc.) never learn about the
+                // text the AI produced before calling a tool.
+                if (!shouldDeleteMessage && streamingProcessor) {
+                    await streamingProcessor.onFinishStreaming(streamingProcessor.messageId, getMessage);
+                }
                 const invocationResult = await ToolManager.invokeFunctionTools(streamingProcessor.toolCalls, {
                     reasoningText: streamingProcessor.reasoningHandler.reasoning,
                 });


### PR DESCRIPTION
## Summary
When an AI response contains both text content and tool calls in streaming mode, `onFinishStreaming()` is never called for the text message. This causes `MESSAGE_RECEIVED` and `CHARACTER_MESSAGE_RENDERED` events to never fire, breaking all extensions that depend on these events (TTS, image forwarding, etc.).

## Changes
Added a new `finalizeIntermediaryMessage` method on `StreamingProcessor` that extracts the shared message-processing logic from `onFinishStreaming`. `onFinishStreaming` now calls `finalizeIntermediaryMessage` internally and adds only the finish-specific operations on top.

### `finalizeIntermediaryMessage` performs (shared with `onFinishStreaming`):
- Final render update (`onProgressStreaming`)
- Code block styling (`addCopyToCodeBlocks`)
- Reasoning handler finalization
- Swipes processing (no-op for intermediary messages since they have no swipes)
- Swipe sync (`syncMesToSwipe`)
- Logprobs saving
- Image attachment processing
- Reasoning signature storage
- `MESSAGE_RECEIVED` and `CHARACTER_MESSAGE_RENDERED` event emission

### `onFinishStreaming` adds on top:
- `markUIGenStopped` (UI unlock)
- `IMPERSONATE_READY` event
- `updateSwipeCounter`
- Auto-swipe logic
- `saveChatConditional`
- `playMessageSound`

## Why not just call `onFinishStreaming`?
As [noted by @Cohee1207](https://github.com/SillyTavern/SillyTavern/pull/5308#pullrequestreview-2782085981), `onFinishStreaming` is too heavy for intermediary messages — it unlocks UI, triggers auto-swipe, plays sounds, and saves the chat, none of which should happen mid-chain.

## Non-streaming path
The non-streaming path is not affected — `saveReply()` already emits `CHARACTER_MESSAGE_RENDERED` before the tool call block runs.

## Testing
- AI returning text + tool call (streaming) → `CHARACTER_MESSAGE_RENDERED` now fires for text message ✅
- AI returning only tool calls (no text, `shouldDeleteMessage=true`) → `finalizeIntermediaryMessage` not called, no change ✅
- AI returning only text (no tool calls) → normal `onFinishStreaming` path, no change ✅
- Non-streaming mode → not affected ✅

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
