### PR TITLE
Fix incorrect translation of "New" button in World Info module

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4797,7 +4797,7 @@
                             <input type="file" id="world_import_file" accept=".json,.lorebook,.png" name="avatar" hidden>
                             <div id="world_create_button" class="menu_button menu_button_icon">
                                 <i class="fa-solid fa-globe"></i>
-                                <span data-i18n="New">New</span>
+                                <span data-i18n="Create">New</span>
                             </div>
                             <small data-i18n="or">or</small>
                             <select id="world_editor_select">

--- a/public/index.html
+++ b/public/index.html
@@ -4797,7 +4797,7 @@
                             <input type="file" id="world_import_file" accept=".json,.lorebook,.png" name="avatar" hidden>
                             <div id="world_create_button" class="menu_button menu_button_icon">
                                 <i class="fa-solid fa-globe"></i>
-                                <span data-i18n="Create">New</span>
+                                <span data-i18n="Create">Create</span>
                             </div>
                             <small data-i18n="or">or</small>
                             <select id="world_editor_select">

--- a/public/locales/zh-cn.json
+++ b/public/locales/zh-cn.json
@@ -395,7 +395,7 @@
     "Date Desc": "日期倒序",
     "category": "分类",
     "Top": "热门",
-    "New": "新建",
+    "New": "最新",
     "All": "全部",
     "All Classes": "所有分类",
     "Toggle grid view": "切换网格视图",

--- a/public/locales/zh-cn.json
+++ b/public/locales/zh-cn.json
@@ -395,7 +395,7 @@
     "Date Desc": "日期倒序",
     "category": "分类",
     "Top": "热门",
-    "New": "最新",
+    "New": "新建",
     "All": "全部",
     "All Classes": "所有分类",
     "Toggle grid view": "切换网格视图",


### PR DESCRIPTION
## Description
Fixed a translation error in the World Info module where the "New" button was incorrectly translated to "最新" (Latest) in Chinese. The correct translation should be "新建" (Create New).

### Changes
- Updated the translation of the "New" button from "最新" to "新建" in the World Info module

### Context
Before: The button text implied "View latest World Info" (查看最新的 world info)  
After: The button text correctly conveys "Create a World Info" (创建一个 world info)


## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
