### PR TITLE
fix: conditionally include secrets in user data backup

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -165,6 +165,8 @@ rateLimiting:
 
 ## BACKUP CONFIGURATION
 backups:
+  # Allow users to create a full backup archive of their data
+  allowFullDataBackup: true
   # Common settings for all backup types
   common:
     # Number of backups to keep for each chat and settings file

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare global {
             /**
              * Authenticated user handle.
              */
-            handle: string;
+            handle: string | null;
             /**
              * Last time the session was extended.
              */

--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -277,6 +277,25 @@ function getActiveSecretLabel(key) {
     return '';
 }
 
+export async function canViewSecrets() {
+    try {
+        const response = await fetch('/api/secrets/settings', {
+            method: 'POST',
+            headers: getRequestHeaders({ omitContentType: true }),
+        });
+
+        if (!response.ok) {
+            return false;
+        }
+
+        const data = await response.json();
+        return data?.allowKeysExposure === true;
+    } catch (error) {
+        console.error('Error getting secrets settings:', error);
+        return false;
+    }
+}
+
 async function viewSecrets() {
     const response = await fetch('/api/secrets/view', {
         method: 'POST',

--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -277,6 +277,10 @@ function getActiveSecretLabel(key) {
     return '';
 }
 
+/**
+ * Checks if secrets can be viewed based on server configuration.
+ * @returns {Promise<boolean|null>} A boolean value, or null if the request fails.
+ */
 export async function canViewSecrets() {
     try {
         const response = await fetch('/api/secrets/settings', {
@@ -285,14 +289,14 @@ export async function canViewSecrets() {
         });
 
         if (!response.ok) {
-            return false;
+            return null;
         }
 
         const data = await response.json();
         return data?.allowKeysExposure === true;
     } catch (error) {
         console.error('Error getting secrets settings:', error);
-        return false;
+        return null;
     }
 }
 

--- a/public/scripts/user.js
+++ b/public/scripts/user.js
@@ -1,5 +1,6 @@
 import { getRequestHeaders } from '../script.js';
 import { POPUP_RESULT, POPUP_TYPE, callGenericPopup } from './popup.js';
+import { canViewSecrets } from './secrets.js';
 import { renderTemplateAsync } from './templates.js';
 import { ensureImageFormatSupported, getBase64Async, humanFileSize } from './utils.js';
 
@@ -264,6 +265,11 @@ async function backupUserData(handle, callback) {
             const data = await response.json();
             toastr.error(data.error || 'Unknown error', 'Failed to backup user data');
             throw new Error('Failed to backup user data');
+        }
+
+        const includesSecrets = await canViewSecrets();
+        if (!includesSecrets) {
+            toastr.warning('The backup will not include secrets due to a server configuration.', 'Secrets Not Included');
         }
 
         const blob = await response.blob();

--- a/public/scripts/user.js
+++ b/public/scripts/user.js
@@ -268,7 +268,7 @@ async function backupUserData(handle, callback) {
         }
 
         const includesSecrets = await canViewSecrets();
-        if (!includesSecrets) {
+        if (includesSecrets === false) {
             toastr.warning('The backup will not include secrets due to a server configuration.', 'Secrets Not Included');
         }
 

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -104,7 +104,7 @@ const EXPORTABLE_KEYS = [
     SECRET_KEYS.DEEPLX_URL,
 ];
 
-const allowKeysExposure = !!getConfigValue('allowKeysExposure', false, 'boolean');
+export const allowKeysExposure = !!getConfigValue('allowKeysExposure', false, 'boolean');
 
 /**
  * SecretManager class to handle all secret operations
@@ -635,4 +635,8 @@ router.post('/rename', (request, response) => {
         console.error('Error renaming secret:', error);
         return response.sendStatus(500);
     }
+});
+
+router.post('/settings', async (_request, response) => {
+    return response.send({ allowKeysExposure });
 });

--- a/src/endpoints/users-private.js
+++ b/src/endpoints/users-private.js
@@ -142,7 +142,7 @@ router.post('/backup', async (request, response) => {
 
         if (!allowFullDataBackup) {
             console.warn('Backup failed: Full data backup is disabled in configuration');
-            return response.status(418).json({ error: 'Full data backup is disabled' });
+            return response.status(403).json({ error: 'Full data backup is disabled' });
         }
 
         const handle = request.body.handle;

--- a/src/endpoints/users-private.js
+++ b/src/endpoints/users-private.js
@@ -8,7 +8,7 @@ import express from 'express';
 import { getUserAvatar, toKey, getPasswordHash, getPasswordSalt, createBackupArchive, ensurePublicDirectoriesExist, toAvatarKey } from '../users.js';
 import { SETTINGS_FILE } from '../constants.js';
 import { checkForNewContent, CONTENT_TYPES } from './content-manager.js';
-import { color, Cache } from '../util.js';
+import { color, Cache, getConfigValue } from '../util.js';
 
 const RESET_CACHE = new Cache(5 * 60 * 1000);
 
@@ -138,6 +138,13 @@ router.post('/change-password', async (request, response) => {
 
 router.post('/backup', async (request, response) => {
     try {
+        const allowFullDataBackup = !!getConfigValue('backups.allowFullDataBackup', true, 'boolean');
+
+        if (!allowFullDataBackup) {
+            console.warn('Backup failed: Full data backup is disabled in configuration');
+            return response.status(418).json({ error: 'Full data backup is disabled' });
+        }
+
         const handle = request.body.handle;
 
         if (!handle) {

--- a/src/users.js
+++ b/src/users.js
@@ -17,7 +17,7 @@ import sanitize from 'sanitize-filename';
 
 import { USER_DIRECTORY_TEMPLATE, DEFAULT_USER, PUBLIC_DIRECTORIES, SETTINGS_FILE, UPLOADS_DIRECTORY } from './constants.js';
 import { getConfigValue, color, delay, generateTimestamp, invalidateFirefoxCache, isPathUnderParent } from './util.js';
-import { readSecret, writeSecret } from './endpoints/secrets.js';
+import { allowKeysExposure, readSecret, writeSecret, SECRETS_FILE } from './endpoints/secrets.js';
 import { getContentOfType } from './endpoints/content-manager.js';
 import { serverDirectory } from './server-directory.js';
 
@@ -1052,7 +1052,14 @@ export async function createBackupArchive(handle, response) {
     archive.pipe(response);
 
     // Append files from a sub-directory, putting its contents at the root of archive
-    archive.directory(directories.root, false);
+    const ignore = allowKeysExposure ? [] : [SECRETS_FILE];
+    archive.glob('**/*', {
+        cwd: directories.root,
+        follow: false,
+        stat: true,
+        dot: true,
+        ignore,
+    });
     archive.finalize();
 }
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Don't include secrets into generated backups if not allowed with config.
2. Show a warning if the backup doesn't include secrets.
3. Add a server config setting to disallow user backup downloads.
4. Fix type error due to handle not allowing nulls.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
