### PR TITLE
Add `disabled` property support to all popup custom input types

### DIFF
--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -84,6 +84,7 @@ export const POPUP_RESULT = {
  * @property {number?} [min] - The minimum value for number inputs
  * @property {number?} [max] - The maximum value for number inputs
  * @property {number?} [step] - The step value for number inputs
+ * @property {boolean?} [disabled=false] - Whether the input should be disabled
  */
 
 /**
@@ -334,6 +335,7 @@ export class Popup {
                 inputElement.type = 'checkbox';
                 inputElement.id = input.id;
                 inputElement.checked = Boolean(input.defaultState ?? false);
+                inputElement.disabled = Boolean(input.disabled ?? false);
                 label.appendChild(inputElement);
                 const labelText = document.createElement('span');
                 labelText.innerText = input.label;
@@ -359,6 +361,7 @@ export class Popup {
                 inputElement.id = input.id;
                 inputElement.value = String(input.defaultState ?? '');
                 inputElement.placeholder = input.tooltip ?? '';
+                inputElement.disabled = Boolean(input.disabled ?? false);
                 setTitleFromTooltip(inputElement, input.tooltip);
 
                 const labelText = document.createElement('span');
@@ -380,6 +383,7 @@ export class Popup {
                 inputElement.value = String(input.defaultState ?? '');
                 inputElement.rows = input.rows ?? 1;
                 inputElement.placeholder = input.tooltip ?? '';
+                inputElement.disabled = Boolean(input.disabled ?? false);
                 setTitleFromTooltip(inputElement, input.tooltip);
 
                 const labelText = document.createElement('span');
@@ -404,6 +408,7 @@ export class Popup {
                 inputElement.min = String(input.min ?? '');
                 inputElement.max = String(input.max ?? '');
                 inputElement.step = String(input.step ?? '');
+                inputElement.disabled = Boolean(input.disabled ?? false);
                 setTitleFromTooltip(inputElement, input.tooltip);
 
                 inputElement.addEventListener('change', () => {


### PR DESCRIPTION
Adds a `disabled` option to the custom input API in the `Popup` class, allowing callers to render read-only informational inputs alongside interactive ones in the same popup.

### What Changed
- Added `disabled` property to the `CustomInput` type definition (JSDoc)
- Applied `disabled` support to all four custom input types:
  - **Checkbox** inputs
  - **Text** inputs
  - **Textarea** inputs
  - **Number** inputs

### Why These Changes
When building popups with mixed content — some fields the user should interact with and others that are purely informational or conditionally locked — there was no way to render a greyed-out/non-editable input using the existing popup API. You'd either have to omit the field or build a custom popup from scratch. This fills that gap.

### How It Works
Each input branch in the popup rendering logic now checks for `input.disabled` and applies it to the created DOM element via `inputElement.disabled = Boolean(input.disabled ?? false)`. The default is `false`, so existing callers are completely unaffected.

### Impact
Callers using `Popup.show` or equivalent helpers can now pass `disabled: true` on any `CustomInput` entry to render it in a non-interactive state — useful for displaying computed values, locked settings, or context-only fields alongside editable ones.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).