### PR TITLE
fix: remove deprecated xAI grok-2-image-1212 model

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2093,7 +2093,6 @@ async function loadXAIModels() {
     return [
         { value: 'grok-imagine-image', text: 'grok-imagine-image' },
         { value: 'grok-imagine-image-pro', text: 'grok-imagine-image-pro' },
-        { value: 'grok-2-image-1212', text: 'grok-2-image-1212' },
     ];
 }
 


### PR DESCRIPTION
## Summary
Remove the deprecated `grok-2-image-1212` model from the xAI image generation model list. This model was deprecated on 2026-02-24 and returns a 500 error when used:

> `grok-2-image-1212` has been fully deprecated and is no longer available as of 2/24/2025. Please use `grok-imagine-image` instead.

Only `grok-imagine-image` and `grok-imagine-image-pro` remain as valid options.

## Checklist:
- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).