### PR TITLE
fix: restore scroll position for all edited messages

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -8056,9 +8056,7 @@ export async function messageEdit(editMessageId) {
     // Sets the cursor at the end of the text
     editTextArea.setSelectionRange(text.length, text.length);
 
-    if (Number(this_edit_mes_id) === chat.length - 1) {
-        chatElement.scrollTop(chatScrollPosition);
-    }
+    chatElement.scrollTop(chatScrollPosition);
 
     updateEditArrowClasses();
 }


### PR DESCRIPTION
Fixes #5355

When editing a non-last message, the chat scrolls away because the browser auto-scrolls the textarea into view on focus. The scroll position was already being saved before focus, but the restore was gated behind `Number(this_edit_mes_id) === chat.length - 1`, so it only worked for the last message.

Removed that condition so `chatElement.scrollTop(chatScrollPosition)` runs for all messages.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).