### PR TITLE
feat: add finalizeIntermediaryMessage

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3612,7 +3612,14 @@ class StreamingProcessor {
         }
     }
 
-    async onFinishStreaming(messageId, text) {
+    /**
+     * Finalizes an intermediary message during a tool call chain.
+     * Performs essential message processing (code blocks, reasoning, swipes, attachments, events)
+     * without the heavier finish operations (UI unlock, auto-swipe, sound, save chat).
+     * @param {number} messageId - The message ID to finalize.
+     * @param {string} text - The message text.
+     */
+    async finalizeIntermediaryMessage(messageId, text) {
         await this.onProgressStreaming(messageId, text, true);
         const messageElement = chatElement.find(`.mes[mesid="${messageId}"]`);
         const message = chat[messageId];
@@ -3645,18 +3652,25 @@ class StreamingProcessor {
             appendMediaToMessage(message, $(this.messageDom));
         }
 
-        // Store reasoning signature for models that support multi-turn context
         if (this.reasoningSignature) {
             message.extra = message.extra || {};
             message.extra.reasoning_signature = this.reasoningSignature;
         }
 
-        this.markUIGenStopped();
-
         if (this.type !== 'impersonate') {
             await eventSource.emit(event_types.MESSAGE_RECEIVED, this.messageId, this.type);
             await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, this.messageId, this.type);
-        } else {
+        }
+
+        return { messageElement, message };
+    }
+
+    async onFinishStreaming(messageId, text) {
+        const { messageElement, message } = await this.finalizeIntermediaryMessage(messageId, text);
+
+        this.markUIGenStopped();
+
+        if (this.type === 'impersonate') {
             await eventSource.emit(event_types.IMPERSONATE_READY, text);
         }
 
@@ -5253,6 +5267,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 const hasToolCalls = ToolManager.hasToolCalls(streamingProcessor.toolCalls);
                 const shouldDeleteMessage = type !== 'swipe' && ['', '...'].includes(lastMessage?.mes) && !lastMessage?.extra?.reasoning && ['', '...'].includes(streamingProcessor?.result);
                 hasToolCalls && shouldDeleteMessage && await deleteLastMessage();
+                if (hasToolCalls && !shouldDeleteMessage) {
+                    await streamingProcessor.finalizeIntermediaryMessage(streamingProcessor.messageId, getMessage);
+                }
                 const invocationResult = await ToolManager.invokeFunctionTools(streamingProcessor.toolCalls, {
                     reasoningText: streamingProcessor.reasoningHandler.reasoning,
                 });

--- a/public/script.js
+++ b/public/script.js
@@ -3665,13 +3665,13 @@ class StreamingProcessor {
     /**
      * Finalizes an intermediary message after generation is complete, or a tool call is performed.
      * Performs essential message processing (code blocks, reasoning, swipes, attachments, events)
-     * without the heavier finish operations (UI unlock, auto-swipe, sound, save chat).
+     * without the heavier finish operations (UI unlock - optional, auto-swipe, sound, save chat).
      * @param {number} messageId - The message ID to finalize.
      * @param {string} text - The message text.
      * @param {Object} options - Additional options for finalization.
-     * @param {boolean} [options.unlockUI=true] - Whether to unlock the generation UI.
+     * @param {boolean} options.unlockUI - Whether to unlock the generation UI.
      */
-    async finalizeIntermediaryMessage(messageId, text, { unlockUI = true } = { unlockUI: true }) {
+    async finalizeIntermediaryMessage(messageId, text, { unlockUI = true }) {
         await this.onProgressStreaming(messageId, text, true);
         const messageElement = chatElement.find(`.mes[mesid="${messageId}"]`);
         const message = chat[messageId];
@@ -3727,7 +3727,7 @@ class StreamingProcessor {
     }
 
     async onFinishStreaming(messageId, text) {
-        await this.finalizeIntermediaryMessage(messageId, text);
+        await this.finalizeIntermediaryMessage(messageId, text, { unlockUI: true });
 
         const isAborted = this.abortController.signal.aborted;
         if (!isAborted && power_user.auto_swipe && generatedTextFiltered(text)) {

--- a/public/script.js
+++ b/public/script.js
@@ -3663,7 +3663,7 @@ class StreamingProcessor {
     }
 
     /**
-     * Finalizes an intermediary message during a tool call chain.
+     * Finalizes an intermediary message after generation is complete, or a tool call is performed.
      * Performs essential message processing (code blocks, reasoning, swipes, attachments, events)
      * without the heavier finish operations (UI unlock, auto-swipe, sound, save chat).
      * @param {number} messageId - The message ID to finalize.
@@ -3702,6 +3702,7 @@ class StreamingProcessor {
             appendMediaToMessage(message, $(this.messageDom));
         }
 
+        // Store reasoning signature for models that support multi-turn context
         if (this.reasoningSignature) {
             message.extra = message.extra || {};
             message.extra.reasoning_signature = this.reasoningSignature;

--- a/public/script.js
+++ b/public/script.js
@@ -3668,8 +3668,10 @@ class StreamingProcessor {
      * without the heavier finish operations (UI unlock, auto-swipe, sound, save chat).
      * @param {number} messageId - The message ID to finalize.
      * @param {string} text - The message text.
+     * @param {Object} options - Additional options for finalization.
+     * @param {boolean} [options.unlockUI=true] - Whether to unlock the generation UI.
      */
-    async finalizeIntermediaryMessage(messageId, text) {
+    async finalizeIntermediaryMessage(messageId, text, { unlockUI = true } = { unlockUI: true }) {
         await this.onProgressStreaming(messageId, text, true);
         const messageElement = chatElement.find(`.mes[mesid="${messageId}"]`);
         const message = chat[messageId];
@@ -3708,24 +3710,24 @@ class StreamingProcessor {
             message.extra.reasoning_signature = this.reasoningSignature;
         }
 
+        if (unlockUI) {
+            this.markUIGenStopped();
+        }
+
         if (this.type !== 'impersonate') {
             await eventSource.emit(event_types.MESSAGE_RECEIVED, this.messageId, this.type);
             await eventSource.emit(event_types.CHARACTER_MESSAGE_RENDERED, this.messageId, this.type);
+        } else {
+            await eventSource.emit(event_types.IMPERSONATE_READY, text);
         }
+
+        updateSwipeCounter(messageId, { message, messageElement });
 
         return { messageElement, message };
     }
 
     async onFinishStreaming(messageId, text) {
-        const { messageElement, message } = await this.finalizeIntermediaryMessage(messageId, text);
-
-        this.markUIGenStopped();
-
-        if (this.type === 'impersonate') {
-            await eventSource.emit(event_types.IMPERSONATE_READY, text);
-        }
-
-        updateSwipeCounter(messageId, { message, messageElement });
+        await this.finalizeIntermediaryMessage(messageId, text);
 
         const isAborted = this.abortController.signal.aborted;
         if (!isAborted && power_user.auto_swipe && generatedTextFiltered(text)) {
@@ -5322,7 +5324,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 const shouldDeleteMessage = type !== 'swipe' && ['', '...'].includes(lastMessage?.mes) && !lastMessage?.extra?.reasoning && ['', '...'].includes(streamingProcessor?.result);
                 hasToolCalls && shouldDeleteMessage && await deleteLastMessage();
                 if (hasToolCalls && !shouldDeleteMessage) {
-                    await streamingProcessor.finalizeIntermediaryMessage(streamingProcessor.messageId, getMessage);
+                    await streamingProcessor.finalizeIntermediaryMessage(streamingProcessor.messageId, getMessage, { unlockUI: false });
                 }
                 const invocationResult = await ToolManager.invokeFunctionTools(streamingProcessor.toolCalls, {
                     reasoningText: streamingProcessor.reasoningHandler.reasoning,

--- a/public/script.js
+++ b/public/script.js
@@ -3722,8 +3722,6 @@ class StreamingProcessor {
         }
 
         updateSwipeCounter(messageId, { message, messageElement });
-
-        return { messageElement, message };
     }
 
     async onFinishStreaming(messageId, text) {

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -21,11 +21,12 @@ import { isTrueBoolean } from './utils.js';
  * @property {string} result - The result of the tool invocation.
  * @property {string?} signature - The thought signature associated with the tool invocation.
  * @property {string?} reasoning - The plaintext reasoning associated with this tool call turn.
+ * @property {boolean} [error] - Whether the tool invocation failed.
  */
 
 /**
  * @typedef {object} ToolInvocationResult
- * @property {ToolInvocation[]} invocations Successful tool invocations
+ * @property {ToolInvocation[]} invocations Tool invocations (both successful and failed)
  * @property {Error[]} errors Errors that occurred during tool invocation
  * @property {string[]} stealthCalls Names of stealth tools that were invoked
  */
@@ -336,10 +337,10 @@ export class ToolManager {
 
             if (error instanceof Error) {
                 error.cause = name;
-                return error.toString();
+                return error;
             }
 
-            return new Error('Unknown error occurred while invoking the tool.', { cause: name }).toString();
+            return new Error('Unknown error occurred while invoking the tool.', { cause: name });
         }
     }
 
@@ -796,9 +797,21 @@ export class ToolManager {
             toastr.clear(toast);
             console.log('[ToolManager] Function tool result:', result);
 
-            // Save a successful invocation
+            // Handle tool errors — still create an invocation so the LLM sees the failure
             if (toolResult instanceof Error) {
                 result.errors.push(toolResult);
+                if (!isStealth) {
+                    result.invocations.push({
+                        id,
+                        displayName,
+                        name,
+                        parameters: stringify(parameters),
+                        result: `Error: ${toolResult.message}`,
+                        error: true,
+                        signature: null,
+                        reasoning: null,
+                    });
+                }
                 continue;
             }
 

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -21,12 +21,11 @@ import { isTrueBoolean } from './utils.js';
  * @property {string} result - The result of the tool invocation.
  * @property {string?} signature - The thought signature associated with the tool invocation.
  * @property {string?} reasoning - The plaintext reasoning associated with this tool call turn.
- * @property {boolean} [error] - Whether the tool invocation failed.
  */
 
 /**
  * @typedef {object} ToolInvocationResult
- * @property {ToolInvocation[]} invocations Tool invocations (both successful and failed)
+ * @property {ToolInvocation[]} invocations Successful tool invocations
  * @property {Error[]} errors Errors that occurred during tool invocation
  * @property {string[]} stealthCalls Names of stealth tools that were invoked
  */
@@ -337,10 +336,10 @@ export class ToolManager {
 
             if (error instanceof Error) {
                 error.cause = name;
-                return error;
+                return error.toString();
             }
 
-            return new Error('Unknown error occurred while invoking the tool.', { cause: name });
+            return new Error('Unknown error occurred while invoking the tool.', { cause: name }).toString();
         }
     }
 
@@ -797,23 +796,9 @@ export class ToolManager {
             toastr.clear(toast);
             console.log('[ToolManager] Function tool result:', result);
 
-            // Handle tool errors — still create an invocation so the LLM sees the failure
+            // Save a successful invocation
             if (toolResult instanceof Error) {
                 result.errors.push(toolResult);
-                if (isStealth) {
-                    result.stealthCalls.push(name);
-                } else {
-                    result.invocations.push({
-                        id,
-                        displayName,
-                        name,
-                        parameters: stringify(parameters),
-                        result: `Error: ${toolResult.message}`,
-                        error: true,
-                        signature: toolCall.signature || null,
-                        reasoning: reasoningText || null,
-                    });
-                }
                 continue;
             }
 
@@ -829,7 +814,6 @@ export class ToolManager {
                 name,
                 parameters: stringify(parameters),
                 result: toolResult,
-                error: false,
                 signature: toolCall.signature || null,
                 reasoning: reasoningText || null,
             };

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -800,7 +800,9 @@ export class ToolManager {
             // Handle tool errors — still create an invocation so the LLM sees the failure
             if (toolResult instanceof Error) {
                 result.errors.push(toolResult);
-                if (!isStealth) {
+                if (isStealth) {
+                    result.stealthCalls.push(name);
+                } else {
                     result.invocations.push({
                         id,
                         displayName,
@@ -808,8 +810,8 @@ export class ToolManager {
                         parameters: stringify(parameters),
                         result: `Error: ${toolResult.message}`,
                         error: true,
-                        signature: null,
-                        reasoning: null,
+                        signature: toolCall.signature || null,
+                        reasoning: reasoningText || null,
                     });
                 }
                 continue;

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -829,6 +829,7 @@ export class ToolManager {
                 name,
                 parameters: stringify(parameters),
                 result: toolResult,
+                error: false,
                 signature: toolCall.signature || null,
                 reasoning: reasoningText || null,
             };


### PR DESCRIPTION
## Summary
Two fixes for tool call handling in streaming mode:

1. **`CHARACTER_MESSAGE_RENDERED` not emitted for streamed text before tool calls** — Extensions (TTS, image forwarding, etc.) that depend on this event miss intermediary messages.
2. **`invokeFunctionTool` error handling is broken** — Errors are `.toString()`'d into plain strings, making the `instanceof Error` check dead code. Failed tool calls are silently treated as successful invocations, `showToolCallError` never fires, and the `error` flag is never set.

## Changes

### Commit 1: `finalizeIntermediaryMessage` for streaming tool call chains

Added a new `finalizeIntermediaryMessage` method on `StreamingProcessor` that extracts the shared message-processing logic from `onFinishStreaming`. `onFinishStreaming` now calls `finalizeIntermediaryMessage` internally and adds only the finish-specific operations on top.

**`finalizeIntermediaryMessage` performs (shared with `onFinishStreaming`):**
- Final render update (`onProgressStreaming`)
- Code block styling (`addCopyToCodeBlocks`)
- Reasoning handler finalization
- Swipes processing (no-op for intermediary messages since they have no swipes)
- Swipe sync (`syncMesToSwipe`)
- Logprobs saving
- Image attachment processing
- Reasoning signature storage
- `MESSAGE_RECEIVED` and `CHARACTER_MESSAGE_RENDERED` event emission

**`onFinishStreaming` adds on top:**
- `markUIGenStopped` (UI unlock)
- `IMPERSONATE_READY` event
- `updateSwipeCounter`
- Auto-swipe logic
- `saveChatConditional`
- `playMessageSound`

The non-streaming path is not affected — `saveReply()` already emits `CHARACTER_MESSAGE_RENDERED` before the tool call block runs.

### Commit 2: Fix `invokeFunctionTool` error handling

**Problem:** `invokeFunctionTool` calls `.toString()` on caught errors before returning, converting them to plain strings. This makes the `toolResult instanceof Error` check in `invokeFunctionTools` dead code — errors silently become "successful" invocations.

**Fix:**
- Return `Error` objects directly from `invokeFunctionTool` instead of calling `.toString()`
- When a tool fails, create an invocation record with `error: true` so the LLM still receives the error message as the tool result
- `showToolCallError` toastr now actually fires when all tools fail and `shouldStopGeneration` is true
- Added `error` field to `ToolInvocation` typedef

## Testing
- AI returning text + tool call (streaming) → `CHARACTER_MESSAGE_RENDERED` now fires ✅
- AI returning only tool calls (no text, `shouldDeleteMessage=true`) → `finalizeIntermediaryMessage` not called ✅
- AI returning only text (no tool calls) → normal `onFinishStreaming` path ✅
- Non-streaming mode → not affected ✅
- Tool call failure → error invocation created with `error: true`, LLM sees error message ✅
- All tool calls fail + `shouldStopGeneration` → `showToolCallError` toastr fires ✅

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
