### PR TITLE
Fix: Prevent Escape Key from Closing Non-Dismissable Popups

### DIFF
--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -1,5 +1,6 @@
 import dialogPolyfill from '../lib/dialog-polyfill.esm.js';
 import { shouldSendOnEnter } from './RossAscends-mods.js';
+import { t } from './i18n.js';
 import { power_user, toastPositionClasses } from './power-user.js';
 import { removeFromArray, runAfterAnimation, uuidv4 } from './utils.js';
 
@@ -173,6 +174,8 @@ export class Popup {
     /** @type {Promise<any>} */ #promise;
     /** @type {(result: any) => any} */ #resolver;
     /** @type {boolean} */ #isClosingPrevented;
+    /** @type {number} */ #lastEscapePress = 0;
+    /** @type {boolean} */ #isShowingForceCloseConfirm = false;
 
     /**
      * Constructs a new Popup object with the given text content, type, inputValue, and options
@@ -484,6 +487,45 @@ export class Popup {
                 evt.stopPropagation();
                 // Set flag so closeListener also blocks the close event (browser may fire it after multiple Escape presses)
                 this.#isClosingPrevented = true;
+
+                // Check for double-escape within 500ms to allow force-closing
+                const now = Date.now();
+                const timeSinceLastEscape = now - this.#lastEscapePress;
+                this.#lastEscapePress = now;
+
+                if (timeSinceLastEscape < 500 && !this.#isShowingForceCloseConfirm) {
+                    this.#isShowingForceCloseConfirm = true;
+
+                    // Defer to next frame to escape the current event context,
+                    // allowing the confirmation popup to stack properly on top
+                    requestAnimationFrame(async () => {
+                        const confirmPopup = new Popup(
+                            PopupUtils.BuildTextWithHeader(
+                                t`Force-close Blocking Popup`, `
+                                <p>${t`This action is blocking and not meant to be closed manually.`}</p>
+                                <p>${t`Force-closing may leave the application in an inconsistent state.`}</p>
+                                <p><strong>${t`Are you sure you want to force-close?`}</strong></p>`),
+                            POPUP_TYPE.CONFIRM,
+                            '',
+                            { okButton: t`Force Close`, cancelButton: t`Cancel` });
+
+                        // If the the main popup closes while the force-close popup is still being displayed, we gracefully cancel that.
+                        const originalOnClose = this.onClose;
+                        this.onClose = async (x) => {
+                            if (originalOnClose) await originalOnClose;
+                            await confirmPopup.completeCancelled();
+                        };
+
+
+                        const result = await confirmPopup.show();
+                        this.#isShowingForceCloseConfirm = false;
+                        if (result === POPUP_RESULT.AFFIRMATIVE) {
+                            // Force-close by bypassing the normal close prevention
+                            this.#isClosingPrevented = false;
+                            await this.complete(POPUP_RESULT.CANCELLED);
+                        }
+                    });
+                }
                 return;
             }
 

--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -476,6 +476,17 @@ export class Popup {
 
         // Bind dialog listeners manually, so we can be sure context is preserved
         const cancelListener = async (evt) => {
+            // If neither cancel button nor close button is visible or present, don't allow escape to close the popup
+            const hasCancelButton = this.cancelButton?.offsetParent !== null && this.buttonControls?.offsetParent !== null;
+            const hasCloseButton = this.closeButton?.offsetParent !== null;
+            if (!hasCancelButton && !hasCloseButton) {
+                evt.preventDefault();
+                evt.stopPropagation();
+                // Set flag so closeListener also blocks the close event (browser may fire it after multiple Escape presses)
+                this.#isClosingPrevented = true;
+                return;
+            }
+
             evt.preventDefault();
             evt.stopPropagation();
             await this.complete(POPUP_RESULT.CANCELLED);


### PR DESCRIPTION
### Summary
This PR fixes a bug where pressing the Escape key could close popups that were intentionally designed to be non-dismissable—specifically popups where both the cancel button and close button are hidden from the user.

### What Changed
- Added validation in the popup's cancel listener to check if cancel and close buttons are actually visible before allowing Escape to dismiss the popup
- When neither button is visible, the Escape key press is now blocked and a prevention flag is set to handle subsequent close events from the browser

### Why These Changes
Some popups in SillyTavern are designed to require explicit user action—they intentionally hide both the cancel and close buttons to prevent accidental dismissal. Examples include loading screens, progress dialogs, or confirmations that must be explicitly completed.

Before this fix, users could bypass this intended behavior simply by pressing Escape, which would close the popup anyway. This created an inconsistent experience where the UI design suggested "you must wait/complete this action," but the keyboard shortcut provided an unintended escape route.

### How It Works
When the Escape key is pressed, the popup now checks whether the cancel button and close button are actually rendered on screen (using `offsetParent` to detect visibility). If both are hidden or not present, the key event is prevented and the popup remains open. A flag is also set to ensure the browser's native dialog close event (which can fire after multiple Escape presses) is also blocked.

### Impact
- Loading screens, progress dialogs, and other "blocking" popups now properly prevent keyboard dismissal
- Popups with visible cancel or close buttons continue to work as expected with Escape
- Improves consistency between visual design intent and actual behavior

## Copilot Summary
This pull request introduces an improvement to the popup dialog behavior in `popup.js`. It ensures that the popup cannot be closed with the Escape key when neither a cancel button nor a close button is visible, enhancing user experience and preventing unintended closures.

Popup dialog behavior improvements:

* Updated the Escape key handler in the `Popup` class to prevent closing the popup if neither the cancel button nor the close button is visible, and set a flag to block subsequent close events in this scenario.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).