### PR TITLE
Add `clean` extension lifecycle hook for optional data cleanup

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -358,10 +358,11 @@ function onToggleAllExtensions(extensionsToToggle, toggleContainer) {
  * Checks whether an extension has a specific hook defined in its manifest.
  * @param {string} name Extension name (with or without 'third-party' prefix)
  * @param {'install' | 'update' | 'delete' | 'clean' | 'enable' | 'disable' | 'activate'} hookName The hook to check
+ * @param {boolean} isExternal Whether the extension is third-party or built-in
  * @returns {boolean}
  */
-function hasExtensionHook(name, hookName) {
-    const fullName = name.startsWith('third-party') ? name : `third-party${name}`;
+function hasExtensionHook(name, hookName, isExternal) {
+    const fullName = isExternal ? (name.startsWith('third-party') ? name : `third-party${name}`) : name;
     const manifest = manifests[fullName];
     if (!manifest || !manifest.hooks || typeof manifest.hooks !== 'object') {
         return false;
@@ -895,7 +896,7 @@ function generateExtensionHtml(name, manifest, isActive, isDisabled, isExternal,
     let updateButton = isExternal ? `<button class="btn_update menu_button displayNone" data-name="${externalId}" title="Update available"><i class="fa-solid fa-download fa-fw"></i></button>` : '';
     let moveButton = isExternal && isUserAdmin ? `<button class="btn_move menu_button" data-name="${externalId}" data-i18n="[title]Move" title="Move"><i class="fa-solid fa-folder-tree fa-fw"></i></button>` : '';
     let branchButton = isExternal && isUserAdmin ? `<button class="btn_branch menu_button" data-name="${externalId}" data-i18n="[title]Switch branch" title="Switch branch"><i class="fa-solid fa-code-branch fa-fw"></i></button>` : '';
-    let cleanButton = hasExtensionHook(externalId, 'clean') ? `<button class="btn_clean menu_button" data-name="${externalId}" data-i18n="[title]Clean extension data" title="Clean extension data"><i class="fa-fw fa-solid fa-broom"></i></button>` : '';
+    let cleanButton = hasExtensionHook(name, 'clean', isExternal) ? `<button class="btn_clean menu_button" data-name="${name}" data-i18n="[title]Clean extension data" title="Clean extension data"><i class="fa-fw fa-solid fa-broom"></i></button>` : '';
     let modulesInfo = '';
 
     if (isActive && Array.isArray(manifest.optional)) {
@@ -1278,7 +1279,8 @@ async function onDeleteClick() {
         return;
     }
 
-    const hasCleanHook = hasExtensionHook(extensionName, 'clean');
+    const isExternal = extensionName.startsWith('third-party');
+    const hasCleanHook = hasExtensionHook(extensionName, 'clean', isExternal);
 
     /** @type {import('./popup.js').CustomPopupInput[]} */
     const customInputs = hasCleanHook ? [{ id: 'extension_delete_cleanup', label: t`Also clean up extension data`, defaultState: false }] : null;

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1320,6 +1320,10 @@ async function onCleanClick() {
 async function cleanExtension(extensionName) {
     const fullExtensionName = extensionName.startsWith('third-party') ? extensionName : `third-party${extensionName}`;
     await callExtensionHook(fullExtensionName, 'clean');
+
+    // Clean might have updated settings, which could race with the page reload, so we'll force save here
+    await saveSettings();
+
     toastr.success(t`Extension ${extensionName} data cleaned`);
     delay(1000).then(() => location.reload());
 }
@@ -1449,6 +1453,9 @@ export async function deleteExtension(extensionName, shouldClean = false) {
     } catch (error) {
         console.error('Error:', error);
     }
+
+    // Delete or clean might have updated settings, which could race with the page reload, so we'll force save here
+    await saveSettings();
 
     toastr.success(t`Extension ${extensionName} deleted`);
     delay(1000).then(() => location.reload());

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1,7 +1,7 @@
 import { DOMPurify, Popper } from '../lib.js';
 
 import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration, CLIENT_VERSION } from '../script.js';
-import { POPUP_RESULT, POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
+import { POPUP_RESULT, POPUP_TYPE, Popup } from './popup.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
 import { delay, equalsIgnoreCaseAndAccents, isSubsetOf, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';
 import { getContext } from './st-context.js';

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -355,11 +355,27 @@ function onToggleAllExtensions(extensionsToToggle, toggleContainer) {
 }
 
 /**
+ * Checks whether an extension has a specific hook defined in its manifest.
+ * @param {string} name Extension name (with or without 'third-party' prefix)
+ * @param {'install' | 'update' | 'delete' | 'clean' | 'enable' | 'disable' | 'activate'} hookName The hook to check
+ * @returns {boolean}
+ */
+function hasExtensionHook(name, hookName) {
+    const fullName = name.startsWith('third-party') ? name : `third-party${name}`;
+    const manifest = manifests[fullName];
+    if (!manifest || !manifest.hooks || typeof manifest.hooks !== 'object') {
+        return false;
+    }
+    const hookFunctionName = manifest.hooks[hookName];
+    return typeof hookFunctionName === 'string' && hookFunctionName.length > 0;
+}
+
+/**
  * Calls a manifest hook for an extension.
  * Hooks are optional function names exported from the extension's JS entry point module.
  * The hook function can optionally return a Promise that will be awaited.
  * @param {string} name Extension name
- * @param {'install' | 'update' | 'delete' | 'enable' | 'disable' | 'activate'} hookName The hook to call
+ * @param {'install' | 'update' | 'delete' | 'clean' | 'enable' | 'disable' | 'activate'} hookName The hook to call
  * @returns {Promise<void>}
  */
 async function callExtensionHook(name, hookName) {
@@ -879,6 +895,7 @@ function generateExtensionHtml(name, manifest, isActive, isDisabled, isExternal,
     let updateButton = isExternal ? `<button class="btn_update menu_button displayNone" data-name="${externalId}" title="Update available"><i class="fa-solid fa-download fa-fw"></i></button>` : '';
     let moveButton = isExternal && isUserAdmin ? `<button class="btn_move menu_button" data-name="${externalId}" data-i18n="[title]Move" title="Move"><i class="fa-solid fa-folder-tree fa-fw"></i></button>` : '';
     let branchButton = isExternal && isUserAdmin ? `<button class="btn_branch menu_button" data-name="${externalId}" data-i18n="[title]Switch branch" title="Switch branch"><i class="fa-solid fa-code-branch fa-fw"></i></button>` : '';
+    let cleanButton = isExternal && hasExtensionHook(externalId, 'clean') ? `<button class="btn_clean menu_button" data-name="${externalId}" data-i18n="[title]Clean extension data" title="Clean extension data"><i class="fa-fw fa-solid fa-broom"></i></button>` : '';
     let modulesInfo = '';
 
     if (isActive && Array.isArray(manifest.optional)) {
@@ -919,6 +936,7 @@ function generateExtensionHtml(name, manifest, isActive, isDisabled, isExternal,
 
             <div class="extension_actions flex-container alignItemsCenter">
                 ${updateButton}
+                ${cleanButton}
                 ${branchButton}
                 ${moveButton}
                 ${deleteButton}
@@ -1249,6 +1267,7 @@ async function updateExtension(extensionName, quiet, timeout = null) {
  * This function makes a POST request to '/api/extensions/delete' with the extension's name.
  * If the extension is deleted, it displays a success message.
  * Creates a popup for the user to confirm before delete.
+ * If the extension has a 'clean' hook, an optional checkbox to also run the cleanup is shown.
  */
 async function onDeleteClick() {
     const extensionName = $(this).data('name');
@@ -1259,11 +1278,50 @@ async function onDeleteClick() {
         return;
     }
 
-    // use callPopup to create a popup for the user to confirm before delete
-    const confirmation = await callGenericPopup(t`Are you sure you want to delete ${extensionName}?`, POPUP_TYPE.CONFIRM, '', {});
+    const hasCleanHook = hasExtensionHook(extensionName, 'clean');
+
+    /** @type {import('./popup.js').CustomPopupInput[]} */
+    const customInputs = hasCleanHook ? [{ id: 'extension_delete_cleanup', label: t`Also clean up extension data`, defaultState: false }] : null;
+
+    const popup = new Popup(t`Are you sure you want to delete ${extensionName}?`, POPUP_TYPE.CONFIRM, '', { customInputs });
+    const confirmation = await popup.show();
     if (confirmation === POPUP_RESULT.AFFIRMATIVE) {
-        await deleteExtension(extensionName);
+        const shouldClean = hasCleanHook && Boolean(popup.inputResults?.get('extension_delete_cleanup'));
+        await deleteExtension(extensionName, shouldClean);
     }
+}
+
+/**
+ * Handles the click event for the clean button of an extension.
+ * Runs the extension's 'clean' hook after user confirmation, then reloads the page.
+ */
+async function onCleanClick() {
+    const extensionName = $(this).data('name');
+    const isCurrentUserAdmin = isAdmin();
+    const isGlobal = getExtensionType(extensionName) === 'global';
+    if (isGlobal && !isCurrentUserAdmin) {
+        toastr.error(t`You don't have permission to clean global extensions.`);
+        return;
+    }
+
+    const confirmation = await Popup.show.confirm(t`Clean extension data`, t`Are you sure you want to clean up data for ${extensionName}? This action cannot be undone.`);
+    if (!confirmation) {
+        return;
+    }
+
+    await cleanExtension(extensionName);
+}
+
+/**
+ * Runs the 'clean' hook for an extension and reloads the page.
+ * @param {string} extensionName Extension name (without 'third-party' prefix)
+ * @returns {Promise<void>}
+ */
+async function cleanExtension(extensionName) {
+    const fullExtensionName = extensionName.startsWith('third-party') ? extensionName : `third-party${extensionName}`;
+    await callExtensionHook(fullExtensionName, 'clean');
+    toastr.success(t`Extension ${extensionName} data cleaned`);
+    delay(1000).then(() => location.reload());
 }
 
 async function onBranchClick() {
@@ -1368,9 +1426,16 @@ async function moveExtension(extensionName, source, destination) {
 /**
  * Deletes an extension via the API.
  * @param {string} extensionName Extension name to delete
+ * @param {boolean} [shouldClean=false] Whether to also run the 'clean' hook before deleting
  */
-export async function deleteExtension(extensionName) {
-    await callExtensionHook(extensionName, 'delete');
+export async function deleteExtension(extensionName, shouldClean = false) {
+    const fullExtensionName = extensionName.startsWith('third-party') ? extensionName : `third-party${extensionName}`;
+
+    if (shouldClean) {
+        await callExtensionHook(fullExtensionName, 'clean');
+    }
+
+    await callExtensionHook(fullExtensionName, 'delete');
 
     try {
         await fetch('/api/extensions/delete', {
@@ -1880,6 +1945,7 @@ export async function initExtensions() {
     $(document).on('click', '.extensions_info .extension_block .toggle_enable', onEnableExtensionClick);
     $(document).on('click', '.extensions_info .extension_block .btn_update', onUpdateClick);
     $(document).on('click', '.extensions_info .extension_block .btn_delete', onDeleteClick);
+    $(document).on('click', '.extensions_info .extension_block .btn_clean', onCleanClick);
     $(document).on('click', '.extensions_info .extension_block .btn_move', onMoveClick);
     $(document).on('click', '.extensions_info .extension_block .btn_branch', onBranchClick);
 

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -895,7 +895,7 @@ function generateExtensionHtml(name, manifest, isActive, isDisabled, isExternal,
     let updateButton = isExternal ? `<button class="btn_update menu_button displayNone" data-name="${externalId}" title="Update available"><i class="fa-solid fa-download fa-fw"></i></button>` : '';
     let moveButton = isExternal && isUserAdmin ? `<button class="btn_move menu_button" data-name="${externalId}" data-i18n="[title]Move" title="Move"><i class="fa-solid fa-folder-tree fa-fw"></i></button>` : '';
     let branchButton = isExternal && isUserAdmin ? `<button class="btn_branch menu_button" data-name="${externalId}" data-i18n="[title]Switch branch" title="Switch branch"><i class="fa-solid fa-code-branch fa-fw"></i></button>` : '';
-    let cleanButton = hasExtensionHook(externalId, 'clean') ? `<button class="btn_clean menu_button" data-name="${externalId}" data-i18n="[title]Clean extension data" title="Clean extension data"><i class="fa-fw fa-solid fa-broom"></i></button>` : '';
+    let cleanButton = isExternal && hasExtensionHook(externalId, 'clean') ? `<button class="btn_clean menu_button" data-name="${externalId}" data-i18n="[title]Clean extension data" title="Clean extension data"><i class="fa-fw fa-solid fa-broom"></i></button>` : '';
     let modulesInfo = '';
 
     if (isActive && Array.isArray(manifest.optional)) {

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -895,7 +895,7 @@ function generateExtensionHtml(name, manifest, isActive, isDisabled, isExternal,
     let updateButton = isExternal ? `<button class="btn_update menu_button displayNone" data-name="${externalId}" title="Update available"><i class="fa-solid fa-download fa-fw"></i></button>` : '';
     let moveButton = isExternal && isUserAdmin ? `<button class="btn_move menu_button" data-name="${externalId}" data-i18n="[title]Move" title="Move"><i class="fa-solid fa-folder-tree fa-fw"></i></button>` : '';
     let branchButton = isExternal && isUserAdmin ? `<button class="btn_branch menu_button" data-name="${externalId}" data-i18n="[title]Switch branch" title="Switch branch"><i class="fa-solid fa-code-branch fa-fw"></i></button>` : '';
-    let cleanButton = isExternal && hasExtensionHook(externalId, 'clean') ? `<button class="btn_clean menu_button" data-name="${externalId}" data-i18n="[title]Clean extension data" title="Clean extension data"><i class="fa-fw fa-solid fa-broom"></i></button>` : '';
+    let cleanButton = hasExtensionHook(externalId, 'clean') ? `<button class="btn_clean menu_button" data-name="${externalId}" data-i18n="[title]Clean extension data" title="Clean extension data"><i class="fa-fw fa-solid fa-broom"></i></button>` : '';
     let modulesInfo = '';
 
     if (isActive && Array.isArray(manifest.optional)) {

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1297,12 +1297,6 @@ async function onDeleteClick() {
  */
 async function onCleanClick() {
     const extensionName = $(this).data('name');
-    const isCurrentUserAdmin = isAdmin();
-    const isGlobal = getExtensionType(extensionName) === 'global';
-    if (isGlobal && !isCurrentUserAdmin) {
-        toastr.error(t`You don't have permission to clean global extensions.`);
-        return;
-    }
 
     const confirmation = await Popup.show.confirm(t`Clean extension data`, t`Are you sure you want to clean up data for ${extensionName}? This action cannot be undone.`);
     if (!confirmation) {

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -358,11 +358,10 @@ function onToggleAllExtensions(extensionsToToggle, toggleContainer) {
  * Checks whether an extension has a specific hook defined in its manifest.
  * @param {string} name Extension name (with or without 'third-party' prefix)
  * @param {'install' | 'update' | 'delete' | 'clean' | 'enable' | 'disable' | 'activate'} hookName The hook to check
- * @param {boolean} isExternal Whether the extension is third-party or built-in
  * @returns {boolean}
  */
-function hasExtensionHook(name, hookName, isExternal) {
-    const fullName = isExternal ? (name.startsWith('third-party') ? name : `third-party${name}`) : name;
+function hasExtensionHook(name, hookName) {
+    const fullName = name.startsWith('third-party') ? name : `third-party${name}`;
     const manifest = manifests[fullName];
     if (!manifest || !manifest.hooks || typeof manifest.hooks !== 'object') {
         return false;
@@ -896,7 +895,7 @@ function generateExtensionHtml(name, manifest, isActive, isDisabled, isExternal,
     let updateButton = isExternal ? `<button class="btn_update menu_button displayNone" data-name="${externalId}" title="Update available"><i class="fa-solid fa-download fa-fw"></i></button>` : '';
     let moveButton = isExternal && isUserAdmin ? `<button class="btn_move menu_button" data-name="${externalId}" data-i18n="[title]Move" title="Move"><i class="fa-solid fa-folder-tree fa-fw"></i></button>` : '';
     let branchButton = isExternal && isUserAdmin ? `<button class="btn_branch menu_button" data-name="${externalId}" data-i18n="[title]Switch branch" title="Switch branch"><i class="fa-solid fa-code-branch fa-fw"></i></button>` : '';
-    let cleanButton = hasExtensionHook(name, 'clean', isExternal) ? `<button class="btn_clean menu_button" data-name="${name}" data-i18n="[title]Clean extension data" title="Clean extension data"><i class="fa-fw fa-solid fa-broom"></i></button>` : '';
+    let cleanButton = hasExtensionHook(externalId, 'clean') ? `<button class="btn_clean menu_button" data-name="${externalId}" data-i18n="[title]Clean extension data" title="Clean extension data"><i class="fa-fw fa-solid fa-broom"></i></button>` : '';
     let modulesInfo = '';
 
     if (isActive && Array.isArray(manifest.optional)) {
@@ -1279,8 +1278,7 @@ async function onDeleteClick() {
         return;
     }
 
-    const isExternal = extensionName.startsWith('third-party');
-    const hasCleanHook = hasExtensionHook(extensionName, 'clean', isExternal);
+    const hasCleanHook = hasExtensionHook(extensionName, 'clean');
 
     /** @type {import('./popup.js').CustomPopupInput[]} */
     const customInputs = hasCleanHook ? [{ id: 'extension_delete_cleanup', label: t`Also clean up extension data`, defaultState: false }] : null;


### PR DESCRIPTION
Extends the existing extension hook system (introduced in #5261) with a new `clean` hook, giving extension authors a dedicated place to implement data cleanup logic. This hook is intentionally separate from `delete` — cleanup is always opt-in for the user, never automatic.

### What Changed

- **New `clean` hook** — Extension authors can export a cleanup function and declare it in `manifest.json` under `hooks.clean`. The existing 5-second timeout and Promise-awaiting behaviour applies.
- **"Clean" button in the extension list** — Extensions that declare a `clean` hook get a broom icon button in their action row (between the update and branch buttons). Clicking it asks for confirmation, runs the hook, then reloads the page.
- **Optional cleanup on delete** — When deleting an extension that has a `clean` hook, the confirmation popup gains an unchecked checkbox: *"Also clean up extension data"*. If checked, the `clean` hook runs before the `delete` hook. If unchecked, nothing changes from the previous behaviour.
- **Bug fix in `deleteExtension`** — The function now correctly resolves the `third-party/` prefix before calling `callExtensionHook`, consistent with how `updateExtension` already handled this.

### Why These Changes

The existing `delete` hook runs unconditionally when an extension is uninstalled, with a hard 5-second timeout before the page reloads regardless. This made it impractical for extensions to ask the user whether to clean up their stored data — there was no time, and always cleaning or never cleaning are both bad defaults.

Separating cleanup into a dedicated `clean` hook solves this cleanly:
- **Temporary installs** — user uninstalls without checking the box, data persists for a future reinstall.
- **Full removal** — user checks the box, extension cleans up everything before being deleted.
- **Manual cleanup** — user can trigger cleanup at any time without uninstalling, via the new Clean button.

### How It Works

Extension authors add to their `manifest.json`:
```json
"hooks": {
    "clean": "myCleanupFunction"
}
```

And export that function from their JS entry point. The UI conditionally shows the checkbox and Clean button only when the hook is declared, so existing extensions are completely unaffected.

### Impact

Extension authors now have a first-class, user-controlled path for data lifecycle management. Users get clear control over whether their extension data persists across uninstalls, with a safe default (keep data) and the ability to clean up on demand.

-----

<img width="821" height="262" alt="image" src="https://github.com/user-attachments/assets/90d1e356-1630-4eca-9bfc-7cc62453920a" />

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).