### PR TITLE
Allow grammar to keep place during continue

### DIFF
--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -202,7 +202,7 @@ export function getKoboldGenerationData(finalPrompt, settings, maxLength, maxCon
         mirostat_eta: (kai_flags.can_use_mirostat || isHorde) ? kai_settings.mirostat_eta : undefined,
         use_default_badwordsids: (kai_flags.can_use_default_badwordsids || isHorde) ? kai_settings.use_default_badwordsids : undefined,
         grammar: (kai_flags.can_use_grammar || isHorde) ? substituteParams(kai_settings.grammar) : undefined,
-        grammar_retain_state: (isContinue ? true : false),
+        grammar_retain_state: (!!isContinue),
         sampler_seed: kai_settings.seed >= 0 ? kai_settings.seed : undefined,
         api_server: kai_settings.api_server,
     };

--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -202,7 +202,7 @@ export function getKoboldGenerationData(finalPrompt, settings, maxLength, maxCon
         mirostat_eta: (kai_flags.can_use_mirostat || isHorde) ? kai_settings.mirostat_eta : undefined,
         use_default_badwordsids: (kai_flags.can_use_default_badwordsids || isHorde) ? kai_settings.use_default_badwordsids : undefined,
         grammar: (kai_flags.can_use_grammar || isHorde) ? substituteParams(kai_settings.grammar) : undefined,
-        grammar_retain_state: (!!isContinue),
+        grammar_retain_state: (kai_flags.can_use_grammar && !!isContinue) ? true : undefined,
         sampler_seed: kai_settings.seed >= 0 ? kai_settings.seed : undefined,
         api_server: kai_settings.api_server,
     };

--- a/public/scripts/kai-settings.js
+++ b/public/scripts/kai-settings.js
@@ -202,6 +202,7 @@ export function getKoboldGenerationData(finalPrompt, settings, maxLength, maxCon
         mirostat_eta: (kai_flags.can_use_mirostat || isHorde) ? kai_settings.mirostat_eta : undefined,
         use_default_badwordsids: (kai_flags.can_use_default_badwordsids || isHorde) ? kai_settings.use_default_badwordsids : undefined,
         grammar: (kai_flags.can_use_grammar || isHorde) ? substituteParams(kai_settings.grammar) : undefined,
+        grammar_retain_state: (isContinue ? true : false),
         sampler_seed: kai_settings.seed >= 0 ? kai_settings.seed : undefined,
         api_server: kai_settings.api_server,
     };

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1756,7 +1756,7 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
 
     if (settings.type === KOBOLDCPP) {
         params.grammar = settings.grammar_string || undefined;
-        params.grammar_retain_state = (settings.grammar_string && !!isContinue);
+        params.grammar_retain_state = (settings.grammar_string && !!isContinue) ? true : undefined;
         params.trim_stop = true;
         params.dry_sequence_breakers = params.parseSequenceBreakers();
     }

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1756,7 +1756,7 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
 
     if (settings.type === KOBOLDCPP) {
         params.grammar = settings.grammar_string || undefined;
-        params.grammar_retain_state = (!!isContinue);
+        params.grammar_retain_state = (settings.grammar_string && !!isContinue);
         params.trim_stop = true;
         params.dry_sequence_breakers = params.parseSequenceBreakers();
     }

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1756,7 +1756,7 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
 
     if (settings.type === KOBOLDCPP) {
         params.grammar = settings.grammar_string || undefined;
-        params.grammar_retain_state = (isContinue ? true : false);
+        params.grammar_retain_state = (!!isContinue);
         params.trim_stop = true;
         params.dry_sequence_breakers = params.parseSequenceBreakers();
     }

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1756,6 +1756,7 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
 
     if (settings.type === KOBOLDCPP) {
         params.grammar = settings.grammar_string || undefined;
+        params.grammar_retain_state = (isContinue ? true : false);
         params.trim_stop = true;
         params.dry_sequence_breakers = params.parseSequenceBreakers();
     }


### PR DESCRIPTION
This is a small change to allow koboldcpp's gramma system to continue gens without losing its place in the grammar.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
