### PR TITLE
Remove long deprecated STscript commands and parameters

### DIFF
--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1897,6 +1897,7 @@ function syncCallback() {
 function registerPersonaSlashCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'persona-lock',
+        aliases: ['lock'],
         callback: lockPersonaCallback,
         returns: 'The current lock state for the given type',
         helpString: 'Locks/unlocks a persona (name and avatar) to the current chat. Gets the current lock state for the given type if no state is provided.',
@@ -1917,43 +1918,6 @@ function registerPersonaSlashCommands() {
             SlashCommandArgument.fromProps({
                 description: 'state',
                 typeList: [ARGUMENT_TYPE.STRING],
-                enumProvider: commonEnumProviders.boolean('onOffToggle'),
-            }),
-        ],
-    }));
-    // TODO: Legacy command. Might be removed in the future and replaced by /persona-lock with aliases.
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'lock',
-        /** @type {(args: { type: string }, value: string) => Promise<string>} */
-        callback: (args, value) => {
-            if (!value) {
-                value = 'toggle';
-                toastr.warning(t`Using /lock without a provided state to toggle the persona is deprecated. Please use /persona-lock instead.
-                        In the future this command with no state provided will return the current state, instead of toggling it.`, t`Deprecation Warning`);
-            }
-            return lockPersonaCallback(args, value);
-        },
-        returns: 'The current lock state for the given type',
-        aliases: ['bind'],
-        helpString: 'Locks/unlocks a persona (name and avatar) to the current chat. Gets the current lock state for the given type if no state is provided.',
-        namedArgumentList: [
-            SlashCommandNamedArgument.fromProps({
-                name: 'type',
-                description: 'The type of the lock, where it should apply to',
-                typeList: [ARGUMENT_TYPE.STRING],
-                defaultValue: 'chat',
-                enumList: [
-                    new SlashCommandEnumValue('chat', 'Lock the persona to the current chat.'),
-                    new SlashCommandEnumValue('character', 'Lock this persona to the currently selected character. If the setting is enabled, multiple personas can be locked to the same character.'),
-                    new SlashCommandEnumValue('default', 'Lock this persona as the default persona for all new chats.'),
-                ],
-            }),
-        ],
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'state',
-                typeList: [ARGUMENT_TYPE.STRING],
-                defaultValue: 'toggle',
                 enumProvider: commonEnumProviders.boolean('onOffToggle'),
             }),
         ],

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1897,7 +1897,7 @@ function syncCallback() {
 function registerPersonaSlashCommands() {
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'persona-lock',
-        aliases: ['lock'],
+        aliases: ['lock', 'bind'],
         callback: lockPersonaCallback,
         returns: 'The current lock state for the given type',
         helpString: 'Locks/unlocks a persona (name and avatar) to the current chat. Gets the current lock state for the given type if no state is provided.',

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2530,19 +2530,6 @@ export function initDefaultSlashCommands() {
                 enumList: slashCommandReturnHelper.enumList({ allowPipe: false, allowObject: true, allowChat: true, allowPopup: true, allowTextVersion: false }),
                 forceEnum: true,
             }),
-            // TODO remove some day
-            SlashCommandNamedArgument.fromProps({
-                name: 'format',
-                description: t`!!! DEPRECATED - use "return" instead !!! output format`,
-                typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
-                forceEnum: true,
-                enumList: [
-                    new SlashCommandEnumValue('popup', t`Show injects in a popup.`, enumTypes.enum, enumIcons.default),
-                    new SlashCommandEnumValue('chat', t`Post a system message to the chat.`, enumTypes.enum, enumIcons.default),
-                    new SlashCommandEnumValue('none', t`Just return the injects as a JSON object.`, enumTypes.enum, enumIcons.default),
-                ],
-            }),
         ],
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
@@ -3400,27 +3387,6 @@ function injectCallback(args, value) {
 async function listInjectsCallback(args) {
     /** @type {import('./slash-commands/SlashCommandReturnHelper.js').SlashCommandReturnType} */
     let returnType = args.return;
-
-    // Old legacy return type handling
-    if (args.format) {
-        toastr.warning(t`Legacy argument 'format' with value '${args.format}' is deprecated. Please use 'return' instead. Routing to the correct return type...`, t`Deprecation warning`);
-        const type = String(args?.format).toLowerCase().trim();
-        if (!chat_metadata.script_injects || !Object.keys(chat_metadata.script_injects).length) {
-            type !== 'none' && toastr.info(t`No script injections for the current chat`);
-        }
-        switch (type) {
-            case 'none':
-                returnType = 'none';
-                break;
-            case 'chat':
-                returnType = 'chat-html';
-                break;
-            case 'popup':
-            default:
-                returnType = 'popup-html';
-                break;
-        }
-    }
 
     // Now the actual new return type handling
     const buildTextValue = (injects) => {

--- a/public/scripts/variables.js
+++ b/public/scripts/variables.js
@@ -264,24 +264,6 @@ async function listVariablesCallback(args) {
     /** @type {import('./slash-commands/SlashCommandReturnHelper.js').SlashCommandReturnType} */
     let returnType = args.return;
 
-    // Old legacy return type handling
-    if (args.format) {
-        toastr.warning(`Legacy argument 'format' with value '${args.format}' is deprecated. Please use 'return' instead. Routing to the correct return type...`, 'Deprecation warning');
-        const type = String(args?.format).toLowerCase().trim();
-        switch (type) {
-            case 'none':
-                returnType = 'none';
-                break;
-            case 'chat':
-                returnType = 'chat-html';
-                break;
-            case 'popup':
-            default:
-                returnType = 'popup-html';
-                break;
-        }
-    }
-
     // Now the actual new return type handling
     const scope = String(args?.scope || '').toLowerCase().trim() || 'all';
     if (!chat_metadata.variables) {
@@ -945,19 +927,6 @@ export function registerVariableCommands() {
                 defaultValue: 'popup-html',
                 enumList: slashCommandReturnHelper.enumList({ allowPipe: false, allowObject: true, allowChat: true, allowPopup: true, allowTextVersion: false }),
                 forceEnum: true,
-            }),
-            // TODO remove some day
-            SlashCommandNamedArgument.fromProps({
-                name: 'format',
-                description: '!!! DEPRECATED - use "return" instead !!! output format',
-                typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
-                forceEnum: true,
-                enumList: [
-                    new SlashCommandEnumValue('popup', 'Show variables in a popup.', enumTypes.enum, enumIcons.default),
-                    new SlashCommandEnumValue('chat', 'Post a system message to the chat.', enumTypes.enum, enumIcons.message),
-                    new SlashCommandEnumValue('none', 'Just return the variables as a JSON list.', enumTypes.enum, enumIcons.array),
-                ],
             }),
         ],
     }));


### PR DESCRIPTION
I think it finally might be time.

They were there long enough, writing toast warnings on every usage. Whoever is still using them....

I am no fan of adding `lock` as an alias, but it was promised, and I mean.. it's okay. Though the more specific name surely fits better.

## Copilot Summary
This pull request removes deprecated legacy support for certain slash command arguments and commands, streamlining the codebase and reducing user confusion. The changes focus on eliminating old argument handling and commands, encouraging users to adopt the updated interfaces.

**Slash command deprecations and cleanup:**

* Removed the legacy `/lock` slash command in favor of using `/persona-lock` with an added `lock` alias for backward compatibility. This simplifies persona locking and consolidates usage. [[1]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fR1900) [[2]](diffhunk://#diff-3cf63e6821a5df0916f0a868536171733a8498919780d8257cdb273eeeda031fL1924-L1960)

* Removed the deprecated `format` argument from both variable and injects slash commands, including its definition and all related legacy handling logic. Users should now use the `return` argument exclusively. [[1]](diffhunk://#diff-e1dcf705a52c8ae63659a818e085595c7c6d8115e28773d632ca70cfbdae36a7L2533-L2545) [[2]](diffhunk://#diff-e1dcf705a52c8ae63659a818e085595c7c6d8115e28773d632ca70cfbdae36a7L3404-L3424) [[3]](diffhunk://#diff-8e14da1ffc63c61cedc40b34451890ab90213d1aacc02b69cff60e4013a1df9bL267-L284) [[4]](diffhunk://#diff-8e14da1ffc63c61cedc40b34451890ab90213d1aacc02b69cff60e4013a1df9bL949-L961)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).