### PR TITLE
feat: add SiliconFlow.cn chat completion and embedding support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3556,6 +3556,11 @@
                             <div data-for="api_key_siliconflow" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'.">
                                 For privacy reasons, your API key will be hidden after you click 'Connect'.
                             </div>
+                            <h4 data-i18n="SiliconFlow Endpoint">SiliconFlow Endpoint</h4>
+                            <select id="siliconflow_endpoint">
+                                <option value="global" data-i18n="Global (siliconflow.com)">Global (siliconflow.com)</option>
+                                <option value="cn" data-i18n="China (siliconflow.cn)">China (siliconflow.cn)</option>
+                            </select>
                             <h4>SiliconFlow Model</h4>
                             <select id="model_siliconflow_select">
                                 <option value="" data-i18n="-- Connect to the API --">-- Connect to the API --</option>

--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -591,7 +591,7 @@ export class ChatCompletionService {
         }
 
         // Ensure api-url is properly applied for all sources that accept it
-        ['custom_url', 'vertexai_region', 'zai_endpoint'].forEach(field => {
+        ['custom_url', 'vertexai_region', 'zai_endpoint', 'siliconflow_endpoint'].forEach(field => {
             // The order is: connection profile => CC preset => CC settings
             overridePayload[field] = overridePayload[field] || settings[field] || oai_settings[field];
         });

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -438,6 +438,7 @@ export class ConnectionManagerRequestService {
                         custom_url: profile['api-url'],
                         vertexai_region: profile['api-url'],
                         zai_endpoint: profile['api-url'],
+                        siliconflow_endpoint: profile['api-url'],
                         reverse_proxy: proxyPreset?.url,
                         proxy_password: proxyPreset?.password,
                         custom_prompt_post_processing: profile['prompt-post-processing'],

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -72,6 +72,7 @@ const settings = {
     google_model: 'text-embedding-005',
     chutes_model: 'chutes-qwen-qwen3-embedding-8b',
     nanogpt_model: 'text-embedding-3-small',
+    siliconflow_model: 'Qwen/Qwen3-Embedding-0.6B',
     summarize: false,
     summarize_sent: false,
     summary_source: 'main',
@@ -837,6 +838,10 @@ function getVectorsRequestBody(args = {}) {
         case 'nanogpt':
             body.model = extension_settings.vectors.nanogpt_model;
             break;
+        case 'siliconflow':
+            body.model = extension_settings.vectors.siliconflow_model;
+            body.siliconflow_endpoint = oai_settings.siliconflow_endpoint;
+            break;
         default:
             break;
     }
@@ -929,7 +934,8 @@ function throwIfSourceInvalid() {
         settings.source === 'mistral' && !secret_state[SECRET_KEYS.MISTRALAI] ||
         settings.source === 'togetherai' && !secret_state[SECRET_KEYS.TOGETHERAI] ||
         settings.source === 'nomicai' && !secret_state[SECRET_KEYS.NOMICAI] ||
-        settings.source === 'cohere' && !secret_state[SECRET_KEYS.COHERE]) {
+        settings.source === 'cohere' && !secret_state[SECRET_KEYS.COHERE] ||
+        settings.source === 'siliconflow' && !secret_state[SECRET_KEYS.SILICONFLOW]) {
         throw new Error('Vectors: API key missing', { cause: 'api_key_missing' });
     }
 
@@ -1147,6 +1153,7 @@ function toggleSettings() {
     $('#webllm_vectorsModel').toggle(settings.source === 'webllm');
     $('#koboldcpp_vectorsModel').toggle(settings.source === 'koboldcpp');
     $('#google_vectorsModel').toggle(settings.source === 'palm' || settings.source === 'vertexai');
+    $('#siliconflow_vectorsModel').toggle(settings.source === 'siliconflow');
     $('#vector_altEndpointUrl').toggle(vectorApiRequiresUrl.includes(settings.source));
     switch (settings.source) {
         case 'webllm':
@@ -1721,6 +1728,11 @@ jQuery(async () => {
     });
     $('#vectors_nanogpt_model').val(settings.nanogpt_model).on('change', () => {
         settings.nanogpt_model = String($('#vectors_nanogpt_model').val());
+        Object.assign(extension_settings.vectors, settings);
+        saveSettingsDebounced();
+    });
+    $('#vectors_siliconflow_model').val(settings.siliconflow_model).on('change', () => {
+        settings.siliconflow_model = String($('#vectors_siliconflow_model').val());
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -1171,6 +1171,9 @@ function toggleSettings() {
         case 'nanogpt':
             loadNanoGPTModels();
             break;
+        case 'siliconflow':
+            loadSiliconFlowModels();
+            break;
     }
 }
 
@@ -1317,6 +1320,45 @@ function populateOpenRouterModelSelect(models) {
         settings.openrouter_model = models[0].id;
     }
     $('#vectors_openrouter_model').val(settings.openrouter_model);
+}
+
+async function loadSiliconFlowModels() {
+    try {
+        const response = await fetch('/api/openai/siliconflow/models/embedding', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                siliconflow_endpoint: oai_settings.siliconflow_endpoint,
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+
+        /** @type {Array<any>} */
+        const data = await response.json();
+        const models = Array.isArray(data) ? data : [];
+        populateSiliconFlowModelSelect(models);
+    } catch (err) {
+        console.warn('SiliconFlow models fetch failed', err);
+        populateSiliconFlowModelSelect([]);
+    }
+}
+
+function populateSiliconFlowModelSelect(models) {
+    const select = $('#vectors_siliconflow_model');
+    select.empty();
+    for (const m of models) {
+        const option = document.createElement('option');
+        option.value = m.id;
+        option.text = m.id;
+        select.append(option);
+    }
+    if (!settings.siliconflow_model && models.length) {
+        settings.siliconflow_model = models[0].id;
+    }
+    $('#vectors_siliconflow_model').val(settings.siliconflow_model);
 }
 
 /**

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -199,18 +199,9 @@
                 <label for="vectors_siliconflow_model" data-i18n="Vectorization Model">
                     Vectorization Model
                 </label>
-                <select id="vectors_siliconflow_model" class="text_pole">
-                    <option value="Qwen/Qwen3-Embedding-0.6B">Qwen3-Embedding-0.6B (1024d, 32K)</option>
-                    <option value="Qwen/Qwen3-Embedding-4B">Qwen3-Embedding-4B (2048d, 32K)</option>
-                    <option value="Qwen/Qwen3-Embedding-8B">Qwen3-Embedding-8B (4096d, 32K)</option>
-                    <option value="BAAI/bge-m3">BAAI/bge-m3 (Multilingual, 1024d) (.cn)</option>
-                    <option value="Pro/BAAI/bge-m3">Pro/BAAI/bge-m3 (Pro Multilingual, 1024d) (.cn)</option>
-                    <option value="BAAI/bge-large-zh-v1.5">BAAI/bge-large-zh-v1.5 (Chinese, 1024d) (.cn)</option>
-                    <option value="BAAI/bge-large-en-v1.5">BAAI/bge-large-en-v1.5 (English, 1024d) (.cn)</option>
-                    <option value="netease-youdao/bce-embedding-base_v1">BCE Embedding Base v1 (768d) (.cn)</option>
-                </select>
-                <i data-i18n="Hint: Set your SiliconFlow API key in API Connections. Models marked (.cn) are only available on the China endpoint.">
-                    Hint: Set your SiliconFlow API key in API Connections. Models marked (.cn) are only available on the China endpoint.
+                <select id="vectors_siliconflow_model" class="text_pole"></select>
+                <i data-i18n="Hint: Set your SiliconFlow API key in API Connections.">
+                    Hint: Set your SiliconFlow API key in API Connections.
                 </i>
             </div>
 

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -25,6 +25,7 @@
                     <option value="ollama">Ollama</option>
                     <option value="openai">OpenAI</option>
                     <option value="openrouter">OpenRouter</option>
+                    <option value="siliconflow">SiliconFlow</option>
                     <option value="togetherai">TogetherAI</option>
                     <option value="vllm">vLLM</option>
                     <option value="webllm" data-i18n="WebLLM Extension">WebLLM Extension</option>
@@ -192,6 +193,24 @@
                 <select id="vectors_openrouter_model" class="text_pole"></select>
                 <i data-i18n="Hint: Set your OpenRouter API key in API Connections.">
                     Hint: Set your OpenRouter API key in API Connections.
+                </i>
+            </div>
+            <div class="flex-container flexFlowColumn" id="siliconflow_vectorsModel">
+                <label for="vectors_siliconflow_model" data-i18n="Vectorization Model">
+                    Vectorization Model
+                </label>
+                <select id="vectors_siliconflow_model" class="text_pole">
+                    <option value="Qwen/Qwen3-Embedding-0.6B">Qwen3-Embedding-0.6B (1024d, 32K)</option>
+                    <option value="Qwen/Qwen3-Embedding-4B">Qwen3-Embedding-4B (2048d, 32K)</option>
+                    <option value="Qwen/Qwen3-Embedding-8B">Qwen3-Embedding-8B (4096d, 32K)</option>
+                    <option value="BAAI/bge-m3">BAAI/bge-m3 (Multilingual, 1024d) (.cn)</option>
+                    <option value="Pro/BAAI/bge-m3">Pro/BAAI/bge-m3 (Pro Multilingual, 1024d) (.cn)</option>
+                    <option value="BAAI/bge-large-zh-v1.5">BAAI/bge-large-zh-v1.5 (Chinese, 1024d) (.cn)</option>
+                    <option value="BAAI/bge-large-en-v1.5">BAAI/bge-large-en-v1.5 (English, 1024d) (.cn)</option>
+                    <option value="netease-youdao/bce-embedding-base_v1">BCE Embedding Base v1 (768d) (.cn)</option>
+                </select>
+                <i data-i18n="Hint: Set your SiliconFlow API key in API Connections. Models marked (.cn) are only available on the China endpoint.">
+                    Hint: Set your SiliconFlow API key in API Connections. Models marked (.cn) are only available on the China endpoint.
                 </i>
             </div>
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -263,6 +263,11 @@ export const ZAI_ENDPOINT = {
     CODING: 'coding',
 };
 
+export const SILICONFLOW_ENDPOINT = {
+    GLOBAL: 'global',
+    CN: 'cn',
+};
+
 const sensitiveFields = [
     'reverse_proxy',
     'proxy_password',
@@ -310,6 +315,7 @@ export const settingsToUpdate = {
     chutes_model: ['#model_chutes_select', 'chutes_model', false, true],
     chutes_sort_models: ['#chutes_sort_models', 'chutes_sort_models', false, true],
     siliconflow_model: ['#model_siliconflow_select', 'siliconflow_model', false, true],
+    siliconflow_endpoint: ['#siliconflow_endpoint', 'siliconflow_endpoint', false, true],
     electronhub_model: ['#model_electronhub_select', 'electronhub_model', false, true],
     electronhub_sort_models: ['#electronhub_sort_models', 'electronhub_sort_models', false, true],
     electronhub_group_models: ['#electronhub_group_models', 'electronhub_group_models', false, true],
@@ -419,6 +425,7 @@ const default_settings = {
     chutes_model: 'deepseek-ai/DeepSeek-V3-0324',
     chutes_sort_models: 'alphabetically',
     siliconflow_model: 'deepseek-ai/DeepSeek-V3',
+    siliconflow_endpoint: SILICONFLOW_ENDPOINT.GLOBAL,
     electronhub_model: 'gpt-4o-mini',
     electronhub_sort_models: 'alphabetically',
     electronhub_group_models: false,
@@ -2804,6 +2811,10 @@ export async function createGenerationParameters(settings, model, type, messages
         delete generate_data.frequency_penalty;
     }
 
+    if (settings.chat_completion_source === chat_completion_sources.SILICONFLOW) {
+        generate_data.siliconflow_endpoint = settings.siliconflow_endpoint || SILICONFLOW_ENDPOINT.GLOBAL;
+    }
+
     // https://docs.nano-gpt.com/api-reference/endpoint/chat-completion#temperature-&-nucleus
     if (settings.chat_completion_source === chat_completion_sources.NANOGPT) {
         generate_data.top_k = Number(settings.top_k_openai);
@@ -4255,6 +4266,10 @@ async function getStatusOpen() {
         data.azure_base_url = oai_settings.azure_base_url;
         data.azure_deployment_name = oai_settings.azure_deployment_name;
         data.azure_api_version = oai_settings.azure_api_version;
+    }
+
+    if (oai_settings.chat_completion_source === chat_completion_sources.SILICONFLOW) {
+        data.siliconflow_endpoint = oai_settings.siliconflow_endpoint;
     }
 
     const canBypass = (oai_settings.chat_completion_source === chat_completion_sources.OPENAI && oai_settings.bypass_status_check) || oai_settings.chat_completion_source === chat_completion_sources.CUSTOM;
@@ -6927,6 +6942,10 @@ export function initOpenAI() {
     });
     $('#zai_endpoint').on('input', function () {
         oai_settings.zai_endpoint = String($(this).val());
+        saveSettingsDebounced();
+    });
+    $('#siliconflow_endpoint').on('input', function () {
+        oai_settings.siliconflow_endpoint = String($(this).val());
         saveSettingsDebounced();
     });
     $('#vertexai_service_account_json').on('input', onVertexAIServiceAccountJsonChange);

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -64,7 +64,7 @@ import { hideChatMessageRange } from './chats.js';
 import { getContext, saveMetadataDebounced } from './extensions.js';
 import { getRegexedString, regex_placement } from './extensions/regex/engine.js';
 import { findGroupMemberId, groups, is_group_generating, openGroupById, regenerateGroup, resetSelectedGroup, saveGroupChat, selected_group, getGroupMembers } from './group-chats.js';
-import { chat_completion_sources, oai_settings, promptManager, ZAI_ENDPOINT } from './openai.js';
+import { chat_completion_sources, oai_settings, promptManager, SILICONFLOW_ENDPOINT, ZAI_ENDPOINT } from './openai.js';
 import { user_avatar } from './personas.js';
 import { addEphemeralStoppingString, chat_styles, context_presets, flushEphemeralStoppingStrings, playMessageSound, power_user } from './power-user.js';
 import { SERVER_INPUTS, textgen_types, textgenerationwebui_settings } from './textgen-settings.js';
@@ -5663,6 +5663,32 @@ async function setApiUrlCallback({ api = null, connect = 'true', quiet = 'false'
         }
 
         return oai_settings.zai_endpoint || ZAI_ENDPOINT.COMMON;
+    }
+
+    const isCurrentlySiliconFlow = main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.SILICONFLOW;
+    if (api === chat_completion_sources.SILICONFLOW || (!api && isCurrentlySiliconFlow)) {
+        if (!url) {
+            return oai_settings.siliconflow_endpoint || SILICONFLOW_ENDPOINT.GLOBAL;
+        }
+
+        const permittedValues = Object.values(SILICONFLOW_ENDPOINT);
+        if (!permittedValues.includes(url)) {
+            !isQuiet && toastr.warning(t`Valid options are: ${permittedValues.join(', ')}`, t`SiliconFlow endpoint '${url}' is not a valid option.`);
+            return '';
+        }
+
+        if (!isCurrentlySiliconFlow && autoConnect) {
+            toastr.warning(t`SiliconFlow is not the currently selected API, so we cannot do an auto-connect. Consider switching to it via /api beforehand.`);
+            return '';
+        }
+
+        $('#siliconflow_endpoint').val(url).trigger('input');
+
+        if (autoConnect) {
+            $('#api_button_openai').trigger('click');
+        }
+
+        return oai_settings.siliconflow_endpoint || SILICONFLOW_ENDPOINT.GLOBAL;
     }
 
     const isCurrentlyVertexAI = main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.VERTEXAI;

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2706,8 +2706,9 @@ export function initDefaultSlashCommands() {
                     new SlashCommandEnumValue('custom', 'custom OpenAI-compatible', enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'openai')), 'O'),
                     new SlashCommandEnumValue('zai', 'Z.AI', enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'zai')), 'Z'),
                     new SlashCommandEnumValue('vertexai', 'Google Vertex AI', enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'vertexai')), 'V'),
+                    new SlashCommandEnumValue('siliconflow', 'SiliconFlow', enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'siliconflow')), 'S'),
                     new SlashCommandEnumValue('kobold', 'KoboldAI Classic', enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'kobold')), 'K'),
-                    ...Object.values(textgen_types).map(api => new SlashCommandEnumValue(api, null, enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'textgenerationwebui')), 'T')),
+                    ...Object.values(textgen_types).filter(api => Object.keys(SERVER_INPUTS).includes(api)).map(api => new SlashCommandEnumValue(api, null, enumTypes.getBasedOnIndex(UNIQUE_APIS.findIndex(x => x === 'textgenerationwebui')), 'T')),
                 ],
             }),
             SlashCommandNamedArgument.fromProps({
@@ -2739,7 +2740,7 @@ export function initDefaultSlashCommands() {
                 ${t`If a manual API is provided to <b>set</b> the URL, make sure to set <code>connect=false</code>, as auto-connect only works for the currently selected API, or consider switching to it with <code>/api</code> first.`}
             </div>
             <div>
-                ${t`This slash command works for most of the Text Completion sources, KoboldAI Classic, and also Custom OpenAI compatible, Z.AI, and Google Vertex AI for the Chat Completion sources. If unsure which APIs are supported, check the auto-completion of the optional <code>api</code> argument of this command.`}
+                ${t`This slash command works for most of the Text Completion sources, KoboldAI Classic, and also Custom OpenAI compatible, Z.AI, SiliconFlow, and Google Vertex AI for the Chat Completion sources. If unsure which APIs are supported, check the auto-completion of the optional <code>api</code> argument of this command.`}
             </div>
         `,
     }));

--- a/src/constants.js
+++ b/src/constants.js
@@ -551,3 +551,8 @@ export const ZAI_ENDPOINT = {
     COMMON: 'common',
     CODING: 'coding',
 };
+
+export const SILICONFLOW_ENDPOINT = {
+    GLOBAL: 'global',
+    CN: 'cn',
+};

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -17,6 +17,7 @@ import {
     OPENAI_VERBOSITY_MODELS,
     OPENROUTER_HEADERS,
     VERTEX_SAFETY,
+    SILICONFLOW_ENDPOINT,
     ZAI_ENDPOINT,
 } from '../../constants.js';
 import {
@@ -87,6 +88,7 @@ const API_COMETAPI = 'https://api.cometapi.com/v1';
 const API_ZAI_COMMON = 'https://api.z.ai/api/paas/v4';
 const API_ZAI_CODING = 'https://api.z.ai/api/coding/paas/v4';
 const API_SILICONFLOW = 'https://api.siliconflow.com/v1';
+const API_SILICONFLOW_CN = 'https://api.siliconflow.cn/v1';
 const API_OPENROUTER = 'https://openrouter.ai/api/v1';
 
 /**
@@ -1825,7 +1827,9 @@ router.post('/status', async function (request, statusResponse) {
                 return statusResponse.status(500).send({ error: true, message: 'Failed to connect to the Azure endpoint.' });
             }
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.SILICONFLOW) {
-            apiUrl = API_SILICONFLOW;
+            const defaultApiUrl = request.body.siliconflow_endpoint === SILICONFLOW_ENDPOINT.CN
+                ? API_SILICONFLOW_CN : API_SILICONFLOW;
+            apiUrl = defaultApiUrl;
             apiKey = readSecret(request.user.directories, SECRET_KEYS.SILICONFLOW);
             headers = {};
         } else {
@@ -2301,7 +2305,9 @@ router.post('/generate', async function (request, response) {
                 setJsonObjectFormat(bodyParams, request.body.messages, request.body.json_schema);
             }
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.SILICONFLOW) {
-            apiUrl = API_SILICONFLOW;
+            const defaultApiUrl = request.body.siliconflow_endpoint === SILICONFLOW_ENDPOINT.CN
+                ? API_SILICONFLOW_CN : API_SILICONFLOW;
+            apiUrl = defaultApiUrl;
             apiKey = readSecret(request.user.directories, SECRET_KEYS.SILICONFLOW);
             headers = {};
             bodyParams = {};

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1832,6 +1832,7 @@ router.post('/status', async function (request, statusResponse) {
             apiUrl = defaultApiUrl;
             apiKey = readSecret(request.user.directories, SECRET_KEYS.SILICONFLOW);
             headers = {};
+            queryParams = { type: 'text', sub_type: 'chat' };
         } else {
             console.warn('This chat completion source is not supported yet.');
             return statusResponse.status(400).send({ error: true });

--- a/src/endpoints/openai.js
+++ b/src/endpoints/openai.js
@@ -8,7 +8,7 @@ import express from 'express';
 import { getConfigValue, mergeObjectWithYaml, excludeKeysByYaml, trimV1, delay } from '../util.js';
 import { setAdditionalHeaders } from '../additional-headers.js';
 import { readSecret, SECRET_KEYS } from './secrets.js';
-import { AIMLAPI_HEADERS, OPENROUTER_HEADERS, ZAI_ENDPOINT } from '../constants.js';
+import { AIMLAPI_HEADERS, OPENROUTER_HEADERS, SILICONFLOW_ENDPOINT, ZAI_ENDPOINT } from '../constants.js';
 
 export const router = express.Router();
 
@@ -525,6 +525,47 @@ router.post('/nanogpt/models/embedding', async (request, response) => {
         return response.json(data.data);
     } catch (error) {
         console.error('NanoGPT embedding models fetch failed', error);
+        response.sendStatus(500);
+    }
+});
+
+router.post('/siliconflow/models/embedding', async (request, response) => {
+    try {
+        const key = readSecret(request.user.directories, SECRET_KEYS.SILICONFLOW);
+
+        if (!key) {
+            console.warn('No SiliconFlow key found');
+            return response.sendStatus(400);
+        }
+
+        const apiUrl = request.body.siliconflow_endpoint === SILICONFLOW_ENDPOINT.CN
+            ? 'https://api.siliconflow.cn/v1/models?type=text&sub_type=embedding'
+            : 'https://api.siliconflow.com/v1/models?type=text&sub_type=embedding';
+
+        const result = await fetch(apiUrl, {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${key}`,
+            },
+        });
+
+        if (!result.ok) {
+            const text = await result.text();
+            console.warn('SiliconFlow embedding models request failed', result.statusText, text);
+            return response.status(500).send(text);
+        }
+
+        /** @type {any} */
+        const data = await result.json();
+
+        if (!Array.isArray(data?.data)) {
+            console.warn('SiliconFlow embedding models response invalid', data);
+            return response.sendStatus(500);
+        }
+
+        return response.json(data.data);
+    } catch (error) {
+        console.error('SiliconFlow embedding models fetch failed', error);
         response.sendStatus(500);
     }
 });

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -38,6 +38,7 @@ const SOURCES = [
     'openrouter',
     'chutes',
     'nanogpt',
+    'siliconflow',
 ];
 
 /**
@@ -85,6 +86,8 @@ async function getVector(source, sourceSettings, text, isQuery, directories) {
             return getOpenAIVector(text, source, directories, sourceSettings.model);
         case 'nanogpt':
             return getOpenAIVector(text, source, directories, sourceSettings.model);
+        case 'siliconflow':
+            return getOpenAIVector(text, source, directories, sourceSettings.model, sourceSettings.urlOverride);
     }
 
     throw new Error(`Unknown vector source ${source}`);
@@ -155,6 +158,9 @@ async function getBatchVector(source, sourceSettings, texts, isQuery, directorie
                 break;
             case 'nanogpt':
                 results.push(...await getOpenAIBatchVector(batch, source, directories, sourceSettings.model));
+                break;
+            case 'siliconflow':
+                results.push(...await getOpenAIBatchVector(batch, source, directories, sourceSettings.model, sourceSettings.urlOverride));
                 break;
             default:
                 throw new Error(`Unknown vector source ${source}`);
@@ -247,6 +253,12 @@ function getSourceSettings(source, request) {
         case 'nanogpt':
             return {
                 model: String(request.body.model || 'text-embedding-3-small'),
+            };
+        case 'siliconflow':
+            return {
+                model: String(request.body.model || 'Qwen/Qwen3-Embedding-0.6B'),
+                urlOverride: request.body.siliconflow_endpoint === 'cn'
+                    ? 'https://api.siliconflow.cn/v1' : null,
             };
         default:
             return {};

--- a/src/vectors/openai-vectors.js
+++ b/src/vectors/openai-vectors.js
@@ -54,6 +54,13 @@ const SOURCES = {
         headers: {},
         processBody: () => {},
     },
+    'siliconflow': {
+        secretKey: SECRET_KEYS.SILICONFLOW,
+        url: 'https://api.siliconflow.com/v1',
+        model: 'Qwen/Qwen3-Embedding-0.6B',
+        headers: {},
+        processBody: () => {},
+    },
 };
 
 /**
@@ -62,9 +69,10 @@ const SOURCES = {
  * @param {string} source - The source of the vector
  * @param {import('../users.js').UserDirectoryList} directories - The directories object for the user
  * @param {string} model - The model to use for the embedding
+ * @param {string|null} urlOverride - Optional URL override for the API endpoint
  * @returns {Promise<number[][]>} - The array of vectors for the texts
  */
-export async function getOpenAIBatchVector(texts, source, directories, model = '') {
+export async function getOpenAIBatchVector(texts, source, directories, model = '', urlOverride = null) {
     const config = SOURCES[source];
 
     if (!config) {
@@ -80,7 +88,7 @@ export async function getOpenAIBatchVector(texts, source, directories, model = '
     }
 
     const modelName = model || config.model;
-    const url = config.url.replace('{{MODEL}}', modelName);
+    const url = urlOverride || config.url.replace('{{MODEL}}', modelName);
     const body = {
         input: texts,
         model: modelName,
@@ -127,9 +135,10 @@ export async function getOpenAIBatchVector(texts, source, directories, model = '
  * @param {string} source - The source of the vector
  * @param {import('../users.js').UserDirectoryList} directories - The directories object for the user
  * @param {string} model - The model to use for the embedding
+ * @param {string|null} urlOverride - Optional URL override for the API endpoint
  * @returns {Promise<number[]>} - The vector for the text
  */
-export async function getOpenAIVector(text, source, directories, model = '') {
-    const vectors = await getOpenAIBatchVector([text], source, directories, model);
+export async function getOpenAIVector(text, source, directories, model = '', urlOverride = null) {
+    const vectors = await getOpenAIBatchVector([text], source, directories, model, urlOverride);
     return vectors[0];
 }


### PR DESCRIPTION
Add SiliconFlow.cn (api.siliconflow.cn) as a new provider with independent API key, alongside embedding/vector support for both SiliconFlow (.com) and SiliconFlow.cn (.cn).

Chat completion (siliconflow_cn):
- New chat completion source with dedicated API key and form
- Full feature parity: streaming, reasoning, tool calling, vision
- Reuses getSiliconflowMaxContext() (same model catalog)

Embeddings (siliconflow + siliconflow_cn):
- SiliconFlow.com: Qwen3-Embedding models (0.6B/4B/8B)
- SiliconFlow.cn: full catalog (Qwen3-Embedding, BGE, BCE)
- Model lists reflect actual per-platform availability

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
