### PR TITLE
Fix stable-diffusion.cpp model routing and URL path handling

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -294,7 +294,6 @@ const defaultSettings = {
 
     // stable-diffusion.cpp settings
     sdcpp_url: 'http://127.0.0.1:1234',
-    sdcpp_model: '',
 
     vlad_url: 'http://localhost:7860',
     vlad_auth: '',
@@ -535,7 +534,6 @@ async function loadSettings() {
     $('#sd_auto_url').val(extension_settings.sd.auto_url);
     $('#sd_auto_auth').val(extension_settings.sd.auto_auth);
     $('#sd_sdcpp_url').val(extension_settings.sd.sdcpp_url);
-    $('#sd_sdcpp_model').val(extension_settings.sd.sdcpp_model);
     $('#sd_vlad_url').val(extension_settings.sd.vlad_url);
     $('#sd_vlad_auth').val(extension_settings.sd.vlad_auth);
     $('#sd_drawthings_url').val(extension_settings.sd.drawthings_url);
@@ -1265,11 +1263,7 @@ function onSdcppUrlInput() {
     saveSettingsDebounced();
 }
 
-function onSdcppModelInput() {
-    extension_settings.sd.sdcpp_model = $('#sd_sdcpp_model').val();
-    extension_settings.sd.model = extension_settings.sd.sdcpp_model;
-    saveSettingsDebounced();
-}
+
 
 function onVladUrlInput() {
     extension_settings.sd.vlad_url = $('#sd_vlad_url').val();
@@ -1824,11 +1818,31 @@ async function loadAutoSamplers() {
 }
 
 async function loadSdcppModels() {
-    // sd.cpp's /sdapi/v1/sd-models endpoint returns dummy data, so we allow the user
-    // to type a model name. This is primarily useful for proxy servers like llama-swap
-    // that use the model field to route requests to the correct backend.
-    const currentModel = extension_settings.sd.sdcpp_model || '';
-    return currentModel ? [{ value: currentModel, text: currentModel }] : [{ value: '', text: 'N/A' }];
+    if (!extension_settings.sd.sdcpp_url) {
+        return [{ value: '', text: 'N/A' }];
+    }
+
+    try {
+        const result = await fetch('/api/sd/sdcpp/models', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({ url: extension_settings.sd.sdcpp_url }),
+        });
+
+        if (!result.ok) {
+            return [{ value: '', text: 'N/A' }];
+        }
+
+        const data = await result.json();
+
+        if (data?.data?.length > 0) {
+            return data.data.map(model => ({ value: model.id, text: model.name || model.id }));
+        }
+    } catch (error) {
+        console.error('Failed to load sd.cpp models:', error);
+    }
+
+    return [{ value: '', text: 'N/A' }];
 }
 
 async function loadSdcppSamplers() {
@@ -3874,7 +3888,7 @@ async function generateAutoImage(prompt, negativePrompt, signal) {
 async function generateSdcppImage(prompt, negativePrompt, signal) {
     const payload = {
         url: extension_settings.sd.sdcpp_url,
-        model: extension_settings.sd.sdcpp_model || undefined,
+        model: extension_settings.sd.model || undefined,
         prompt: prompt,
         negative_prompt: negativePrompt,
         steps: extension_settings.sd.steps,
@@ -5802,7 +5816,6 @@ jQuery(async () => {
     $('#sd_auto_auth').on('input', onAutoAuthInput);
     $('#sd_sdcpp_validate').on('click', validateSdcppUrl);
     $('#sd_sdcpp_url').on('input', onSdcppUrlInput);
-    $('#sd_sdcpp_model').on('input', onSdcppModelInput);
     $('#sd_drawthings_validate').on('click', validateDrawthingsUrl);
     $('#sd_drawthings_url').on('input', onDrawthingsUrlInput);
     $('#sd_drawthings_auth').on('input', onDrawthingsAuthInput);

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -294,6 +294,7 @@ const defaultSettings = {
 
     // stable-diffusion.cpp settings
     sdcpp_url: 'http://127.0.0.1:1234',
+    sdcpp_model: '',
 
     vlad_url: 'http://localhost:7860',
     vlad_auth: '',
@@ -534,6 +535,7 @@ async function loadSettings() {
     $('#sd_auto_url').val(extension_settings.sd.auto_url);
     $('#sd_auto_auth').val(extension_settings.sd.auto_auth);
     $('#sd_sdcpp_url').val(extension_settings.sd.sdcpp_url);
+    $('#sd_sdcpp_model').val(extension_settings.sd.sdcpp_model);
     $('#sd_vlad_url').val(extension_settings.sd.vlad_url);
     $('#sd_vlad_auth').val(extension_settings.sd.vlad_auth);
     $('#sd_drawthings_url').val(extension_settings.sd.drawthings_url);
@@ -1263,6 +1265,12 @@ function onSdcppUrlInput() {
     saveSettingsDebounced();
 }
 
+function onSdcppModelInput() {
+    extension_settings.sd.sdcpp_model = $('#sd_sdcpp_model').val();
+    extension_settings.sd.model = extension_settings.sd.sdcpp_model;
+    saveSettingsDebounced();
+}
+
 function onVladUrlInput() {
     extension_settings.sd.vlad_url = $('#sd_vlad_url').val();
     saveSettingsDebounced();
@@ -1815,6 +1823,14 @@ async function loadAutoSamplers() {
     }
 }
 
+async function loadSdcppModels() {
+    // sd.cpp's /sdapi/v1/sd-models endpoint returns dummy data, so we allow the user
+    // to type a model name. This is primarily useful for proxy servers like llama-swap
+    // that use the model field to route requests to the correct backend.
+    const currentModel = extension_settings.sd.sdcpp_model || '';
+    return currentModel ? [{ value: currentModel, text: currentModel }] : [{ value: '', text: 'N/A' }];
+}
+
 async function loadSdcppSamplers() {
     // The sdcpp server does not provide an API for samplers, so we return the known list.
     return ['euler', 'euler_a', 'heun', 'dpm2', 'dpm++2s_a', 'dpm++2m', 'dpm++2mv2', 'ipndm', 'ipndm_v', 'lcm', 'ddim_trailing', 'tcd'];
@@ -1910,7 +1926,7 @@ async function loadModels() {
             models = await loadAutoModels();
             break;
         case sources.sdcpp:
-            models = [{ value: '', text: 'N/A' }];
+            models = await loadSdcppModels();
             break;
         case sources.drawthings:
             models = await loadDrawthingsModels();
@@ -3858,6 +3874,7 @@ async function generateAutoImage(prompt, negativePrompt, signal) {
 async function generateSdcppImage(prompt, negativePrompt, signal) {
     const payload = {
         url: extension_settings.sd.sdcpp_url,
+        model: extension_settings.sd.sdcpp_model || undefined,
         prompt: prompt,
         negative_prompt: negativePrompt,
         steps: extension_settings.sd.steps,
@@ -5785,6 +5802,7 @@ jQuery(async () => {
     $('#sd_auto_auth').on('input', onAutoAuthInput);
     $('#sd_sdcpp_validate').on('click', validateSdcppUrl);
     $('#sd_sdcpp_url').on('input', onSdcppUrlInput);
+    $('#sd_sdcpp_model').on('input', onSdcppModelInput);
     $('#sd_drawthings_validate').on('click', validateDrawthingsUrl);
     $('#sd_drawthings_url').on('input', onDrawthingsUrlInput);
     $('#sd_drawthings_auth').on('input', onDrawthingsAuthInput);

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -1263,8 +1263,6 @@ function onSdcppUrlInput() {
     saveSettingsDebounced();
 }
 
-
-
 function onVladUrlInput() {
     extension_settings.sd.vlad_url = $('#sd_vlad_url').val();
     saveSettingsDebounced();

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -92,6 +92,8 @@
                         </span>
                     </div>
                 </div>
+                <label for="sd_sdcpp_model">Model name <small>(optional, for proxy servers like llama-swap)</small></label>
+                <input id="sd_sdcpp_model" type="text" class="text_pole" placeholder="Example: sdxl-illustrious" value="" />
                 <i data-i18n="The server must be accessible from the SillyTavern host machine.">The server must be accessible from the SillyTavern host machine.</i>
             </div>
             <div data-sd-source="drawthings">

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -92,8 +92,6 @@
                         </span>
                     </div>
                 </div>
-                <label for="sd_sdcpp_model">Model name <small>(optional, for proxy servers like llama-swap)</small></label>
-                <input id="sd_sdcpp_model" type="text" class="text_pole" placeholder="Example: sdxl-illustrious" value="" />
                 <i data-i18n="The server must be accessible from the SillyTavern host machine.">The server must be accessible from the SillyTavern host machine.</i>
             </div>
             <div data-sd-source="drawthings">

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -883,7 +883,9 @@ sdcpp.post('/generate', async (request, response) => {
             batch_size: request.body.batch_size,
             sampler_name: request.body.sampler_name,
             scheduler: request.body.scheduler,
-            clip_skip: request.body.clip_skip,
+            // sd.cpp produces blank images when clip_skip is 1, which is the
+            // default (no skipping). Only send clip_skip when it's > 1.
+            clip_skip: request.body.clip_skip > 1 ? request.body.clip_skip : undefined,
         };
 
         for (const [key, value] of Object.entries(payload)) {

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -833,7 +833,7 @@ const sdcpp = express.Router();
 
 sdcpp.post('/ping', async (request, response) => {
     try {
-        const url = urlJoin(request.body.url, '/v1/images/generations');
+        const url = new URL(urlJoin(request.body.url, '/v1/images/generations'));
 
         const result = await fetch(url, { method: 'OPTIONS' });
         if (!result.ok) {
@@ -849,7 +849,7 @@ sdcpp.post('/ping', async (request, response) => {
 
 sdcpp.post('/models', async (request, response) => {
     try {
-        const url = urlJoin(request.body.url, '/v1/models');
+        const url = new URL(urlJoin(request.body.url, '/v1/models'));
 
         const result = await fetch(url);
         if (!result.ok) {
@@ -866,7 +866,7 @@ sdcpp.post('/models', async (request, response) => {
 
 sdcpp.post('/generate', async (request, response) => {
     try {
-        const url = urlJoin(request.body.url, '/sdapi/v1/txt2img');
+        const url = new URL(urlJoin(request.body.url, '/sdapi/v1/txt2img'));
 
         const payload = {
             model: request.body.model,

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -833,8 +833,7 @@ const sdcpp = express.Router();
 
 sdcpp.post('/ping', async (request, response) => {
     try {
-        const url = new URL(request.body.url);
-        url.pathname = url.pathname.replace(/\/$/, '') + '/v1/images/generations';
+        const url = urlJoin(request.body.url, '/v1/images/generations');
 
         const result = await fetch(url, { method: 'OPTIONS' });
         if (!result.ok) {
@@ -850,8 +849,7 @@ sdcpp.post('/ping', async (request, response) => {
 
 sdcpp.post('/models', async (request, response) => {
     try {
-        const url = new URL(request.body.url);
-        url.pathname = url.pathname.replace(/\/$/, '') + '/v1/models';
+        const url = urlJoin(request.body.url, '/v1/models');
 
         const result = await fetch(url);
         if (!result.ok) {
@@ -868,8 +866,7 @@ sdcpp.post('/models', async (request, response) => {
 
 sdcpp.post('/generate', async (request, response) => {
     try {
-        const url = new URL(request.body.url);
-        url.pathname = url.pathname.replace(/\/$/, '') + '/sdapi/v1/txt2img';
+        const url = urlJoin(request.body.url, '/sdapi/v1/txt2img');
 
         const payload = {
             model: request.body.model,

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -848,6 +848,24 @@ sdcpp.post('/ping', async (request, response) => {
     }
 });
 
+sdcpp.post('/models', async (request, response) => {
+    try {
+        const url = new URL(request.body.url);
+        url.pathname = url.pathname.replace(/\/$/, '') + '/v1/models';
+
+        const result = await fetch(url);
+        if (!result.ok) {
+            throw new Error('stable-diffusion.cpp server returned an error.');
+        }
+
+        const data = await result.json();
+        return response.send(data);
+    } catch (error) {
+        console.error(error);
+        return response.sendStatus(500);
+    }
+});
+
 sdcpp.post('/generate', async (request, response) => {
     try {
         const url = new URL(request.body.url);

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -834,7 +834,7 @@ const sdcpp = express.Router();
 sdcpp.post('/ping', async (request, response) => {
     try {
         const url = new URL(request.body.url);
-        url.pathname = '/v1/images/generations';
+        url.pathname = url.pathname.replace(/\/$/, '') + '/v1/images/generations';
 
         const result = await fetch(url, { method: 'OPTIONS' });
         if (!result.ok) {
@@ -851,9 +851,10 @@ sdcpp.post('/ping', async (request, response) => {
 sdcpp.post('/generate', async (request, response) => {
     try {
         const url = new URL(request.body.url);
-        url.pathname = '/sdapi/v1/txt2img';
+        url.pathname = url.pathname.replace(/\/$/, '') + '/sdapi/v1/txt2img';
 
         const payload = {
+            model: request.body.model,
             prompt: request.body.prompt,
             negative_prompt: request.body.negative_prompt,
             width: request.body.width,


### PR DESCRIPTION
## Summary

- **Fetch models from sd.cpp server** and populate the standard Model dropdown, instead of hardcoding "N/A". Works with both standalone sd-server (returns a single local model) and proxy servers like [llama-swap](https://github.com/mostlygeek/llama-swap) (returns multiple models).
- **Include model field** in SDAPI `txt2img` request payload. Standalone sd-server ignores it; proxy servers like llama-swap use it to route requests to the correct backend.
- **Append to URL pathname** instead of overwriting it. Same pattern as #5178 — preserves base paths for proxy servers that use path-based routing (e.g. `/upstream/model-name`).
- **Don't send `clip_skip=1`** to sd-server. sd.cpp produces blank white images when `clip_skip` is explicitly set to 1 (which is the default "no skipping" behavior). Only send when > 1.

## Context

The existing sd.cpp integration assumes a single standalone sd-server instance with one model loaded. Proxy servers like llama-swap can serve multiple sd-server models behind a single endpoint, but need a `model` field in the request body to route correctly. The `/v1/models` endpoint exists on both standalone sd-server and llama-swap, so we can populate the model dropdown generically.

## Backward Compatibility

Tested against both configurations:

| Scenario | `/v1/models` | `model` in payload | `clip_skip` fix |
|---|---|---|---|
| Standalone sd-server | Returns `[{id: "sd-cpp-local"}]` → dropdown shows one entry | Ignored silently | Prevents blank images |
| llama-swap proxy | Returns full model list → dropdown shows all models | Used for routing | Same |

## Test Plan

- [x] Standalone sd-server: Connect, model dropdown populates with "sd-cpp-local", image generates correctly
- [x] llama-swap proxy: Connect, model dropdown populates with all configured models, selecting a model routes to correct backend
- [x] URL path preservation: base paths like `/upstream/model-name` are preserved when appending `/sdapi/v1/txt2img`
- [x] `clip_skip=1` no longer sent, preventing blank white images from sd.cpp
- [x] `clip_skip > 1` still sent correctly when configured