### PR TITLE
Add Entry Preview to World Info Deletion Confirmation Dialog

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1,7 +1,7 @@
-import { DOMPurify, Fuse } from '../lib.js';
+import { Fuse } from '../lib.js';
 
 import { saveSettings, substituteParams, getRequestHeaders, chat_metadata, this_chid, characters, saveCharacterDebounced, menu_type, eventSource, event_types, getExtensionPromptByName, saveMetadata, getCurrentChatId, extension_prompt_roles, create_save, createOrEditCharacter, name1, getOneCharacter, select_selected_character } from '../script.js';
-import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents, uuidv4, normalizeArray, getUniqueName, logSlashCommandWarn, addLongPressEvent } from './utils.js';
+import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents, uuidv4, normalizeArray, getUniqueName, logSlashCommandWarn, addLongPressEvent, escapeHtml } from './utils.js';
 import { extension_settings, getContext } from './extensions.js';
 import { NOTE_MODULE_NAME, metadata_keys, shouldWIAddPrompt } from './authors-note.js';
 import { isMobile } from './RossAscends-mods.js';
@@ -3980,7 +3980,7 @@ export async function deleteWorldInfoEntry(data, uid, { silent = false } = {}) {
 
     const popupHeader = t`Delete world info entry with UID: ${uid}?`;
     const popupText = previewText
-        ? `<strong>${t`Entry`}:</strong><br>${DOMPurify.sanitize(previewText).replace(/\n/g, '<br>')}<br><br>${t`This action is irreversible!`}`
+        ? `<strong>${t`Entry`}:</strong><br>${escapeHtml(previewText).replace(/\n/g, '<br>')}<br><br>${t`This action is irreversible!`}`
         : t`This action is irreversible!`;
 
     const confirmation = silent || await Popup.show.confirm(popupHeader, popupText);

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1,4 +1,4 @@
-import { Fuse } from '../lib.js';
+import { DOMPurify, Fuse } from '../lib.js';
 
 import { saveSettings, substituteParams, getRequestHeaders, chat_metadata, this_chid, characters, saveCharacterDebounced, menu_type, eventSource, event_types, getExtensionPromptByName, saveMetadata, getCurrentChatId, extension_prompt_roles, create_save, createOrEditCharacter, name1, getOneCharacter, select_selected_character } from '../script.js';
 import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents, uuidv4, normalizeArray, getUniqueName, logSlashCommandWarn, addLongPressEvent } from './utils.js';
@@ -3980,7 +3980,7 @@ export async function deleteWorldInfoEntry(data, uid, { silent = false } = {}) {
 
     const popupHeader = t`Delete world info entry with UID: ${uid}?`;
     const popupText = previewText
-        ? `<strong>${t`Entry`}:</strong><br>${previewText.replace(/\n/g, '<br>')}<br><br>${t`This action is irreversible!`}`
+        ? `<strong>${t`Entry`}:</strong><br>${DOMPurify.sanitize(previewText).replace(/\n/g, '<br>')}<br><br>${t`This action is irreversible!`}`
         : t`This action is irreversible!`;
 
     const confirmation = silent || await Popup.show.confirm(popupHeader, popupText);

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3965,7 +3965,25 @@ export async function deleteWorldInfoEntry(data, uid, { silent = false } = {}) {
         return;
     }
 
-    const confirmation = silent || await Popup.show.confirm(t`Delete the entry with UID: ${uid}?`, t`This action is irreversible!`);
+    const entry = data.entries[uid];
+    if (!entry) {
+        return false;
+    }
+
+    let previewText = '';
+    if (entry.comment && entry.comment.trim()) {
+        previewText = entry.comment.trim();
+    } else if (entry.content) {
+        const lines = entry.content.split(/\r?\n/).filter(line => line.trim());
+        previewText = lines.slice(0, 2).join('\n');
+    }
+
+    const popupHeader = t`Delete world info entry with UID: ${uid}?`;
+    const popupText = previewText
+        ? `<strong>${t`Entry`}:</strong><br>${previewText.replace(/\n/g, '<br>')}<br><br>${t`This action is irreversible!`}`
+        : t`This action is irreversible!`;
+
+    const confirmation = silent || await Popup.show.confirm(popupHeader, popupText);
     if (!confirmation) {
         return false;
     }


### PR DESCRIPTION
This PR enhances the World Info entry deletion confirmation popup to display identifying information about the entry being deleted, helping users avoid accidentally removing the wrong entry.

### What Changed
- The `deleteWorldInfoEntry` function now displays the entry's **memo/comment field** (if populated) or the **first two lines of content** in the deletion confirmation dialog
- Updated popup header wording from "Delete the entry" to "Delete world info entry" for clarity
- Added safety check to return `false` if the entry doesn't exist

### Why This Was Needed
When managing large World Info books with many entries, the current deletion confirmation only shows the numeric UID— which isn't meaningful to users trying to identify which entry they're about to delete. This lack of context can lead to accidental deletion of important entries, forcing users to rely on external backups or recreation.

### How It Works
When a user clicks to delete a World Info entry, the confirmation dialog now extracts identifying information:
- **Priority 1**: If the entry has a memo/comment field (the "Add Memo" feature), display that text
- **Priority 2**: Otherwise, extract the first two non-empty lines from the entry's content

This preview is displayed in the popup body with a bold "Entry:" label, followed by the standard irreversible action warning. The inline HTML support allows newlines to render properly for readability.

### Impact
- **Reduced accidents**: Users can now visually confirm they're deleting the intended entry before confirming
- **Better UX**: No need to cross-reference UIDs or memorize entry positions when cleaning up World Info books
- **Backwards compatible**: The `silent` option continues to work as before for programmatic deletions

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).