### PR TITLE
Split the connection manager settings away from the main user config.

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7958,6 +7958,9 @@ export async function saveSettings(loopCounter = 0) {
         TempResponseLength.restore(null);
     }
 
+    const extensionSettingsPayload = { ...extension_settings };
+    delete extensionSettingsPayload.connectionManager;
+
     const payload = {
         firstRun: firstRun,
         accountStorage: accountStorage.getState(),
@@ -7974,7 +7977,7 @@ export async function saveSettings(loopCounter = 0) {
         swipes: swipes,
         horde_settings: horde_settings,
         power_user: power_user,
-        extension_settings: extension_settings,
+        extension_settings: extensionSettingsPayload,
         tags: tags,
         tag_map: tag_map,
         nai_settings: nai_settings,

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -60,6 +60,12 @@ let manifests = {};
  * Default URL for the Extras API.
  */
 const defaultUrl = 'http://localhost:5100';
+const CONNECTION_MANAGER_GET_ENDPOINT = '/api/settings/get-connections';
+const CONNECTION_MANAGER_SAVE_ENDPOINT = '/api/settings/save-connections';
+const CONNECTION_MANAGER_DEFAULT_SETTINGS = Object.freeze({
+    profiles: [],
+    selectedProfile: null,
+});
 
 let requiresReload = false;
 let stateChanged = false;
@@ -211,6 +217,75 @@ export const extension_settings = {
         sort: 'dateAsc',
     },
 };
+
+/**
+ * Sanitizes the connection manager settings.
+ * @param {any} settings Incoming settings
+ * @returns {{profiles: object[], selectedProfile: string | null}}
+ */
+function normalizeConnectionManagerSettings(settings) {
+    const profiles = Array.isArray(settings?.profiles)
+        ? settings.profiles.filter(profile => profile && typeof profile === 'object')
+        : [];
+    const selectedProfile = typeof settings?.selectedProfile === 'string'
+        ? settings.selectedProfile
+        : CONNECTION_MANAGER_DEFAULT_SETTINGS.selectedProfile;
+
+    return {
+        profiles,
+        selectedProfile,
+    };
+}
+
+/**
+ * Checks if a connection manager object has data.
+ * @param {{profiles: object[], selectedProfile: string | null}} settings
+ * @returns {boolean}
+ */
+function hasConnectionManagerData(settings) {
+    return settings.profiles.length > 0 || !!settings.selectedProfile;
+}
+
+/**
+ * Loads persisted connection manager settings from the server.
+ * @returns {Promise<{exists: boolean, connections: {profiles: object[], selectedProfile: string | null}}>}
+ */
+async function fetchConnectionManagerSettings() {
+    const response = await fetch(CONNECTION_MANAGER_GET_ENDPOINT, {
+        method: 'POST',
+        headers: getRequestHeaders(),
+        body: JSON.stringify({}),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Connection manager settings load failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    const connections = normalizeConnectionManagerSettings(data?.connections);
+
+    return {
+        exists: Boolean(data?.exists),
+        connections,
+    };
+}
+
+/**
+ * Saves the current connection manager settings to a dedicated user file.
+ * @param {any} settings Settings object to persist
+ */
+export async function saveConnectionManagerSettings(settings = extension_settings.connectionManager) {
+    const normalized = normalizeConnectionManagerSettings(settings);
+    const response = await fetch(CONNECTION_MANAGER_SAVE_ENDPOINT, {
+        method: 'POST',
+        headers: getRequestHeaders(),
+        body: JSON.stringify(normalized),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Connection manager settings save failed: ${response.status} ${response.statusText}`);
+    }
+}
 
 function showHideExtensionsMenu() {
     // Get the number of menu items that are not hidden
@@ -1519,8 +1594,28 @@ export async function installExtension(url, global, branch = '') {
  * @param {boolean} enableAutoUpdate Enable auto-update
  */
 export async function loadExtensionSettings(settings, versionChanged, enableAutoUpdate) {
+    const legacyConnectionManager = normalizeConnectionManagerSettings(
+        settings?.extension_settings?.connectionManager ?? extension_settings.connectionManager,
+    );
+
     if (settings.extension_settings) {
         Object.assign(extension_settings, settings.extension_settings);
+    }
+
+    try {
+        const { exists, connections } = await fetchConnectionManagerSettings();
+        if (exists) {
+            extension_settings.connectionManager = connections;
+        } else if (hasConnectionManagerData(legacyConnectionManager)) {
+            extension_settings.connectionManager = legacyConnectionManager;
+            await saveConnectionManagerSettings(legacyConnectionManager);
+            console.info('Migrated connection profiles from settings.json to connections.json');
+        } else {
+            extension_settings.connectionManager = structuredClone(CONNECTION_MANAGER_DEFAULT_SETTINGS);
+        }
+    } catch (error) {
+        console.error('Failed to load connection profiles from connections.json', error);
+        extension_settings.connectionManager = legacyConnectionManager;
     }
 
     $('#extensions_url').val(extension_settings.apiUrl);

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -1,7 +1,7 @@
 import { DOMPurify, Fuse } from '../../../lib.js';
 
-import { event_types, eventSource, main_api, online_status, saveSettingsDebounced } from '../../../script.js';
-import { extension_settings, renderExtensionTemplateAsync } from '../../extensions.js';
+import { event_types, eventSource, main_api, online_status } from '../../../script.js';
+import { extension_settings, renderExtensionTemplateAsync, saveConnectionManagerSettings } from '../../extensions.js';
 import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from '../../popup.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
 import { SlashCommandAbortController } from '../../slash-commands/SlashCommandAbortController.js';
@@ -11,7 +11,7 @@ import { SlashCommandDebugController } from '../../slash-commands/SlashCommandDe
 import { enumTypes, SlashCommandEnumValue } from '../../slash-commands/SlashCommandEnumValue.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
 import { SlashCommandScope } from '../../slash-commands/SlashCommandScope.js';
-import { collapseSpaces, getUniqueName, isFalseBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
+import { collapseSpaces, debounceAsync, getUniqueName, isFalseBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
 import { t } from '../../i18n.js';
 import { getSecretLabelById } from '../../secrets.js';
 
@@ -23,6 +23,18 @@ const DEFAULT_SETTINGS = {
     profiles: [],
     selectedProfile: null,
 };
+
+const saveConnectionManagerSettingsDebounced = debounceAsync(
+    () => saveConnectionManagerSettings(extension_settings.connectionManager),
+    300,
+);
+
+function persistConnectionManagerSettings() {
+    void saveConnectionManagerSettingsDebounced().catch((error) => {
+        console.error('Failed to save connection profiles', error);
+        toastr.error('Connection profiles could not be saved.');
+    });
+}
 
 // Commands that can record an empty value into the profile
 const ALLOW_EMPTY = [
@@ -337,7 +349,7 @@ async function deleteConnectionProfile() {
 
     extension_settings.connectionManager.profiles.splice(index, 1);
     extension_settings.connectionManager.selectedProfile = null;
-    saveSettingsDebounced();
+    persistConnectionManagerSettings();
 
     await eventSource.emit(event_types.CONNECTION_PROFILE_DELETED, profile);
 }
@@ -509,7 +521,7 @@ async function renderDetailsContent(detailsContent) {
 
         const profileId = selectedProfile.value;
         extension_settings.connectionManager.selectedProfile = profileId;
-        saveSettingsDebounced();
+        persistConnectionManagerSettings();
         await renderDetailsContent(detailsContent);
 
         toggleProfileSpecificButtons();
@@ -553,7 +565,7 @@ async function renderDetailsContent(detailsContent) {
         }
         extension_settings.connectionManager.profiles.push(profile);
         extension_settings.connectionManager.selectedProfile = profile.id;
-        saveSettingsDebounced();
+        persistConnectionManagerSettings();
         renderConnectionProfiles(profiles);
         await renderDetailsContent(detailsContent);
         await eventSource.emit(event_types.CONNECTION_PROFILE_CREATED, profile);
@@ -571,7 +583,7 @@ async function renderDetailsContent(detailsContent) {
         const oldProfile = structuredClone(profile);
         await updateConnectionProfile(profile);
         await renderDetailsContent(detailsContent);
-        saveSettingsDebounced();
+        persistConnectionManagerSettings();
         await eventSource.emit(event_types.CONNECTION_PROFILE_UPDATED, oldProfile, profile);
         await eventSource.emit(event_types.CONNECTION_PROFILE_LOADED, profile.name);
         toastr.success('Connection profile updated', '', { timeOut: 1500 });
@@ -654,7 +666,7 @@ async function renderDetailsContent(detailsContent) {
             profile.name = newName;
         }
 
-        saveSettingsDebounced();
+        persistConnectionManagerSettings();
         await eventSource.emit(event_types.CONNECTION_PROFILE_UPDATED, oldProfile, profile);
         renderConnectionProfiles(profiles);
         await renderDetailsContent(detailsContent);
@@ -769,7 +781,7 @@ async function renderDetailsContent(detailsContent) {
             }
             extension_settings.connectionManager.profiles.push(profile);
             extension_settings.connectionManager.selectedProfile = profile.id;
-            saveSettingsDebounced();
+            persistConnectionManagerSettings();
             renderConnectionProfiles(profiles);
             await renderDetailsContent(detailsContent);
             await eventSource.emit(event_types.CONNECTION_PROFILE_CREATED, profile);
@@ -790,7 +802,7 @@ async function renderDetailsContent(detailsContent) {
             const oldProfile = structuredClone(profile);
             await updateConnectionProfile(profile);
             await renderDetailsContent(detailsContent);
-            saveSettingsDebounced();
+            persistConnectionManagerSettings();
             await eventSource.emit(event_types.CONNECTION_PROFILE_UPDATED, oldProfile, profile);
             return profile.name;
         },

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ export const PUBLIC_DIRECTORIES = {
 };
 
 export const SETTINGS_FILE = 'settings.json';
+export const CONNECTIONS_FILE = 'connections.json';
 
 /**
  * @type {import('./users.js').UserDirectoryList}

--- a/src/endpoints/settings.js
+++ b/src/endpoints/settings.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import bytes from 'bytes';
 
-import { SETTINGS_FILE } from '../constants.js';
+import { CONNECTIONS_FILE, SETTINGS_FILE } from '../constants.js';
 import { getConfigValue, generateTimestamp, removeOldBackups } from '../util.js';
 import { getAllUserHandles, getUserDirectories } from '../users.js';
 import { getFileNameValidationFunction } from '../middleware/validateFileName.js';
@@ -21,6 +21,10 @@ const REQUEST_COMPRESSION_TIMEOUT = Number(getConfigValue('performance.requestCo
 
 // 10 minutes
 const AUTOSAVE_INTERVAL = 10 * 60 * 1000;
+const DEFAULT_CONNECTION_SETTINGS = Object.freeze({
+    profiles: [],
+    selectedProfile: null,
+});
 
 /**
  * Map of functions to trigger settings autosave for a user.
@@ -201,6 +205,25 @@ function getLatestBackup(handle) {
     return path.join(userDirectories.backups, latestBackup);
 }
 
+/**
+ * Sanitizes connection manager data for storage and transport.
+ * @param {any} data Incoming data
+ * @returns {{profiles: object[], selectedProfile: string | null}}
+ */
+function sanitizeConnectionSettings(data) {
+    const profiles = Array.isArray(data?.profiles)
+        ? data.profiles.filter(profile => profile && typeof profile === 'object')
+        : [];
+    const selectedProfile = typeof data?.selectedProfile === 'string'
+        ? data.selectedProfile
+        : DEFAULT_CONNECTION_SETTINGS.selectedProfile;
+
+    return {
+        profiles,
+        selectedProfile,
+    };
+}
+
 export const router = express.Router();
 
 router.post('/save', function (request, response) {
@@ -293,6 +316,42 @@ router.post('/get', (request, response) => {
             timeout: REQUEST_COMPRESSION_TIMEOUT || 0,
         },
     });
+});
+
+router.post('/get-connections', (request, response) => {
+    try {
+        const pathToConnections = path.join(request.user.directories.root, CONNECTIONS_FILE);
+        if (!fs.existsSync(pathToConnections)) {
+            return response.send({
+                exists: false,
+                connections: DEFAULT_CONNECTION_SETTINGS,
+            });
+        }
+
+        const raw = fs.readFileSync(pathToConnections, 'utf8');
+        const parsed = JSON.parse(raw);
+        const connections = sanitizeConnectionSettings(parsed);
+
+        return response.send({
+            exists: true,
+            connections,
+        });
+    } catch (error) {
+        console.error(error);
+        return response.sendStatus(500);
+    }
+});
+
+router.post('/save-connections', (request, response) => {
+    try {
+        const pathToConnections = path.join(request.user.directories.root, CONNECTIONS_FILE);
+        const connections = sanitizeConnectionSettings(request.body);
+        writeFileAtomicSync(pathToConnections, JSON.stringify(connections, null, 4), 'utf8');
+        return response.send({ result: 'ok' });
+    } catch (error) {
+        console.error(error);
+        return response.sendStatus(500);
+    }
 });
 
 router.post('/get-snapshots', async (request, response) => {


### PR DESCRIPTION
Hello.

I serve ST for a couple of friends.
One thing i often suffer, is syncing the connection config for everyone.
There is so much stuff inside the settings.json, that make it hard for me to simple paste over my config.

This PR breaks the save location to a new file.
It keep the same format inside it, but now i can just copy over to other users and i am done.