### PR TITLE
Add VSCode settings for TypeScript SDK configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+    "js/ts.tsdk.path": "./node_modules/typescript/lib"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,7 +138,8 @@
                 "eslint": "^8.57.1",
                 "eslint-plugin-jest": "^27.9.0",
                 "eslint-plugin-jsdoc": "^48.10.0",
-                "eslint-plugin-playwright": "^2.3.0"
+                "eslint-plugin-playwright": "^2.3.0",
+                "typescript": "^5.9.3"
             },
             "engines": {
                 "node": ">= 20"

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
         "eslint": "^8.57.1",
         "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-jsdoc": "^48.10.0",
-        "eslint-plugin-playwright": "^2.3.0"
+        "eslint-plugin-playwright": "^2.3.0",
+        "typescript": "^5.9.3"
     }
 }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

VSCode force updating TypeScript to v6.0? Say: no, thank you.

https://code.visualstudio.com/docs/typescript/typescript-transpiling#_using-newer-typescript-versions

<img width="536" height="178" alt="image" src="https://github.com/user-attachments/assets/a3444cb0-6048-4cb5-86a3-dd02975afc5e" />

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
