### PR TITLE
chore: Add `getExtensionManifest()` to the extension context API

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -474,6 +474,21 @@ export function findExtension(name) {
 }
 
 /**
+ * Returns a deep clone of the manifest for the given extension name.
+ * Accepts either the short name (e.g. `SillyTavern-MyExtension`) or the full internal key
+ * (e.g. `third-party/SillyTavern-MyExtension`). Returns null if the extension is not found.
+ * @param {string} name - Extension name or internal key
+ * @returns {object|null} Cloned manifest object, or null if not found
+ */
+export function getExtensionManifest(name) {
+    const found = extensionNames.find(extName =>
+        equalsIgnoreCaseAndAccents(extName, name) || equalsIgnoreCaseAndAccents(extName, `third-party/${name}`),
+    );
+    const manifest = found ? manifests[found] : null;
+    return manifest ? structuredClone(manifest) : null;
+}
+
+/**
  * Loads manifest.json files for extensions.
  * @param {string[]} names Array of extension names
  * @returns {Promise<Record<string, object>>} Object with extension names as keys and their manifests as values

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -71,6 +71,7 @@ import {
 } from '../script.js';
 import {
     extension_settings,
+    getExtensionManifest,
     ModuleWorkerWrapper,
     openThirdPartyExtensionMenu,
     renderExtensionTemplate,
@@ -290,6 +291,7 @@ export function getContext() {
         getReasoningTemplateByName,
         unshallowCharacter,
         unshallowGroupMembers,
+        getExtensionManifest,
         openThirdPartyExtensionMenu,
         symbols: {
             ignore: IGNORE_SYMBOL,


### PR DESCRIPTION
Exposes a new `getExtensionManifest()` function through `getContext()`, allowing extensions to look up the loaded manifest of any registered extension at runtime.

### What Changed
- Added `getExtensionManifest(name)` to `extensions.js` — returns a safe `structuredClone` of the manifest for the given extension
- Exposed the new function via `getContext()` in `st-context.js`

### How It Works
The function accepts either the short extension name (e.g. `"my-extension"`) or its full internal key (e.g. `"third-party/my-extension"`). Returns `null` if the extension is not registered.

### Why
Extensions sometimes need to read their own (or another extension's) manifest data — for example to check the version, display name, or declared capabilities — without having to fetch and parse the `manifest.json` file themselves. This gives them direct access to the already-loaded manifest object.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).