### PR TITLE
Enable interleaved tool reasoning for custom OpenAI-compat endpoints

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2011,7 +2011,7 @@
                                             <strong data-i18n="enable_functions_desc_4">Not supported when Prompt Post-Processing with "no tools" is used!</strong>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="openrouter">
+                                    <div class="range-block" data-source="openrouter,custom">
                                         <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10">
                                             <div class="flex-container oneline-dropdown">
                                                 <label for="tool_reasoning_mode" data-i18n="Interleaved Thinking">

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1020,8 +1020,8 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
                 const clone = structuredClone(invocation);
                 if (!reasoningIsEligible) {
                     delete clone.reasoning;
-                } else if (previousAssistantReasoning) {
-                    // Prefer currently editable assistant-text reasoning based on forwarding mode over invocation snapshot.
+                } else if (previousAssistantReasoning && !clone.reasoning) {
+                    // Fall back to adjacent assistant-text reasoning only when the invocation has none of its own.
                     clone.reasoning = previousAssistantReasoning;
                 }
                 return clone;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -257,6 +257,7 @@ export const tool_reasoning_modes = {
 // Providers that support interleaved reasoning forwarding in tool-call chains.
 const interleaved_reasoning_providers = [
     chat_completion_sources.OPENROUTER,
+    chat_completion_sources.CUSTOM,
 ];
 
 export const ZAI_ENDPOINT = {


### PR DESCRIPTION
## Problem

When a local reasoning model (e.g. KoboldCPP in Chat Completions / OpenAI-compat mode) reasons before calling a tool, the reasoning is silently stripped from the follow-up inference request. The model receives its own tool-call with no memory of why it issued it, leading to confused follow-up responses.

Two things blocked this from working for the `custom` source:

1. `interleaved_reasoning_providers` was hardcoded to `[OPENROUTER]`, causing `toolReasoningMode` to be unconditionally forced to `DISABLED` for all other sources — ignoring the user's setting and actively deleting `invocation.reasoning` before the API payload is built.
2. The **Interleaved Thinking** UI control (`#tool_reasoning_mode`) was hidden behind `data-source="openrouter"`, so custom source users had no way to opt in even if the gate were removed.

## Changes

- **`public/scripts/openai.js`**: Add `chat_completion_sources.CUSTOM` to `interleaved_reasoning_providers`.
- **`public/index.html`**: Extend `data-source="openrouter"` → `data-source="openrouter,custom"` on the Interleaved Thinking control wrapper.

## Notes

- The custom source streaming path already correctly reads `delta.reasoning_content` / `delta.reasoning` from chunks (`openai.js:3092-3095`). No streaming changes needed.
- This is purely opt-in: requires the user to have **Request model reasoning** enabled *and* to set Interleaved Thinking to a non-disabled value. Default behaviour for all sources is unchanged.
- OpenRouter behaviour is unaffected.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
