### PR TITLE
feat: charRefImages prompt block — multimodal reference media for characters

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -306,6 +306,7 @@ class PromptManager {
             personaDescription: t`Persona Description`,
             worldInfoBefore: t`World Info (↑Char)`,
             worldInfoAfter: t`World Info (↓Char)`,
+            charRefImages: t`Character Reference Images`,
         };
     }
 
@@ -1032,6 +1033,20 @@ class PromptManager {
                 }
             }
         }
+
+        // The "Append a prompt" footer dropdown filters out system_prompt:true entries
+        // (see renderPromptManager → `.filter(p => !p?.system_prompt)`), so users who
+        // created their per-character prompt order before charRefImages existed have no
+        // non-destructive way to surface it (only "Reset character" would, and that wipes
+        // their customizations). Auto-insert it before chatHistory to match the position
+        // it sits at in promptManagerDefaultPromptOrder.
+        for (const entry of this.serviceSettings.prompt_order) {
+            if (!Array.isArray(entry?.order)) continue;
+            if (entry.order.some(o => o.identifier === 'charRefImages')) continue;
+            const chatHistoryIdx = entry.order.findIndex(o => o.identifier === 'chatHistory');
+            const insertAt = chatHistoryIdx === -1 ? entry.order.length : chatHistoryIdx;
+            entry.order.splice(insertAt, 0, { identifier: 'charRefImages', enabled: true });
+        }
     }
 
     /**
@@ -1087,6 +1102,7 @@ class PromptManager {
             'personaDescription',
             'worldInfoBefore',
             'worldInfoAfter',
+            'charRefImages',
         ];
         return forceEditPrompts.includes(prompt.identifier) || !prompt.marker;
     }
@@ -1107,6 +1123,7 @@ class PromptManager {
             'main',
             'chatHistory',
             'dialogueExamples',
+            'charRefImages',
         ];
         return prompt.marker && !forceTogglePrompts.includes(prompt.identifier) ? false : !this.configuration.toggleDisabled.includes(prompt.identifier);
     }
@@ -2077,6 +2094,12 @@ const chatCompletionDefaultPrompts = {
             'system_prompt': true,
             'marker': true,
         },
+        {
+            'identifier': 'charRefImages',
+            'name': 'Character Reference Images',
+            'system_prompt': true,
+            'marker': true,
+        },
     ],
 };
 
@@ -2123,6 +2146,10 @@ const promptManagerDefaultPromptOrder = [
     },
     {
         'identifier': 'dialogueExamples',
+        'enabled': true,
+    },
+    {
+        'identifier': 'charRefImages',
         'enabled': true,
     },
     {

--- a/public/scripts/char-media.js
+++ b/public/scripts/char-media.js
@@ -1,0 +1,140 @@
+/**
+ * Handles inline media (reference images, video, audio) for character cards.
+ * These attachments are stored in character data extensions and can be sent
+ * to multimodal models as additional context alongside character descriptions.
+ */
+
+import { characters, this_chid } from '../script.js';
+import {
+    getBase64Async,
+    saveBase64AsFile,
+    getStringHash,
+    getFileExtension,
+} from './utils.js';
+import { writeExtensionField } from './extensions.js';
+import { MEDIA_TYPE } from './constants.js';
+import { t } from './i18n.js';
+import { deleteMediaFromServer } from './chats.js';
+
+/**
+ * @typedef {object} CharacterMediaAttachment
+ * @property {string} url - Server-relative URL of the uploaded asset
+ * @property {string} name - Original file name
+ * @property {string} type - One of MEDIA_TYPE values: 'image', 'video', 'audio'
+ * @property {number} created - Timestamp of when the asset was attached
+ */
+
+const EXTENSION_KEY = 'inline_media';
+const PROMPT_KEY = 'inline_media_prompt';
+
+/**
+ * Gets the inline media array for the current character.
+ * @returns {CharacterMediaAttachment[]}
+ */
+export function getCharacterInlineMedia() {
+    const character = characters[this_chid];
+    if (!character?.data?.extensions?.[EXTENSION_KEY]) {
+        return [];
+    }
+    return character.data.extensions[EXTENSION_KEY];
+}
+
+/**
+ * Gets the per-character body of the reference-media user message.
+ * Empty string when unset, which means the message is sent with no body
+ * (just attachments).
+ * @returns {string}
+ */
+export function getCharacterInlineMediaPrompt() {
+    const character = characters[this_chid];
+    const value = character?.data?.extensions?.[PROMPT_KEY];
+    return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Persists the per-character override for the reference-media message body.
+ * @param {string} value
+ */
+export async function setCharacterInlineMediaPrompt(value) {
+    if (this_chid === undefined) return;
+    await writeExtensionField(this_chid, PROMPT_KEY, value || '');
+}
+
+/**
+ * Uploads a media file (image / video / audio) and attaches it to the current character.
+ * @param {File} file - The media file to upload
+ * @returns {Promise<CharacterMediaAttachment|null>} The created attachment, or null on failure
+ */
+export async function attachMediaToCharacter(file) {
+    if (this_chid === undefined) {
+        toastr.warning(t`No character selected.`);
+        return null;
+    }
+
+    const character = characters[this_chid];
+    if (!character) {
+        return null;
+    }
+
+    const mediaType = MEDIA_TYPE.getFromMime(file.type);
+    if (!mediaType) {
+        toastr.warning(t`Unsupported file type. Reference attachments must be image, video, or audio.`);
+        return null;
+    }
+
+    try {
+        const base64 = await getBase64Async(file);
+        const base64Data = base64.split(',')[1];
+        const extension = getFileExtension(file);
+        const slug = getStringHash(file.name);
+        const fileName = `char_ref_${Date.now()}_${slug}`;
+        const charName = character.name || 'unknown';
+
+        const url = await saveBase64AsFile(base64Data, charName, fileName, extension);
+
+        /** @type {CharacterMediaAttachment} */
+        const attachment = {
+            url,
+            name: file.name,
+            type: mediaType,
+            created: Date.now(),
+        };
+
+        const media = getCharacterInlineMedia();
+        media.push(attachment);
+        await writeExtensionField(this_chid, EXTENSION_KEY, media);
+
+        return attachment;
+    } catch (error) {
+        console.error('Failed to attach reference media to character', error);
+        toastr.error(t`Failed to upload the file.`);
+        return null;
+    }
+}
+
+/**
+ * Removes an inline media attachment from the character by index, both from the card's
+ * extensions array and from disk under userImages. The asset is owned by exactly this
+ * attachment entry — once unreferenced it would be orphaned. Best-effort: a failed
+ * server-side delete still removes the entry from the card.
+ * @param {number} index - Index in the inline_media array
+ * @returns {Promise<void>}
+ */
+export async function removeCharacterInlineMedia(index) {
+    const media = [...getCharacterInlineMedia()];
+    if (index < 0 || index >= media.length) {
+        console.warn('Invalid media index', index);
+        return;
+    }
+
+    const [removed] = media.splice(index, 1);
+    await writeExtensionField(this_chid, EXTENSION_KEY, media);
+
+    if (removed?.url) {
+        try {
+            await deleteMediaFromServer(removed.url, /* silent */ true);
+        } catch (error) {
+            console.warn('Failed to delete inline_media asset from disk', removed.url, error);
+        }
+    }
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -80,6 +80,7 @@ import { t } from './i18n.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
+import { getCharacterInlineMedia, getCharacterInlineMediaPrompt } from './char-media.js';
 import { syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
 
 export {
@@ -1208,6 +1209,48 @@ async function populateChatCompletion(prompts, chatCompletion, { bias, quietProm
     await addToChatCompletion('scenario');
     await addToChatCompletion('personaDescription');
 
+    // Inline character reference media (image / video / audio): built as a user message attached to
+    // the charRefImages prompt block. Position is governed by the user's prompt manager order
+    // (movable / disable-able). Each attachment is gated by the model's per-modality capability.
+    if (prompts.has('charRefImages')) {
+        const media = getCharacterInlineMedia();
+        const refPrompt = prompts.get('charRefImages');
+        const isDisabled = promptManager.isPromptDisabledForActiveCharacter('charRefImages');
+        const isAbsolute = refPrompt.injection_position === INJECTION_POSITION.ABSOLUTE;
+        const imageInlining = isImageInliningSupported();
+        const videoInlining = isVideoInliningSupported();
+        const audioInlining = isAudioInliningSupported();
+        const supported = media.filter(m => {
+            const type = m.type ?? MEDIA_TYPE.IMAGE;
+            return (type === MEDIA_TYPE.IMAGE && imageInlining)
+                || (type === MEDIA_TYPE.VIDEO && videoInlining)
+                || (type === MEDIA_TYPE.AUDIO && audioInlining);
+        });
+        if (supported.length > 0 && !isDisabled && !isAbsolute) {
+            // Per-character body for the user message accompanying attachments (Advanced
+            // Definitions → Reference Media). Empty by default so the message ships as a
+            // pure-attachment payload; authors can opt in by writing something here.
+            const promptBody = getCharacterInlineMediaPrompt();
+            const effectivePrompt = new Prompt({ ...refPrompt, content: substituteParams(promptBody) });
+            const message = await Message.fromPromptAsync(effectivePrompt);
+            for (const attachment of supported) {
+                const type = attachment.type ?? MEDIA_TYPE.IMAGE;
+                try {
+                    if (type === MEDIA_TYPE.IMAGE) await message.addImage(attachment.url);
+                    else if (type === MEDIA_TYPE.VIDEO) await message.addVideo(attachment.url);
+                    else if (type === MEDIA_TYPE.AUDIO) await message.addAudio(attachment.url);
+                } catch (error) {
+                    console.error('Failed to inline character reference media', attachment.url, error);
+                }
+            }
+            if (chatCompletion.canAfford(message)) {
+                const collection = new MessageCollection('charRefImages');
+                collection.add(message);
+                chatCompletion.add(collection, prompts.index('charRefImages'));
+            }
+        }
+    }
+
     // Collection of control prompts that will always be positioned last
     chatCompletion.setOverriddenPrompts(prompts.overriddenPrompts);
     const controlPrompts = new MessageCollection('controlPrompts');
@@ -1424,6 +1467,11 @@ async function preparePromptsForChatCompletion({ scenario, charPersonality, name
     if (power_user.persona_description && power_user.persona_description_position === persona_description_positions.IN_PROMPT) {
         systemPrompts.push({ role: 'system', content: power_user.persona_description, identifier: 'personaDescription' });
     }
+
+    // Character Reference Images marker — content comes from the per-character override at
+    // populate time (empty by default; the message ships as pure attachments). Sent as a user
+    // role since most VLMs don't accept image content parts in system messages.
+    systemPrompts.push({ role: 'user', content: '', identifier: 'charRefImages' });
 
     const knownExtensionPrompts = [
         '1_memory',

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -14,7 +14,7 @@ import storage from 'node-persist';
 
 import { AVATAR_WIDTH, AVATAR_HEIGHT, DEFAULT_AVATAR_PATH } from '../constants.js';
 import { default as validateAvatarUrlMiddleware, getFileNameValidationFunction, forbiddenRegExp } from '../middleware/validateFileName.js';
-import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements } from '../util.js';
+import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements, isPathUnderParent } from '../util.js';
 import { TavernCardValidator } from '../validator/TavernCardValidator.js';
 import { parse, read, write } from '../character-card-parser.js';
 import { readWorldInfoFile } from './worldinfo.js';
@@ -499,6 +499,7 @@ function unsetPrivateFields(char) {
     _.set(char, 'fav', false);
     _.set(char, 'data.extensions.fav', false);
     _.unset(char, 'chat');
+    _.unset(char, 'data.extensions.inline_media');
 }
 
 function readFromV2(char) {
@@ -1424,6 +1425,31 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
     const avatarPath = path.join(request.user.directories.characters, request.body.avatar_url);
     if (!fs.existsSync(avatarPath)) {
         return response.sendStatus(400);
+    }
+
+    // Best-effort cleanup of inline_media reference assets attached to this character.
+    // Read the card before unlinking so the data is still available; failures here must not
+    // block the deletion itself.
+    try {
+        const card = await readCharacterData(avatarPath);
+        const cardJson = typeof card === 'string' ? tryParse(card) : null;
+        const inlineMedia = cardJson?.data?.extensions?.inline_media;
+        if (Array.isArray(inlineMedia)) {
+            for (const item of inlineMedia) {
+                if (!item?.url || typeof item.url !== 'string') continue;
+                const assetPath = path.normalize(path.join(request.user.directories.root, item.url));
+                if (!isPathUnderParent(request.user.directories.userImages, assetPath)) continue;
+                if (fs.existsSync(assetPath)) {
+                    try {
+                        await fsPromises.unlink(assetPath);
+                    } catch (err) {
+                        console.warn(`[Characters] Failed to remove inline_media asset ${item.url}:`, err);
+                    }
+                }
+            }
+        }
+    } catch (err) {
+        console.warn('[Characters] Failed to read inline_media for cleanup:', err);
     }
 
     fs.unlinkSync(avatarPath);

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -7,6 +7,7 @@ import { getSettingsBackupFilePrefix } from './settings.js';
 import { CHAT_BACKUPS_PREFIX } from './chats.js';
 import { isPathUnderParent, tryParse } from '../util.js';
 import { SETTINGS_FILE } from '../constants.js';
+import { read as readPngCharacterData } from '../character-card-parser.js';
 
 const sha256 = str => crypto.createHash('sha256').update(str).digest('hex');
 
@@ -205,6 +206,11 @@ export class DataMaidService {
                         }
                     }
                 }
+            }
+            // Character cards' inline_media (reference images / video / audio for VLMs) are stored
+            // under userImages — register their URLs so they aren't flagged as loose files.
+            for (const url of await this.#parseAllCharacterInlineMedia()) {
+                knownImages.add(url);
             }
             const knownImageFullPaths = new Set();
             knownImages.forEach(image => {
@@ -624,6 +630,37 @@ export class DataMaidService {
             console.error('[Data Maid] Error parsing chats:', error);
             return [];
         }
+    }
+
+    /**
+     * Reads every character card and returns the union of `data.extensions.inline_media[*].url`
+     * values. These reference assets live under userImages but are owned by character cards
+     * rather than chat messages, so they need to be tracked separately for loose-file detection.
+     * @returns {Promise<string[]>} List of inline_media URLs across all characters.
+     */
+    async #parseAllCharacterInlineMedia() {
+        const urls = [];
+        try {
+            const characters = await fs.promises.readdir(this.directories.characters, { withFileTypes: true });
+            for (const file of characters) {
+                if (!file.isFile() || path.parse(file.name).ext !== '.png') continue;
+                try {
+                    const filePath = path.join(this.directories.characters, file.name);
+                    const buffer = await fs.promises.readFile(filePath);
+                    const cardJson = tryParse(readPngCharacterData(buffer));
+                    const inlineMedia = cardJson?.data?.extensions?.inline_media;
+                    if (!Array.isArray(inlineMedia)) continue;
+                    for (const item of inlineMedia) {
+                        if (typeof item?.url === 'string' && item.url) urls.push(item.url);
+                    }
+                } catch (error) {
+                    console.warn(`[Data Maid] Error reading inline_media from ${file.name}:`, error);
+                }
+            }
+        } catch (error) {
+            console.error('[Data Maid] Error scanning characters for inline_media:', error);
+        }
+        return urls;
     }
 
     /**


### PR DESCRIPTION
## What

Adds a moveable preset block in the prompt manager (`charRefImages`, `system_prompt: true` marker, default position before `chatHistory`) that ships character-card-attached image / video / audio assets to multimodal models as a user message.

Related: #2920, #3401.

Major changes since the last revision (per review feedback from @Cohee1207):

- **Single area for all attachments**, not per-field. Old per-textarea wiring removed.
- **Storage non-exported.** `data.extensions.inline_media` is stripped via `unsetPrivateFields`, so cards remain shareable (cross-user image references would break anyway).
- **Position is a real preset block.** `charRefImages` registers in `chatCompletionDefaultPrompts.prompts` + `promptManagerDefaultPromptOrder`. Movable / disable-able / per-character role in the prompt manager. Token counts surface naturally in the manager's accounting.
- **All three media types from day 1**, gated by `isImageInliningSupported` / `isVideoInliningSupported` / `isAudioInliningSupported`. Audio / video parts pass through `addAudio` / `addVideo` (same path as in-chat attachments), images via `addImage`.
- **Lifecycle.** Character deletion best-effort unlinks all `inline_media[*].url` files under `userImages` (path-confined via `isPathUnderParent`). Single-attachment removal in the editor unlinks via `/api/images/delete`.
- **Data Maid integration.** Card scan registers `inline_media` URLs as known images so reference assets aren't flagged as loose.
- **Per-character body for the user message** that ships alongside attachments. `data.extensions.inline_media_prompt`, edited in the Advanced Definitions drawer, blank by default. Supports `{{macros}}` via `substituteParams`.
- **UI lives in Advanced Definitions** as a collapsible "Reference Media" drawer (collapsible inline-drawer matching the surrounding Prompt Overrides / Creator's Metadata sections). Paste + drag-drop work directly on the drawer.

## Files

Two-PR split is intentional for review:

- **base PR** (this one, branch `feature/card-inline-images`): single commit; storage helpers + `charRefImages` prompt block registration + `populateChatCompletion` populate path + character-delete cleanup + Data Maid integration.
- **UI PR** (`feature/card-inline-images-ui`, will follow): single commit on top; Advanced Definitions drawer, type-aware previews, paste + drag-drop, prompt textarea, create-mode handling.

## Notes for review

- **Auto-insert into existing per-character prompt orders.** `sanitizeServiceSettings` adds `charRefImages` before `chatHistory` if missing. Necessary because the prompt manager's "Append a prompt" footer dropdown filters out `system_prompt: true` entries (`PromptManager.js:1634`), so users who created their preset before this PR have no non-destructive path to surface the block — only "Reset character" would, and that wipes their customization. Same gap exists for every marker upstream has added since the prompt manager existed; this PR fixes it just for ours. Happy to generalize as a separate PR if preferred.
- **Skipped a refactor to a built-in extension** (per @Wolfsblvt's question). The data lives in the v2-spec `data.extensions` namespace because that's the canonical escape hatch for non-spec card data. We use `writeExtensionField` (the same helper `regex` and `stable-diffusion` use) because the lifecycle requirement matches theirs — immediate persist on per-action UI events. Splitting into a real bundled extension would require new core APIs for prompt-manager marker registration, multimodal `extension_prompt` content, server-side character-deletion hooks, and Data Maid contributors. None of those exist today; the refactor is multi-PR core infra work before this feature can sit as an extension on top.
- **noass extension compatibility.** The noass extension's own message-merging step coerces array-shaped multimodal content into `[object Object],[object Object]` because it concatenates with `+=` against string content. Same bug would hit any in-chat image attachment under noass — not specific to charRefImages. Left as upstream work in the noass repo.

## How to test

1. Open Advanced Definitions on a character → expand the "Reference Media" drawer.
2. Add image / video / audio via the **+** button, paste, or drag-and-drop.
3. With a vision-capable model selected, generate. Verify in itemization that `charRefImages` is present and contains the attached media. Check the prompt manager — block should be movable / disable-able.
4. Optional Reference Media Prompt textarea: write a body (with `{{macros}}` if desired). Empty = pure attachments.
5. Switching to a non-multimodal model should produce no `charRefImages` collection (no token charge).
6. Delete an attachment → file removed from `User Data/.../user/images/<charname>/`.
7. Delete the character → all attached media files removed.
8. Run Data Maid → reference assets should not appear under loose images.