### PR TITLE
Emit `PERSONA_CREATED` event on persona duplication

### DIFF
--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1826,6 +1826,8 @@ async function duplicatePersona(avatarId) {
         title: descriptor?.title ?? '',
     };
 
+    await eventSource.emit(event_types.PERSONA_CREATED, { avatarId: user_avatar, name: name1, description: '', title: '', duplicatedFromAvatarId: avatarId });
+
     await uploadUserAvatar(getUserAvatar(avatarId), newAvatarId);
     await getUserAvatars(true, newAvatarId);
     saveSettingsDebounced();

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -1826,9 +1826,17 @@ async function duplicatePersona(avatarId) {
         title: descriptor?.title ?? '',
     };
 
-    await eventSource.emit(event_types.PERSONA_CREATED, { avatarId: user_avatar, name: name1, description: '', title: '', duplicatedFromAvatarId: avatarId });
-
     await uploadUserAvatar(getUserAvatar(avatarId), newAvatarId);
+
+    const eventData = {
+        avatarId: newAvatarId,
+        name: personaName,
+        description: descriptor?.description ?? '',
+        title: descriptor?.title ?? '',
+        duplicatedFromAvatarId: avatarId,
+    };
+    await eventSource.emit(event_types.PERSONA_CREATED, eventData);
+
     await getUserAvatars(true, newAvatarId);
     saveSettingsDebounced();
 }


### PR DESCRIPTION
Forgot to fire `PERSONA_CREATED` during persona duplication in #5443.

No additional event for that, just utilizes `duplicatedFromAvatarId` to check where it was duplicated from

Adds PERSONA_CREATED event emission in duplicatePersona() to notify listeners when a persona is duplicated. Includes the new avatarId, name, and duplicatedFromAvatarId in the event payload.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
