### PR TITLE
Enhanced `/persona-sync` Command with Range, Name Filter, and Quiet Mode

### DIFF
--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -2093,12 +2093,12 @@ function registerPersonaSlashCommands() {
         <div>
             <strong>${t`Examples:`}</strong>
             <ul>
-                <li><pre><code>/sync</code></pre> ${t`- Sync all user messages`}</li>
-                <li><pre><code>/sync 5</code></pre> ${t`- Sync only message 5`}</li>
-                <li><pre><code>/sync 0-10</code></pre> ${t`- Sync messages 0 through 10`}</li>
-                <li><pre><code>/sync from=OldPersona 0-20</code></pre> ${t`- Sync only messages with name "OldPersona" in range 0-20`}</li>
-                <li><pre><code>/sync quiet=false</code></pre> ${t`- Sync all with confirmation popup`}</li>
-                <li><pre><code>/sync from=TempName quiet=false 5-15</code></pre> ${t`- Sync messages with name "TempName" in range 5-15 with confirmation`}</li>
+                <li><pre><code>/persona-sync</code></pre> ${t`- Sync all user messages`}</li>
+                <li><pre><code>/persona-sync 5</code></pre> ${t`- Sync only message 5`}</li>
+                <li><pre><code>/persona-sync 0-10</code></pre> ${t`- Sync messages 0 through 10`}</li>
+                <li><pre><code>/persona-sync from=OldPersona 0-20</code></pre> ${t`- Sync only messages with name "OldPersona" in range 0-20`}</li>
+                <li><pre><code>/persona-sync quiet=false</code></pre> ${t`- Sync all with confirmation popup`}</li>
+                <li><pre><code>/persona-sync from=TempName quiet=false 5-15</code></pre> ${t`- Sync messages with name "TempName" in range 5-15 with confirmation`}</li>
             </ul>
         </div>
     `,

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -24,7 +24,29 @@ import {
 } from '../script.js';
 import { persona_description_positions, power_user } from './power-user.js';
 import { getTokenCountAsync } from './tokenizers.js';
-import { PAGINATION_TEMPLATE, clearInfoBlock, debounce, delay, download, ensureImageFormatSupported, flashHighlight, getBase64Async, getCharIndex, isFalseBoolean, isTrueBoolean, onlyUnique, parseJsonFile, setInfoBlock, localizePagination, renderPaginationDropdown, paginationDropdownChangeHandler, addLongPressEvent, stringToRange } from './utils.js';
+import {
+    PAGINATION_TEMPLATE,
+    clearInfoBlock,
+    debounce,
+    delay,
+    download,
+    ensureImageFormatSupported,
+    flashHighlight,
+    getBase64Async,
+    getCharIndex,
+    isFalseBoolean,
+    isTrueBoolean,
+    onlyUnique,
+    parseJsonFile,
+    setInfoBlock,
+    localizePagination,
+    renderPaginationDropdown,
+    paginationDropdownChangeHandler,
+    addLongPressEvent,
+    stringToRange,
+    sortIgnoreCaseAndAccents,
+    equalsIgnoreCaseAndAccents,
+} from './utils.js';
 import { debounce_timeout } from './constants.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
 import { groups, selected_group } from './group-chats.js';
@@ -36,8 +58,8 @@ import { saveMetadataDebounced } from './extensions.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { SlashCommandNamedArgument, ARGUMENT_TYPE, SlashCommandArgument } from './slash-commands/SlashCommandArgument.js';
-import { commonEnumProviders } from './slash-commands/SlashCommandCommonEnumsProvider.js';
-import { SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js';
+import { commonEnumProviders, enumIcons } from './slash-commands/SlashCommandCommonEnumsProvider.js';
+import { SlashCommandEnumValue, enumTypes } from './slash-commands/SlashCommandEnumValue.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { isFirefox } from './browser-fixes.js';
 
@@ -1760,13 +1782,27 @@ async function onPersonasRestoreInput(e) {
     $('#personas_restore_input').val('');
 }
 
-async function syncUserNameToPersona({ start = 0, end = chat.length - 1, silent = false } = {}) {
+/**
+ * Synchronizes user-sent messages in the chat to the current persona.
+ * @param {object} [options={}] - Optional parameters
+ * @param {number} [options.start=0] - Start index of the message range (inclusive)
+ * @param {number} [options.end=chat.length - 1] - End index of the message range (inclusive)
+ * @param {boolean} [options.quiet=false] - If true, skips the confirmation popup
+ * @param {string} [options.nameFilter=''] - Filter messages by name (case-insensitive)
+ * @returns {Promise<void>}
+ */
+async function syncUserNameToPersona({ start = 0, end = chat.length - 1, quiet = false, nameFilter = '' } = {}) {
     const isRangeAll = start === 0 && end === chat.length - 1;
-    const confirmMessage = isRangeAll
+    const hasNameFilter = nameFilter?.trim();
+    const confirmMessage = isRangeAll && !hasNameFilter
         ? t`All user-sent messages in this chat will be attributed to ${name1}.`
-        : t`User-sent messages in the specified range will be attributed to ${name1}.`;
+        : isRangeAll && hasNameFilter
+            ? t`User-sent messages with name "${nameFilter}" will be attributed to ${name1}.`
+            : !isRangeAll && !hasNameFilter
+                ? t`User-sent messages in the specified range will be attributed to ${name1}.`
+                : t`User-sent messages with name "${nameFilter}" in the specified range will be attributed to ${name1}.`;
 
-    if (!silent) {
+    if (!quiet) {
         const confirmation = await Popup.show.confirm(t`Are you sure?`, confirmMessage);
         if (!confirmation) {
             return;
@@ -1775,7 +1811,7 @@ async function syncUserNameToPersona({ start = 0, end = chat.length - 1, silent 
 
     for (let i = start; i <= end; i++) {
         const mes = chat[i];
-        if (mes?.is_user) {
+        if (mes?.is_user && (!hasNameFilter || equalsIgnoreCaseAndAccents(mes.name, nameFilter))) {
             mes.name = name1;
             mes.force_avatar = getThumbnailUrl('persona', user_avatar);
         }
@@ -1946,13 +1982,27 @@ async function syncCallback(args, value) {
         return '';
     }
 
-    const silent = isTrueBoolean(args?.silent);
+    const quiet = !isFalseBoolean(args?.quiet);
+    const nameFilter = typeof args?.from === 'string' ? args.from.trim() : '';
     const start = range ? range.start : 0;
     const end = range ? range.end : chat.length - 1;
 
-    await syncUserNameToPersona({ start, end, silent });
+    await syncUserNameToPersona({ start, end, quiet, nameFilter });
 
     return '';
+}
+
+/**
+ * Returns all unique user message names in the current chat for enum autocomplete.
+ * @returns {SlashCommandEnumValue[]}
+ */
+function userMessageNamesEnumProvider() {
+    return chat
+        .filter(mes => mes.is_user)
+        .map(mes => mes.name)
+        .filter(onlyUnique)
+        .sort(sortIgnoreCaseAndAccents)
+        .map(name => new SlashCommandEnumValue(name, null, enumTypes.name, enumIcons.persona));
 }
 
 function registerPersonaSlashCommands() {
@@ -2009,10 +2059,17 @@ function registerPersonaSlashCommands() {
         callback: syncCallback,
         namedArgumentList: [
             SlashCommandNamedArgument.fromProps({
-                name: 'silent',
+                name: 'from',
+                description: t`only sync messages from a certain persona name`,
+                typeList: [ARGUMENT_TYPE.STRING],
+                enumProvider: userMessageNamesEnumProvider,
+            }),
+            SlashCommandNamedArgument.fromProps({
+                name: 'quiet',
                 description: t`suppress the confirmation popup`,
                 typeList: [ARGUMENT_TYPE.BOOLEAN],
                 enumList: commonEnumProviders.boolean('trueFalse')(),
+                defaultValue: 'true',
             }),
         ],
         unnamedArgumentList: [
@@ -2022,7 +2079,28 @@ function registerPersonaSlashCommands() {
                 defaultValue: '0-{{lastMessageId}}',
             }),
         ],
-        helpString: 'Syncs the user persona in user-attributed messages in the current chat.',
+        helpString: `
+        <div>
+            ${t`Syncs the user persona (name and avatar) in user-attributed messages in the current chat.`}
+        </div>
+        <div>
+            ${t`If <code>from</code> is set, only messages with that specific persona name will be synced. Useful when multiple personas have been used in the same chat.`}
+        </div>
+        <div>
+            ${t`If <code>quiet</code> is set to <code>false</code>, a confirmation popup will be shown before syncing.`}
+        </div>
+        <div>
+            <strong>${t`Examples:`}</strong>
+            <ul>
+                <li><pre><code>/sync</code></pre> ${t`- Sync all user messages`}</li>
+                <li><pre><code>/sync 5</code></pre> ${t`- Sync only message 5`}</li>
+                <li><pre><code>/sync 0-10</code></pre> ${t`- Sync messages 0 through 10`}</li>
+                <li><pre><code>/sync from=OldPersona 0-20</code></pre> ${t`- Sync only messages with name "OldPersona" in range 0-20`}</li>
+                <li><pre><code>/sync quiet=false</code></pre> ${t`- Sync all with confirmation popup`}</li>
+                <li><pre><code>/sync from=TempName quiet=false 5-15</code></pre> ${t`- Sync messages with name "TempName" in range 5-15 with confirmation`}</li>
+            </ul>
+        </div>
+    `,
     }));
 }
 

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -46,6 +46,7 @@ import {
     stringToRange,
     sortIgnoreCaseAndAccents,
     equalsIgnoreCaseAndAccents,
+    uuidv4,
 } from './utils.js';
 import { debounce_timeout } from './constants.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -24,7 +24,7 @@ import {
 } from '../script.js';
 import { persona_description_positions, power_user } from './power-user.js';
 import { getTokenCountAsync } from './tokenizers.js';
-import { PAGINATION_TEMPLATE, clearInfoBlock, debounce, delay, download, ensureImageFormatSupported, flashHighlight, getBase64Async, getCharIndex, isFalseBoolean, isTrueBoolean, onlyUnique, parseJsonFile, setInfoBlock, localizePagination, renderPaginationDropdown, paginationDropdownChangeHandler, addLongPressEvent, uuidv4 } from './utils.js';
+import { PAGINATION_TEMPLATE, clearInfoBlock, debounce, delay, download, ensureImageFormatSupported, flashHighlight, getBase64Async, getCharIndex, isFalseBoolean, isTrueBoolean, onlyUnique, parseJsonFile, setInfoBlock, localizePagination, renderPaginationDropdown, paginationDropdownChangeHandler, addLongPressEvent, stringToRange } from './utils.js';
 import { debounce_timeout } from './constants.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
 import { groups, selected_group } from './group-chats.js';
@@ -1760,15 +1760,22 @@ async function onPersonasRestoreInput(e) {
     $('#personas_restore_input').val('');
 }
 
-async function syncUserNameToPersona() {
-    const confirmation = await Popup.show.confirm(t`Are you sure?`, t`All user-sent messages in this chat will be attributed to ${name1}.`);
+async function syncUserNameToPersona({ start = 0, end = chat.length - 1, silent = false } = {}) {
+    const isRangeAll = start === 0 && end === chat.length - 1;
+    const confirmMessage = isRangeAll
+        ? t`All user-sent messages in this chat will be attributed to ${name1}.`
+        : t`User-sent messages in the specified range will be attributed to ${name1}.`;
 
-    if (!confirmation) {
-        return;
+    if (!silent) {
+        const confirmation = await Popup.show.confirm(t`Are you sure?`, confirmMessage);
+        if (!confirmation) {
+            return;
+        }
     }
 
-    for (const mes of chat) {
-        if (mes.is_user) {
+    for (let i = start; i <= end; i++) {
+        const mes = chat[i];
+        if (mes?.is_user) {
             mes.name = name1;
             mes.force_avatar = getThumbnailUrl('persona', user_avatar);
         }
@@ -1931,8 +1938,20 @@ async function setNameCallback({ mode = 'all' }, name) {
     return '';
 }
 
-function syncCallback() {
-    $('#sync_name_button').trigger('click');
+async function syncCallback(args, value) {
+    const range = value ? stringToRange(value, 0, chat.length - 1) : null;
+
+    if (value && !range) {
+        console.warn(`WARN: Invalid range provided for /persona-sync command: ${value}`);
+        return '';
+    }
+
+    const silent = isTrueBoolean(args?.silent);
+    const start = range ? range.start : 0;
+    const end = range ? range.end : chat.length - 1;
+
+    await syncUserNameToPersona({ start, end, silent });
+
     return '';
 }
 
@@ -1988,6 +2007,21 @@ function registerPersonaSlashCommands() {
         name: 'persona-sync',
         aliases: ['sync'],
         callback: syncCallback,
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'silent',
+                description: t`suppress the confirmation popup`,
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description: t`message index (starts with 0) or range, syncs all user messages if not provided`,
+                typeList: [ARGUMENT_TYPE.NUMBER, ARGUMENT_TYPE.RANGE],
+                defaultValue: '0-{{lastMessageId}}',
+            }),
+        ],
         helpString: 'Syncs the user persona in user-attributed messages in the current chat.',
     }));
 }

--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -2158,7 +2158,7 @@ export async function initPersonas() {
         debouncedPersonaSearch(searchQuery);
     });
 
-    $('#sync_name_button').on('click', syncUserNameToPersona);
+    $('#sync_name_button').on('click', async () => await syncUserNameToPersona());
     $('#avatar_upload_file').on('change', changeUserAvatar);
 
     $(document).on('click', '#user_avatar_block .avatar-container', async function () {


### PR DESCRIPTION
This PR significantly enhances the `/persona-sync` (aliased as `/sync`) slash command to give users more granular control over which messages get their persona synced. Previously, the command would always sync **all** user-sent messages in the current chat with a mandatory confirmation dialog. Now users can target specific message ranges, filter by previous persona names, and optionally suppress the confirmation popup.

### What Changed
- **Range targeting** – Sync specific message indices or ranges (e.g., `/sync 0-10`)
- **Name filtering** – Only sync messages that were previously sent under a specific persona name via the `from` argument (e.g., `/sync from=OldPersona`)
- **Quiet mode** – Skip the confirmation popup when desired via `quiet=true` (defaults to quiet mode for script automation)
- **Smart autocomplete** – Added enum provider that suggests existing user message names from the current chat for the `from` argument
- **Context-aware confirmation messages** – The confirmation dialog now clearly indicates whether you're syncing all messages, a specific range, filtered by name, or a combination

### Why These Changes
When users switch personas mid-chat or have used multiple temporary names, they often want to selectively re-attribute only certain messages to their current persona without affecting others. The previous all-or-nothing approach with a mandatory confirmation was limiting for:
- Users with long chat histories who only want to fix recent messages
- Automated scripts or extensions that need to sync personas without user interaction
- Scenarios where multiple personas were used intentionally and only specific ones need updating

### How It Works
The core `syncUserNameToPersona()` function now accepts an options object with `start`, `end`, `quiet`, and `nameFilter` parameters. The slash command callback parses the optional range argument and named arguments, delegating all logic to this shared function—ensuring consistency whether triggered via slash command or UI.

The `userMessageNamesEnumProvider()` scans the current chat for unique user message names, making it easy to discover and autocomplete previously used persona names when using the `from` filter.

### Impact
These changes make persona management significantly more flexible and scriptable while maintaining safety through the quiet mode toggle. Users can now precisely control which messages get re-attributed, and extension developers can leverage the sync functionality without interrupting the user experience with confirmation dialogs.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).