### PR TITLE
Skip TTS for voices explicitly set to disabled (fixes #4970)

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -419,9 +419,10 @@ function onAudioControlClicked() {
     // Not pausing, doing a full stop to anything TTS is doing. Better UX as pause is not as useful
     if (!audioElement.paused || isTtsProcessing()) {
         resetTtsPlayback();
-    } else {
+    } else if (context?.chat?.length > 0) {
         // Default play behavior if not processing or playing is to play the last message.
-        processAndQueueTtsMessage(context.chat[context.chat.length - 1]);
+        const id = context.chat.length - 1;
+        processAndQueueTtsMessage(context.chat[id], id, { manual: true });
     }
     updateUiAudioPlayState();
 }

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -494,7 +494,7 @@ async function processAudioJobQueue() {
 
 /** @type {TtsMessage[]} */
 const ttsJobQueue = [];
-/** @type {TtsMessage} */
+/** @type {TtsMessage|null} */
 let currentTtsJob = null; // Null if nothing is currently being processed
 
 function completeTtsJob() {

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -642,6 +642,7 @@ async function processTtsQueue() {
                     }
                     toastr.info(`TTS voice for ${char} is disabled.`);
                 }
+                currentTtsJob = null;
                 return;
             }
 

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -638,9 +638,7 @@ async function processTtsQueue() {
             if (voiceMapEntry === DISABLED_VOICE_MARKER) {
                 const storageKey = `tts_disabled_warned_${char}`;
                 if (!accountStorage.getItem(storageKey) || currentTtsJob.manual) {
-                    if (!currentTtsJob.manual) {
-                        accountStorage.setItem(storageKey, 'true');
-                    }
+                    accountStorage.setItem(storageKey, 'true');
                     toastr.info(`TTS voice for ${char} is disabled.`);
                 }
                 currentTtsJob = null;

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -166,7 +166,7 @@ async function onNarrateOneMessage() {
     }
 
     resetTtsPlayback();
-    processAndQueueTtsMessage(message, Number(id));
+    processAndQueueTtsMessage(message, Number(id), { manual: true });
     moduleWorker();
 }
 
@@ -200,7 +200,7 @@ async function onNarrateText(args, text) {
     }
 
     resetTtsPlayback();
-    processAndQueueTtsMessage({ mes: text, name: name });
+    processAndQueueTtsMessage({ mes: text, name: name }, null, { manual: true });
     await moduleWorker();
 
     // Return back to the chat voices
@@ -253,7 +253,7 @@ function isTtsProcessing() {
 }
 
 /**
- * @typedef {ChatMessage & { id?: number }} TtsMessage
+ * @typedef {ChatMessage & { id?: number, manual?: boolean, segmentText?: string, segmentType?: string }} TtsMessage
  */
 
 /**
@@ -261,12 +261,15 @@ function isTtsProcessing() {
  * (if enabled) and adds each part to the TTS job queue.
  * @param {ChatMessage} message - The message object to be processed.
  * @param {number|null} [messageId=null] - The chat message index to associate with TTS events.
+ * @param {object} [options={}] - Additional options for processing.
+ * @param {boolean} [options.manual=false] - Whether this TTS job was manually triggered (e.g., from the UI) rather than automatically from a new chat message.
  * @returns {void}
  */
-function processAndQueueTtsMessage(message, messageId = null) {
+function processAndQueueTtsMessage(message, messageId = null, { manual = false } = {}) {
     /** @type {TtsMessage} */
     const clone = structuredClone(message);
     clone.id = messageId ?? null;
+    clone.manual = manual ?? false;
 
     if (!extension_settings.tts.narrate_by_paragraphs) {
         ttsJobQueue.push(clone);
@@ -489,8 +492,10 @@ async function processAudioJobQueue() {
 //  TTS Control   //
 //################//
 
+/** @type {TtsMessage[]} */
 const ttsJobQueue = [];
-let currentTtsJob; // Null if nothing is currently being processed
+/** @type {TtsMessage} */
+let currentTtsJob = null; // Null if nothing is currently being processed
 
 function completeTtsJob() {
     console.info(`Current TTS job for ${currentTtsJob?.name} completed.`);
@@ -631,8 +636,10 @@ async function processTtsQueue() {
 
             if (voiceMapEntry === DISABLED_VOICE_MARKER) {
                 const storageKey = `tts_disabled_warned_${char}`;
-                if (!accountStorage.getItem(storageKey)) {
-                    accountStorage.setItem(storageKey, 'true');
+                if (!accountStorage.getItem(storageKey) || currentTtsJob.manual) {
+                    if (!currentTtsJob.manual) {
+                        accountStorage.setItem(storageKey, 'true');
+                    }
                     toastr.info(`TTS voice for ${char} is disabled.`);
                 }
                 return;
@@ -741,6 +748,7 @@ async function processTtsQueue() {
                 mes: currentTtsJob.mes,
                 extra: currentTtsJob.extra,
                 id: currentTtsJob.id,
+                manual: currentTtsJob.manual,
             };
             ttsJobQueue.unshift(segmentJob);
         }

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -1,6 +1,7 @@
 import { cancelTtsPlay, eventSource, event_types, getCurrentChatId, isStreamingEnabled, name2, saveSettingsDebounced, substituteParams } from '../../../script.js';
 import { ModuleWorkerWrapper, extension_settings, getContext, renderExtensionTemplateAsync } from '../../extensions.js';
 import { delay, escapeRegex, getBase64Async, getStringHash, onlyUnique, regexFromString } from '../../utils.js';
+import { accountStorage } from '../../util/AccountStorage.js';
 import { EdgeTtsProvider } from './edge.js';
 import { ElevenLabsTtsProvider } from './elevenlabs.js';
 import { SileroTtsProvider } from './silerotts.js';
@@ -186,7 +187,16 @@ async function onNarrateText(args, text) {
         ? voiceMap[DEFAULT_VOICE_MARKER]
         : voiceMap[name];
 
-    if (!voiceMapEntry || voiceMapEntry === DISABLED_VOICE_MARKER) {
+    if (voiceMapEntry === DISABLED_VOICE_MARKER) {
+        const storageKey = `tts_disabled_warned_${name}`;
+        if (!accountStorage.getItem(storageKey)) {
+            accountStorage.setItem(storageKey, 'true');
+            toastr.info(`TTS voice for ${name} is disabled.`);
+        }
+        return;
+    }
+
+    if (!voiceMapEntry) {
         toastr.info(`Specified voice for ${name} was not found. Check the TTS extension settings.`);
         return;
     }
@@ -621,7 +631,16 @@ async function processTtsQueue() {
 
             const voiceMapEntry = voiceMap[voiceMapKey] === DEFAULT_VOICE_MARKER ? voiceMap[DEFAULT_VOICE_MARKER] : voiceMap[voiceMapKey];
 
-            if (!voiceMapEntry || voiceMapEntry === DISABLED_VOICE_MARKER) {
+            if (voiceMapEntry === DISABLED_VOICE_MARKER) {
+                const storageKey = `tts_disabled_warned_${char}`;
+                if (!accountStorage.getItem(storageKey)) {
+                    accountStorage.setItem(storageKey, 'true');
+                    toastr.info(`TTS voice for ${char} is disabled.`);
+                }
+                return;
+            }
+
+            if (!voiceMapEntry) {
                 throw `${char} not in voicemap. Configure character in extension settings voice map`;
             }
 

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -188,16 +188,14 @@ async function onNarrateText(args, text) {
         : voiceMap[name];
 
     if (voiceMapEntry === DISABLED_VOICE_MARKER) {
-        const storageKey = `tts_disabled_warned_${name}`;
-        if (!accountStorage.getItem(storageKey)) {
-            accountStorage.setItem(storageKey, 'true');
-            toastr.info(`TTS voice for ${name} is disabled.`);
-        }
+        toastr.info(`TTS voice for ${name} is disabled.`);
+        await initVoiceMap(false);
         return;
     }
 
     if (!voiceMapEntry) {
         toastr.info(`Specified voice for ${name} was not found. Check the TTS extension settings.`);
+        await initVoiceMap(false);
         return;
     }
 

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -852,7 +852,7 @@ async function playFullConversation() {
 
     context.chat.forEach((msg, i) => {
         if (!msg.is_system && msg.mes !== '...' && msg.mes !== '') {
-            processAndQueueTtsMessage(msg, i);
+            processAndQueueTtsMessage(msg, i, { manual: false });
         }
     });
 
@@ -1192,7 +1192,7 @@ async function onMessageEvent(messageId, lastCharIndex) {
         message.id = messageId;
         ttsJobQueue.push(message);
     } else {
-        processAndQueueTtsMessage(message, messageId);
+        processAndQueueTtsMessage(message, messageId, { manual: false });
     }
 }
 

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -643,6 +643,7 @@ async function processTtsQueue() {
                     toastr.info(`TTS voice for ${char} is disabled.`);
                 }
                 currentTtsJob = null;
+                setTimeout(() => wrapper.update(), 0);
                 return;
             }
 


### PR DESCRIPTION
Silently return instead of throwing an error or showing a toast when a voice is set to disabled.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).