### PR TITLE
Migrate built-in extensions to use manifest-based activate hooks

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -741,7 +741,7 @@ async function firstLoadInit() {
     initKoboldSettings();
     initNovelAISettings();
     initSystemPrompts();
-    initExtensions();
+    await initExtensions();
     initExtensionSlashCommands();
     ToolManager.initToolSlashCommands();
     await initPresetManager();

--- a/public/scripts/extensions/assets/index.js
+++ b/public/scripts/extensions/assets/index.js
@@ -435,7 +435,7 @@ async function updateCurrentAssets() {
 //#############################//
 
 // This function is called when the extension is loaded
-jQuery(async () => {
+export async function init() {
     // This is an example of loading HTML from a file
     const windowTemplate = await renderExtensionTemplateAsync(MODULE_NAME, 'window', {});
     const windowHtml = $(windowTemplate);
@@ -496,4 +496,4 @@ jQuery(async () => {
     eventSource.on(event_types.OPEN_CHARACTER_LIBRARY, async (forceDefault) => {
         openCharacterBrowser(forceDefault);
     });
-});
+}

--- a/public/scripts/extensions/assets/manifest.json
+++ b/public/scripts/extensions/assets/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Keij#6799",
     "version": "0.1.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/attachments/index.js
+++ b/public/scripts/extensions/attachments/index.js
@@ -243,7 +243,7 @@ function handleCharacterRename(oldAvatar, newAvatar) {
     }
 }
 
-jQuery(async () => {
+export async function init() {
     eventSource.on(event_types.APP_READY, cleanUpAttachments);
     eventSource.on(event_types.CHARACTER_DELETED, cleanUpCharacterAttachments);
     eventSource.on(event_types.CHARACTER_RENAMED, handleCharacterRename);
@@ -407,4 +407,4 @@ jQuery(async () => {
             }),
         ],
     }));
-});
+}

--- a/public/scripts/extensions/attachments/manifest.json
+++ b/public/scripts/extensions/attachments/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Cohee1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -455,7 +455,7 @@ function isVideoCaptioningAvailable() {
     return ['google', 'vertexai', 'zai'].includes(extension_settings.caption.multimodal_api);
 }
 
-jQuery(async function () {
+export async function init() {
     function addSendPictureButton() {
         const sendButton = $(`
         <div id="send_picture" class="list-group-item flex-container flexGap5">
@@ -808,4 +808,4 @@ jQuery(async function () {
     }));
 
     document.body.classList.add('caption');
-});
+}

--- a/public/scripts/extensions/caption/manifest.json
+++ b/public/scripts/extensions/caption/manifest.json
@@ -9,5 +9,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -474,7 +474,7 @@ async function renderDetailsContent(detailsContent) {
     }
 }
 
-(async function () {
+export async function init() {
     extension_settings.connectionManager = extension_settings.connectionManager || structuredClone(DEFAULT_SETTINGS);
 
     for (const key of Object.keys(DEFAULT_SETTINGS)) {
@@ -824,4 +824,4 @@ async function renderDetailsContent(detailsContent) {
             return JSON.stringify(profile);
         },
     }));
-})();
+}

--- a/public/scripts/extensions/connection-manager/manifest.json
+++ b/public/scripts/extensions/connection-manager/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Cohee1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -2140,7 +2140,7 @@ function migrateSettings() {
     }
 }
 
-(async function () {
+export async function init() {
     function addExpressionImage() {
         const html = `
         <div id="expression-wrapper">
@@ -2511,4 +2511,4 @@ function migrateSettings() {
             </div>
         `,
     }));
-})();
+}

--- a/public/scripts/extensions/expressions/manifest.json
+++ b/public/scripts/extensions/expressions/manifest.json
@@ -9,5 +9,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/gallery/index.js
+++ b/public/scripts/extensions/gallery/index.js
@@ -818,7 +818,7 @@ function addGalleryWandButton() {
 }
 
 // On extension load, ensure the settings are initialized
-(function () {
+export async function init() {
     initSettings();
     eventSource.on(event_types.CHARACTER_RENAMED, (oldAvatar, newAvatar) => {
         const context = SillyTavern.getContext();
@@ -850,4 +850,4 @@ function addGalleryWandButton() {
         }),
     );
     addGalleryWandButton();
-})();
+}

--- a/public/scripts/extensions/gallery/manifest.json
+++ b/public/scripts/extensions/gallery/manifest.json
@@ -8,5 +8,8 @@
     "css": "style.css",
     "author": "City-Unit",
     "version": "1.5.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/memory/index.js
+++ b/public/scripts/extensions/memory/index.js
@@ -1063,7 +1063,7 @@ function setupListeners() {
     });
 }
 
-jQuery(async function () {
+export async function init() {
     async function addExtensionControls() {
         const settingsHtml = await renderExtensionTemplateAsync('memory', 'settings', { defaultSettings });
         $('#summarize_container').append(settingsHtml);
@@ -1128,4 +1128,4 @@ jQuery(async function () {
             () => summaryMacroHandler(),
             'Returns the latest memory/summary from the current chat.');
     }
-});
+}

--- a/public/scripts/extensions/memory/manifest.json
+++ b/public/scripts/extensions/memory/manifest.json
@@ -9,5 +9,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -229,7 +229,7 @@ const finalizeInit = async () => {
     debug('/executing queue');
     isReady = true;
     debug('READY');
-}
+};
 
 
 const purgeCharacterQuickReplySets = ({ character }) => {

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -214,7 +214,8 @@ const init = async () => {
     eventSource.on(event_types.APP_READY, async () => await finalizeInit());
 
     globalThis.quickReplyApi = quickReplyApi;
-};
+}
+
 const finalizeInit = async () => {
     debug('executing startup');
     await autoExec.handleStartup();

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -169,7 +169,7 @@ const handleCharChange = () => {
     settings.charConfig = charConfig;
 };
 
-const init = async () => {
+export async function init() {
     await loadSets();
     await loadSettings();
     log('settings: ', settings);
@@ -229,8 +229,8 @@ const finalizeInit = async () => {
     debug('/executing queue');
     isReady = true;
     debug('READY');
-};
-await init();
+}
+
 
 const purgeCharacterQuickReplySets = ({ character }) => {
     // Remove the character's Quick Reply Sets from the settings.

--- a/public/scripts/extensions/quick-reply/manifest.json
+++ b/public/scripts/extensions/quick-reply/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "RossAscends#1779",
     "version": "2.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/regex/index.js
+++ b/public/scripts/extensions/regex/index.js
@@ -1709,7 +1709,7 @@ function onPresetRenamed({ apiId, oldName, newName }) {
 
 // Workaround for loading in sequence with other extensions
 // NOTE: Always puts extension at the top of the list, but this is fine since it's static
-jQuery(async () => {
+export async function init() {
     if (!Array.isArray(extension_settings.regex)) {
         extension_settings.regex = [];
     }
@@ -2123,4 +2123,4 @@ jQuery(async () => {
 
     presetManager.setupEventListeners();
     presetManager.registerSlashCommands();
-});
+}

--- a/public/scripts/extensions/regex/manifest.json
+++ b/public/scripts/extensions/regex/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "kingbri",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -5441,7 +5441,7 @@ function registerFunctionTool() {
     });
 }
 
-jQuery(async () => {
+export async function init() {
     await addSDGenButtons();
 
     const getSelectEnumProvider = (id, text) => () => Array.from(document.querySelectorAll(`#${id} > [value]`)).map(x => new SlashCommandEnumValue(x.getAttribute('value'), text ? x.textContent : null));
@@ -5948,4 +5948,4 @@ jQuery(async () => {
             t`Character's negative Image Generation prompt prefix`,
         );
     }
-});
+}

--- a/public/scripts/extensions/stable-diffusion/manifest.json
+++ b/public/scripts/extensions/stable-diffusion/manifest.json
@@ -10,5 +10,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/token-counter/index.js
+++ b/public/scripts/extensions/token-counter/index.js
@@ -101,7 +101,7 @@ async function doCount() {
     return count;
 }
 
-jQuery(() => {
+export function init() {
     const buttonHtml = `
         <div id="token_counter" class="list-group-item flex-container flexGap5">
             <div class="fa-solid fa-1 extensionsMenuExtensionButton" /></div>` +
@@ -115,4 +115,4 @@ jQuery(() => {
         returns: 'number of tokens',
         helpString: 'Counts the number of tokens in the current chat.',
     }));
-});
+}

--- a/public/scripts/extensions/token-counter/manifest.json
+++ b/public/scripts/extensions/token-counter/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/translate/index.js
+++ b/public/scripts/extensions/translate/index.js
@@ -707,7 +707,7 @@ const handleMessageReasoningDelete = createEventHandler(removeReasoningDisplayTe
 
 globalThis.translate = translate;
 
-jQuery(async () => {
+export async function init() {
     const html = await renderExtensionTemplateAsync('translate', 'index');
     const buttonHtml = await renderExtensionTemplateAsync('translate', 'buttons');
 
@@ -801,4 +801,4 @@ jQuery(async () => {
         },
         returns: ARGUMENT_TYPE.STRING,
     }));
-});
+}

--- a/public/scripts/extensions/translate/manifest.json
+++ b/public/scripts/extensions/translate/manifest.json
@@ -7,5 +7,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -1531,7 +1531,7 @@ async function initVoiceMapInternal(unrestricted) {
     updateVoiceMap();
 }
 
-jQuery(async function () {
+export async function init() {
     async function addExtensionControls() {
         const settingsHtml = $(await renderExtensionTemplateAsync('tts', 'settings'));
         $('#tts_container').append(settingsHtml);
@@ -1619,4 +1619,4 @@ jQuery(async function () {
     }));
 
     document.body.appendChild(audioElement);
-});
+}

--- a/public/scripts/extensions/tts/manifest.json
+++ b/public/scripts/extensions/tts/manifest.json
@@ -11,5 +11,8 @@
     "css": "style.css",
     "author": "Ouoertheo#7264",
     "version": "1.0.0",
-    "homePage": "None"
+    "homePage": "None",
+    "hooks": {
+        "activate": "init"
+    }
 }

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -1760,7 +1760,7 @@ async function activateWorldInfo(chat) {
     await eventSource.emit(event_types.WORLDINFO_FORCE_ACTIVATE, activatedEntries);
 }
 
-jQuery(async () => {
+export async function init() {
     if (!extension_settings.vectors) {
         extension_settings.vectors = settings;
     }
@@ -2376,4 +2376,4 @@ jQuery(async () => {
         }
         await purgeAllVectorIndexes();
     });
-});
+}

--- a/public/scripts/extensions/vectors/manifest.json
+++ b/public/scripts/extensions/vectors/manifest.json
@@ -10,5 +10,8 @@
     "css": "style.css",
     "author": "Cohee#1207",
     "version": "1.0.0",
-    "homePage": "https://github.com/SillyTavern/SillyTavern"
+    "homePage": "https://github.com/SillyTavern/SillyTavern",
+    "hooks": {
+        "activate": "init"
+    }
 }


### PR DESCRIPTION
Converts all 14 built-in extensions from legacy jQuery/IIFE self-invoking patterns to proper exported `init()` functions, registered as `activate` hooks in their manifest files. This leverages the extension hooks system introduced in #5261 to give the extension loader explicit control over when each extension initializes.

Supersedes #5332

### What Changed

- **14 built-in extensions converted** from `jQuery(async () => { ... });` or `(async function() { ... })()` wrappers to `export async function init() { ... }` with corresponding `"hooks": { "activate": "init" }` in their manifests:
  - assets, attachments, caption, connection-manager, expressions, gallery, memory, quick-reply, regex, stable-diffusion, token-counter, translate, tts, vectors
- **`initExtensions()` is now properly awaited** in the app startup sequence — it was already an `async` function but wasn't being awaited, meaning extension activation could race with subsequent initialization steps

### Why These Changes

Previously, built-in extensions initialized themselves via jQuery ready handlers or immediately-invoked async functions. This meant the extension loader had no control over *when* they ran or any way to observe their lifecycle. With the hooks system from #5261, extensions can declare an `activate` hook in their manifest, and the loader calls it at the right time during startup. This is the standard pattern going forward for both built-in and third-party extensions.

By converting all built-in extensions to this pattern, we:
- Establish a consistent initialization model across the entire extension ecosystem
- Allow the extension loader to properly sequence and await activation
- Make extensions easier to reason about (explicit exported function vs hidden side effects)
- Set the example for third-party extension developers

### Impact

- Extensions now initialize through a well-defined, controlled pathway instead of self-executing side effects
- The startup sequence is more predictable since `initExtensions()` is awaited
- No user-facing behavior changes — extensions load and function identically
- Third-party extensions using the old patterns continue to work (backward compatible)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).