### PR TITLE
Fix: Skip Pseudo-Elements When Generating Dynamic Focus Styles

### DIFF
--- a/public/scripts/dynamic-styles.js
+++ b/public/scripts/dynamic-styles.js
@@ -126,6 +126,12 @@ function applyDynamicFocusStyles(styleSheet, { fromExtension = false } = {}) {
             // If something like :focus-within or a more specific selector like `.blah:has(:focus-visible)` for elements inside,
             // it should be manually defined in CSS.
             const focusSelector = rule.selectorText.replace(/:hover/g, ':focus-visible');
+
+            // Skip pseudo-elements (::before, ::after, ::-webkit-scrollbar, etc.)
+            // as they cannot have :focus-visible appended (invalid CSS syntax)
+            if (focusSelector.includes('::')) {
+                return;
+            }
             let focusRule = `${focusSelector} { ${rule.style.cssText} }`;
 
             // Wrap the generated rule into the same @media/@supports/@container chain (if any)


### PR DESCRIPTION
Eliminates console warnings caused by attempting to create invalid CSS rules when the dynamic focus styles feature encounters hover rules on pseudo-elements.

### What Changed
- Added validation to skip pseudo-elements (`::-webkit-scrollbar`, `::before`, `::after`, etc.) when generating `:focus-visible` counterparts from `:hover` rules
- Prevents the dynamic styles engine from trying to insert syntactically invalid CSS like `::-webkit-scrollbar-track:focus-visible`

### Why These Changes
The dynamic focus styles feature automatically creates keyboard-accessible focus styles by converting `:hover` rules to `:focus-visible` equivalents. However, CSS pseudo-elements cannot have pseudo-classes appended to them—attempting to do so results in invalid syntax that browsers reject with console warnings.

This was particularly noticeable with `::-webkit-scrollbar-track:hover` rules, which would generate warnings like:
> Failed to insert focus rule: SyntaxError: Failed to execute 'insertRule' on 'CSSStyleSheet': Failed to parse the rule '::-webkit-scrollbar-track:focus-visible { ... }'

### How It Works
After computing the focus-visible selector, the code now checks if the selector contains `::` (indicating a pseudo-element). If so, it skips that rule entirely—focus-visible styling doesn't apply meaningfully to pseudo-elements anyway, as they cannot receive focus.

### Impact
- Cleaner browser console without spurious CSS parsing warnings
- More robust dynamic styles processing that gracefully handles edge cases in CSS selectors

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).