### PR TITLE
Add Arguments Logging to Deprecated MacrosParser Method Warnings for Better Debugging Context

### DIFF
--- a/public/scripts/macros.js
+++ b/public/scripts/macros.js
@@ -58,10 +58,11 @@ export class MacrosParser {
      *
      * @param {string} method
      * @param {string} replacement
+     * @param {IArguments} [methodArgs=null]
      * @returns {void}
      */
-    static #logDeprecated(method, replacement) {
-        console.warn(`[DEPRECATED] MacrosParser.${method} is deprecated and will be removed in a future version. Use ${replacement} instead.`);
+    static #logDeprecated(method, replacement, methodArgs = null) {
+        console.warn(`[DEPRECATED] MacrosParser.${method} is deprecated and will be removed in a future version. Use ${replacement} instead. Arguments:`, (methodArgs ?? 'none'));
     }
 
     /**
@@ -155,7 +156,7 @@ export class MacrosParser {
      * @returns {string|MacroFunction|undefined} The macro value
      */
     static get(key) {
-        MacrosParser.#logDeprecated('get', 'macros.registry.getMacro (from scripts/macros/macro-system.js)');
+        MacrosParser.#logDeprecated('get', 'macros.registry.getMacro (from scripts/macros/macro-system.js)', arguments);
         return MacrosParser.#macros.get(key);
     }
 
@@ -165,7 +166,7 @@ export class MacrosParser {
      * @returns {boolean} True if the macro is registered, false otherwise
      */
     static has(key) {
-        MacrosParser.#logDeprecated('has', 'macros.registry.hasMacro (from scripts/macros/macro-system.js)');
+        MacrosParser.#logDeprecated('has', 'macros.registry.hasMacro (from scripts/macros/macro-system.js)', arguments);
         if (power_user.experimental_macro_engine) {
             return macroSystem.registry.hasMacro(key);
         }
@@ -180,7 +181,7 @@ export class MacrosParser {
      * @param {string} [description] Optional description of the macro
      */
     static registerMacro(key, value, description = '') {
-        MacrosParser.#logDeprecated('registerMacro', 'macros.registry.registerMacro (from scripts/macros/macro-system.js) or substituteParams({ dynamicMacros })');
+        MacrosParser.#logDeprecated('registerMacro', 'macros.registry.registerMacro (from scripts/macros/macro-system.js) or substituteParams({ dynamicMacros })', arguments);
         if (typeof key !== 'string') {
             throw new Error('Macro key must be a string');
         }
@@ -223,7 +224,7 @@ export class MacrosParser {
      * @param {string} key Macro name (key)
      */
     static unregisterMacro(key) {
-        MacrosParser.#logDeprecated('unregisterMacro', 'macros.registry.unregisterMacro (from scripts/macros/macro-system.js)');
+        MacrosParser.#logDeprecated('unregisterMacro', 'macros.registry.unregisterMacro (from scripts/macros/macro-system.js)', arguments);
         if (typeof key !== 'string') {
             throw new Error('Macro key must be a string');
         }


### PR DESCRIPTION
Extends the deprecation warning system for the legacy `MacrosParser` class to log the actual arguments passed to deprecated methods, making it easier for developers to identify and migrate old code.

### What Changed
- Enhanced the `#logDeprecated` helper method to accept and display method arguments
- Updated all four deprecated method warnings (`get`, `has`, `registerMacro`, `unregisterMacro`) to forward their arguments to the logger
- Console warnings now show the exact arguments that were passed, or "none" if called without arguments

### Why These Changes
The SillyTavern macro system was refactored with a new API (`macros.registry`), but the legacy `MacrosParser` static methods remain for backward compatibility. When extension developers or legacy code use these deprecated methods, the previous warnings only indicated *which* method was called—not *how* it was called. This made debugging migrations difficult, especially when trying to identify which macros were being registered or retrieved.

### How It Works
When deprecated methods like `MacrosParser.registerMacro()` or `MacrosParser.get()` are called, the warning message now includes the actual arguments that were passed. This allows developers to:

- See exactly which macro keys are being registered/retrieved
- Identify patterns in legacy code that need updating
- More quickly locate and fix deprecated usage in their extensions

### Impact
- **For extension developers**: Much faster debugging when updating code for the new macro system
- **For maintainers**: Better visibility into what legacy macro operations are still occurring in the wild
- **No breaking changes**: Purely additive logging enhancement to existing deprecation warnings


<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).