### PR TITLE
Fix: Suppress false "Unsupported language" console warnings for English locale variants

### DIFF
--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -139,7 +139,8 @@ async function getLocaleData(language) {
 function findLang(language) {
     const supportedLang = langs.find(x => x.lang === language);
 
-    if (!supportedLang && language !== 'en') {
+    const isEn = language.startsWith('en'); // includes 'en', and more specific locales like 'en-us', 'en-au', etc
+    if (!supportedLang && !isEn) {
         console.warn(`Unsupported language: ${language}`);
     }
     return supportedLang;


### PR DESCRIPTION
Fixes a spurious `console.warn` that fires for users whose browser or OS reports a regional English locale (e.g. `en-US`, `en-GB`, `en-AU`) instead of the bare `"en"` code.

### What Changed
- In `findLang()`, the check that guards the unsupported-language warning now uses `language.startsWith('en')` instead of a strict `!== 'en'` comparison.

### Why It Was Needed
SillyTavern does not have an English local file (like `en.json`) and does not register regional English variants like `en-US` in the supported-languages list. When a user's system language is set to any of these variants, `findLang()` would fail to find a matching entry **and** incorrectly treat them as an unsupported language, logging a `console.warn` on every lookup. Because English is the default/fallback language — and no locale file is expected for regional variants — the warning was a false positive causing noise in the browser console.

### How It Works
The fix introduces a simple prefix check (`language.startsWith('en')`) that covers the bare `"en"` code as well as any more-specific BCP 47 English tag. If the language isn't in the supported list **and** isn't any form of English, the warning fires as before. Otherwise it is silently skipped.

### Impact
Users with regional English system locales (a common default on macOS, Windows, and most browsers) will no longer see misleading console warnings about an unsupported language.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).