### PR TITLE
Correct input_video to video_url in embedOpenRouterMedia()

### DIFF
--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1339,7 +1339,7 @@ export function embedOpenRouterMedia(messages, { audio = true, video = true } = 
 
         for (const contentPart of message.content) {
             if (video && contentPart?.type === 'video_url' && contentPart.video_url?.url?.startsWith('data:')) {
-                contentPart.type = 'input_video';
+                contentPart.type = 'video_url';
             }
 
             if (audio && contentPart?.type === 'audio_url' && contentPart.audio_url?.url?.startsWith('data:')) {


### PR DESCRIPTION
Per OpenRouter [docs](https://openrouter.ai/docs/guides/overview/multimodal/videos), content.type should be "video_url" instead "input_video" (both happen to work with Gemini). This PR applies the fix. Previously, models other than Gemini would return an error.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
