### PR TITLE
Fix: Remove `COMFY_RUNPOD` from secrets input map — invalid element reference

### DIFF
--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -184,7 +184,6 @@ const INPUT_MAP = {
     [SECRET_KEYS.AZURE_OPENAI]: '#api_key_azure_openai',
     [SECRET_KEYS.ZAI]: '#api_key_zai',
     [SECRET_KEYS.SILICONFLOW]: '#api_key_siliconflow',
-    [SECRET_KEYS.COMFY_RUNPOD]: '#api_key_comfy_runpod',
     [SECRET_KEYS.POLLINATIONS]: '#api_key_pollinations',
     [SECRET_KEYS.WORKERS_AI]: '#api_key_workers_ai',
 };


### PR DESCRIPTION
Removes a stale and incorrect entry from the secrets `INPUT_MAP` that was added by mistake in PR #4891.

### What Changed
- Removed the `COMFY_RUNPOD` → `#api_key_comfy_runpod` mapping from `INPUT_MAP` in `secrets.js`

### Why This Was Needed
The entry was incorrectly added to `INPUT_MAP`, which is meant to map secret keys to `<input>` elements in the DOM. The referenced element (`#api_key_comfy_runpod`) is actually a **button**, not an input field. On top of that, this element is injected into the DOM during extension setup — which happens well after the secrets initialization step runs. This means the mapping could never resolve to a valid input, and the reference was effectively dead weight at best and a source of confusing warnings at worst.

### Impact
Cleans up an invalid mapping that caused unnecessary warnings during secrets initialization. No functionality is affected.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).