### PR TITLE
Fix async file deletion bugs in assets endpoint

### DIFF
--- a/src/endpoints/assets.js
+++ b/src/endpoints/assets.js
@@ -232,9 +232,7 @@ router.post('/download', async (request, response) => {
         const destination = path.resolve(temp_path);
         // Delete if previous download failed
         if (fs.existsSync(temp_path)) {
-            fs.unlink(temp_path, (err) => {
-                if (err) throw err;
-            });
+            await fs.promises.unlink(temp_path);
         }
         const fileStream = fs.createWriteStream(destination, { flags: 'wx' });
         // @ts-ignore
@@ -291,21 +289,17 @@ router.post('/delete', async (request, response) => {
     console.info('Request received to delete', category, file_path);
 
     try {
-        // Delete if previous download failed
-        if (fs.existsSync(file_path)) {
-            fs.unlink(file_path, (err) => {
-                if (err) throw err;
-            });
-            console.info('Asset deleted.');
-        } else {
+        if (!fs.existsSync(file_path)) {
             console.error('Asset not found.');
-            response.sendStatus(400);
+            return response.sendStatus(400);
         }
-        // Move into asset place
-        response.sendStatus(200);
+
+        await fs.promises.unlink(file_path);
+        console.info('Asset deleted.');
+        return response.sendStatus(200);
     } catch (error) {
         console.error(error);
-        response.sendStatus(500);
+        return response.sendStatus(500);
     }
 });
 


### PR DESCRIPTION
- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

- Add missing `return` before `sendStatus(400)` in the `/delete` handler. Without it, `sendStatus(200)` always executes after `sendStatus(400)`, triggering `ERR_HTTP_HEADERS_SENT`, which the catch block compounds by attempting a third `sendStatus(500)`.
- Replace callback-based `fs.unlink()` with `await fs.promises.unlink()` in both the `/delete` and `/download` handlers. The callbacks fired asynchronously, so `throw err` inside them was an unhandled exception (not caught by the surrounding try/catch). In the download handler, the un-awaited unlink also raced with `createWriteStream({ flags: 'wx' })`.