### PR TITLE
Desktop notification

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5208,6 +5208,15 @@
                                 <input id="play_sound_unfocused" type="checkbox" />
                                 <small data-i18n="Background Sound Only">Background Sound Only</small>
                             </label>
+                            <label for="desktop_notifications">
+                                <small data-i18n="Desktop Notifications">Desktop Notifications</small>
+                                <i class="fa-solid fa-desktop" title="Works best on desktop. Requires a secure context (HTTPS or localhost)." data-i18n="[title]Works best on desktop. Requires a secure context (HTTPS or localhost)."></i>
+                            </label>
+                            <select id="desktop_notifications" class="text_pole">
+                                <option value="off" data-i18n="Disabled">Disabled</option>
+                                <option value="background" data-i18n="Background Only">Background Only</option>
+                                <option value="always" data-i18n="Always">Always</option>
+                            </select>
                             <label class="checkbox_label" for="relaxed_api_urls" title="Reduce the formatting requirements on API URLs." data-i18n="[title]Reduce the formatting requirements on API URLs">
                                 <input id="relaxed_api_urls" type="checkbox" />
                                 <small data-i18n="Relaxed API URLS">Relaxed API URLs</small>

--- a/public/script.js
+++ b/public/script.js
@@ -76,8 +76,10 @@ import {
 
 import {
     collapseNewlines,
+    getChatNotificationIcon,
     loadPowerUserSettings,
     playMessageSound,
+    sendDesktopNotification,
     fixMarkdown,
     power_user,
     persona_description_positions,
@@ -3692,6 +3694,10 @@ class StreamingProcessor {
         await saveChatConditional();
 
         playMessageSound();
+        const lastMessage = chat[chat.length - 1];
+        if (lastMessage) {
+            sendDesktopNotification({ title: lastMessage.name, body: lastMessage.mes.length > 100 ? lastMessage.mes.substring(0, 100) + '…' : lastMessage.mes, icon: getChatNotificationIcon(lastMessage.name) });
+        }
     }
 
     onErrorStreaming() {
@@ -5425,6 +5431,10 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
         if (type !== 'quiet') {
             playMessageSound();
+            const lastMessage = chat[chat.length - 1];
+            if (lastMessage) {
+                sendDesktopNotification({ title: lastMessage.name, body: lastMessage.mes.length > 100 ? lastMessage.mes.substring(0, 100) + '…' : lastMessage.mes, icon: getChatNotificationIcon(lastMessage.name) });
+            }
         }
 
         const isAborted = abortController && abortController.signal.aborted;
@@ -5455,6 +5465,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         // if the response JSON was thrown (novel|textgenerationwebui|kobold), show the error message
         if (typeof exception?.error?.message === 'string') {
             toastr.error(exception.error.message, t`Text generation error`, { timeOut: 10000, extendedTimeOut: 20000 });
+            sendDesktopNotification({ title: t`Text generation error`, body: exception.error.message, icon: getChatNotificationIcon() });
         }
 
         unblockGeneration(type);

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -31,6 +31,8 @@ import {
     extension_prompt_roles,
     deleteMessage,
     settingsReady,
+    getThumbnailUrl,
+    this_chid,
 } from '../script.js';
 import { isMobile, initMovingUI, favsToHotswap } from './RossAscends-mods.js';
 import {
@@ -50,7 +52,7 @@ import { tokenizers } from './tokenizers.js';
 import { BIAS_CACHE } from './logit-bias.js';
 import { renderTemplateAsync } from './templates.js';
 
-import { countOccurrences, debounce, delay, download, getFileText, getSanitizedFilename, getStringHash, isOdd, isTrueBoolean, onlyUnique, resetScrollHeight, shuffle, sortMoments, stringToRange, timestampToMoment } from './utils.js';
+import { countOccurrences, debounce, delay, download, fetchAsSquareDataUrl, getFileText, getSanitizedFilename, getStringHash, isOdd, isTrueBoolean, onlyUnique, resetScrollHeight, shuffle, sortMoments, stringToRange, timestampToMoment } from './utils.js';
 import { FILTER_TYPES } from './filters.js';
 import { PARSER_FLAG, SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
@@ -155,6 +157,7 @@ export const power_user = {
     show_card_avatar_urls: false,
     play_message_sound: false,
     play_sound_unfocused: true,
+    desktop_notifications: 'off',
     auto_save_msg_edits: false,
     confirm_message_delete: true,
 
@@ -404,6 +407,53 @@ export function playMessageSound({ force } = {}) {
         audio.pause();
         audio.currentTime = 0;
         audio.play();
+    }
+}
+
+/**
+ * Returns the thumbnail URL for the notification icon of the current chat.
+ * Looks up the character by message name first (correct for group chats),
+ * then falls back to the currently selected character.
+ * @param {string} [characterName] Name of the character who sent the message.
+ * @returns {string | undefined}
+ */
+export function getChatNotificationIcon(characterName) {
+    const character = (characterName ? characters.find(c => c.name === characterName) : undefined)
+        ?? (this_chid !== undefined ? characters[this_chid] : undefined);
+    return character ? getThumbnailUrl('avatar', character.avatar) : undefined;
+}
+
+/**
+ * Sends a desktop notification if enabled in power user settings.
+ * @param {object} [param] Arguments object.
+ * @param {string} [param.title] Notification title.
+ * @param {string} [param.body] Notification body text.
+ * @param {string} [param.icon] Notification icon URL.
+ * @param {boolean} [param.force] Whether to force send regardless of settings.
+ * @returns {Promise<void>}
+ */
+export async function sendDesktopNotification({ title = 'SillyTavern', body = '', icon = 'img/logo.png', force = false } = {}) {
+    if (power_user.desktop_notifications === 'off' && !force) {
+        return;
+    }
+
+    if (power_user.desktop_notifications === 'background' && browser_has_focus && !force) {
+        return;
+    }
+
+    if (!('Notification' in window)) {
+        return;
+    }
+
+    const resolvedIcon = await fetchAsSquareDataUrl(icon);
+
+    if (Notification.permission === 'granted') {
+        new Notification(title, { body, icon: resolvedIcon });
+    } else if (Notification.permission === 'default') {
+        const permission = await Notification.requestPermission();
+        if (permission === 'granted') {
+            new Notification(title, { body, icon: resolvedIcon });
+        }
     }
 }
 
@@ -1710,6 +1760,7 @@ export async function loadPowerUserSettings(settings, data) {
     $('#auto_continue_target_length').val(power_user.auto_continue.target_length);
     $('#play_message_sound').prop('checked', power_user.play_message_sound);
     $('#play_sound_unfocused').prop('checked', power_user.play_sound_unfocused);
+    $('#desktop_notifications').val(power_user.desktop_notifications);
     $('#never_resize_avatars').prop('checked', power_user.never_resize_avatars);
     $('#show_card_avatar_urls').prop('checked', power_user.show_card_avatar_urls);
     $('#auto_save_msg_edits').prop('checked', power_user.auto_save_msg_edits);
@@ -3552,6 +3603,19 @@ jQuery(() => {
 
     $('#play_sound_unfocused').on('input', function () {
         power_user.play_sound_unfocused = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#desktop_notifications').on('change', async function () {
+        const value = String($(this).val());
+        if (value !== 'off' && 'Notification' in window && Notification.permission === 'default') {
+            const permission = await Notification.requestPermission();
+            if (permission !== 'granted') {
+                $(this).val('off');
+                return;
+            }
+        }
+        power_user.desktop_notifications = value;
         saveSettingsDebounced();
     });
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -72,7 +72,7 @@ import { getRegexedString, regex_placement } from './extensions/regex/engine.js'
 import { findGroupMemberId, groups, is_group_generating, openGroupById, regenerateGroup, resetSelectedGroup, saveGroupChat, selected_group, getGroupMembers } from './group-chats.js';
 import { chat_completion_sources, oai_settings, promptManager, ZAI_ENDPOINT } from './openai.js';
 import { user_avatar } from './personas.js';
-import { addEphemeralStoppingString, chat_styles, context_presets, flushEphemeralStoppingStrings, playMessageSound, power_user } from './power-user.js';
+import { addEphemeralStoppingString, chat_styles, context_presets, flushEphemeralStoppingStrings, getChatNotificationIcon, playMessageSound, power_user, sendDesktopNotification } from './power-user.js';
 import { SERVER_INPUTS, textgen_types, textgenerationwebui_settings } from './textgen-settings.js';
 import { decodeTextTokens, getAvailableTokenizers, getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, selectTokenizer } from './tokenizers.js';
 import { debounce, delay, equalsIgnoreCaseAndAccents, findChar, getCharIndex, isFalseBoolean, isTrueBoolean, onlyUnique, regexFromString, showFontAwesomePicker, stringToRange, trimToEndSentence, trimToStartSentence, waitUntilCondition } from './utils.js';
@@ -3756,6 +3756,41 @@ export function initDefaultSlashCommands() {
                 return value;
             }
         },
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'notify',
+        returns: t`an empty string`,
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: t`notification body text`,
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: false,
+            }),
+        ],
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'title',
+                description: t`notification title`,
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: false,
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'avatar',
+                description: t`character avatar to use as the notification icon (avatar key or character name)`,
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: false,
+                enumProvider: commonEnumProviders.characters('character'),
+            }),
+        ],
+        callback: async (args, body) => {
+            const avatarArg = args.avatar ? String(args.avatar) : null;
+            const character = avatarArg ? findChar({ name: avatarArg }) : null;
+            const icon = character ? getThumbnailUrl('avatar', character.avatar) : getChatNotificationIcon();
+            await sendDesktopNotification({ title: String(args.title || 'SillyTavern'), body: String(body || ''), icon, force: true });
+            return '';
+        },
+        helpString: t`Sends a desktop notification. Use <code>title=</code> to set the title, <code>avatar=</code> to set the icon from a character, and the unnamed argument as the body text.`,
     }));
 
     registerVariableCommands();

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2993,3 +2993,25 @@ export function addLongPressEvent(selector, callback, delay = 500) {
         timer = null;
     }
 }
+
+/**
+ * Fetches an image URL and returns it as a square data URL, padded with
+ * transparent pixels. Falls back to the original URL on failure.
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+export async function fetchAsSquareDataUrl(url) {
+    try {
+        const blob = await fetch(url).then(r => r.blob());
+        const bitmap = await createImageBitmap(blob);
+        const size = Math.max(bitmap.width, bitmap.height);
+        const canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        canvas.getContext('2d').drawImage(bitmap, (size - bitmap.width) / 2, (size - bitmap.height) / 2);
+        return canvas.toDataURL();
+    } catch {
+        return url;
+    }
+}
+


### PR DESCRIPTION
Add support for desktop notifications.

When receiving a new message in a chat, SillyTavern can send a desktop notification.
It's controlled by a new drop-down in the Miscellaneous section:
<img width="545" height="239" alt="image" src="https://github.com/user-attachments/assets/f35f0cba-521a-443a-90f2-8b3a99f94277" />

I tested this locally by rebuilding and checking if I'm getting notifications when receiving new messages, with the right icons. `npm run lint` ran without reporting anything.

The limit of 100 characters for the notification is arbitrary. I can bump it up, store it in a function, or make it configurable if that's desirable.

This PR also adds a new /notify slash command that sends a notification (and that's also a good way to test if it works):
<img width="949" height="376" alt="image" src="https://github.com/user-attachments/assets/76c704de-cdd5-41be-96a3-ce9e326f4973" />

And the resulting notification on my desktop (Linux, swaync, Firefox):
<img width="808" height="151" alt="image" src="https://github.com/user-attachments/assets/e1735dda-fa07-47c0-806c-fcda899bc1ce" />

This also worked on Chromium.

Disclaimer: I'm not a frontend developer, so this was mostly coded with Claude. It looks okay to me, and it looks to respect the conventions of the codebase (as much as I understand), but please tell me if something should be done differently.


## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
