### PR TITLE
Add storage provider registry for external storage backends

### DIFF
--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -8,6 +8,7 @@ import sanitize from 'sanitize-filename';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import _ from 'lodash';
 
+import { getStorageProvider } from '../storage-provider.js';
 import validateAvatarUrlMiddleware from '../middleware/validateFileName.js';
 import {
     getConfigValue,
@@ -462,6 +463,12 @@ export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false
     if (chatIntegritySlug && !await checkChatIntegrity(filePath, chatIntegritySlug)) {
         throw new IntegrityMismatchError(`Chat integrity check failed for "${filePath}". The expected integrity slug was "${chatIntegritySlug}".`);
     }
+    const storageProvider = getStorageProvider();
+    if (storageProvider?.saveChat) {
+        await storageProvider.saveChat(handle, cardName, path.basename(filePath), jsonlData);
+        return;
+    }
+
     tryWriteFileSync(filePath, jsonlData);
     getBackupFunction(handle)(backupDirectory, cardName, jsonlData);
 }
@@ -495,7 +502,20 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
  * @param {string} chatFilePath The full chat file path.
  * @returns {Array}} If the chatFilePath cannot be read, this will return [].
  */
-export function getChatData(chatFilePath) {
+export async function getChatData(chatFilePath) {
+    const storageProvider = getStorageProvider();
+    if (storageProvider?.readChat) {
+        // Extract character name and file name from the path
+        const fileName = path.basename(chatFilePath);
+        const characterName = path.basename(path.dirname(chatFilePath));
+        // userHandle is not available here; pass characterName as context
+        const data = await storageProvider.readChat(null, characterName, fileName);
+        if (data !== null) {
+            const lines = data.split('\n');
+            return lines.map(line => tryParse(line)).filter(x => x);
+        }
+    }
+
     let chatData = [];
 
     const chatJSON = tryReadFileSync(chatFilePath) ?? '';
@@ -510,9 +530,23 @@ export function getChatData(chatFilePath) {
     return chatData;
 }
 
-router.post('/get', validateAvatarUrlMiddleware, function (request, response) {
+router.post('/get', validateAvatarUrlMiddleware, async function (request, response) {
     try {
         const dirName = String(request.body.avatar_url).replace('.png', '');
+
+        // If a storage provider is registered, read from it directly
+        const storageProvider = getStorageProvider();
+        if (storageProvider?.readChat && request.body.file_name) {
+            const handle = request.user.profile.handle;
+            const chatFileName = `${String(request.body.file_name)}.jsonl`;
+            const data = await storageProvider.readChat(handle, dirName, chatFileName);
+            if (data !== null) {
+                const lines = data.split('\n');
+                return response.send(lines.map(line => tryParse(line)).filter(x => x));
+            }
+            return response.send({});
+        }
+
         const directoryPath = path.join(request.user.directories.chats, dirName);
         const chatDirExists = fs.existsSync(directoryPath);
 
@@ -529,7 +563,7 @@ router.post('/get', validateAvatarUrlMiddleware, function (request, response) {
         const chatFileName = `${String(request.body.file_name)}.jsonl`;
         const chatFilePath = path.join(directoryPath, sanitize(chatFileName));
 
-        return response.send(getChatData(chatFilePath));
+        return response.send(await getChatData(chatFilePath));
     } catch (error) {
         console.error(error);
         return response.send({});
@@ -540,6 +574,15 @@ router.post('/rename', validateAvatarUrlMiddleware, async function (request, res
     try {
         if (!request.body || !request.body.original_file || !request.body.renamed_file) {
             return response.sendStatus(400);
+        }
+
+        const storageProvider = getStorageProvider();
+        if (storageProvider?.renameChat) {
+            const handle = request.user.profile.handle;
+            const characterName = request.body.is_group ? null : String(request.body.avatar_url).replace('.png', '');
+            await storageProvider.renameChat(handle, characterName, request.body.original_file, request.body.renamed_file);
+            const sanitizedFileName = path.parse(sanitize(request.body.renamed_file)).name;
+            return response.send({ ok: true, sanitizedFileName });
         }
 
         const pathToFolder = request.body.is_group
@@ -566,7 +609,7 @@ router.post('/rename', validateAvatarUrlMiddleware, async function (request, res
     }
 });
 
-router.post('/delete', validateAvatarUrlMiddleware, function (request, response) {
+router.post('/delete', validateAvatarUrlMiddleware, async function (request, response) {
     try {
         if (!path.extname(request.body.chatfile)) {
             request.body.chatfile += '.jsonl';
@@ -574,6 +617,14 @@ router.post('/delete', validateAvatarUrlMiddleware, function (request, response)
 
         const dirName = String(request.body.avatar_url).replace('.png', '');
         const chatFileName = String(request.body.chatfile);
+
+        const storageProvider = getStorageProvider();
+        if (storageProvider?.deleteChat) {
+            const handle = request.user.profile.handle;
+            await storageProvider.deleteChat(handle, dirName, chatFileName);
+            return response.send({ ok: true });
+        }
+
         const chatFilePath = path.join(request.user.directories.chats, dirName, sanitize(chatFileName));
         //Return success if the file was deleted.
         if (tryDeleteFile(chatFilePath)) {
@@ -773,7 +824,7 @@ router.post('/import', validateAvatarUrlMiddleware, function (request, response)
     }
 });
 
-router.post('/group/get', (request, response) => {
+router.post('/group/get', async (request, response) => {
     if (!request.body || !request.body.id) {
         return response.sendStatus(400);
     }
@@ -781,7 +832,7 @@ router.post('/group/get', (request, response) => {
     const id = request.body.id;
     const chatFilePath = path.join(request.user.directories.groupChats, sanitize(`${id}.jsonl`));
 
-    return response.send(getChatData(chatFilePath));
+    return response.send(await getChatData(chatFilePath));
 });
 
 router.post('/group/info', async (request, response) => {
@@ -854,6 +905,13 @@ router.post('/group/save', async function (request, response) {
 router.post('/search', validateAvatarUrlMiddleware, async function (request, response) {
     try {
         const { query, avatar_url, group_id } = request.body;
+
+        const storageProvider = getStorageProvider();
+        if (storageProvider?.searchChats) {
+            const handle = request.user.profile.handle;
+            const results = await storageProvider.searchChats(handle, query);
+            return response.send(results);
+        }
 
         /** @type {string[]} */
         let chatFiles = [];
@@ -958,6 +1016,13 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
 
 router.post('/recent', async function (request, response) {
     try {
+        const storageProvider = getStorageProvider();
+        if (storageProvider?.listChats) {
+            const handle = request.user.profile.handle;
+            const results = await storageProvider.listChats(handle, null);
+            return response.send(results);
+        }
+
         /** @typedef {{pngFile?: string, groupId?: string, filePath: string, mtime: number}} ChatFile */
         /** @type {ChatFile[]} */
         const allChatFiles = [];

--- a/src/endpoints/images.js
+++ b/src/endpoints/images.js
@@ -5,6 +5,7 @@ import { Buffer } from 'node:buffer';
 import express from 'express';
 import sanitize from 'sanitize-filename';
 
+import { getStorageProvider } from '../storage-provider.js';
 import { clientRelativePath, removeFileExtension, getImages, isPathUnderParent } from '../util.js';
 import { MEDIA_EXTENSIONS, MEDIA_REQUEST_TYPE } from '../constants.js';
 
@@ -67,8 +68,16 @@ router.post('/upload', async (request, response) => {
             pathToNewFile = path.join(request.user.directories.userImages, sanitize(request.body.ch_name), sanitize(filename));
         }
 
-        ensureDirectoryExistence(pathToNewFile);
         const imageBuffer = Buffer.from(image, 'base64');
+
+        const storageProvider = getStorageProvider();
+        if (storageProvider?.saveFile) {
+            const relativePath = clientRelativePath(request.user.directories.root, pathToNewFile);
+            const url = await storageProvider.saveFile(request.user.profile.handle, relativePath, imageBuffer);
+            return response.send({ path: url });
+        }
+
+        ensureDirectoryExistence(pathToNewFile);
         await fs.promises.writeFile(pathToNewFile, new Uint8Array(imageBuffer));
         response.send({ path: clientRelativePath(request.user.directories.root, pathToNewFile) });
     } catch (error) {
@@ -77,7 +86,7 @@ router.post('/upload', async (request, response) => {
     }
 });
 
-router.post('/list/:folder?', (request, response) => {
+router.post('/list/:folder?', async (request, response) => {
     try {
         if (request.params.folder) {
             if (request.body.folder) {
@@ -96,6 +105,17 @@ router.post('/list/:folder?', (request, response) => {
         const type = Number(request.body.type ?? MEDIA_REQUEST_TYPE.IMAGE);
         const sort = request.body.sortField || 'date';
         const order = request.body.sortOrder || 'asc';
+
+        const storageProvider = getStorageProvider();
+        if (storageProvider?.listFiles) {
+            const handle = request.user.profile.handle;
+            const folder = sanitize(request.body.folder);
+            const files = await storageProvider.listFiles(handle, folder, sort, type);
+            if (order === 'desc') {
+                files.reverse();
+            }
+            return response.send(files);
+        }
 
         if (!fs.existsSync(directoryPath)) {
             fs.mkdirSync(directoryPath, { recursive: true });
@@ -134,6 +154,12 @@ router.post('/delete', async (request, response) => {
     try {
         if (!request.body.path) {
             return response.status(400).send('No path specified');
+        }
+
+        const storageProvider = getStorageProvider();
+        if (storageProvider?.deleteFile) {
+            await storageProvider.deleteFile(request.user.profile.handle, request.body.path);
+            return response.sendStatus(200);
         }
 
         const pathToDelete = path.join(request.user.directories.root, request.body.path);

--- a/src/storage-provider.js
+++ b/src/storage-provider.js
@@ -1,0 +1,26 @@
+/**
+ * Storage provider registry for external storage backends.
+ * When no provider is registered, all operations fall through to
+ * the default filesystem-based storage.
+ * @module storage-provider
+ */
+
+/** @type {import('./storage-provider-types').StorageProvider|null} */
+let provider = null;
+
+/**
+ * Registers an external storage provider.
+ * @param {import('./storage-provider-types').StorageProvider} p The storage provider to register
+ */
+export function registerStorageProvider(p) {
+    provider = p;
+    console.log('[StorageProvider] External storage provider registered');
+}
+
+/**
+ * Returns the currently registered storage provider, or null if none.
+ * @returns {import('./storage-provider-types').StorageProvider|null}
+ */
+export function getStorageProvider() {
+    return provider;
+}

--- a/src/users.js
+++ b/src/users.js
@@ -15,8 +15,9 @@ import _ from 'lodash';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import sanitize from 'sanitize-filename';
 
+import { getStorageProvider } from './storage-provider.js';
 import { USER_DIRECTORY_TEMPLATE, DEFAULT_USER, PUBLIC_DIRECTORIES, SETTINGS_FILE, UPLOADS_DIRECTORY } from './constants.js';
-import { getConfigValue, color, delay, generateTimestamp, invalidateFirefoxCache } from './util.js';
+import { getConfigValue, color, delay, generateTimestamp, invalidateFirefoxCache, clientRelativePath } from './util.js';
 import { readSecret, writeSecret } from './endpoints/secrets.js';
 import { getContentOfType } from './endpoints/content-manager.js';
 import { serverDirectory } from './server-directory.js';
@@ -949,6 +950,17 @@ function createRouteHandler(directoryFn) {
         try {
             const directory = directoryFn(req);
             const filePath = decodeURIComponent(req.params[0]);
+
+            const storageProvider = getStorageProvider();
+            if (storageProvider?.serveFile) {
+                const handle = req.user?.profile?.handle;
+                // Compute relative path including the route prefix (e.g., user/images/filename)
+                const root = req.user?.directories?.root;
+                const fullRelPath = root ? clientRelativePath(root, path.join(directory, filePath)).replace(/^\/+/, '') : filePath;
+                const served = await storageProvider.serveFile(handle, fullRelPath, res);
+                if (served) return;
+            }
+
             const exists = fs.existsSync(path.join(directory, filePath));
             if (!exists) {
                 return res.sendStatus(404);


### PR DESCRIPTION
Adds a minimal hook system that allows plugins to intercept storage operations (chat CRUD, image CRUD, file serving). When no provider is registered, all operations fall through to the existing filesystem code — zero behavior change for default installs.

Modified files:
- src/storage-provider.js (new): registry with register/get functions
- src/endpoints/chats.js: provider dispatch for save/read/delete/rename/search/list
- src/endpoints/images.js: provider dispatch for upload/list/delete
- src/users.js: provider dispatch for file serving

<!-- Put X in the box below to confirm -->

## Checklist:

- [ ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
