### PR TITLE
Use custom init script instead of postinstall

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY --chown=node:node . ./
 
 RUN \
   echo "*** Install npm packages ***" && \
-  npm ci --no-audit --no-fund --loglevel=error --no-progress --omit=dev && npm cache clean --force
+  npm ci --no-audit --no-fund --loglevel=error --no-progress --omit=dev --ignore-scripts && npm cache clean --force
 
 # Create config directory and link config.yaml. Added hardcoded dirs(constants.js?)
 # that must be present for Non-Root Mode and volumeless docker runs.

--- a/Start.bat
+++ b/Start.bat
@@ -1,7 +1,7 @@
 @echo off
 pushd %~dp0
 set NODE_ENV=production
-call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev --ignore-scripts
 call npm run init
 node server.js %*
 pause

--- a/Start.bat
+++ b/Start.bat
@@ -2,6 +2,7 @@
 pushd %~dp0
 set NODE_ENV=production
 call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+call npm run init
 node server.js %*
 pause
 popd

--- a/UpdateAndStart.bat
+++ b/UpdateAndStart.bat
@@ -21,6 +21,7 @@ if %errorlevel% neq 0 (
 )
 set NODE_ENV=production
 call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+call npm run init
 node server.js %*
 :end
 pause

--- a/UpdateAndStart.bat
+++ b/UpdateAndStart.bat
@@ -20,7 +20,7 @@ if %errorlevel% neq 0 (
     )
 )
 set NODE_ENV=production
-call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev --ignore-scripts
 call npm run init
 node server.js %*
 :end

--- a/UpdateForkAndStart.bat
+++ b/UpdateForkAndStart.bat
@@ -103,6 +103,7 @@ if %errorlevel% neq 0 (
 echo Installing npm packages and starting server
 set NODE_ENV=production
 call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+call npm run init
 node server.js %*
 
 :end

--- a/UpdateForkAndStart.bat
+++ b/UpdateForkAndStart.bat
@@ -102,7 +102,7 @@ if %errorlevel% neq 0 (
 
 echo Installing npm packages and starting server
 set NODE_ENV=production
-call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev --ignore-scripts
 call npm run init
 node server.js %*
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Function to handle startup logic (Config check + Postinstall + Start)
+# Function to handle startup logic (Config check + init + Start)
 start_sillytavern() {
     local PREFIX="$1"
     shift # Remove the first argument (PREFIX) so $@ contains the rest
@@ -11,8 +11,8 @@ start_sillytavern() {
         $PREFIX cp "default/config.yaml" "config/config.yaml"
     fi
 
-    # Execute postinstall to auto-populate config.yaml with missing values
-    $PREFIX npm run postinstall
+    # Execute init script to auto-populate config.yaml with missing values
+    $PREFIX npm run init
 
     # Start the server
     exec $PREFIX node server.js --listen "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
         "": {
             "name": "sillytavern",
             "version": "1.17.0",
-            "hasInstallScript": true,
             "license": "AGPL-3.0",
             "dependencies": {
                 "@adobe/css-tools": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     },
     "version": "1.17.0",
     "scripts": {
+        "init": "node src/server-init.js",
         "start": "node server.js",
         "debug": "node --inspect server.js",
         "start:global": "node server.js --global",
@@ -122,7 +123,6 @@
         "start:deno": "deno run --allow-run --allow-net --allow-read --allow-write --allow-sys --allow-env server.js",
         "start:bun": "bun server.js",
         "start:no-csrf": "node server.js --disableCsrf",
-        "postinstall": "node post-install.js",
         "lint": "eslint \"src/**/*.js\" \"public/**/*.js\" ./*.js",
         "lint:fix": "eslint \"src/**/*.js\" \"public/**/*.js\" ./*.js --fix",
         "plugins:update": "node plugins update",

--- a/src/electron/Start.bat
+++ b/src/electron/Start.bat
@@ -1,6 +1,6 @@
 @echo off
 pushd %~dp0
-call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev --ignore-scripts
 npm run start server.js %*
 pause
 popd

--- a/src/electron/Start.bat
+++ b/src/electron/Start.bat
@@ -1,6 +1,7 @@
 @echo off
 pushd %~dp0
 call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+call npm run init
 npm run start server.js %*
 pause
 popd

--- a/src/electron/Start.bat
+++ b/src/electron/Start.bat
@@ -1,7 +1,6 @@
 @echo off
 pushd %~dp0
 call npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
-call npm run init
 npm run start server.js %*
 pause
 popd

--- a/src/electron/start.sh
+++ b/src/electron/start.sh
@@ -5,6 +5,7 @@ cd "$(dirname "$0")"
 
 echo "Assuming nodejs and npm is already installed. If you haven't installed them already, do so now"
 echo "Installing Electron Wrapper's Node Modules..."
+export NODE_ENV=production
 npm i --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
 
 echo "Starting Electron Wrapper..."

--- a/src/electron/start.sh
+++ b/src/electron/start.sh
@@ -5,7 +5,6 @@ cd "$(dirname "$0")"
 
 echo "Assuming nodejs and npm is already installed. If you haven't installed them already, do so now"
 echo "Installing Electron Wrapper's Node Modules..."
-export NODE_ENV=production
 npm i --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
 
 echo "Starting Electron Wrapper..."

--- a/src/server-init.js
+++ b/src/server-init.js
@@ -7,7 +7,7 @@ import process from 'node:process';
 import yaml from 'yaml';
 import chalk from 'chalk';
 import { createRequire } from 'node:module';
-import { addMissingConfigValues } from './src/config-init.js';
+import { addMissingConfigValues } from './config-init.js';
 
 /**
  * Colorizes console output.
@@ -88,7 +88,7 @@ function createDefaultFiles() {
                 );
             } else {
                 throw new Error(
-                    'FATAL: Unexpected default file format in `post-install.js#createDefaultFiles()`.',
+                    'FATAL: Unexpected default file format in `server-init.js#createDefaultFiles()`.',
                 );
             }
         } catch (error) {

--- a/start.sh
+++ b/start.sh
@@ -10,7 +10,7 @@ fi
 
 echo "Installing Node Modules..."
 export NODE_ENV=production
-npm i --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+npm install --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev --ignore-scripts
 npm run init
 
 echo "Entering SillyTavern..."

--- a/start.sh
+++ b/start.sh
@@ -11,6 +11,7 @@ fi
 echo "Installing Node Modules..."
 export NODE_ENV=production
 npm i --no-save --no-audit --no-fund --loglevel=error --no-progress --omit=dev
+npm run init
 
 echo "Entering SillyTavern..."
 node "server.js" "$@"


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

1. Add npmrc with common security hardening settings 
2. Replace postinstall script with custom package.json script and call it in startup scripts. Cause we won't be able to call it 

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
