### PR TITLE
Use 'Last User Prefix' for Last Prompt Line When Sending TC Impersonation Requests

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4387,7 +4387,7 @@
                                         <small data-i18n="First User Prefix">First User Prefix</small>
                                         <textarea id="instruct_first_input_sequence" data-macros class="text_pole textarea_compact autoSetHeight"></textarea>
                                     </div>
-                                    <div class="flexAuto" title="Inserted before the last User's message." data-i18n="[title]instruct_last_input_sequence">
+                                    <div class="flexAuto" title="Inserted before the last User's message or as a last prompt line when generating an impersonation." data-i18n="[title]instruct_last_input_sequence">
                                         <small data-i18n="Last User Prefix">Last User Prefix</small>
                                         <textarea id="instruct_last_input_sequence" data-macros class="text_pole wide100p textarea_compact autoSetHeight"></textarea>
                                     </div>

--- a/public/script.js
+++ b/public/script.js
@@ -4705,7 +4705,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.FIRST);
         }
 
-        if (lastUserMessageIndex >= 0 && j === lastUserMessageIndex && isInstruct) {
+        if (lastUserMessageIndex >= 0 && j === lastUserMessageIndex && isInstruct && !isImpersonate) {
             // Reformat with the last input sequence (if any)
             chat2[i] = formatMessageHistoryItem(coreChat[j], isInstruct, force_output_sequence.LAST);
         }

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -597,7 +597,7 @@ export function formatInstructModePrompt(name, isImpersonate, promptBias, name1,
     function getSequence() {
         // User impersonation prompt
         if (isImpersonate) {
-            return instruct.input_sequence;
+            return instruct.last_input_sequence || instruct.input_sequence;
         }
 
         // Neutral / system / quiet prompt


### PR DESCRIPTION
Instead of having the last user prefix applied to the last user messgae, it will instead be applied to the last prompt line when sending an impersonation requests.

This is helpful in scenarios where the user swaps the `assistant` and `user` roles when sending impersonation request, as some models, like Gemma 4 for example, work better with having the thinking tags in the last prompt line even if they aren't being used.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).