### PR TITLE
refactor(tts): remove redundant 4-space codeblock filter

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -649,7 +649,6 @@ async function processTtsQueue() {
     text = substituteParams(text);
 
     if (extension_settings.tts.skip_codeblocks) {
-        // text = text.replace(/^\s{4}.*$/gm, '').trim();
         text = text.replace(/```.*?```/gs, '').trim();
         text = text.replace(/~~~.*?~~~/gs, '').trim();
     }

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -649,7 +649,7 @@ async function processTtsQueue() {
     text = substituteParams(text);
 
     if (extension_settings.tts.skip_codeblocks) {
-        text = text.replace(/^\s{4}.*$/gm, '').trim();
+        // text = text.replace(/^\s{4}.*$/gm, '').trim();
         text = text.replace(/```.*?```/gs, '').trim();
         text = text.replace(/~~~.*?~~~/gs, '').trim();
     }


### PR DESCRIPTION
- Deleted the regex that removed lines starting with four spaces.
- Original intent was to strip "indented code blocks" (Markdown legacy syntax).
- In practice, SillyTavern already handles explicit code fences (```...``` and ~~~...~~~).
- Indented code blocks are rarely used and the regex caused unnecessary text loss in normal messages.
- Simplifies codeblock skipping logic and avoids accidental removal of valid content.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
