### PR TITLE
fix: limit max-height of select[multiple] on mobile to prevent Chrome 145+ full-screen rendering

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -500,6 +500,11 @@
     .horde_multiple_hint {
         display: none;
     }
+
+    select[multiple] {
+        max-height: 50px;
+        overflow-y: auto;
+    }
 }
 
 /*landscape mode phones and ipads*/


### PR DESCRIPTION
Fixes #5242

## Problem

Chrome 145+ significantly changed how native `<select multiple>` elements are rendered on Android — they now display as oversized, nearly full-screen selection lists. This happens because multiple Select2 dropdowns across the project are wrapped in `if (!isMobile())` guards, causing them to fall back to native `<select>` elements on mobile browsers, which with Chrome 145+ renders very poorly.

## Solution

As suggested by @Cohee1207, add a `max-height: 50px` constraint on `select[multiple]` within the mobile CSS breakpoint (`max-width: 1000px`). This prevents the full-screen rendering introduced in Chrome 145+ while keeping the element scrollable via `overflow-y: auto`.

```css
select[multiple] {
    max-height: 50px;
    overflow-y: auto;
}
```

## Testing

- Open SillyTavern on Android using Chrome 145+
- Navigate to World Info settings → Global lorebook selector
- The dropdown should no longer render as a huge full-screen multi-select list
- The native `<select>` element should be constrained to 50px height and scrollable