### PR TITLE
fix(openrouter): respect gemini.thoughtSignatures setting for message signatures

### DIFF
--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1425,7 +1425,9 @@ export function addOpenRouterSignatures(messages, model) {
             details.push(detail);
         };
         if (typeof message.signature === 'string') {
-            addDetail(message.signature);
+            if (enableThoughtSignatures) {
+                addDetail(message.signature);
+            }
             delete message.signature;
         }
         if (Array.isArray(message.tool_calls)) {


### PR DESCRIPTION
Description:

What is the reason for a change?

In PR #5025 , a `gemini.thoughtSignatures` setting was added to config.yaml to control whether thought signatures are sent back to the API. However, we noticed that this option is only respected when using the official Gemini API directly (via the `convertGooglePrompt` function in `src/prompt-converters.js`). When accessing Gemini through OpenRouter (via the `addOpenRouterSignatures` function), this setting is ignored, and signatures are always converted and sent.

This PR unifies the behavior across both endpoints by ensuring the `gemini.thoughtSignatures` setting is also respected in addOpenRouterSignatures.

What did you do to achieve this?
  - Modified addOpenRouterSignatures to check enableThoughtSignatures before converting and appending message.signature to reasoning_details.
  - Ensures that message.signature is still unconditionally deleted from the message object to prevent HTTP 400 schema validation errors with OpenAI-compatible endpoints.
  - Note: According to the official Gemini 3 documentation, thought signatures must be sent back during function calling/tool usage. Therefore, the logic for toolCall.signature remains unchanged and is intentionally unaffected by the enableThoughtSignatures setting.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
