### PR TITLE
Add `/regex-state` slash command to check regex script status

### DIFF
--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -2069,6 +2069,37 @@ jQuery(async () => {
         helpString: 'Runs a Regex extension script by name on the provided string. The script must be enabled.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'regex-state',
+        /** @param {object} _ @param {string} name */
+        callback: (_, name) => {
+            if (!name) {
+                toastr.warning('No regex script name provided.');
+                return '';
+            }
+
+            const scripts = getRegexScripts();
+            const script = scripts.find(s => equalsIgnoreCaseAndAccents(s.scriptName, name));
+
+            if (!script) {
+                toastr.warning(`Regex script "${name}" not found.`);
+                return '';
+            }
+
+            return script.disabled ? 'off' : 'on';
+        },
+        returns: '\'on\' (for enabled) or \'off\' (for disabled)',
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: 'script name',
+                typeList: [ARGUMENT_TYPE.STRING],
+                isRequired: true,
+                enumProvider: localEnumProviders.regexScripts,
+            }),
+        ],
+        helpString: 'Returns the current state of a regex script.',
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'regex-toggle',
         callback: toggleRegexCallback,
         returns: 'The name of the script that was toggled',

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -2085,9 +2085,9 @@ jQuery(async () => {
                 return '';
             }
 
-            return script.disabled ? 'off' : 'on';
+            return script.disabled ? 'false' : 'true';
         },
-        returns: '\'on\' (for enabled) or \'off\' (for disabled)',
+        returns: 'true (for enabled) or false (for disabled)',
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: 'script name',


### PR DESCRIPTION
This PR introduces a new `/regex-state` slash command that allows users to check whether a specific regex script is currently enabled or disabled, providing a simple way to query script state without modifying it.

### What Changed
- **New slash command**: Added `/regex-state` command to the regex extension
- **State checking functionality**: Returns 'on' for enabled scripts and 'off' for disabled scripts
- **Error handling**: Provides appropriate warnings when no script name is provided or when a script doesn't exist
- **Comprehensive integration**: Follows existing slash command patterns with proper argument validation and enum providers

### Why These Changes
The regex extension already had `/regex-toggle` to change script states, but lacked a way to simply check the current state without potentially modifying it. Users needed a read-only operation to query script status for conditional logic, debugging, or state verification purposes. This fills that gap by providing a dedicated state-checking command.

The use of 'on' and 'off' is chosen on purpose, to be able to plug the value into another script as a direct state, so both slash commands use the same state values.

### How It Works
The new command accepts a single required argument - the regex script name - and uses the existing `getRegexScripts()` function to locate the script. It performs case-insensitive matching with accent support and returns a simple 'on'/'off' string based on the script's `disabled` property. The command integrates seamlessly with the existing slash command infrastructure, including auto-completion via the `localEnumProviders.regexScripts` enum provider.

### Impact
This enhancement enables users to:
- Query regex script status within macros and conditional logic
- Debug script states without accidentally toggling them
- Build more sophisticated automation that depends on knowing current script states
- Maintain better visibility into which regex scripts are active in their setup


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).