### PR TITLE
Add splash screen with detailed loading progress feedback during initialization, leveraging new extension hooks system

### DIFF
--- a/public/css/loader.css
+++ b/public/css/loader.css
@@ -53,35 +53,3 @@
     opacity: 1;
     color: color-mix(in srgb, currentColor 40%, #e74c3c 60%);
 }
-
-/* Splash screen styles for branded loading */
-#loader.splash-screen {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 2.5rem;
-    width: 100%;
-    height: 100%;
-}
-
-#loader.splash-screen #load-spinner {
-    position: static;
-    top: unset;
-    left: unset;
-}
-
-.splash-logo {
-    /* max original px, or 50% on mobile */
-    width: min(330px, 50%);
-    height: auto;
-    filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
-}
-
-.splash-message {
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 500;
-    opacity: 0.9;
-    letter-spacing: 0.02em;
-}

--- a/public/css/loader.css
+++ b/public/css/loader.css
@@ -53,3 +53,35 @@
     opacity: 1;
     color: color-mix(in srgb, currentColor 40%, #e74c3c 60%);
 }
+
+/* Splash screen styles for branded loading */
+#loader.splash-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2.5rem;
+    width: 100%;
+    height: 100%;
+}
+
+#loader.splash-screen #load-spinner {
+    position: static;
+    top: unset;
+    left: unset;
+}
+
+.splash-logo {
+    /* max original px, or 50% on mobile */
+    width: min(330px, 50%);
+    height: auto;
+    filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
+}
+
+.splash-message {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    opacity: 0.9;
+    letter-spacing: 0.02em;
+}

--- a/public/css/splashscreen.css
+++ b/public/css/splashscreen.css
@@ -1,0 +1,82 @@
+/* Splash screen styles for branded loading */
+#loader.splash-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2.5rem;
+    width: 100%;
+    height: 100%;
+}
+
+#loader.splash-screen #load-spinner {
+    position: static;
+    top: unset;
+    left: unset;
+}
+
+.splash-logo {
+    /* max original px, or 50% on mobile */
+    width: min(330px, 50%);
+    height: auto;
+    filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
+}
+
+.splash-message {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    opacity: 0.9;
+    letter-spacing: 0.02em;
+}
+
+/* Splash status lines for detailed progress */
+.splash-status {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 4.5rem;
+    text-align: center;
+}
+
+.splash-status-section {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 400;
+    opacity: 0.75;
+}
+
+.splash-status-extension {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    opacity: 0.6;
+    min-height: 1.25em;
+}
+
+.splash-status-tag {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    background-color: color-mix(in srgb, currentColor 15%, transparent);
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+}
+
+.splash-status-extension-name {
+    font-weight: 500;
+}
+
+.splash-status-extension-status {
+    margin: 0;
+    font-size: 0.8rem;
+    opacity: 0.5;
+    font-style: italic;
+    min-height: 1em;
+}

--- a/public/css/splashscreen.css
+++ b/public/css/splashscreen.css
@@ -36,9 +36,12 @@
     flex-direction: column;
     align-items: center;
     gap: 0.5rem;
-    min-height: 4.5rem;
+    min-height: 5.5rem;
     text-align: center;
+    /* Reserve exact space for all lines to prevent jumping */
+    height: 5.5rem;
 }
+
 
 .splash-status-section {
     margin: 0;
@@ -51,10 +54,19 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    margin-top: 0.5rem;
     gap: 0.5rem;
     font-size: 0.875rem;
-    opacity: 0.6;
+    opacity: 0;
     min-height: 1.25em;
+    transition: opacity 0.2s ease;
+    /* Allow multi-line content */
+    flex-wrap: wrap;
+    text-align: center;
+}
+
+.splash-status-extension.has-content {
+    opacity: 0.6;
 }
 
 .splash-status-tag {
@@ -76,7 +88,15 @@
 .splash-status-extension-status {
     margin: 0;
     font-size: 0.8rem;
-    opacity: 0.5;
+    opacity: 0;
     font-style: italic;
-    min-height: 1em;
+    min-height: 3em;
+    transition: opacity 0.2s ease;
+    /* Allow multi-line content */
+    white-space: pre-wrap;
+    text-align: center;
+}
+
+.splash-status-extension-status.has-content {
+    opacity: 0.5;
 }

--- a/public/script.js
+++ b/public/script.js
@@ -699,9 +699,13 @@ async function firstLoadInit() {
     }
 
     const initLoaderHandle = loader.show({
-        title: t`SillyTavern`,
-        message: t`Initializing...`,
-        toastMode: loader.ToastMode.STATIC,
+        toastMode: loader.ToastMode.NONE,
+        overlayContent: `
+            <div id="loader" class="splash-screen">
+                <img src="/img/logo.png" alt="SillyTavern" class="splash-logo" />
+                <div id="load-spinner" class="fa-solid fa-gear fa-spin fa-3x"></div>
+                <h2 class="splash-message">${t`Initializing...`}</h2>
+            </div>`,
     });
 
     registerPromptManagerMigration();

--- a/public/script.js
+++ b/public/script.js
@@ -245,6 +245,7 @@ import {
 } from './scripts/personas.js';
 import { getBackgrounds, initBackgrounds, loadBackgroundSettings, background_settings } from './scripts/backgrounds.js';
 import { loader } from './scripts/action-loader.js';
+import { splashScreen, createSplashScreen, destroySplashScreen } from './scripts/splashscreen.js';
 import { BulkEditOverlay } from './scripts/BulkEditOverlay.js';
 import { initTextGenModels } from './scripts/textgen-models.js';
 import { appendFileContent, hasPendingFileAttachment, populateFileAttachment, decodeStyleTags, encodeStyleTags, isExternalMediaAllowed, preserveNeutralChat, restoreNeutralChat, formatCreatorNotes, initChatUtilities, addDOMPurifyHooks } from './scripts/chats.js';
@@ -698,27 +699,14 @@ async function firstLoadInit() {
         throw new Error('Initialization failed');
     }
 
-    const initLoaderOverlay = loader.createOverlay();
-    initLoaderOverlay.classList.add('splash-screen');
-
-    const splashLogo = document.createElement('img');
-    splashLogo.src = '/img/logo.png';
-    splashLogo.alt = 'SillyTavern';
-    splashLogo.className = 'splash-logo';
-    splashLogo.ariaLabel = t`SillyTavern Logo`;
-
-    const splashMessage = document.createElement('h2');
-    splashMessage.className = 'splash-message';
-    splashMessage.textContent = t`Initializing...`;
-
-    initLoaderOverlay.prepend(splashLogo);
-    initLoaderOverlay.appendChild(splashMessage);
+    const initLoaderOverlay = createSplashScreen('/img/logo.png', t`Initializing...`);
 
     const initLoaderHandle = loader.show({
         toastMode: loader.ToastMode.NONE,
         overlayContent: initLoaderOverlay,
     });
 
+    splashScreen.setStatus(t`Preparing core systems...`);
     registerPromptManagerMigration();
     initDomHandlers();
     initStandaloneMode();
@@ -731,24 +719,35 @@ async function firstLoadInit() {
     await initSecrets();
     await readSecretState();
     await initLocales();
+    splashScreen.setStatus(t`Loading chat utilities...`);
     initChatUtilities();
     initDefaultSlashCommands();
+
+    splashScreen.setStatus(t`Configuring AI backends...`);
     initTextGenModels();
     initOpenAI();
     initTextGenSettings();
     initKoboldSettings();
     initNovelAISettings();
     initSystemPrompts();
+
+    splashScreen.setStatus(t`Loading extensions...`);
     initExtensions();
     initExtensionSlashCommands();
     ToolManager.initToolSlashCommands();
+
+    splashScreen.setStatus(t`Loading presets...`);
     await initPresetManager();
     await initSystemMessages();
+
+    splashScreen.setStatus(t`Loading settings...`);
     await getSettings(initLoaderHandle);
     initKeyboard();
     initDynamicStyles();
     initTags();
     initBookmarks();
+
+    splashScreen.setStatus(t`Loading user data...`);
     await getUserAvatars(true, user_avatar);
     await getCharacters();
     await getBackgrounds();
@@ -756,6 +755,8 @@ async function firstLoadInit() {
     initBackgrounds();
     initAuthorsNote();
     await initPersonas();
+
+    splashScreen.setStatus(t`Preparing UI components...`);
     await initSlashCommandAutoComplete();
     initMacroAutoComplete();
     initWorldInfo();
@@ -776,8 +777,12 @@ async function firstLoadInit() {
     initItemizedPrompts();
     initAccessibility();
     addDebugFunctions();
+
+    splashScreen.setStatus(t`Finalizing...`);
     doDailyExtensionUpdatesCheck();
     await eventSource.emit(event_types.APP_INITIALIZED);
+
+    destroySplashScreen();
     await initLoaderHandle.hide();
     await fixViewport();
     await eventSource.emit(event_types.APP_READY);

--- a/public/script.js
+++ b/public/script.js
@@ -698,14 +698,25 @@ async function firstLoadInit() {
         throw new Error('Initialization failed');
     }
 
+    const initLoaderOverlay = loader.createOverlay();
+    initLoaderOverlay.classList.add('splash-screen');
+
+    const splashLogo = document.createElement('img');
+    splashLogo.src = '/img/logo.png';
+    splashLogo.alt = 'SillyTavern';
+    splashLogo.className = 'splash-logo';
+    splashLogo.ariaLabel = t`SillyTavern Logo`;
+
+    const splashMessage = document.createElement('h2');
+    splashMessage.className = 'splash-message';
+    splashMessage.textContent = t`Initializing...`;
+
+    initLoaderOverlay.prepend(splashLogo);
+    initLoaderOverlay.appendChild(splashMessage);
+
     const initLoaderHandle = loader.show({
         toastMode: loader.ToastMode.NONE,
-        overlayContent: `
-            <div id="loader" class="splash-screen">
-                <img src="/img/logo.png" alt="SillyTavern" class="splash-logo" />
-                <div id="load-spinner" class="fa-solid fa-gear fa-spin fa-3x"></div>
-                <h2 class="splash-message">${t`Initializing...`}</h2>
-            </div>`,
+        overlayContent: initLoaderOverlay,
     });
 
     registerPromptManagerMigration();

--- a/public/script.js
+++ b/public/script.js
@@ -744,6 +744,7 @@ async function firstLoadInit() {
     await getSettings(initLoaderHandle);
 
     splashscreen.setStatus(t`Loading characters...`);
+    initTags();
     await getCharacters();
 
     splashscreen.setStatus(t`Loading user data...`);
@@ -757,7 +758,6 @@ async function firstLoadInit() {
     splashscreen.setStatus(t`Preparing UI components...`);
     initKeyboard();
     initDynamicStyles();
-    initTags();
     initBookmarks();
     await initSlashCommandAutoComplete();
     initMacroAutoComplete();

--- a/public/script.js
+++ b/public/script.js
@@ -244,7 +244,7 @@ import {
     isPersonaPanelOpen,
 } from './scripts/personas.js';
 import { getBackgrounds, initBackgrounds, loadBackgroundSettings, background_settings } from './scripts/backgrounds.js';
-import { hideLoader, showLoader } from './scripts/loader.js';
+import { loader } from './scripts/action-loader.js';
 import { BulkEditOverlay } from './scripts/BulkEditOverlay.js';
 import { initTextGenModels } from './scripts/textgen-models.js';
 import { appendFileContent, hasPendingFileAttachment, populateFileAttachment, decodeStyleTags, encodeStyleTags, isExternalMediaAllowed, preserveNeutralChat, restoreNeutralChat, formatCreatorNotes, initChatUtilities, addDOMPurifyHooks } from './scripts/chats.js';
@@ -698,7 +698,12 @@ async function firstLoadInit() {
         throw new Error('Initialization failed');
     }
 
-    showLoader();
+    const initLoaderHandle = loader.show({
+        title: t`SillyTavern`,
+        message: t`Initializing...`,
+        toastMode: loader.ToastMode.STATIC,
+    });
+
     registerPromptManagerMigration();
     initDomHandlers();
     initStandaloneMode();
@@ -724,7 +729,7 @@ async function firstLoadInit() {
     ToolManager.initToolSlashCommands();
     await initPresetManager();
     await initSystemMessages();
-    await getSettings();
+    await getSettings(initLoaderHandle);
     initKeyboard();
     initDynamicStyles();
     initTags();
@@ -758,7 +763,7 @@ async function firstLoadInit() {
     addDebugFunctions();
     doDailyExtensionUpdatesCheck();
     await eventSource.emit(event_types.APP_INITIALIZED);
-    await hideLoader();
+    await initLoaderHandle.hide();
     await fixViewport();
     await eventSource.emit(event_types.APP_READY);
 }
@@ -7757,7 +7762,7 @@ function reloadLoop() {
 
 //MARK: getSettings()
 ///////////////////////////////////////////
-export async function getSettings() {
+export async function getSettings(initLoaderHandle = null) {
     const response = await fetch('/api/settings/get', {
         method: 'POST',
         headers: getRequestHeaders(),
@@ -7875,7 +7880,7 @@ export async function getSettings() {
         firstRun = !!settings.firstRun;
 
         if (firstRun) {
-            hideLoader();
+            await initLoaderHandle?.hide();
             await doOnboarding(user_avatar);
             firstRun = false;
         }
@@ -10451,7 +10456,7 @@ export async function doNewChat({ deleteCurrentChat = false } = {}) {
  * @param {string} param.newFileName New name for the chat (no JSONL extension)
  * @param {boolean} [param.loader=true] Whether to show loader during the operation
  */
-export async function renameGroupOrCharacterChat({ characterId, groupId, oldFileName, newFileName, loader }) {
+export async function renameGroupOrCharacterChat({ characterId, groupId, oldFileName, newFileName, loader: showLoader }) {
     const currentChatId = getCurrentChatId();
     const body = {
         is_group: !!groupId,
@@ -10469,9 +10474,13 @@ export async function renameGroupOrCharacterChat({ characterId, groupId, oldFile
         return;
     }
 
-    try {
-        loader && showLoader();
+    const loaderHandle = showLoader ? loader.show({
+        title: t`Rename Chat`,
+        message: t`Renaming chat...`,
+        toastMode: loader.ToastMode.STATIC,
+    }) : null;
 
+    try {
         const response = await fetch('/api/chats/rename', {
             method: 'POST',
             body: JSON.stringify(body),
@@ -10504,11 +10513,10 @@ export async function renameGroupOrCharacterChat({ characterId, groupId, oldFile
             await reloadCurrentChat();
         }
     } catch {
-        loader && hideLoader();
         await delay(500);
         await callGenericPopup('An error has occurred. Chat was not renamed.', POPUP_TYPE.TEXT);
     } finally {
-        loader && hideLoader();
+        await loaderHandle?.hide();
     }
 }
 
@@ -11066,21 +11074,32 @@ jQuery(async function () {
     async function handleDeleteChat(chatFile, group, fromSlashCommand = false) {
         // Close past chat popup.
         $('#select_chat_cross').trigger('click');
-        showLoader();
-        if (group) {
-            await deleteGroupChat(group, chatFile);
-        } else {
-            await delChat(`${chatFile}.jsonl`);
+
+        const loaderHandle = loader.show({
+            title: t`Delete Chat`,
+            message: t`Deleting chat...`,
+            toastMode: loader.ToastMode.STATIC,
+        });
+
+        try {
+            if (group) {
+                await deleteGroupChat(group, chatFile);
+            } else {
+                await delChat(`${chatFile}.jsonl`);
+            }
+        } catch (error) {
+            loaderHandle.hide();
+            throw error;
         }
 
         if (fromSlashCommand) {  // When called from `/delchat` command, don't re-open the history view.
             $('#options').hide();  // Hide option popup menu.
-            hideLoader();
+            await loaderHandle.hide();
         } else {  // Open the history view again after 2 seconds (delay to avoid edge cases for deleting last chat).
-            setTimeout(function () {
+            setTimeout(async function () {
                 $('#option_select_chat').trigger('click');
                 $('#options').hide();  // Hide option popup menu.
-                hideLoader();
+                await loaderHandle.hide();
             }, 2000);
         }
     }

--- a/public/script.js
+++ b/public/script.js
@@ -245,7 +245,7 @@ import {
 } from './scripts/personas.js';
 import { getBackgrounds, initBackgrounds, loadBackgroundSettings, background_settings } from './scripts/backgrounds.js';
 import { loader } from './scripts/action-loader.js';
-import { splashScreen, createSplashScreen, destroySplashScreen } from './scripts/splashscreen.js';
+import { splashscreen, createSplashScreen, destroySplashScreen } from './scripts/splashscreen.js';
 import { BulkEditOverlay } from './scripts/BulkEditOverlay.js';
 import { initTextGenModels } from './scripts/textgen-models.js';
 import { appendFileContent, hasPendingFileAttachment, populateFileAttachment, decodeStyleTags, encodeStyleTags, isExternalMediaAllowed, preserveNeutralChat, restoreNeutralChat, formatCreatorNotes, initChatUtilities, addDOMPurifyHooks } from './scripts/chats.js';
@@ -706,7 +706,7 @@ async function firstLoadInit() {
         overlayContent: initLoaderOverlay,
     });
 
-    splashScreen.setStatus(t`Preparing core systems...`);
+    splashscreen.setStatus(t`Preparing core systems...`);
     registerPromptManagerMigration();
     initDomHandlers();
     initStandaloneMode();
@@ -719,11 +719,11 @@ async function firstLoadInit() {
     await initSecrets();
     await readSecretState();
     await initLocales();
-    splashScreen.setStatus(t`Loading chat utilities...`);
+    splashscreen.setStatus(t`Loading chat utilities...`);
     initChatUtilities();
     initDefaultSlashCommands();
 
-    splashScreen.setStatus(t`Configuring AI backends...`);
+    splashscreen.setStatus(t`Configuring AI backends...`);
     initTextGenModels();
     initOpenAI();
     initTextGenSettings();
@@ -731,32 +731,34 @@ async function firstLoadInit() {
     initNovelAISettings();
     initSystemPrompts();
 
-    splashScreen.setStatus(t`Loading extensions...`);
-    initExtensions();
+    splashscreen.setStatus(t`Initializing extensions...`);
+    await initExtensions();
     initExtensionSlashCommands();
     ToolManager.initToolSlashCommands();
 
-    splashScreen.setStatus(t`Loading presets...`);
+    splashscreen.setStatus(t`Loading presets...`);
     await initPresetManager();
     await initSystemMessages();
 
-    splashScreen.setStatus(t`Loading settings...`);
+    splashscreen.setStatus(t`Loading settings...`);
     await getSettings(initLoaderHandle);
-    initKeyboard();
-    initDynamicStyles();
-    initTags();
-    initBookmarks();
 
-    splashScreen.setStatus(t`Loading user data...`);
-    await getUserAvatars(true, user_avatar);
+    splashscreen.setStatus(t`Loading characters...`);
     await getCharacters();
+
+    splashscreen.setStatus(t`Loading user data...`);
+    await getUserAvatars(true, user_avatar);
     await getBackgrounds();
     await initTokenizers();
     initBackgrounds();
     initAuthorsNote();
     await initPersonas();
 
-    splashScreen.setStatus(t`Preparing UI components...`);
+    splashscreen.setStatus(t`Preparing UI components...`);
+    initKeyboard();
+    initDynamicStyles();
+    initTags();
+    initBookmarks();
     await initSlashCommandAutoComplete();
     initMacroAutoComplete();
     initWorldInfo();
@@ -778,8 +780,10 @@ async function firstLoadInit() {
     initAccessibility();
     addDebugFunctions();
 
-    splashScreen.setStatus(t`Finalizing...`);
+    splashscreen.setStatus(t`Checking extension updates...`);
     doDailyExtensionUpdatesCheck();
+
+    splashscreen.setStatus(t`Finalizing...`);
     await eventSource.emit(event_types.APP_INITIALIZED);
 
     destroySplashScreen();
@@ -7891,6 +7895,7 @@ export async function getSettings(initLoaderHandle = null) {
         initMacros();
 
         if (data.enable_extensions) {
+            splashscreen.setStatus(t`Loading extensions...`);
             const enableAutoUpdate = Boolean(data.enable_extensions_auto_update);
             const isVersionChanged = settings.currentVersion !== currentVersion;
             await loadExtensionSettings(settings, isVersionChanged, enableAutoUpdate);

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -14,10 +14,11 @@ import {
 } from '../script.js';
 
 import { favsToHotswap } from './RossAscends-mods.js';
-import { hideLoader, showLoader } from './loader.js';
+import { loader } from './action-loader.js';
 import { convertCharacterToPersona } from './personas.js';
 import { callGenericPopup, POPUP_TYPE } from './popup.js';
 import { createTagInput, getTagKeyForEntity, getTagsList, printTagList, tag_map, compareTagsForSort, removeTagFromMap, importTags, tag_import_setting } from './tags.js';
+import { t } from './i18n.js';
 
 /**
  * Static object representing the actions of the
@@ -846,15 +847,15 @@ class BulkEditOverlay {
 
                 const deleteChats = checkbox.prop('checked') ?? false;
 
-                showLoader();
-                const toast = toastr.info('We\'re deleting your characters, please wait...', 'Working on it');
+                const loaderHandle = loader.show({
+                    title: t`Bulk Delete`,
+                    message: t`Deleting ${characterIds.length} character(s)...`,
+                    toastMode: loader.ToastMode.STATIC,
+                });
                 const avatarList = characterIds.map(id => characters[id]?.avatar).filter(a => a);
                 return CharacterContextMenu.delete(avatarList, deleteChats)
                     .then(() => this.browseState())
-                    .finally(() => {
-                        toastr.clear(toast);
-                        hideLoader();
-                    });
+                    .finally(() => loaderHandle.hide());
             });
 
         // At this moment the popup is already changed in the dom, but not yet closed/resolved. We build the avatar list here

--- a/public/scripts/action-loader.js
+++ b/public/scripts/action-loader.js
@@ -1,16 +1,19 @@
 /**
- * Action loader utility - shows loader overlay with stoppable toast notification.
+ * Unified action loader system - shows loader overlay with optional toast notifications.
  * Designed to be flexible and reusable for various long-running operations.
- * Supports stacking multiple loaders - overlay stays single, but toasts can stack.
  *
- * With default arguments, will function as a generation loader / wrapper.
+ * Features:
+ * - Stacking multiple loaders - overlay stays single, but toasts can stack
+ * - Blocking and non-blocking modes
+ * - Stoppable or static toasts
+ * - Class-based handle system for fine-grained control
  *
  * @module action-loader
  */
 
 import { t } from './i18n.js';
 import { stopGeneration } from '../script.js';
-import { showLoader, hideLoader, isLoaderDisplayed } from './loader.js';
+import { Popup, POPUP_RESULT, POPUP_TYPE } from './popup.js';
 
 /**
  * Enum representing the toast display mode for the action loader.
@@ -118,8 +121,8 @@ export class ActionLoaderHandle {
         }
 
         // Show the blocking loader overlay if this is the first blocking handle
-        if (blocking && !hasBlockingLoaders() && !isLoaderDisplayed()) {
-            showLoader();
+        if (blocking && !hasBlockingLoaders() && !isOverlayDisplayed()) {
+            showOverlay();
         }
 
         // Register this handle
@@ -191,7 +194,7 @@ export class ActionLoaderHandle {
 
         // Hide the overlay if this was the last blocking handle
         if (this.#blocking && !hasBlockingLoaders()) {
-            await hideLoader();
+            await hideOverlay();
         }
     }
 
@@ -301,6 +304,12 @@ export const loader = {
     get: getLoaderHandleById,
 
     /**
+     * Checks if any blocking loader overlay is currently displayed.
+     * @returns {boolean} True if a blocking overlay is shown
+     */
+    isBlocking: isOverlayDisplayed,
+
+    /**
      * Toast display mode constants.
      * @type {typeof ActionLoaderToastMode}
      */
@@ -404,3 +413,107 @@ export function getLoaderHandleById(id) {
     }
     return undefined;
 }
+
+// ============================================================================
+// Internal overlay management
+// ============================================================================
+
+/** @type {Popup|null} The current loader overlay popup */
+let loaderPopup = null;
+
+/** Whether the initial HTML preloader has been removed */
+let preloaderYoinked = false;
+
+/**
+ * Checks if the loader overlay is currently displayed.
+ * @returns {boolean} True if overlay is shown
+ */
+function isOverlayDisplayed() {
+    return !!loaderPopup;
+}
+
+/**
+ * Shows the blocking loader overlay.
+ * Internal function - use showActionLoader() instead.
+ */
+function showOverlay() {
+    // Two loaders don't make sense. Don't await, we can overlay the old loader while it closes
+    if (loaderPopup) loaderPopup.complete(POPUP_RESULT.CANCELLED);
+
+    loaderPopup = new Popup(`
+        <div id="loader">
+            <div id="load-spinner" class="fa-solid fa-gear fa-spin fa-3x"></div>
+        </div>`, POPUP_TYPE.DISPLAY, null, { transparent: true, animation: 'none', wide: true, large: true });
+
+    // No close button, loaders are not closable
+    loaderPopup.closeButton.style.display = 'none';
+
+    loaderPopup.show();
+}
+
+/**
+ * Hides the blocking loader overlay with animation.
+ * Internal function - use hideActionLoader() instead.
+ * @returns {Promise<void>}
+ */
+async function hideOverlay() {
+    if (!loaderPopup) {
+        return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+        const spinner = $('#load-spinner');
+        if (!spinner.length) {
+            console.warn('Spinner element not found, skipping animation');
+            cleanup();
+            return;
+        }
+
+        // Check if transitions are enabled
+        const transitionDuration = spinner[0] ? getComputedStyle(spinner[0]).transitionDuration : '0s';
+        const hasTransitions = parseFloat(transitionDuration) > 0;
+
+        if (hasTransitions) {
+            Promise.race([
+                new Promise((r) => setTimeout(r, 500)), // Fallback timeout
+                new Promise((r) => spinner.one('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', r)),
+            ]).finally(cleanup);
+        } else {
+            cleanup();
+        }
+
+        function cleanup() {
+            $('#loader').remove();
+            // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
+            // If it's present, we remove it once and then it's gone.
+            yoinkPreloader();
+
+            loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE)
+                .catch((err) => console.error('Error completing loaderPopup:', err))
+                .finally(() => {
+                    loaderPopup = null;
+                    resolve();
+                });
+        }
+
+        // Apply the styles
+        spinner.css({
+            'filter': 'blur(15px)',
+            'opacity': '0',
+        });
+    });
+}
+
+/**
+ * Removes the initial HTML preloader element.
+ * Called once after the first loader hide.
+ */
+function yoinkPreloader() {
+    if (preloaderYoinked) return;
+    document.getElementById('preloader')?.remove();
+    preloaderYoinked = true;
+}
+
+// ============================================================================
+// End internal overlay management
+// ============================================================================

--- a/public/scripts/action-loader.js
+++ b/public/scripts/action-loader.js
@@ -36,6 +36,7 @@ export const ActionLoaderToastMode = {
  * @property {string} [message='Generating...'] - The message to display in the toast
  * @property {string} [title] - Optional title for the toast notification
  * @property {string} [stopTooltip='Stop'] - Tooltip text for the stop button
+ * @property {string|null} [overlayContent=null] - Custom HTML content for the overlay (replaces default spinner)
  * @property {(() => void)|null} [onStop=null] - Custom stop handler. If null, calls `stopGeneration()`
  * @property {(() => void)|null} [onHide=null] - Custom hide handler. Called when the loader is hidden (not stopped).
  */
@@ -98,6 +99,7 @@ export class ActionLoaderHandle {
      * @param {string} [options.message='Generating...'] - Message to display in the toast
      * @param {string} [options.title] - Title for the toast notification
      * @param {string} [options.stopTooltip='Stop'] - Tooltip for the stop button
+     * @param {string|null} [options.overlayContent] - Custom HTML content for the overlay (replaces default spinner)
      * @param {(() => void)|null} [options.onStop] - Custom stop handler
      * @param {(() => void)|null} [options.onHide] - Custom hide handler
      */
@@ -107,6 +109,7 @@ export class ActionLoaderHandle {
         message = t`Generating...`,
         title = '',
         stopTooltip = t`Stop`,
+        overlayContent = null,
         onStop = null,
         onHide = null,
     } = {}) {
@@ -116,13 +119,13 @@ export class ActionLoaderHandle {
         this.#onHide = onHide;
 
         // Warn if non-blocking loader has no toast - it won't be visible to the user
-        if (!blocking && toastMode === ActionLoaderToastMode.NONE) {
+        if (!blocking && toastMode === ActionLoaderToastMode.NONE && !overlayContent) {
             console.warn('[ActionLoader] Non-blocking loader created without a toast. This loader will not be visible to the user.');
         }
 
         // Show the blocking loader overlay if this is the first blocking handle
         if (blocking && !hasBlockingLoaders() && !isOverlayDisplayed()) {
-            showOverlay();
+            showOverlay(overlayContent);
         }
 
         // Register this handle
@@ -435,15 +438,18 @@ function isOverlayDisplayed() {
 /**
  * Shows the blocking loader overlay.
  * Internal function - use showActionLoader() instead.
+ * @param {string|null} [customContent] - Custom HTML content for the overlay
  */
-function showOverlay() {
+function showOverlay(customContent = null) {
     // Two loaders don't make sense. Don't await, we can overlay the old loader while it closes
     if (loaderPopup) loaderPopup.complete(POPUP_RESULT.CANCELLED);
 
-    loaderPopup = new Popup(`
+    const content = customContent ?? `
         <div id="loader">
             <div id="load-spinner" class="fa-solid fa-gear fa-spin fa-3x"></div>
-        </div>`, POPUP_TYPE.DISPLAY, null, { transparent: true, animation: 'none', wide: true, large: true });
+        </div>`;
+
+    loaderPopup = new Popup(content, POPUP_TYPE.DISPLAY, null, { transparent: true, animation: 'none', wide: true, large: true });
 
     // No close button, loaders are not closable
     loaderPopup.closeButton.style.display = 'none';

--- a/public/scripts/action-loader.js
+++ b/public/scripts/action-loader.js
@@ -36,7 +36,7 @@ export const ActionLoaderToastMode = {
  * @property {string} [message='Generating...'] - The message to display in the toast
  * @property {string} [title] - Optional title for the toast notification
  * @property {string} [stopTooltip='Stop'] - Tooltip text for the stop button
- * @property {string|null} [overlayContent=null] - Custom HTML content for the overlay (replaces default spinner)
+ * @property {HTMLElement|string|null} [overlayContent=null] - Custom content for the overlay (replaces default spinner)
  * @property {(() => void)|null} [onStop=null] - Custom stop handler. If null, calls `stopGeneration()`
  * @property {(() => void)|null} [onHide=null] - Custom hide handler. Called when the loader is hidden (not stopped).
  */
@@ -99,7 +99,7 @@ export class ActionLoaderHandle {
      * @param {string} [options.message='Generating...'] - Message to display in the toast
      * @param {string} [options.title] - Title for the toast notification
      * @param {string} [options.stopTooltip='Stop'] - Tooltip for the stop button
-     * @param {string|null} [options.overlayContent] - Custom HTML content for the overlay (replaces default spinner)
+     * @param {HTMLElement|string|null} [options.overlayContent] - Custom content for the overlay (replaces default spinner)
      * @param {(() => void)|null} [options.onStop] - Custom stop handler
      * @param {(() => void)|null} [options.onHide] - Custom hide handler
      */
@@ -323,6 +323,12 @@ export const loader = {
      * @type {typeof ActionLoaderHandle}
      */
     Handle: ActionLoaderHandle,
+
+    /**
+     * Creates a fresh default loader overlay element.
+     * @type {typeof createDefaultLoaderOverlay}
+     */
+    createOverlay: createDefaultLoaderOverlay,
 };
 
 /**
@@ -428,6 +434,42 @@ let loaderPopup = null;
 let preloaderYoinked = false;
 
 /**
+ * Creates the default loader overlay element.
+ * Always returns a fresh element instance.
+ *
+ * @returns {HTMLDivElement} A new loader overlay element
+ */
+export function createDefaultLoaderOverlay() {
+    const loaderElement = document.createElement('div');
+    loaderElement.id = 'loader';
+
+    const spinnerElement = document.createElement('div');
+    spinnerElement.id = 'load-spinner';
+    spinnerElement.className = 'fa-solid fa-gear fa-spin fa-3x';
+
+    loaderElement.appendChild(spinnerElement);
+
+    return loaderElement;
+}
+
+/**
+ * Normalizes custom overlay content into a value supported by Popup.
+ * @param {string|HTMLElement|null} customContent - Custom overlay content
+ * @returns {string|HTMLElement} Content for Popup
+ */
+function getOverlayContent(customContent) {
+    if (typeof customContent === 'string') {
+        return customContent;
+    }
+
+    if (customContent instanceof HTMLElement) {
+        return customContent;
+    }
+
+    return createDefaultLoaderOverlay();
+}
+
+/**
  * Checks if the loader overlay is currently displayed.
  * @returns {boolean} True if overlay is shown
  */
@@ -438,16 +480,13 @@ function isOverlayDisplayed() {
 /**
  * Shows the blocking loader overlay.
  * Internal function - use showActionLoader() instead.
- * @param {string|null} [customContent] - Custom HTML content for the overlay
+ * @param {HTMLElement|string|null} [customContent] - Custom content for the overlay
  */
 function showOverlay(customContent = null) {
     // Two loaders don't make sense. Don't await, we can overlay the old loader while it closes
     if (loaderPopup) loaderPopup.complete(POPUP_RESULT.CANCELLED);
 
-    const content = customContent ?? `
-        <div id="loader">
-            <div id="load-spinner" class="fa-solid fa-gear fa-spin fa-3x"></div>
-        </div>`;
+    const content = getOverlayContent(customContent);
 
     loaderPopup = new Popup(content, POPUP_TYPE.DISPLAY, null, { transparent: true, animation: 'none', wide: true, large: true });
 

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -25,7 +25,7 @@ import {
     saveGroupBookmarkChat,
     selected_group,
 } from './group-chats.js';
-import { hideLoader, showLoader } from './loader.js';
+import { loader } from './action-loader.js';
 import { getLastMessageId } from './macros.js';
 import { Popup } from './popup.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
@@ -661,15 +661,20 @@ export function initBookmarks() {
             return;
         }
 
+        const loaderHandle = loader.show({
+            title: t`Bookmark`,
+            message: t`Loading chat...`,
+            toastMode: loader.ToastMode.STATIC,
+        });
+
         try {
-            showLoader();
             if (selected_group) {
                 await openGroupChat(selected_group, fileName);
             } else {
                 await openCharacterChat(fileName);
             }
         } finally {
-            await hideLoader();
+            await loaderHandle.hide();
         }
 
         $('#shadow_select_chat_popup').css('display', 'none');

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -662,7 +662,7 @@ export function initBookmarks() {
         }
 
         const loaderHandle = loader.show({
-            title: t`Bookmark`,
+            title: t`Chat History`,
             message: t`Loading chat...`,
             toastMode: loader.ToastMode.STATIC,
         });

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1,7 +1,6 @@
 import { DOMPurify, Popper } from '../lib.js';
 
 import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration, CLIENT_VERSION } from '../script.js';
-import { loader } from './action-loader.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
 import { delay, equalsIgnoreCaseAndAccents, isSubsetOf, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1,7 +1,7 @@
 import { DOMPurify, Popper } from '../lib.js';
 
 import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration, CLIENT_VERSION } from '../script.js';
-import { showLoader } from './loader.js';
+import { loader } from './action-loader.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
 import { delay, equalsIgnoreCaseAndAccents, isSubsetOf, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';
@@ -1158,7 +1158,11 @@ async function showExtensionsDetails() {
         abortController.abort();
     }
     if (requiresReload) {
-        showLoader();
+        loader.show({
+            title: t`Extensions`,
+            message: t`Reloading to apply changes...`,
+            toastMode: loader.ToastMode.STATIC,
+        });
         location.reload();
     }
 }

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1158,11 +1158,6 @@ async function showExtensionsDetails() {
         abortController.abort();
     }
     if (requiresReload) {
-        loader.show({
-            title: t`Extensions`,
-            message: t`Reloading to apply changes...`,
-            toastMode: loader.ToastMode.STATIC,
-        });
         location.reload();
     }
 }

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -573,7 +573,7 @@ async function activateExtensions() {
         if (meetsModuleRequirements && meetsExtensionDeps && meetsClientMinimumVersion && !isDisabled) {
             try {
                 console.debug('Activating extension', name);
-                registerExtension(name, displayName, name.startsWith('third-party') ? 'third-party' : 'built-in');
+                registerExtension(name, displayName, name.startsWith('third-party') ? 'third-party' : 'built-in', { showNow: true });
                 const promise = addExtensionLocale(name, manifest).finally(() =>
                     Promise.all([addExtensionScript(name, manifest), addExtensionStyle(name, manifest)]),
                 );

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1,6 +1,7 @@
 import { DOMPurify, Popper } from '../lib.js';
 
 import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration, CLIENT_VERSION } from '../script.js';
+import { registerExtension } from './splashscreen.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
 import { delay, equalsIgnoreCaseAndAccents, isSubsetOf, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';
@@ -572,6 +573,7 @@ async function activateExtensions() {
         if (meetsModuleRequirements && meetsExtensionDeps && meetsClientMinimumVersion && !isDisabled) {
             try {
                 console.debug('Activating extension', name);
+                registerExtension(name, displayName, name.startsWith('third-party') ? 'third-party' : 'built-in');
                 const promise = addExtensionLocale(name, manifest).finally(() =>
                     Promise.all([addExtensionScript(name, manifest), addExtensionStyle(name, manifest)]),
                 );

--- a/public/scripts/extensions/assets/index.js
+++ b/public/scripts/extensions/assets/index.js
@@ -435,7 +435,7 @@ async function updateCurrentAssets() {
 //#############################//
 
 // This function is called when the extension is loaded
-jQuery(async () => {
+export async function init() {
     // This is an example of loading HTML from a file
     const windowTemplate = await renderExtensionTemplateAsync(MODULE_NAME, 'window', {});
     const windowHtml = $(windowTemplate);
@@ -496,4 +496,4 @@ jQuery(async () => {
     eventSource.on(event_types.OPEN_CHARACTER_LIBRARY, async (forceDefault) => {
         openCharacterBrowser(forceDefault);
     });
-});
+}

--- a/public/scripts/extensions/assets/manifest.json
+++ b/public/scripts/extensions/assets/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Keij#6799",
     "version": "0.1.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/attachments/index.js
+++ b/public/scripts/extensions/attachments/index.js
@@ -243,7 +243,7 @@ function handleCharacterRename(oldAvatar, newAvatar) {
     }
 }
 
-jQuery(async () => {
+export async function init() {
     eventSource.on(event_types.APP_READY, cleanUpAttachments);
     eventSource.on(event_types.CHARACTER_DELETED, cleanUpCharacterAttachments);
     eventSource.on(event_types.CHARACTER_RENAMED, handleCharacterRename);
@@ -407,4 +407,4 @@ jQuery(async () => {
             }),
         ],
     }));
-});
+}

--- a/public/scripts/extensions/attachments/manifest.json
+++ b/public/scripts/extensions/attachments/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Cohee1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -454,7 +454,7 @@ function isVideoCaptioningAvailable() {
     return ['google', 'vertexai', 'zai'].includes(extension_settings.caption.multimodal_api);
 }
 
-jQuery(async function () {
+export async function init() {
     function addSendPictureButton() {
         const sendButton = $(`
         <div id="send_picture" class="list-group-item flex-container flexGap5">
@@ -804,4 +804,4 @@ jQuery(async function () {
     }));
 
     document.body.classList.add('caption');
-});
+}

--- a/public/scripts/extensions/caption/manifest.json
+++ b/public/scripts/extensions/caption/manifest.json
@@ -9,5 +9,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -474,7 +474,7 @@ async function renderDetailsContent(detailsContent) {
     }
 }
 
-(async function () {
+export async function init() {
     extension_settings.connectionManager = extension_settings.connectionManager || structuredClone(DEFAULT_SETTINGS);
 
     for (const key of Object.keys(DEFAULT_SETTINGS)) {
@@ -824,4 +824,4 @@ async function renderDetailsContent(detailsContent) {
             return JSON.stringify(profile);
         },
     }));
-})();
+}

--- a/public/scripts/extensions/connection-manager/manifest.json
+++ b/public/scripts/extensions/connection-manager/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Cohee1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -18,6 +18,7 @@ import { generateWebLlmChatPrompt, isWebLlmSupported } from '../shared.js';
 import { Popup, POPUP_RESULT } from '../../popup.js';
 import { t } from '../../i18n.js';
 import { removeReasoningFromString } from '../../reasoning.js';
+import { splashscreen } from '../../splashscreen.js';
 export { MODULE_NAME };
 
 /**
@@ -2140,7 +2141,8 @@ function migrateSettings() {
     }
 }
 
-(async function () {
+export async function init() {
+    splashscreen.setExtensionStatus('Loading expression sprites...');
     function addExpressionImage() {
         const html = `
         <div id="expression-wrapper">
@@ -2224,6 +2226,7 @@ function migrateSettings() {
 
     addExpressionImage();
     addVisualNovelMode();
+    splashscreen.setExtensionStatus('Initializing settings...');
     migrateSettings();
     await addSettings();
     const wrapper = new ModuleWorkerWrapper(moduleWorker);
@@ -2283,6 +2286,7 @@ function migrateSettings() {
         },
     };
 
+    splashscreen.setExtensionStatus('Registering slash commands...');
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'expression-set',
         aliases: ['sprite', 'emote'],
@@ -2511,4 +2515,4 @@ function migrateSettings() {
             </div>
         `,
     }));
-})();
+}

--- a/public/scripts/extensions/expressions/manifest.json
+++ b/public/scripts/extensions/expressions/manifest.json
@@ -9,5 +9,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/gallery/index.js
+++ b/public/scripts/extensions/gallery/index.js
@@ -818,7 +818,7 @@ function addGalleryWandButton() {
 }
 
 // On extension load, ensure the settings are initialized
-(function () {
+export async function init() {
     initSettings();
     eventSource.on(event_types.CHARACTER_RENAMED, (oldAvatar, newAvatar) => {
         const context = SillyTavern.getContext();
@@ -850,4 +850,4 @@ function addGalleryWandButton() {
         }),
     );
     addGalleryWandButton();
-})();
+}

--- a/public/scripts/extensions/gallery/manifest.json
+++ b/public/scripts/extensions/gallery/manifest.json
@@ -8,5 +8,8 @@
     "css": "style.css",
     "author": "City-Unit",
     "version": "1.5.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/memory/index.js
+++ b/public/scripts/extensions/memory/index.js
@@ -1130,4 +1130,4 @@ export async function init() {
             () => summaryMacroHandler(),
             'Returns the latest memory/summary from the current chat.');
     }
-};
+}

--- a/public/scripts/extensions/memory/index.js
+++ b/public/scripts/extensions/memory/index.js
@@ -28,6 +28,7 @@ import { SlashCommand } from '../../slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '../../slash-commands/SlashCommandArgument.js';
 import { macros, MacroCategory } from '../../macros/macro-system.js';
 import { countWebLlmTokens, generateWebLlmChatPrompt, getWebLlmContextSize, isWebLlmSupported } from '../shared.js';
+import { splashscreen } from '../../splashscreen.js';
 import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { removeReasoningFromString } from '../../reasoning.js';
 import { MacrosParser } from '/scripts/macros.js';
@@ -1063,7 +1064,8 @@ function setupListeners() {
     });
 }
 
-jQuery(async function () {
+export async function init() {
+    splashscreen.setExtensionStatus('Loading summarization settings...');
     async function addExtensionControls() {
         const settingsHtml = await renderExtensionTemplateAsync('memory', 'settings', { defaultSettings });
         $('#summarize_container').append(settingsHtml);
@@ -1128,4 +1130,4 @@ jQuery(async function () {
             () => summaryMacroHandler(),
             'Returns the latest memory/summary from the current chat.');
     }
-});
+};

--- a/public/scripts/extensions/memory/manifest.json
+++ b/public/scripts/extensions/memory/manifest.json
@@ -9,5 +9,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -1,5 +1,6 @@
 import { chat, chat_metadata, eventSource, event_types, getRequestHeaders, this_chid, characters } from '../../../script.js';
 import { extension_settings } from '../../extensions.js';
+import { splashscreen } from '../../splashscreen.js';
 import { QuickReplyApi } from './api/QuickReplyApi.js';
 import { AutoExecuteHandler } from './src/AutoExecuteHandler.js';
 import { QuickReply } from './src/QuickReply.js';
@@ -169,7 +170,8 @@ const handleCharChange = () => {
     settings.charConfig = charConfig;
 };
 
-const init = async () => {
+export async function init() {
+    splashscreen.setExtensionStatus('Loading quick reply sets...');
     await loadSets();
     await loadSettings();
     log('settings: ', settings);
@@ -229,7 +231,6 @@ const finalizeInit = async () => {
     isReady = true;
     debug('READY');
 };
-await init();
 
 const purgeCharacterQuickReplySets = ({ character }) => {
     // Remove the character's Quick Reply Sets from the settings.

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -216,7 +216,8 @@ export async function init() {
     eventSource.on(event_types.APP_READY, async () => await finalizeInit());
 
     globalThis.quickReplyApi = quickReplyApi;
-};
+}
+
 const finalizeInit = async () => {
     debug('executing startup');
     await autoExec.handleStartup();

--- a/public/scripts/extensions/quick-reply/manifest.json
+++ b/public/scripts/extensions/quick-reply/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "RossAscends#1779",
     "version": "2.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -11,6 +11,7 @@ import { download, equalsIgnoreCaseAndAccents, escapeHtml, getFileText, getSorta
 import { allowPresetScripts, allowScopedScripts, disallowPresetScripts, disallowScopedScripts, getCurrentPresetAPI, getCurrentPresetName, getRegexScripts, getScriptsByType, isPresetScriptsAllowed, isScopedScriptsAllowed, regex_placement, RegexProvider, runRegexScript, saveScriptsByType, SCRIPT_TYPE_UNKNOWN, SCRIPT_TYPES, substitute_find_regex } from './engine.js';
 import { t } from '../../i18n.js';
 import { accountStorage } from '../../util/AccountStorage.js';
+import { splashscreen } from '../../splashscreen.js';
 import { getPresetManager } from '../../preset-manager.js';
 
 // Re-exports for legacy extensions
@@ -1707,9 +1708,8 @@ function onPresetRenamed({ apiId, oldName, newName }) {
     }
 }
 
-// Workaround for loading in sequence with other extensions
-// NOTE: Always puts extension at the top of the list, but this is fine since it's static
-jQuery(async () => {
+export async function init() {
+    splashscreen.setExtensionStatus('Loading regex scripts...');
     if (!Array.isArray(extension_settings.regex)) {
         extension_settings.regex = [];
     }
@@ -2123,4 +2123,4 @@ jQuery(async () => {
 
     presetManager.setupEventListeners();
     presetManager.registerSlashCommands();
-});
+};

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -2123,4 +2123,4 @@ export async function init() {
 
     presetManager.setupEventListeners();
     presetManager.registerSlashCommands();
-};
+}

--- a/public/scripts/extensions/regex/manifest.json
+++ b/public/scripts/extensions/regex/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "kingbri",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -62,6 +62,7 @@ import { t, translate } from '../../i18n.js';
 import { oai_settings } from '../../openai.js';
 import { power_user } from '/scripts/power-user.js';
 import { MacrosParser } from '/scripts/macros.js';
+import { splashscreen } from '/scripts/splashscreen.js';
 
 export { MODULE_NAME };
 
@@ -5442,11 +5443,13 @@ function registerFunctionTool() {
     });
 }
 
-jQuery(async () => {
+export async function init() {
+    splashscreen.setExtensionStatus('Configuring image generation...');
     await addSDGenButtons();
 
     const getSelectEnumProvider = (id, text) => () => Array.from(document.querySelectorAll(`#${id} > [value]`)).map(x => new SlashCommandEnumValue(x.getAttribute('value'), text ? x.textContent : null));
 
+    splashscreen.setExtensionStatus('Registering slash commands...');
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'imagine',
         returns: 'URL of the generated image, or an empty string if the generation failed',
@@ -5757,7 +5760,7 @@ jQuery(async () => {
         helpString: '(workflowName) - change the workflow to be used for image generation with ComfyUI, e.g. <pre><code>/imagine-comfy-workflow MyWorkflow</code></pre>',
     }));
 
-
+    splashscreen.setExtensionStatus('Loading settings...');
     const template = await renderExtensionTemplateAsync('stable-diffusion', 'settings', defaultSettings);
     $('#sd_container').append(template);
     $('#sd_source').on('change', onSourceChange);
@@ -5949,4 +5952,4 @@ jQuery(async () => {
             t`Character's negative Image Generation prompt prefix`,
         );
     }
-});
+}

--- a/public/scripts/extensions/stable-diffusion/manifest.json
+++ b/public/scripts/extensions/stable-diffusion/manifest.json
@@ -10,5 +10,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/token-counter/index.js
+++ b/public/scripts/extensions/token-counter/index.js
@@ -101,7 +101,7 @@ async function doCount() {
     return count;
 }
 
-jQuery(() => {
+export function init() {
     const buttonHtml = `
         <div id="token_counter" class="list-group-item flex-container flexGap5">
             <div class="fa-solid fa-1 extensionsMenuExtensionButton" /></div>` +
@@ -115,4 +115,4 @@ jQuery(() => {
         returns: 'number of tokens',
         helpString: 'Counts the number of tokens in the current chat.',
     }));
-});
+}

--- a/public/scripts/extensions/token-counter/manifest.json
+++ b/public/scripts/extensions/token-counter/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/translate/index.js
+++ b/public/scripts/extensions/translate/index.js
@@ -19,6 +19,7 @@ import { enumIcons } from '../../slash-commands/SlashCommandCommonEnumsProvider.
 import { enumTypes, SlashCommandEnumValue } from '../../slash-commands/SlashCommandEnumValue.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
 import { splitRecursive } from '../../utils.js';
+import { splashscreen } from '../../splashscreen.js';
 
 export const autoModeOptions = {
     NONE: 'none',
@@ -707,7 +708,8 @@ const handleMessageReasoningDelete = createEventHandler(removeReasoningDisplayTe
 
 globalThis.translate = translate;
 
-jQuery(async () => {
+export async function init() {
+    splashscreen.setExtensionStatus('Loading translation settings...');
     const html = await renderExtensionTemplateAsync('translate', 'index');
     const buttonHtml = await renderExtensionTemplateAsync('translate', 'buttons');
 
@@ -801,4 +803,4 @@ jQuery(async () => {
         },
         returns: ARGUMENT_TYPE.STRING,
     }));
-});
+}

--- a/public/scripts/extensions/translate/manifest.json
+++ b/public/scripts/extensions/translate/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -38,6 +38,7 @@ import { ElectronHubTtsProvider } from './electronhub.js';
 import { ChutesTtsProvider } from './chutes.js';
 import { VolcengineTtsProvider } from './volcengine.js';
 import { applyLocale, t } from '/scripts/i18n.js';
+import { splashscreen } from '/scripts/splashscreen.js';
 
 const UPDATE_INTERVAL = 1000;
 const wrapper = new ModuleWorkerWrapper(moduleWorker);
@@ -1506,7 +1507,8 @@ async function initVoiceMapInternal(unrestricted) {
     updateVoiceMap();
 }
 
-jQuery(async function () {
+export async function init() {
+    splashscreen.setExtensionStatus('Loading TTS providers...');
     async function addExtensionControls() {
         const settingsHtml = $(await renderExtensionTemplateAsync('tts', 'settings'));
         $('#tts_container').append(settingsHtml);
@@ -1594,4 +1596,4 @@ jQuery(async function () {
     }));
 
     document.body.appendChild(audioElement);
-});
+}

--- a/public/scripts/extensions/tts/manifest.json
+++ b/public/scripts/extensions/tts/manifest.json
@@ -11,5 +11,8 @@
     "css": "style.css",
     "author": "Ouoertheo#7264",
     "version": "1.0.0",
-    "homePage": "None"
+    "homePage": "None",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -38,6 +38,7 @@ import { generateWebLlmChatPrompt, isWebLlmSupported } from '../shared.js';
 import { WebLlmVectorProvider } from './webllm.js';
 import { removeReasoningFromString } from '../../reasoning.js';
 import { oai_settings } from '../../openai.js';
+import { splashscreen } from '../../splashscreen.js';
 
 /**
  * @typedef {object} HashedMessage
@@ -1655,7 +1656,8 @@ async function activateWorldInfo(chat) {
     await eventSource.emit(event_types.WORLDINFO_FORCE_ACTIVATE, activatedEntries);
 }
 
-jQuery(async () => {
+export async function init() {
+    splashscreen.setExtensionStatus('Configuring vector storage...');
     if (!extension_settings.vectors) {
         extension_settings.vectors = settings;
     }
@@ -2256,4 +2258,4 @@ jQuery(async () => {
         }
         await purgeAllVectorIndexes();
     });
-});
+}

--- a/public/scripts/extensions/vectors/manifest.json
+++ b/public/scripts/extensions/vectors/manifest.json
@@ -10,5 +10,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -1,4 +1,4 @@
-import { showActionLoader, ActionLoaderToastMode } from './action-loader.js';
+import { loader } from './action-loader.js';
 
 /**
  * Handle for the legacy loader created by showLoader().
@@ -27,9 +27,9 @@ export function showLoader() {
     }
 
     // Create a blocking loader with no toast (matches old behavior)
-    legacyLoaderHandle = showActionLoader({
+    legacyLoaderHandle = loader.show({
         blocking: true,
-        toastMode: ActionLoaderToastMode.NONE,
+        toastMode: loader.ToastMode.NONE,
     });
 }
 

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -1,80 +1,59 @@
-import { POPUP_RESULT, POPUP_TYPE, Popup } from './popup.js';
+import { showActionLoader, ActionLoaderToastMode } from './action-loader.js';
 
-/** @type {Popup} */
-let loaderPopup;
+/**
+ * Handle for the legacy loader created by showLoader().
+ * @type {import('./action-loader.js').ActionLoaderHandle|null}
+ */
+let legacyLoaderHandle = null;
 
-let preloaderYoinked = false;
-
-export function isLoaderDisplayed() {
-    return !!loaderPopup;
-}
-
+/**
+ * Shows the loader overlay.
+ *
+ * @deprecated Use `showActionLoader()` from action-loader.js instead.
+ * This function now creates a blocking action loader with no toast.
+ * The new system supports stacking multiple loaders and provides better control.
+ *
+ * @example
+ * // New recommended approach:
+ * import { showActionLoader } from './action-loader.js';
+ * const handle = showActionLoader({ message: 'Loading...' });
+ * // ... do work ...
+ * handle.hide();
+ */
 export function showLoader() {
-    // Two loaders don't make sense. Don't await, we can overlay the old loader while it closes
-    if (loaderPopup) loaderPopup.complete(POPUP_RESULT.CANCELLED);
+    // Hide any existing legacy loader first to maintain old behavior
+    if (legacyLoaderHandle && legacyLoaderHandle.isActive) {
+        legacyLoaderHandle.hide();
+    }
 
-    loaderPopup = new Popup(`
-        <div id="loader">
-            <div id="load-spinner" class="fa-solid fa-gear fa-spin fa-3x"></div>
-        </div>`, POPUP_TYPE.DISPLAY, null, { transparent: true, animation: 'none', wide: true, large: true });
-
-    // No close button, loaders are not closable
-    loaderPopup.closeButton.style.display = 'none';
-
-    loaderPopup.show();
+    // Create a blocking loader with no toast (matches old behavior)
+    legacyLoaderHandle = showActionLoader({
+        blocking: true,
+        toastMode: ActionLoaderToastMode.NONE,
+    });
 }
 
+/**
+ * Hides the loader overlay.
+ *
+ * @deprecated Use `hideActionLoader()` or `handle.hide()` from action-loader.js instead.
+ * This function now hides the legacy loader created by showLoader().
+ *
+ * @example
+ * // New recommended approach:
+ * import { showActionLoader } from './action-loader.js';
+ * const handle = showActionLoader({ message: 'Loading...' });
+ * // ... do work ...
+ * await handle.hide();
+ *
+ * @returns {Promise<void>}
+ */
 export async function hideLoader() {
-    if (!loaderPopup) {
+    if (!legacyLoaderHandle || !legacyLoaderHandle.isActive) {
         console.warn('There is no loader showing to hide');
         return Promise.resolve();
     }
 
-    return new Promise((resolve) => {
-        const spinner = $('#load-spinner');
-        if (!spinner.length) {
-            console.warn('Spinner element not found, skipping animation');
-            cleanup();
-            return;
-        }
-
-        // Check if transitions are enabled
-        const transitionDuration = spinner[0] ? getComputedStyle(spinner[0]).transitionDuration : '0s';
-        const hasTransitions = parseFloat(transitionDuration) > 0;
-
-        if (hasTransitions) {
-            Promise.race([
-                new Promise((r) => setTimeout(r, 500)), // Fallback timeout
-                new Promise((r) => spinner.one('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', r)),
-            ]).finally(cleanup);
-        } else {
-            cleanup();
-        }
-
-        function cleanup() {
-            $('#loader').remove();
-            // Yoink preloader entirely; it only exists to cover up unstyled content while loading JS
-            // If it's present, we remove it once and then it's gone.
-            yoinkPreloader();
-
-            loaderPopup.complete(POPUP_RESULT.AFFIRMATIVE)
-                .catch((err) => console.error('Error completing loaderPopup:', err))
-                .finally(() => {
-                    loaderPopup = null;
-                    resolve();
-                });
-        }
-
-        // Apply the styles
-        spinner.css({
-            'filter': 'blur(15px)',
-            'opacity': '0',
-        });
-    });
-}
-
-function yoinkPreloader() {
-    if (preloaderYoinked) return;
-    document.getElementById('preloader').remove();
-    preloaderYoinked = true;
+    await legacyLoaderHandle.hide();
+    legacyLoaderHandle = null;
 }

--- a/public/scripts/splashscreen.js
+++ b/public/scripts/splashscreen.js
@@ -143,6 +143,7 @@ export function registerExtension(folderName, displayName, type, { showNow = fal
         // Clear previous extension's status when switching
         if (extensionStatusElement) {
             extensionStatusElement.textContent = '';
+            extensionStatusElement.classList.remove('has-content');
         }
         displayExtensionInfo(displayName, type);
         currentDisplayedExtension = normalizedFolder;
@@ -219,6 +220,7 @@ function setExtensionStatus(text) {
     // Update the status text
     if (extensionStatusElement) {
         extensionStatusElement.textContent = text;
+        extensionStatusElement.classList.toggle('has-content', !!text);
     }
 }
 
@@ -232,7 +234,10 @@ function displayExtensionInfo(name, type) {
 
     extensionElement.innerHTML = '';
 
-    if (!name) return;
+    if (!name) {
+        extensionElement.classList.remove('has-content');
+        return;
+    }
 
     const tagSpan = document.createElement('span');
     tagSpan.className = 'splash-status-tag';
@@ -244,6 +249,7 @@ function displayExtensionInfo(name, type) {
 
     extensionElement.appendChild(tagSpan);
     extensionElement.appendChild(nameSpan);
+    extensionElement.classList.add('has-content');
 }
 
 /**
@@ -258,8 +264,14 @@ function clear() {
  * Clears extension-related lines (3 and 4).
  */
 function clearExtension() {
-    if (extensionElement) extensionElement.innerHTML = '';
-    if (extensionStatusElement) extensionStatusElement.textContent = '';
+    if (extensionElement) {
+        extensionElement.innerHTML = '';
+        extensionElement.classList.remove('has-content');
+    }
+    if (extensionStatusElement) {
+        extensionStatusElement.textContent = '';
+        extensionStatusElement.classList.remove('has-content');
+    }
     currentDisplayedExtension = null;
 }
 

--- a/public/scripts/splashscreen.js
+++ b/public/scripts/splashscreen.js
@@ -1,0 +1,270 @@
+/**
+ * Splash screen module for displaying initialization progress.
+ * Provides a clean API for updating status during app startup.
+ *
+ * Structure:
+ * - Line 1: Main heading (e.g., "Initializing...")
+ * - Line 2: Section status (e.g., "Loading extensions...")
+ * - Line 3: Extension info with tag (e.g., "[Third-party] Greeting Tools")
+ * - Line 4: Extension status detail (e.g., "Loading models...")
+ *
+ * @module splashscreen
+ */
+
+import { t } from './i18n.js';
+
+/**
+ * Splash screen public API.
+ *
+ * @example
+ * import { splashScreen } from './splashscreen.js';
+ *
+ * // Update section status during init
+ * splashScreen.setStatus('Loading extensions...');
+ *
+ * // Extension updates its status (auto-detects extension name/type)
+ * splashScreen.setExtensionStatus('Loading models...');
+ */
+export const splashScreen = {
+    /** Whether the splash screen is currently active */
+    get isOpen() {
+        return splashContainer !== null;
+    },
+
+    /**
+     * Updates the section status (line 2).
+     * Automatically clears extension lines when changing sections.
+     * @param {string} text - Section text (e.g., "Loading extensions...")
+     */
+    setStatus,
+
+    /**
+     * Updates the extension status (lines 3 and 4).
+     * Auto-detects the calling extension and displays its name/type.
+     * @param {string} text - Status detail text
+     */
+    setExtensionStatus,
+
+    /**
+     * Clears all status lines.
+     */
+    clear,
+
+    /**
+     * Clears extension-related lines (3 and 4).
+     */
+    clearExtension,
+};
+
+/**
+ * Creates the splash screen element with logo, message, and status lines.
+ * @param {string} logoSrc - Path to the logo image
+ * @param {string} mainMessage - Main heading message
+ * @returns {HTMLDivElement} The splash screen container element
+ */
+export function createSplashScreen(logoSrc, mainMessage) {
+    const container = document.createElement('div');
+    container.id = 'loader';
+    container.classList.add('splash-screen');
+
+    // Logo
+    const logo = document.createElement('img');
+    logo.src = logoSrc;
+    logo.alt = 'SillyTavern';
+    logo.className = 'splash-logo';
+    logo.ariaLabel = t`SillyTavern Logo`;
+
+    // Spinner
+    const spinner = document.createElement('div');
+    spinner.id = 'load-spinner';
+    spinner.className = 'fa-solid fa-gear fa-spin fa-3x';
+
+    // Main message (line 1)
+    const message = document.createElement('h2');
+    message.className = 'splash-message';
+    message.textContent = mainMessage;
+
+    // Status container for lines 2-4
+    const statusContainer = document.createElement('div');
+    statusContainer.className = 'splash-status';
+
+    // Section status (line 2)
+    sectionElement = document.createElement('p');
+    sectionElement.className = 'splash-status-section';
+
+    // Extension info (line 3) - tag + extension name
+    extensionElement = document.createElement('div');
+    extensionElement.className = 'splash-status-extension';
+
+    // Extension status (line 4)
+    extensionStatusElement = document.createElement('p');
+    extensionStatusElement.className = 'splash-status-extension-status';
+
+    statusContainer.appendChild(sectionElement);
+    statusContainer.appendChild(extensionElement);
+    statusContainer.appendChild(extensionStatusElement);
+
+    container.appendChild(logo);
+    container.appendChild(spinner);
+    container.appendChild(message);
+    container.appendChild(statusContainer);
+
+    splashContainer = container;
+    currentDisplayedExtension = null;
+    return container;
+}
+
+/**
+ * Destroys the splash screen and clears all references.
+ * Call this when the splash screen is no longer needed.
+ */
+export function destroySplashScreen() {
+    splashContainer = null;
+    sectionElement = null;
+    extensionElement = null;
+    extensionStatusElement = null;
+    currentDisplayedExtension = null;
+}
+
+/**
+ * Registers an extension for splash screen status tracking.
+ * Internal use - called by the extension loader during activation.
+ * @param {string} folderName - Extension folder name (e.g., "third-party/SillyTavern-GreetingTools")
+ * @param {string} displayName - Extension display name
+ * @param {'built-in'|'third-party'} type - Extension type
+ */
+export function registerExtension(folderName, displayName, type) {
+    const normalizedFolder = folderName.replace(/\\/g, '/');
+    extensionRegistry.set(normalizedFolder, { displayName, type });
+}
+
+// ============================================================================
+// Private state and functions
+// ============================================================================
+
+/** @type {HTMLElement|null} Current splash screen container */
+let splashContainer = null;
+
+/** @type {HTMLElement|null} Section status element (line 2) */
+let sectionElement = null;
+
+/** @type {HTMLElement|null} Extension info element (line 3) */
+let extensionElement = null;
+
+/** @type {HTMLElement|null} Extension status element (line 4) */
+let extensionStatusElement = null;
+
+/** @type {string|null} Currently displayed extension folder */
+let currentDisplayedExtension = null;
+
+/**
+ * Registry mapping extension folder names to their display info.
+ * @type {Map<string, {displayName: string, type: 'built-in'|'third-party'}>}
+ */
+const extensionRegistry = new Map();
+
+/**
+ * Updates the section status (line 2).
+ * Automatically clears extension lines when changing sections.
+ * @param {string} text - Section text
+ */
+function setStatus(text) {
+    if (sectionElement) {
+        sectionElement.textContent = text;
+    }
+    // Clear extension lines when changing sections
+    clearExtension();
+}
+
+/**
+ * Updates the extension status (lines 3 and 4).
+ * Auto-detects the calling extension from the stack trace.
+ * If a different extension calls this, updates the display to that extension.
+ * @param {string} text - Status detail text
+ */
+function setExtensionStatus(text) {
+    if (!splashContainer) return;
+
+    // Detect which extension is calling
+    const callerFolder = getCallerExtensionFolder();
+    if (!callerFolder) return;
+
+    // Look up extension info from registry
+    const extensionInfo = extensionRegistry.get(callerFolder);
+    if (!extensionInfo) return;
+
+    // If a different extension is calling, update the display
+    if (currentDisplayedExtension !== callerFolder) {
+        displayExtensionInfo(extensionInfo.displayName, extensionInfo.type);
+        currentDisplayedExtension = callerFolder;
+    }
+
+    // Update the status text
+    if (extensionStatusElement) {
+        extensionStatusElement.textContent = text;
+    }
+}
+
+/**
+ * Displays extension info (line 3).
+ * @param {string} name - Extension display name
+ * @param {'built-in'|'third-party'} type - Extension type
+ */
+function displayExtensionInfo(name, type) {
+    if (!extensionElement) return;
+
+    extensionElement.innerHTML = '';
+
+    if (!name) return;
+
+    const tagSpan = document.createElement('span');
+    tagSpan.className = 'splash-status-tag';
+    tagSpan.textContent = type === 'third-party' ? t`Third-party` : t`Built-in`;
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'splash-status-extension-name';
+    nameSpan.textContent = name;
+
+    extensionElement.appendChild(tagSpan);
+    extensionElement.appendChild(nameSpan);
+}
+
+/**
+ * Clears all status lines.
+ */
+function clear() {
+    if (sectionElement) sectionElement.textContent = '';
+    clearExtension();
+}
+
+/**
+ * Clears extension-related lines (3 and 4).
+ */
+function clearExtension() {
+    if (extensionElement) extensionElement.innerHTML = '';
+    if (extensionStatusElement) extensionStatusElement.textContent = '';
+    currentDisplayedExtension = null;
+}
+
+/**
+ * Gets the extension folder of the caller from the stack trace.
+ * @returns {string|null} The extension folder name, or null if not from an extension
+ */
+function getCallerExtensionFolder() {
+    try {
+        const stack = new Error().stack || '';
+        const lines = stack.split('\n');
+
+        for (const line of lines) {
+            // Match extension paths: extensions/third-party/name or extensions/name
+            const match = line.match(/extensions\/(third-party\/[^/\\]+|[^/\\]+)/i);
+            if (match) {
+                return match[1].replace(/\\/g, '/');
+            }
+        }
+    } catch {
+        // Graceful degradation
+    }
+
+    return null;
+}

--- a/public/scripts/splashscreen.js
+++ b/public/scripts/splashscreen.js
@@ -17,15 +17,15 @@ import { t } from './i18n.js';
  * Splash screen public API.
  *
  * @example
- * import { splashScreen } from './splashscreen.js';
+ * import { splashscreen } from './splashscreen.js';
  *
  * // Update section status during init
- * splashScreen.setStatus('Loading extensions...');
+ * splashscreen.setStatus('Loading extensions...');
  *
  * // Extension updates its status (auto-detects extension name/type)
- * splashScreen.setExtensionStatus('Loading models...');
+ * splashscreen.setExtensionStatus('Loading models...');
  */
-export const splashScreen = {
+export const splashscreen = {
     /** Whether the splash screen is currently active */
     get isOpen() {
         return splashContainer !== null;
@@ -132,10 +132,21 @@ export function destroySplashScreen() {
  * @param {string} folderName - Extension folder name (e.g., "third-party/SillyTavern-GreetingTools")
  * @param {string} displayName - Extension display name
  * @param {'built-in'|'third-party'} type - Extension type
+ * @param {Object} options - Configuration options
+ * @param {boolean} [options.showNow=false] - If true, immediately display this extension on line 3
  */
-export function registerExtension(folderName, displayName, type) {
+export function registerExtension(folderName, displayName, type, { showNow = false } = {}) {
     const normalizedFolder = folderName.replace(/\\/g, '/');
     extensionRegistry.set(normalizedFolder, { displayName, type });
+
+    if (showNow && splashContainer) {
+        // Clear previous extension's status when switching
+        if (extensionStatusElement) {
+            extensionStatusElement.textContent = '';
+        }
+        displayExtensionInfo(displayName, type);
+        currentDisplayedExtension = normalizedFolder;
+    }
 }
 
 // ============================================================================
@@ -192,6 +203,12 @@ function setExtensionStatus(text) {
     // Look up extension info from registry
     const extensionInfo = extensionRegistry.get(callerFolder);
     if (!extensionInfo) return;
+
+    // If being called and the section is not during loading extensions, it might be called
+    // from the APP_INITIALIZED event or similar. We treat this as a different section then, and explicitly override it.
+    if (sectionElement && sectionElement.textContent !== t`Loading extensions...`) {
+        sectionElement.textContent = t`Initializing extensions...`;
+    }
 
     // If a different extension is calling, update the display
     if (currentDisplayedExtension !== callerFolder) {

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -189,7 +189,9 @@ export function getContext() {
         /** @deprecated Use callGenericPopup or Popup instead. */
         callPopup,
         callGenericPopup,
+        /** @deprecated Use loader.show instead. */
         showLoader,
+        /** @deprecated Use loader.hide instead. */
         hideLoader,
         mainApi: main_api,
         extensionSettings: extension_settings,

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -107,6 +107,7 @@ import { ConnectionManagerRequestService } from './extensions/shared.js';
 import { updateReasoningUI, parseReasoningFromString, getReasoningTemplateByName } from './reasoning.js';
 import { IGNORE_SYMBOL } from './constants.js';
 import { macros } from './macros/macro-system.js';
+import { splashscreen } from './splashscreen.js';
 
 export function getContext() {
     return {
@@ -239,6 +240,7 @@ export function getContext() {
         scrollOnMediaLoad,
         macros,
         loader,
+        splashscreen,
         swipe: {
             left: swipe_left,
             right: swipe_right,

--- a/public/style.css
+++ b/public/style.css
@@ -4,6 +4,7 @@
 @import url(css/popup.css);
 @import url(css/promptmanager.css);
 @import url(css/loader.css);
+@import url(css/splashscreen.css);
 @import url(css/character-group-overlay.css);
 @import url(css/file-form.css);
 @import url(css/logprobs.css);


### PR DESCRIPTION
### Summary

This PR builds on top of the extension hooks system introduced in #5261 to provide users with real-time visual feedback during SillyTavern's initialization process. Instead of just seeing a spinner, users now see exactly what's loading—including which extension is being activated and what it's doing. This system is built upon the new action loader in #5326.

> [!IMPORTANT]
> This PR is based on #5326, and should **only** be merged after that. When that happens, this branch will be retargeted to staging. 

### What Changed

- **New splash screen module** (`splashscreen.js`) with a dedicated API for managing loading status
- **Dedicated splash screen styles** moved from inline loader.css to `splashscreen.css`
- **Core initialization progress** in `script.js` now reports each major phase (loading settings, characters, extensions, etc.)
- **Extension loader integration** registers each extension with the splash screen as it activates
- **14 built-in extensions converted** from jQuery/IIFE patterns to exported `init()` functions with `activate` hooks:
  - assets, attachments, caption, connection-manager, expressions, gallery, memory, quick-reply, regex, stable-diffusion, token-counter, translate, tts, vectors
- **Per-extension status updates** allow extensions to report what they're doing during initialization

### Why These Changes

The previous loading experience showed only a generic spinner with no indication of progress. For users with many extensions or slower connections, this made it unclear whether the app was frozen or still loading. By leveraging the new hooks system from the parent branch, extensions can now actively participate in the loading feedback loop without any additional boilerplate.

### How It Works

The splash screen module exposes a simple API:
- `createSplashScreen()` / `destroySplashScreen()` for lifecycle management
- `splashscreen.setStatus()` for core initialization phases
- `splashscreen.setExtensionStatus()` for extension-specific status (auto-detects the calling extension)
- `registerExtension()` tracks which extensions are loading and displays their name/type

When extensions call `setExtensionStatus()`, the module automatically identifies which extension is calling (via stack trace inspection) and updates the display accordingly. This means extensions just import the module and call the function—no need to pass identifiers or register manually.

The UI shows:
1. SillyTavern logo
2. Current initialization phase (e.g., "Loading extensions...")
3. Current extension being loaded (with "Built-in" or "Third-party" tag)
4. Extension-specific status (e.g., "Loading expression sprites...")

### Impact

- **Better user experience** during startup with clear progress indication
- **Easier debugging** when an extension causes loading to hang
- **Foundation for future progress bars** or more detailed loading analytics
- **Demonstrates the hooks system** as a practical example for extension developers

![sillytavern_loading_screen](https://github.com/user-attachments/assets/a9520ac5-889f-48aa-8135-5719fe01d10e)

## Copilot Summary
This pull request introduces a major refactor and enhancement of the splash screen and extension initialization process in the application. The core improvements include extracting splash screen styles and logic into dedicated files, adding detailed status updates during initialization, and standardizing extension activation with manifest-based hooks and status reporting. These changes provide a more informative and visually stable loading experience, while also modernizing extension lifecycle management.

**Splash Screen Refactor and Status Updates:**

- Extracted all splash screen-related CSS from `loader.css` into a new `splashscreen.css` file and expanded it with new classes for detailed status and extension progress lines. `[1]` `[2]`
- Replaced manual DOM construction of the splash screen in `script.js` with a reusable `createSplashScreen` function, and added granular status updates throughout the initialization sequence (e.g., "Loading chat utilities...", "Configuring AI backends...", etc.). `[1]` `[2]` `[3]` `[4]`
- Added the ability to display extension-specific progress/status in the splash screen during activation and loading. `[1]` `[2]` `[3]` `[4]` `[5]` `[6]`

**Extension Activation Standardization:**

- Refactored all core and example extensions to export an `init` function instead of using an IIFE or jQuery-ready block, and updated their `manifest.json` files to declare `"hooks": { "activate": "init" }` for manifest-based activation. `[1]` `[2]` `[3]` `[4]` `[5]` `[6]` `[7]` `[8]` `[9]` `[10]` `[11]` `[12]` `[13]` `[14]` `[15]` `[16]`
- Extensions now optionally report their status to the splash screen during activation, improving user feedback on what is loading. `[1]` `[2]` `[3]` `[4]` `[5]`

**Loader and Initialization Improvements:**

- The loader now uses the new splash screen overlay for initialization, and the splash screen is destroyed once initialization is complete, ensuring a seamless transition to the main UI. `[1]` `[2]`
- Status updates are also shown when loading extension settings and during extension auto-update checks, providing more transparency during startup. `[1]` `[2]`

These changes collectively modernize the startup experience, improve maintainability, and provide a clearer, more engaging loading sequence for users.

**References:**  
`[1]` `[2]` `[3]` `[4]` `[5]` `[6]` `[7]` `[8]` `[9]` `[10]` `[11]` `[12]` `[13]` `[14]` `[15]` `[16]` `[17]` `[18]` `[19]` `[20]` `[21]` `[22]` `[23]` `[24]` `[25]` `[26]` `[27]` `[28]` `[29]`

<!-- Put X in the box below to confirm -->

## Checklist:

- `x] I have read the [Contribution guidelines`.