### PR TITLE
feat(ui): editor for charRefImages in advanced definitions

### DIFF
--- a/public/css/char-ref-images.css
+++ b/public/css/char-ref-images.css
@@ -1,0 +1,115 @@
+.char_ref_images_block {
+    margin-top: 5px;
+}
+
+.char_ref_images_header {
+    gap: 5px;
+    font-size: 0.85em;
+    opacity: 0.8;
+    cursor: default;
+}
+
+.char_ref_images_hint {
+    flex: 1;
+    opacity: 0.7;
+}
+
+.char_ref_images_count:empty {
+    display: none;
+}
+
+.char_ref_images_list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 5px;
+}
+
+.char_ref_images_list:empty {
+    display: none;
+}
+
+.char_ref_image_item {
+    position: relative;
+    width: 60px;
+    height: 60px;
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid var(--SmartThemeBorderColor, #555);
+    cursor: pointer;
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.char_ref_image_item img,
+.char_ref_image_item video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    pointer-events: none;
+}
+
+.char_ref_image_item[data-media-type="audio"] {
+    width: 220px;
+}
+
+.char_ref_image_item audio {
+    width: 100%;
+    height: 100%;
+}
+
+.char_ref_image_item[data-media-type="video"]::before,
+.char_ref_image_item[data-media-type="audio"]::before {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    color: #fff;
+    text-shadow: 0 0 3px rgba(0, 0, 0, 0.8);
+    font-family: "Font Awesome 6 Free", sans-serif;
+    font-weight: 900;
+    font-size: 10px;
+    pointer-events: none;
+}
+
+.char_ref_image_item[data-media-type="video"]::before {
+    content: "\f03d"; /* fa-video */
+}
+
+.char_ref_image_item[data-media-type="audio"]::before {
+    content: "\f028"; /* fa-volume-high */
+}
+
+.char_ref_image_item .char_ref_image_delete {
+    position: absolute;
+    top: 1px;
+    right: 1px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    width: 18px;
+    height: 18px;
+    font-size: 10px;
+    cursor: pointer;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    line-height: 1;
+}
+
+.char_ref_image_item:hover .char_ref_image_delete {
+    display: flex;
+}
+
+.char_ref_images_prompt_field {
+    margin-top: 8px;
+}
+
+.char_ref_images_prompt_field h5 {
+    gap: 4px;
+    margin-bottom: 4px;
+}
+
+.char_ref_images_prompt_field h5 small {
+    opacity: 0.7;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,7 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css">
     <link rel="stylesheet" type="text/css" href="css/macros.css">
     <link rel="stylesheet" type="text/css" href="css/user.css">
+    <link rel="stylesheet" type="text/css" href="css/char-ref-images.css">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>
@@ -6162,7 +6163,7 @@
                                     <span data-i18n="extension_token_counter">Tokens:</span> <span data-token-counter="description_textarea" data-token-permanent="true">counting...</span>
                                 </div>
                             </div>
-                            <div id="firstMessageWrapper" class="flex-container flexFlowColumn flex1">
+            <div id="firstMessageWrapper" class="flex-container flexFlowColumn flex1">
                                 <div id="first_message_div" class="title_restorable">
                                     <div class="flex-container alignitemscenter flex1">
                                         <span data-i18n="First message" class="mdhotkey_location">First message</span>
@@ -6522,6 +6523,19 @@
                             <span data-i18n="extension_token_counter">Tokens:</span> <span data-token-counter="post_history_instructions_textarea">counting...</span>
                         </div>
                     </div>
+                </div>
+            </div>
+            <hr>
+            <div class="inline-drawer">
+                <div class="inline-drawer-toggle inline-drawer-header">
+                    <h4>
+                        <span data-i18n="Reference Media">Reference Media</span>
+                        <small data-i18n="(Sent as a user message to multimodal models)">(Sent as a user message to multimodal models)</small>
+                    </h4>
+                    <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
+                </div>
+                <div class="inline-drawer-content">
+                    <div id="char_ref_images_container"></div>
                 </div>
             </div>
             <hr>

--- a/public/script.js
+++ b/public/script.js
@@ -267,6 +267,7 @@ import { addShowdownPatch } from './scripts/util/showdown-patch.js';
 import { applyBrowserFixes } from './scripts/browser-fixes.js';
 import { initServerHistory } from './scripts/server-history.js';
 import { initSettingsSearch } from './scripts/setting-search.js';
+import { initCharacterMedia } from './scripts/char-media.js';
 import { initBulkEdit } from './scripts/bulk-edit.js';
 import { getContext } from './scripts/st-context.js';
 import { extractReasoningFromData, extractReasoningSignatureFromData, initReasoning, parseReasoningInSwipes, PromptReasoning, ReasoningHandler, removeReasoningFromString, updateReasoningUI } from './scripts/reasoning.js';
@@ -771,6 +772,7 @@ async function firstLoadInit() {
     initInputMarkdown();
     initServerHistory();
     initSettingsSearch();
+    initCharacterMedia();
     initBulkEdit();
     initReasoning();
     initWelcomeScreen();

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -306,6 +306,7 @@ class PromptManager {
             personaDescription: t`Persona Description`,
             worldInfoBefore: t`World Info (↑Char)`,
             worldInfoAfter: t`World Info (↓Char)`,
+            charRefImages: t`Character Reference Images`,
         };
     }
 
@@ -1032,6 +1033,20 @@ class PromptManager {
                 }
             }
         }
+
+        // The "Append a prompt" footer dropdown filters out system_prompt:true entries
+        // (see renderPromptManager → `.filter(p => !p?.system_prompt)`), so users who
+        // created their per-character prompt order before charRefImages existed have no
+        // non-destructive way to surface it (only "Reset character" would, and that wipes
+        // their customizations). Auto-insert it before chatHistory to match the position
+        // it sits at in promptManagerDefaultPromptOrder.
+        for (const entry of this.serviceSettings.prompt_order) {
+            if (!Array.isArray(entry?.order)) continue;
+            if (entry.order.some(o => o.identifier === 'charRefImages')) continue;
+            const chatHistoryIdx = entry.order.findIndex(o => o.identifier === 'chatHistory');
+            const insertAt = chatHistoryIdx === -1 ? entry.order.length : chatHistoryIdx;
+            entry.order.splice(insertAt, 0, { identifier: 'charRefImages', enabled: true });
+        }
     }
 
     /**
@@ -1087,6 +1102,7 @@ class PromptManager {
             'personaDescription',
             'worldInfoBefore',
             'worldInfoAfter',
+            'charRefImages',
         ];
         return forceEditPrompts.includes(prompt.identifier) || !prompt.marker;
     }
@@ -1107,6 +1123,7 @@ class PromptManager {
             'main',
             'chatHistory',
             'dialogueExamples',
+            'charRefImages',
         ];
         return prompt.marker && !forceTogglePrompts.includes(prompt.identifier) ? false : !this.configuration.toggleDisabled.includes(prompt.identifier);
     }
@@ -2077,6 +2094,12 @@ const chatCompletionDefaultPrompts = {
             'system_prompt': true,
             'marker': true,
         },
+        {
+            'identifier': 'charRefImages',
+            'name': 'Character Reference Images',
+            'system_prompt': true,
+            'marker': true,
+        },
     ],
 };
 
@@ -2123,6 +2146,10 @@ const promptManagerDefaultPromptOrder = [
     },
     {
         'identifier': 'dialogueExamples',
+        'enabled': true,
+    },
+    {
+        'identifier': 'charRefImages',
         'enabled': true,
     },
     {

--- a/public/scripts/char-media.js
+++ b/public/scripts/char-media.js
@@ -4,7 +4,14 @@
  * to multimodal models as additional context alongside character descriptions.
  */
 
-import { characters, this_chid } from '../script.js';
+import {
+    characters,
+    this_chid,
+    eventSource,
+    event_types,
+    menu_type,
+    create_save,
+} from '../script.js';
 import {
     getBase64Async,
     saveBase64AsFile,
@@ -15,6 +22,9 @@ import { writeExtensionField } from './extensions.js';
 import { MEDIA_TYPE } from './constants.js';
 import { t } from './i18n.js';
 import { deleteMediaFromServer } from './chats.js';
+import { renderTemplateAsync } from './templates.js';
+import { POPUP_RESULT, POPUP_TYPE, callGenericPopup } from './popup.js';
+import { DragAndDropHandler } from './dragdrop.js';
 
 /**
  * @typedef {object} CharacterMediaAttachment
@@ -28,15 +38,44 @@ const EXTENSION_KEY = 'inline_media';
 const PROMPT_KEY = 'inline_media_prompt';
 
 /**
- * Gets the inline media array for the current character.
+ * Whether the editor is currently in create-new-character mode.
+ * @returns {boolean}
+ */
+function isCreateMode() {
+    return menu_type === 'create';
+}
+
+/**
+ * Gets the inline media array for the current character / pending create draft.
  * @returns {CharacterMediaAttachment[]}
  */
 export function getCharacterInlineMedia() {
+    if (isCreateMode()) {
+        const arr = create_save.extensions?.[EXTENSION_KEY];
+        return Array.isArray(arr) ? arr : [];
+    }
     const character = characters[this_chid];
     if (!character?.data?.extensions?.[EXTENSION_KEY]) {
         return [];
     }
     return character.data.extensions[EXTENSION_KEY];
+}
+
+/**
+ * Persists the inline media array for the current character / pending create draft.
+ * In create mode, writes only to the in-memory `create_save.extensions` — the
+ * server persists it later via the create form's `extensions` field.
+ * @param {CharacterMediaAttachment[]} media
+ */
+async function setCharacterInlineMedia(media) {
+    if (isCreateMode()) {
+        if (!create_save.extensions || typeof create_save.extensions !== 'object') {
+            create_save.extensions = {};
+        }
+        create_save.extensions[EXTENSION_KEY] = media;
+        return;
+    }
+    await writeExtensionField(this_chid, EXTENSION_KEY, media);
 }
 
 /**
@@ -46,6 +85,10 @@ export function getCharacterInlineMedia() {
  * @returns {string}
  */
 export function getCharacterInlineMediaPrompt() {
+    if (isCreateMode()) {
+        const value = create_save.extensions?.[PROMPT_KEY];
+        return typeof value === 'string' ? value : '';
+    }
     const character = characters[this_chid];
     const value = character?.data?.extensions?.[PROMPT_KEY];
     return typeof value === 'string' ? value : '';
@@ -56,8 +99,16 @@ export function getCharacterInlineMediaPrompt() {
  * @param {string} value
  */
 export async function setCharacterInlineMediaPrompt(value) {
+    const next = value || '';
+    if (isCreateMode()) {
+        if (!create_save.extensions || typeof create_save.extensions !== 'object') {
+            create_save.extensions = {};
+        }
+        create_save.extensions[PROMPT_KEY] = next;
+        return;
+    }
     if (this_chid === undefined) return;
-    await writeExtensionField(this_chid, PROMPT_KEY, value || '');
+    await writeExtensionField(this_chid, PROMPT_KEY, next);
 }
 
 /**
@@ -66,13 +117,14 @@ export async function setCharacterInlineMediaPrompt(value) {
  * @returns {Promise<CharacterMediaAttachment|null>} The created attachment, or null on failure
  */
 export async function attachMediaToCharacter(file) {
-    if (this_chid === undefined) {
+    const inCreate = isCreateMode();
+    if (!inCreate && this_chid === undefined) {
         toastr.warning(t`No character selected.`);
         return null;
     }
 
-    const character = characters[this_chid];
-    if (!character) {
+    const character = inCreate ? null : characters[this_chid];
+    if (!inCreate && !character) {
         return null;
     }
 
@@ -88,7 +140,9 @@ export async function attachMediaToCharacter(file) {
         const extension = getFileExtension(file);
         const slug = getStringHash(file.name);
         const fileName = `char_ref_${Date.now()}_${slug}`;
-        const charName = character.name || 'unknown';
+        const charName = inCreate
+            ? (String($('#character_name_pole').val() || '').trim() || create_save.name || 'unknown')
+            : (character.name || 'unknown');
 
         const url = await saveBase64AsFile(base64Data, charName, fileName, extension);
 
@@ -100,9 +154,8 @@ export async function attachMediaToCharacter(file) {
             created: Date.now(),
         };
 
-        const media = getCharacterInlineMedia();
-        media.push(attachment);
-        await writeExtensionField(this_chid, EXTENSION_KEY, media);
+        const media = [...getCharacterInlineMedia(), attachment];
+        await setCharacterInlineMedia(media);
 
         return attachment;
     } catch (error) {
@@ -128,7 +181,7 @@ export async function removeCharacterInlineMedia(index) {
     }
 
     const [removed] = media.splice(index, 1);
-    await writeExtensionField(this_chid, EXTENSION_KEY, media);
+    await setCharacterInlineMedia(media);
 
     if (removed?.url) {
         try {
@@ -137,4 +190,190 @@ export async function removeCharacterInlineMedia(index) {
             console.warn('Failed to delete inline_media asset from disk', removed.url, error);
         }
     }
+}
+
+/**
+ * Builds a preview element for an attachment, dispatched on its media type.
+ * Falls back to an image element for legacy entries that have no `type` field.
+ * @param {CharacterMediaAttachment} attachment
+ * @returns {JQuery<HTMLElement>}
+ */
+function buildPreviewElement(attachment) {
+    const type = attachment.type ?? MEDIA_TYPE.IMAGE;
+    if (type === MEDIA_TYPE.VIDEO) {
+        return $('<video preload="metadata" muted playsinline></video>')
+            .attr('src', attachment.url)
+            .attr('aria-label', attachment.name);
+    }
+    if (type === MEDIA_TYPE.AUDIO) {
+        return $('<audio preload="metadata" controls></audio>')
+            .attr('src', attachment.url)
+            .attr('aria-label', attachment.name);
+    }
+    return $('<img>')
+        .attr('src', attachment.url)
+        .attr('alt', attachment.name);
+}
+
+/**
+ * Builds a fullscreen-popup element for an attachment, dispatched on its media type.
+ * @param {CharacterMediaAttachment} attachment
+ * @returns {JQuery<HTMLElement>}
+ */
+function buildFullPreviewElement(attachment) {
+    const type = attachment.type ?? MEDIA_TYPE.IMAGE;
+    const styles = { maxWidth: '100%', maxHeight: '80vh' };
+    if (type === MEDIA_TYPE.VIDEO) {
+        return $('<video controls autoplay></video>')
+            .attr('src', attachment.url)
+            .css(styles);
+    }
+    if (type === MEDIA_TYPE.AUDIO) {
+        return $('<audio controls autoplay></audio>')
+            .attr('src', attachment.url);
+    }
+    return $('<img>').attr('src', attachment.url).css(styles);
+}
+
+/**
+ * Monotonic render counter — bumped at the start of each render so any
+ * in-flight render whose async template fetch finishes after a newer one
+ * started can detect it's stale and bail out (otherwise both `appendChild`
+ * after their awaits, leaving the previous card's images visible).
+ */
+let renderSeq = 0;
+
+/**
+ * Renders the reference media UI in the character editor.
+ */
+export async function renderCharacterRefImages() {
+    const container = document.getElementById('char_ref_images_container');
+    if (!container) return;
+
+    const mySeq = ++renderSeq;
+
+    if (this_chid === undefined && !isCreateMode()) {
+        container.replaceChildren();
+        return;
+    }
+
+    const media = getCharacterInlineMedia();
+    const template = $(await renderTemplateAsync('charRefImages'));
+
+    if (mySeq !== renderSeq) return;
+
+    const list = template.find('.char_ref_images_list');
+    const countSpan = template.find('.char_ref_images_count');
+
+    if (media.length > 0) {
+        countSpan.text(`(${media.length})`);
+    }
+
+    for (let i = 0; i < media.length; i++) {
+        const attachment = media[i];
+        const item = $('<div class="char_ref_image_item"></div>');
+        item.attr('title', attachment.name);
+        item.attr('data-media-type', attachment.type ?? MEDIA_TYPE.IMAGE);
+
+        item.append(buildPreviewElement(attachment));
+
+        const deleteBtn = $('<button class="char_ref_image_delete"><i class="fa-solid fa-xmark"></i></button>');
+        deleteBtn.on('click', async (e) => {
+            e.stopPropagation();
+            const confirm = await callGenericPopup(t`Remove this reference attachment?`, POPUP_TYPE.CONFIRM);
+            if (confirm !== POPUP_RESULT.AFFIRMATIVE) return;
+            await removeCharacterInlineMedia(i);
+            await renderCharacterRefImages();
+        });
+        item.append(deleteBtn);
+
+        // Click-to-enlarge — but don't hijack clicks on the embedded media controls
+        // (e.g. play/pause for video & audio).
+        item.on('click', function (event) {
+            const target = /** @type {HTMLElement} */ (event.target);
+            if (target && (target.closest('audio') || target.closest('video'))) return;
+            callGenericPopup(buildFullPreviewElement(attachment), POPUP_TYPE.TEXT, '', { wide: true, large: true });
+        });
+
+        list.append(item);
+    }
+
+    const addBtn = template.find('.char_ref_images_add');
+    const fileInput = template.find('.char_ref_images_input');
+
+    addBtn.on('click', () => fileInput.trigger('click'));
+    fileInput.on('change', async function () {
+        if (!(this instanceof HTMLInputElement) || !this.files?.length) return;
+        for (const file of this.files) {
+            await attachMediaToCharacter(file);
+        }
+        if (this.files.length > 0) {
+            toastr.success(t`${this.files.length} attachment(s) added as reference.`);
+        }
+        await renderCharacterRefImages();
+    });
+
+    // Per-character body for the user message that ships alongside the attachments.
+    // Blank means no body text — the message is sent as pure attachments.
+    const promptInput = template.find('.char_ref_images_prompt');
+    promptInput.val(getCharacterInlineMediaPrompt());
+    promptInput.on('change', async function () {
+        if (!(this instanceof HTMLTextAreaElement)) return;
+        await setCharacterInlineMediaPrompt(this.value);
+    });
+
+    container.replaceChildren(template.get(0));
+}
+
+/**
+ * Wires paste + drag-drop on the Reference Media drawer container so users can paste
+ * or drop image / video / audio files directly into the editor. Only consumes events
+ * that carry supported media; pasting plain text into the prompt textarea passes through.
+ * Idempotent — safe to call once at init.
+ */
+function setupRefImagesDropTarget() {
+    const container = document.getElementById('char_ref_images_container');
+    if (!container) return;
+
+    const ingest = async (files) => {
+        const supported = files.filter(f => MEDIA_TYPE.getFromMime(f.type) !== null);
+        if (supported.length === 0) return;
+        for (const file of supported) {
+            await attachMediaToCharacter(file);
+        }
+        toastr.success(t`${supported.length} attachment(s) added as reference.`);
+        await renderCharacterRefImages();
+    };
+
+    container.addEventListener('paste', (e) => {
+        const clipboardEvent = /** @type {ClipboardEvent} */ (e);
+        const files = clipboardEvent.clipboardData?.files;
+        if (!files?.length) return;
+        const fileArr = Array.from(files);
+        if (!fileArr.some(f => MEDIA_TYPE.getFromMime(f.type) !== null)) return;
+        clipboardEvent.preventDefault();
+        clipboardEvent.stopPropagation();
+        ingest(fileArr);
+    });
+
+    new DragAndDropHandler('#char_ref_images_container', (files) => {
+        ingest(files);
+    });
+}
+
+/**
+ * Initialize event listeners for character media management.
+ */
+export function initCharacterMedia() {
+    eventSource.on(event_types.CHARACTER_EDITOR_OPENED, () => {
+        renderCharacterRefImages();
+    });
+
+    // The "+" Create button enters create mode via select_rm_create() without
+    // firing CHARACTER_EDITOR_OPENED, so wire the same setup here.
+    $(document).on('click', '#rm_button_create', () => {
+        renderCharacterRefImages();
+    });
+
+    setupRefImagesDropTarget();
 }

--- a/public/scripts/char-media.js
+++ b/public/scripts/char-media.js
@@ -1,0 +1,140 @@
+/**
+ * Handles inline media (reference images, video, audio) for character cards.
+ * These attachments are stored in character data extensions and can be sent
+ * to multimodal models as additional context alongside character descriptions.
+ */
+
+import { characters, this_chid } from '../script.js';
+import {
+    getBase64Async,
+    saveBase64AsFile,
+    getStringHash,
+    getFileExtension,
+} from './utils.js';
+import { writeExtensionField } from './extensions.js';
+import { MEDIA_TYPE } from './constants.js';
+import { t } from './i18n.js';
+import { deleteMediaFromServer } from './chats.js';
+
+/**
+ * @typedef {object} CharacterMediaAttachment
+ * @property {string} url - Server-relative URL of the uploaded asset
+ * @property {string} name - Original file name
+ * @property {string} type - One of MEDIA_TYPE values: 'image', 'video', 'audio'
+ * @property {number} created - Timestamp of when the asset was attached
+ */
+
+const EXTENSION_KEY = 'inline_media';
+const PROMPT_KEY = 'inline_media_prompt';
+
+/**
+ * Gets the inline media array for the current character.
+ * @returns {CharacterMediaAttachment[]}
+ */
+export function getCharacterInlineMedia() {
+    const character = characters[this_chid];
+    if (!character?.data?.extensions?.[EXTENSION_KEY]) {
+        return [];
+    }
+    return character.data.extensions[EXTENSION_KEY];
+}
+
+/**
+ * Gets the per-character body of the reference-media user message.
+ * Empty string when unset, which means the message is sent with no body
+ * (just attachments).
+ * @returns {string}
+ */
+export function getCharacterInlineMediaPrompt() {
+    const character = characters[this_chid];
+    const value = character?.data?.extensions?.[PROMPT_KEY];
+    return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Persists the per-character override for the reference-media message body.
+ * @param {string} value
+ */
+export async function setCharacterInlineMediaPrompt(value) {
+    if (this_chid === undefined) return;
+    await writeExtensionField(this_chid, PROMPT_KEY, value || '');
+}
+
+/**
+ * Uploads a media file (image / video / audio) and attaches it to the current character.
+ * @param {File} file - The media file to upload
+ * @returns {Promise<CharacterMediaAttachment|null>} The created attachment, or null on failure
+ */
+export async function attachMediaToCharacter(file) {
+    if (this_chid === undefined) {
+        toastr.warning(t`No character selected.`);
+        return null;
+    }
+
+    const character = characters[this_chid];
+    if (!character) {
+        return null;
+    }
+
+    const mediaType = MEDIA_TYPE.getFromMime(file.type);
+    if (!mediaType) {
+        toastr.warning(t`Unsupported file type. Reference attachments must be image, video, or audio.`);
+        return null;
+    }
+
+    try {
+        const base64 = await getBase64Async(file);
+        const base64Data = base64.split(',')[1];
+        const extension = getFileExtension(file);
+        const slug = getStringHash(file.name);
+        const fileName = `char_ref_${Date.now()}_${slug}`;
+        const charName = character.name || 'unknown';
+
+        const url = await saveBase64AsFile(base64Data, charName, fileName, extension);
+
+        /** @type {CharacterMediaAttachment} */
+        const attachment = {
+            url,
+            name: file.name,
+            type: mediaType,
+            created: Date.now(),
+        };
+
+        const media = getCharacterInlineMedia();
+        media.push(attachment);
+        await writeExtensionField(this_chid, EXTENSION_KEY, media);
+
+        return attachment;
+    } catch (error) {
+        console.error('Failed to attach reference media to character', error);
+        toastr.error(t`Failed to upload the file.`);
+        return null;
+    }
+}
+
+/**
+ * Removes an inline media attachment from the character by index, both from the card's
+ * extensions array and from disk under userImages. The asset is owned by exactly this
+ * attachment entry — once unreferenced it would be orphaned. Best-effort: a failed
+ * server-side delete still removes the entry from the card.
+ * @param {number} index - Index in the inline_media array
+ * @returns {Promise<void>}
+ */
+export async function removeCharacterInlineMedia(index) {
+    const media = [...getCharacterInlineMedia()];
+    if (index < 0 || index >= media.length) {
+        console.warn('Invalid media index', index);
+        return;
+    }
+
+    const [removed] = media.splice(index, 1);
+    await writeExtensionField(this_chid, EXTENSION_KEY, media);
+
+    if (removed?.url) {
+        try {
+            await deleteMediaFromServer(removed.url, /* silent */ true);
+        } catch (error) {
+            console.warn('Failed to delete inline_media asset from disk', removed.url, error);
+        }
+    }
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -80,6 +80,7 @@ import { t } from './i18n.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
+import { getCharacterInlineMedia, getCharacterInlineMediaPrompt } from './char-media.js';
 import { syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
 
 export {
@@ -1208,6 +1209,48 @@ async function populateChatCompletion(prompts, chatCompletion, { bias, quietProm
     await addToChatCompletion('scenario');
     await addToChatCompletion('personaDescription');
 
+    // Inline character reference media (image / video / audio): built as a user message attached to
+    // the charRefImages prompt block. Position is governed by the user's prompt manager order
+    // (movable / disable-able). Each attachment is gated by the model's per-modality capability.
+    if (prompts.has('charRefImages')) {
+        const media = getCharacterInlineMedia();
+        const refPrompt = prompts.get('charRefImages');
+        const isDisabled = promptManager.isPromptDisabledForActiveCharacter('charRefImages');
+        const isAbsolute = refPrompt.injection_position === INJECTION_POSITION.ABSOLUTE;
+        const imageInlining = isImageInliningSupported();
+        const videoInlining = isVideoInliningSupported();
+        const audioInlining = isAudioInliningSupported();
+        const supported = media.filter(m => {
+            const type = m.type ?? MEDIA_TYPE.IMAGE;
+            return (type === MEDIA_TYPE.IMAGE && imageInlining)
+                || (type === MEDIA_TYPE.VIDEO && videoInlining)
+                || (type === MEDIA_TYPE.AUDIO && audioInlining);
+        });
+        if (supported.length > 0 && !isDisabled && !isAbsolute) {
+            // Per-character body for the user message accompanying attachments (Advanced
+            // Definitions → Reference Media). Empty by default so the message ships as a
+            // pure-attachment payload; authors can opt in by writing something here.
+            const promptBody = getCharacterInlineMediaPrompt();
+            const effectivePrompt = new Prompt({ ...refPrompt, content: substituteParams(promptBody) });
+            const message = await Message.fromPromptAsync(effectivePrompt);
+            for (const attachment of supported) {
+                const type = attachment.type ?? MEDIA_TYPE.IMAGE;
+                try {
+                    if (type === MEDIA_TYPE.IMAGE) await message.addImage(attachment.url);
+                    else if (type === MEDIA_TYPE.VIDEO) await message.addVideo(attachment.url);
+                    else if (type === MEDIA_TYPE.AUDIO) await message.addAudio(attachment.url);
+                } catch (error) {
+                    console.error('Failed to inline character reference media', attachment.url, error);
+                }
+            }
+            if (chatCompletion.canAfford(message)) {
+                const collection = new MessageCollection('charRefImages');
+                collection.add(message);
+                chatCompletion.add(collection, prompts.index('charRefImages'));
+            }
+        }
+    }
+
     // Collection of control prompts that will always be positioned last
     chatCompletion.setOverriddenPrompts(prompts.overriddenPrompts);
     const controlPrompts = new MessageCollection('controlPrompts');
@@ -1424,6 +1467,11 @@ async function preparePromptsForChatCompletion({ scenario, charPersonality, name
     if (power_user.persona_description && power_user.persona_description_position === persona_description_positions.IN_PROMPT) {
         systemPrompts.push({ role: 'system', content: power_user.persona_description, identifier: 'personaDescription' });
     }
+
+    // Character Reference Images marker — content comes from the per-character override at
+    // populate time (empty by default; the message ships as pure attachments). Sent as a user
+    // role since most VLMs don't accept image content parts in system messages.
+    systemPrompts.push({ role: 'user', content: '', identifier: 'charRefImages' });
 
     const knownExtensionPrompts = [
         '1_memory',

--- a/public/scripts/templates/charRefImages.html
+++ b/public/scripts/templates/charRefImages.html
@@ -1,0 +1,19 @@
+<div class="char_ref_images_block">
+    <div class="char_ref_images_header flex-container alignitemscenter">
+        <i class="fa-solid fa-photo-film fa-fw"></i>
+        <span class="char_ref_images_count"></span>
+        <small class="char_ref_images_hint" data-i18n="Attach images, video, or audio. Sent based on model capabilities.">Attach images, video, or audio. Sent based on model capabilities.</small>
+        <div class="char_ref_images_add menu_button menu_button_icon margin0" title="Attach a reference media file" data-i18n="[title]Attach a reference media file">
+            <i class="fa-solid fa-plus fa-fw"></i>
+        </div>
+        <input type="file" class="char_ref_images_input" accept="image/*,video/*,audio/*" multiple style="display: none;">
+    </div>
+    <div class="char_ref_images_list"></div>
+    <div class="char_ref_images_prompt_field">
+        <h5 class="flex-container alignItemsBaseline margin0">
+            <span data-i18n="Reference Media Prompt">Reference Media Prompt</span>
+            <small data-i18n="(Body of the user message sent with attachments. Leave blank for none.)">(Body of the user message sent with attachments. Leave blank for none.)</small>
+        </h5>
+        <textarea class="char_ref_images_prompt text_pole" rows="2" data-macros autocomplete="off"></textarea>
+    </div>
+</div>

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -14,7 +14,7 @@ import storage from 'node-persist';
 
 import { AVATAR_WIDTH, AVATAR_HEIGHT, DEFAULT_AVATAR_PATH } from '../constants.js';
 import { default as validateAvatarUrlMiddleware, getFileNameValidationFunction, forbiddenRegExp } from '../middleware/validateFileName.js';
-import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements } from '../util.js';
+import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements, isPathUnderParent } from '../util.js';
 import { TavernCardValidator } from '../validator/TavernCardValidator.js';
 import { parse, read, write } from '../character-card-parser.js';
 import { readWorldInfoFile } from './worldinfo.js';
@@ -499,6 +499,7 @@ function unsetPrivateFields(char) {
     _.set(char, 'fav', false);
     _.set(char, 'data.extensions.fav', false);
     _.unset(char, 'chat');
+    _.unset(char, 'data.extensions.inline_media');
 }
 
 function readFromV2(char) {
@@ -1424,6 +1425,31 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
     const avatarPath = path.join(request.user.directories.characters, request.body.avatar_url);
     if (!fs.existsSync(avatarPath)) {
         return response.sendStatus(400);
+    }
+
+    // Best-effort cleanup of inline_media reference assets attached to this character.
+    // Read the card before unlinking so the data is still available; failures here must not
+    // block the deletion itself.
+    try {
+        const card = await readCharacterData(avatarPath);
+        const cardJson = typeof card === 'string' ? tryParse(card) : null;
+        const inlineMedia = cardJson?.data?.extensions?.inline_media;
+        if (Array.isArray(inlineMedia)) {
+            for (const item of inlineMedia) {
+                if (!item?.url || typeof item.url !== 'string') continue;
+                const assetPath = path.normalize(path.join(request.user.directories.root, item.url));
+                if (!isPathUnderParent(request.user.directories.userImages, assetPath)) continue;
+                if (fs.existsSync(assetPath)) {
+                    try {
+                        await fsPromises.unlink(assetPath);
+                    } catch (err) {
+                        console.warn(`[Characters] Failed to remove inline_media asset ${item.url}:`, err);
+                    }
+                }
+            }
+        }
+    } catch (err) {
+        console.warn('[Characters] Failed to read inline_media for cleanup:', err);
     }
 
     fs.unlinkSync(avatarPath);

--- a/src/endpoints/data-maid.js
+++ b/src/endpoints/data-maid.js
@@ -7,6 +7,7 @@ import { getSettingsBackupFilePrefix } from './settings.js';
 import { CHAT_BACKUPS_PREFIX } from './chats.js';
 import { isPathUnderParent, tryParse } from '../util.js';
 import { SETTINGS_FILE } from '../constants.js';
+import { read as readPngCharacterData } from '../character-card-parser.js';
 
 const sha256 = str => crypto.createHash('sha256').update(str).digest('hex');
 
@@ -205,6 +206,11 @@ export class DataMaidService {
                         }
                     }
                 }
+            }
+            // Character cards' inline_media (reference images / video / audio for VLMs) are stored
+            // under userImages — register their URLs so they aren't flagged as loose files.
+            for (const url of await this.#parseAllCharacterInlineMedia()) {
+                knownImages.add(url);
             }
             const knownImageFullPaths = new Set();
             knownImages.forEach(image => {
@@ -624,6 +630,37 @@ export class DataMaidService {
             console.error('[Data Maid] Error parsing chats:', error);
             return [];
         }
+    }
+
+    /**
+     * Reads every character card and returns the union of `data.extensions.inline_media[*].url`
+     * values. These reference assets live under userImages but are owned by character cards
+     * rather than chat messages, so they need to be tracked separately for loose-file detection.
+     * @returns {Promise<string[]>} List of inline_media URLs across all characters.
+     */
+    async #parseAllCharacterInlineMedia() {
+        const urls = [];
+        try {
+            const characters = await fs.promises.readdir(this.directories.characters, { withFileTypes: true });
+            for (const file of characters) {
+                if (!file.isFile() || path.parse(file.name).ext !== '.png') continue;
+                try {
+                    const filePath = path.join(this.directories.characters, file.name);
+                    const buffer = await fs.promises.readFile(filePath);
+                    const cardJson = tryParse(readPngCharacterData(buffer));
+                    const inlineMedia = cardJson?.data?.extensions?.inline_media;
+                    if (!Array.isArray(inlineMedia)) continue;
+                    for (const item of inlineMedia) {
+                        if (typeof item?.url === 'string' && item.url) urls.push(item.url);
+                    }
+                } catch (error) {
+                    console.warn(`[Data Maid] Error reading inline_media from ${file.name}:`, error);
+                }
+            }
+        } catch (error) {
+            console.error('[Data Maid] Error scanning characters for inline_media:', error);
+        }
+        return urls;
     }
 
     /**


### PR DESCRIPTION
## What

UI for the `charRefImages` prompt block introduced in #5374. Adds a "Reference Media" collapsible drawer inside the Advanced Definitions popup with a thumbnail grid, an attachable prompt body textarea, and paste / drag-drop support.

**Depends on #5374** — should be merged after that PR.

Related: #2920, #3401.

## Changes

- **Drawer in Advanced Definitions** — collapsible inline-drawer matching the surrounding Prompt Overrides / Creator's Metadata sections (per @Cohee1207's preference). Container moved out of the sidebar.
- **Type-aware previews.** `<img>` for images, `<video preload=metadata muted>` for videos, `<audio preload=metadata controls>` for audio. Click-to-enlarge opens a popup with proper controls. Hover delete + confirmation. Distinct video / audio glyph overlay; audio thumbnails are wider since the controls take width.
- **Paste + drag-and-drop on the drawer.** Files in `image/*`, `video/*`, `audio/*` are accepted. Pasting plain text into the prompt textarea passes through normally — `preventDefault` only fires when the clipboard carries supported media files.
- **Reference Media Prompt textarea.** Per-character body for the user message that ships alongside attachments. Stored at `data.extensions.inline_media_prompt`. Blank = no body, attachments only. Supports `{{macros}}` via `substituteParams`.
- **Create-mode aware.** Works in the in-flight character creation draft (writes to `create_save.extensions`, persisted by the server on Save). The "+" Create button enters create mode via `select_rm_create()` without firing `CHARACTER_EDITOR_OPENED`, so we wire the same setup off `#rm_button_create` click.
- **Stale-render guard.** Monotonic `renderSeq` counter; an in-flight async render whose template fetch finishes after a newer one started detects the staleness and bails, so switching characters doesn't leave the previous card's images on screen.

## How to test

1. Merge or checkout #5374 first.
2. Open any character card → click Advanced Definitions → expand "Reference Media".
3. Add an image, a video, and an audio file via the **+** button, paste, and drag-drop. Verify previews render with the right element type.
4. Hover a thumbnail → click delete → confirm. File should also disappear from disk under `User Data/.../user/images/<charname>/`.
5. Click a thumbnail → full-size popup with controls (play / pause for video / audio).
6. Edit the Reference Media Prompt textarea. With a vision-capable model, generate and verify the user message body matches.
7. Switch to a different character with reference media — previews should update without flicker / stale images.
8. Open the **+** Create flow, attach media, fill in name etc., Save — the new card should have `data.extensions.inline_media` and `data.extensions.inline_media_prompt` persisted.