### PR TITLE
Fix npm audit (yaml, picomatch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
                 "webpack": "^5.105.4",
                 "write-file-atomic": "^5.0.1",
                 "ws": "^8.18.3",
-                "yaml": "^2.8.1",
+                "yaml": "^2.8.3",
                 "yargs": "^17.7.1",
                 "yauzl": "^3.2.1"
             },
@@ -7508,9 +7508,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9655,15 +9655,18 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
                 "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
         "ip-matching": "^2.1.2",
         "ip-regex": "^5.0.0",
         "ipaddr.js": "^2.2.0",
-        "isomorphic-git": "^1.36.3",
         "is-docker": "^3.0.0",
+        "isomorphic-git": "^1.36.3",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",
         "mime-types": "^3.0.2",
@@ -91,7 +91,7 @@
         "webpack": "^5.105.4",
         "write-file-atomic": "^5.0.1",
         "ws": "^8.18.3",
-        "yaml": "^2.8.1",
+        "yaml": "^2.8.3",
         "yargs": "^17.7.1",
         "yauzl": "^3.2.1"
     },


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Bump packages to solve dependabot warnings:

- yaml (direct dependency)
- picomatch (transitive dependency)

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
