### PR TITLE
Activate WI entries via function calling / tool

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6761,6 +6761,22 @@
         <div id="entry_edit_template" class="template_element">
             <div class="world_entry_edit">
                 <div class="flex-container wide100p alignitemscenter">
+                    <div name="toolBlock" class="flex-container flexFlowColumn wide100p" style="display: none;">
+                        <div name="toolCallWarning" class="flex-container wide100p alignitemscenter" style="display: none;">
+                            <i class="fa-solid fa-triangle-exclamation warning"></i>
+                            <small data-i18n="Please use Chat Completion and turn on Function Calling to activate world info entries via tool call.">Please use Chat Completion and turn on Function Calling to activate world info entries via tool call.</small>
+                        </div>
+                        <div class="flex-container wide100p alignitemscenter">
+                            <div class="world_entry_form_control flex1">
+                                <small class="textAlignCenter" data-i18n="Tool Name">Tool Name</small>
+                                <input class="text_pole margin0" name="toolName" type="text" placeholder="Short tool identifier" data-i18n="[placeholder]Short tool identifier">
+                            </div>
+                            <div class="world_entry_form_control flex2">
+                                <small class="textAlignCenter" data-i18n="Tool Description">Tool Description</small>
+                                <input class="text_pole margin0" name="toolDescription" type="text" placeholder="Description for the AI" data-i18n="[placeholder]Description for the AI">
+                            </div>
+                        </div>
+                    </div>
                     <div name="keywordsAndLogicBlock" class="flex-container wide100p alignitemscenter">
                         <div class="world_entry_form_control keyprimary flex1">
                             <small class="displayNone">
@@ -7106,10 +7122,11 @@
                                             <textarea class="text_pole" rows="1" name="comment" data-i18n="[placeholder]Entry Title/Memo" placeholder="Entry Title/Memo"></textarea>
                                         </div>
                                         <!-- <span class="world_entry_form_position_value"></span> -->
-                                        <select data-i18n="[title]WI Entry Status:🔵 Constant🟢 Normal🔗 Vectorized" title="WI Entry Status:&#13;🔵 Constant&#13;🟢 Normal&#13;🔗 Vectorized" name="entryStateSelector" class="text_pole widthNatural margin0">
+                                        <select data-i18n="[title]WI Entry Status:🔵 Constant🟢 Normal🔗 Vectorized🛠️ Tool" title="WI Entry Status:&#13;🔵 Constant&#13;🟢 Normal&#13;🔗 Vectorized&#13;🛠️ Tool" name="entryStateSelector" class="text_pole widthNatural margin0">
                                             <option value="constant" title="Constant" data-i18n="[title]WI_Entry_Status_Constant">🔵</option>
                                             <option value="normal" title="Normal" data-i18n="[title]WI_Entry_Status_Normal">🟢</option>
                                             <option value="vectorized" title="Vectorized" data-i18n="[title]WI_Entry_Status_Vectorized">🔗</option>
+                                            <option value="tool" title="Tool" data-i18n="[title]WI_Entry_Status_Tool">🛠️</option>
                                         </select>
                                     </div>
                                     <div class="WIEnteryHeaderControls flex-container">

--- a/public/scripts/char-data.js
+++ b/public/scripts/char-data.js
@@ -32,6 +32,7 @@
  * @property {string} automation_id - An identifier used for automation purposes related to the extension.
  * @property {number} role - The specific function or purpose of the extension.
  * @property {boolean} vectorized - Indicates if the extension is optimized for vectorized processing.
+ * @property {boolean} tool - Indicates if the entry should be loaded via tool call.
  * @property {number} display_index - The order in which the extension should be displayed for user interfaces.
  * @property {boolean} match_persona_description - Wether to match against the persona description.
  * @property {boolean} match_character_description - Wether to match against the persona description.

--- a/public/scripts/slash-commands/SlashCommandCommonEnumsProvider.js
+++ b/public/scripts/slash-commands/SlashCommandCommonEnumsProvider.js
@@ -68,6 +68,7 @@ export const enumIcons = {
     normal: '🟢',
     disabled: '❌',
     vectorized: '🔗',
+    tool: '🛠️',
 
     /**
      * Returns the appropriate state icon based on a boolean
@@ -89,6 +90,7 @@ export const enumIcons = {
         if (entry.constant) return enumIcons.constant;
         if (entry.disable) return enumIcons.disabled;
         if (entry.vectorized) return enumIcons.vectorized;
+        if (entry.tool) return enumIcons.tool;
         return enumIcons.normal;
     },
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -23,6 +23,7 @@ import { renderTemplateAsync } from './templates.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { getOrCreatePersonaDescriptor, setPersonaDescription, user_avatar } from './personas.js';
+import { ToolManager } from './tool-calling.js';
 
 export const world_info_insertion_strategy = {
     evenly: 0,
@@ -882,6 +883,59 @@ export const wi_anchor_position = {
 export const worldInfoCache = new StructuredCloneMap({ cloneOnGet: true, cloneOnSet: false });
 
 /**
+ * Registers or unregisters the activateWI function tool based on whether any tool entries exist.
+ */
+async function registerWIFunctionTool() {
+    if (!ToolManager.isToolCallingSupported()) {
+        ToolManager.unregisterFunctionTool('activateWI');
+        return;
+    }
+
+    const sortedEntries = await getSortedEntries();
+    const toolEntries = sortedEntries.filter(entry => entry.tool === true);
+
+    if (toolEntries.length === 0) {
+        ToolManager.unregisterFunctionTool('activateWI');
+        return;
+    }
+
+    const toolNames = toolEntries.map(e => e.toolName).filter(Boolean);
+    const toolLines = toolEntries.map(e => `"${e.toolName}": ${e.toolDescription}`).join('\n');
+    const description = `This function loads further WI entries on demand. It accepts an array with one or more of the following strings:\n${toolLines}`;
+
+    ToolManager.registerFunctionTool({
+        name: 'activateWI',
+        displayName: 'Activate WI Entry',
+        description,
+        parameters: Object.freeze({
+            $schema: 'http://json-schema.org/draft-04/schema#',
+            type: 'object',
+            properties: {
+                names: {
+                    type: 'array',
+                    description: 'Array of tool names to activate.',
+                    items: toolNames.length > 0
+                        ? { type: 'string', enum: toolNames }
+                        : { type: 'string' },
+                },
+            },
+            required: ['names'],
+        }),
+        action: async (/** @type {{ names: string[] }} */ { names }) => {
+            if (!Array.isArray(names) || names.length === 0) return 'No names provided.';
+            const entries = await getSortedEntries();
+            const active = entries.filter(entry => entry.tool === true && !entry.disable && names.includes(entry.toolName));
+            if (active.length === 0) return 'No matching WI tool entries found.';
+            for (const entry of active) {
+                WorldInfoBuffer.externalActivations.set(`${entry.world}.${entry.uid}`, entry);
+            }
+            return `Activated ${active.length} WI entr${active.length === 1 ? 'y' : 'ies'}.`;
+        },
+        formatMessage: () => '',
+    });
+}
+
+/**
  * Gets the world info based on chat messages.
  * @param {string[]} chat - The chat messages to scan, in reverse order.
  * @param {number} maxContext - The maximum context size of the generation.
@@ -896,6 +950,10 @@ export async function getWorldInfoPrompt(chat, maxContext, isDryRun, globalScanD
     worldInfoBefore = activatedWorldInfo.worldInfoBefore;
     worldInfoAfter = activatedWorldInfo.worldInfoAfter;
     worldInfoString = worldInfoBefore + worldInfoAfter;
+
+    if (!isDryRun) {
+        registerWIFunctionTool();
+    }
 
     if (!isDryRun && activatedWorldInfo.allActivatedEntries && activatedWorldInfo.allActivatedEntries.size > 0) {
         const arg = Array.from(activatedWorldInfo.allActivatedEntries.values());
@@ -2634,6 +2692,9 @@ export const originalWIDataKeyMap = {
     'scanDepth': 'extensions.scan_depth',
     'automationId': 'extensions.automation_id',
     'vectorized': 'extensions.vectorized',
+    'tool': 'extensions.tool',
+    'toolName': 'extensions.tool_name',
+    'toolDescription': 'extensions.tool_description',
     'groupOverride': 'extensions.group_override',
     'groupWeight': 'extensions.group_weight',
     'sticky': 'extensions.sticky',
@@ -3194,7 +3255,7 @@ function handleNumberInputHelper({ inputElem, entry, entryKey, data, name, min, 
 }
 
 /**
- * Helper to handle tri-state selector for constant/normal/vectorized.
+ * Helper to handle quad-state selector for constant/normal/vectorized/tool.
  * @param {object} params - Parameters for handling the entry state selector.
  * @param {JQuery<HTMLElement>} params.entryStateSelector - The select element for entry state.
  * @param {object} params.entry - The entry object containing the state.
@@ -3213,25 +3274,39 @@ function handleEntryStateSelectorHelper({ entryStateSelector, entry, data, name 
             case 'constant':
                 data.entries[uid].constant = true;
                 data.entries[uid].vectorized = false;
+                data.entries[uid].tool = false;
                 setWIOriginalDataValue(data, uid, 'constant', true);
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
+                setWIOriginalDataValue(data, uid, 'extensions.tool', false);
                 break;
             case 'normal':
                 data.entries[uid].constant = false;
                 data.entries[uid].vectorized = false;
+                data.entries[uid].tool = false;
                 setWIOriginalDataValue(data, uid, 'constant', false);
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
+                setWIOriginalDataValue(data, uid, 'extensions.tool', false);
                 break;
             case 'vectorized':
                 data.entries[uid].constant = false;
                 data.entries[uid].vectorized = true;
+                data.entries[uid].tool = false;
                 setWIOriginalDataValue(data, uid, 'constant', false);
                 setWIOriginalDataValue(data, uid, 'extensions.vectorized', true);
+                setWIOriginalDataValue(data, uid, 'extensions.tool', false);
+                break;
+            case 'tool':
+                data.entries[uid].constant = false;
+                data.entries[uid].vectorized = false;
+                data.entries[uid].tool = true;
+                setWIOriginalDataValue(data, uid, 'constant', false);
+                setWIOriginalDataValue(data, uid, 'extensions.vectorized', false);
+                setWIOriginalDataValue(data, uid, 'extensions.tool', true);
                 break;
         }
         !noSave && await saveWorldInfo(name, data);
     });
-    const entryState = () => entry.constant === true ? 'constant' : entry.vectorized === true ? 'vectorized' : 'normal';
+    const entryState = () => entry.constant === true ? 'constant' : entry.tool === true ? 'tool' : entry.vectorized === true ? 'vectorized' : 'normal';
     entryStateSelector.find(`option[value=${entryState()}]`).prop('selected', true).trigger('input', { noSave: true });
 }
 
@@ -3746,6 +3821,44 @@ export async function getWorldEntry(name, data, entry) {
         automationIdInput.val(entry.automationId ?? '').trigger('input', { noSave: true });
         setTimeout(() => createEntryInputAutocomplete(automationIdInput, getAutomationIdCallback(data)), 1);
 
+        // Tool Name
+        const toolNameInput = editTemplate.find('input[name="toolName"]');
+        toolNameInput.data('uid', entry.uid);
+        toolNameInput.on('input', async function (_, { noSave = false } = {}) {
+            const uid = $(this).data('uid');
+            const value = $(this).val();
+            data.entries[uid].toolName = value;
+            setWIOriginalDataValue(data, uid, 'extensions.tool_name', data.entries[uid].toolName);
+            !noSave && await saveWorldInfo(name, data);
+        });
+        toolNameInput.val(entry.toolName ?? '').trigger('input', { noSave: true });
+
+        // Tool Description
+        const toolDescriptionInput = editTemplate.find('input[name="toolDescription"]');
+        toolDescriptionInput.data('uid', entry.uid);
+        toolDescriptionInput.on('input', async function (_, { noSave = false } = {}) {
+            const uid = $(this).data('uid');
+            const value = $(this).val();
+            data.entries[uid].toolDescription = value;
+            setWIOriginalDataValue(data, uid, 'extensions.tool_description', data.entries[uid].toolDescription);
+            !noSave && await saveWorldInfo(name, data);
+        });
+        toolDescriptionInput.val(entry.toolDescription ?? '').trigger('input', { noSave: true });
+
+        // Show/hide toolBlock based on entry state
+        const toolBlock = editTemplate.find('div[name="toolBlock"]');
+        const toolCallWarning = toolBlock.find('div[name="toolCallWarning"]');
+        const updateToolBlock = (/** @type {boolean} */ show) => {
+            toolBlock.toggle(show);
+            if (show) {
+                toolCallWarning.toggle(!ToolManager.isToolCallingSupported());
+            }
+        };
+        updateToolBlock(/** @type {any} */ (entry).tool === true);
+        headerTemplate.find('select[name="entryStateSelector"]').on('input.toolBlock', function () {
+            updateToolBlock($(this).val() === 'tool');
+        });
+
         // Generation Type Triggers
         const generationTypeTriggers = editTemplate.find('select[name="triggers"]');
         generationTypeTriggers.data('uid', entry.uid);
@@ -3981,6 +4094,7 @@ export async function deleteWorldInfoEntry(data, uid, { silent = false } = {}) {
  *
  * @type {{[key: string]: WIEntryFieldDefinition}}
  */
+
 export const newWorldInfoEntryDefinition = {
     key: { default: [], type: 'array' },
     keysecondary: { default: [], type: 'array' },
@@ -3988,6 +4102,7 @@ export const newWorldInfoEntryDefinition = {
     content: { default: '', type: 'string' },
     constant: { default: false, type: 'boolean' },
     vectorized: { default: false, type: 'boolean' },
+    tool: { default: false, type: 'boolean' },
     selective: { default: true, type: 'boolean' },
     selectiveLogic: { default: world_info_logic.AND_ANY, type: 'enum' },
     addMemo: { default: false, type: 'boolean' },
@@ -4016,6 +4131,8 @@ export const newWorldInfoEntryDefinition = {
     matchWholeWords: { default: null, type: 'boolean?' },
     useGroupScoring: { default: null, type: 'boolean?' },
     automationId: { default: '', type: 'string' },
+    toolName: { default: '', type: 'string' },
+    toolDescription: { default: '', type: 'string' },
     role: { default: 0, type: 'enum' },
     sticky: { default: null, type: 'number?' },
     cooldown: { default: null, type: 'number?' },
@@ -5351,6 +5468,7 @@ function convertAgnaiMemoryBook(inputObj) {
             constant: false,
             selective: false,
             vectorized: false,
+            tool: false,
             selectiveLogic: world_info_logic.AND_ANY,
             order: entry.weight,
             position: 0,
@@ -5396,6 +5514,7 @@ function convertRisuLorebook(inputObj) {
             constant: entry.alwaysActive,
             selective: entry.selective,
             vectorized: false,
+            tool: false,
             selectiveLogic: world_info_logic.AND_ANY,
             order: entry.insertorder,
             position: world_info_position.before,
@@ -5446,6 +5565,7 @@ function convertNovelLorebook(inputObj) {
             constant: false,
             selective: false,
             vectorized: false,
+            tool: false,
             selectiveLogic: world_info_logic.AND_ANY,
             order: entry.contextConfig?.budgetPriority ?? 0,
             position: 0,
@@ -5518,6 +5638,10 @@ export function convertCharacterBook(characterBook) {
             automationId: entry.extensions?.automation_id ?? '',
             role: entry.extensions?.role ?? extension_prompt_roles.SYSTEM,
             vectorized: entry.extensions?.vectorized ?? false,
+            tool: entry.extensions?.tool ?? false,
+            toolName: entry.extensions?.tool_name ?? '',
+            toolDescription: entry.extensions?.tool_description ?? '',
+                        //TODO: Add new attribute here
             sticky: entry.extensions?.sticky ?? null,
             cooldown: entry.extensions?.cooldown ?? null,
             delay: entry.extensions?.delay ?? null,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3854,7 +3854,7 @@ export async function getWorldEntry(name, data, entry) {
                 toolCallWarning.toggle(!ToolManager.isToolCallingSupported());
             }
         };
-        updateToolBlock(/** @type {any} */ (entry).tool === true);
+        updateToolBlock(/** @type {any} */(entry).tool === true);
         headerTemplate.find('select[name="entryStateSelector"]').on('input.toolBlock', function () {
             updateToolBlock($(this).val() === 'tool');
         });
@@ -5641,7 +5641,6 @@ export function convertCharacterBook(characterBook) {
             tool: entry.extensions?.tool ?? false,
             toolName: entry.extensions?.tool_name ?? '',
             toolDescription: entry.extensions?.tool_description ?? '',
-                        //TODO: Add new attribute here
             sticky: entry.extensions?.sticky ?? null,
             cooldown: entry.extensions?.cooldown ?? null,
             delay: entry.extensions?.delay ?? null,

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -701,6 +701,7 @@ function convertWorldInfoToCharacterBook(name, entries) {
                 automation_id: entry.automationId ?? '',
                 role: entry.role ?? 0,
                 vectorized: entry.vectorized ?? false,
+                tool: entry.tool ?? false,
                 sticky: entry.sticky ?? null,
                 cooldown: entry.cooldown ?? null,
                 delay: entry.delay ?? null,


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

# Tool Calling for WI items
This PR implements a new functionality that activates WI items via tool call.
I have done some basic, successful tests but would like to route this idea through you before I invest more time into it.

## Reason
I would like to give the LLM an easy way to load additional instructions on-demand into the context.
For example, I'm currently working on implementing an RPG framework in SillyTavern with a lot of instructions and >10 different tools, that need to be used in different situations.
The tool calls are not simple, they need explanation when to call them, how to call them, and ideally examples as well.

I'm having several options now:
- I put all the instructions for every tool upfront into the context. This will often not work, because the LLM will ignore the instructions or mess them up.
- I put the instructions into the lorebook and trigger them with keywords. Here the problem is that they are not dynamically loaded into the context. I would need to instruct my character to e. g. end the message with "![DICE]<!!>" to load the dice instructions. "![DICE]" would be the keyword for the world entry, and "<!!>" a custom stopping string that finishes the message. That _can_ work (although it doesn't always do it perfectly), but of course I would still need to trigger another message to finally load the dice instructions into the context.
- I experimented with embeddings as well, but felt that it often didn't load the right instructions when they were needed.
- Tool calling seems like a great solution for that problem: The LLM decides itself when it wants to fetch the additional instructions, calls the tool, and then continues the message with the new instructions. Weaker LLMs benefit from that, because they only "see" the instructions in the moment they are needed. The unavoidable downside is that this calls the LLM a second time and that this might lead to extra costs if you use an external provider.

## Other ideas for using this functionality
- I'm using this now for instructions, but this method works for all WI entries that are difficult to trigger with keywords, regular expressions or embeddings: Triggering WI entries based on a "concept" rather than a keyword, languages that don't use Latin letters, etc.
- I didn't try this out yet, but my understanding is that activating WI entries can trigger quick replies. This would be an easy workaround to trigger quick replies via tool call.
- This can be used with clever WI rules to simulate an agentic system. The LLM chooses which agent / WI item to use, and the WI instructions tell the LLM what the "agent" should be doing, which tools it may use, and fires WI entries automatically.

## Functional Requirements
- It should be possible to trigger WI entries via tool. Such entries should have a tool name and a description. The setup of these entries happens in the lorebook.
- During the injection of the WI entries into the prompt, there should be a function (registerWIFunctionTool) that checks if the selected lorebooks have tool calls in them. If yes, this function should create a tool "activateWI" that accepts the tool names of the WI entries as parameters. The respective descriptions need to be part of the activateWI tool description so that the LLM can choose the correct WI entry.

## Prerequisites
- The user must use Chat Completion.
- Function Calling must be enabled.
- Depending on the model, the character card must nudge the LLM to actually use the activateWI tool.

## Implementation
See code.

## Out of scope
- Translations
- Change SillyTavern demo characters
