### PR TITLE
Fix missing filename sanitization on character JSON import + sanitize existing bad filenames on disk

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -889,7 +889,8 @@ async function importFromJson(uploadPath, { request }, preservedFileName) {
         unsetPrivateFields(jsonData);
         jsonData = readFromV2(jsonData);
         jsonData.create_date = new Date().toISOString();
-        const pngName = preservedFileName || getPngName(jsonData.data?.name || jsonData.name, request.user.directories);
+        jsonData.name = sanitize(jsonData.data?.name || jsonData.name);
+        const pngName = preservedFileName || getPngName(jsonData.name, request.user.directories);
         const char = JSON.stringify(jsonData);
         const result = await writeCharacterData(DEFAULT_AVATAR_PATH, char, pngName, request);
         return result ? pngName : '';
@@ -1318,7 +1319,8 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
 router.post('/all', async function (request, response) {
     try {
         const files = fs.readdirSync(request.user.directories.characters);
-        const pngFiles = files.filter(file => file.endsWith('.png'));
+        const pngFiles = files.filter(file => file.endsWith('.png'))
+            .map(file => sanitizeOnDiskFileName(file, request.user.directories));
         const processingPromises = pngFiles.map(file => processCharacter(file, request.user.directories, { shallow: useShallowCharacters }));
         const data = (await Promise.all(processingPromises)).filter(c => c.name);
         return response.send(data);
@@ -1387,12 +1389,53 @@ router.post('/chats', validateAvatarUrlMiddleware, async function (request, resp
 });
 
 /**
+ * Checks if a character file on disk has an unsanitized filename and renames it if needed.
+ * Also renames the associated chats directory to keep them in sync.
+ * @param {string} fileName The original filename (e.g. "Maya \ Lisa.png")
+ * @param {import('../users.js').UserDirectoryList} directories User directories
+ * @returns {string} The sanitized filename, or the original if no change was needed
+ */
+function sanitizeOnDiskFileName(fileName, directories) {
+    const nameWithoutExt = path.parse(fileName).name;
+    const sanitizedName = sanitize(nameWithoutExt);
+
+    if (sanitizedName === nameWithoutExt) {
+        return fileName;
+    }
+
+    const newInternalName = getPngName(sanitizedName, directories);
+    const newFileName = `${newInternalName}.png`;
+
+    const oldFilePath = path.join(directories.characters, fileName);
+    const newFilePath = path.join(directories.characters, newFileName);
+
+    try {
+        fs.renameSync(oldFilePath, newFilePath);
+        console.info(`Sanitized character filename: "${fileName}" -> "${newFileName}"`);
+
+        const oldChatsDir = path.join(directories.chats, nameWithoutExt);
+        const newChatsDir = path.join(directories.chats, newInternalName);
+
+        if (fs.existsSync(oldChatsDir) && !fs.existsSync(newChatsDir)) {
+            fs.renameSync(oldChatsDir, newChatsDir);
+            console.info(`Renamed chat directory: "${nameWithoutExt}" -> "${newInternalName}"`);
+        }
+    } catch (err) {
+        console.error(`Failed to sanitize character filename: ${fileName}`, err);
+        return fileName;
+    }
+
+    return newFileName;
+}
+
+/**
  * Gets the name for the uploaded PNG file.
  * @param {string} file File name
  * @param {import('../users.js').UserDirectoryList} directories User directories
  * @returns {string} - The name for the uploaded PNG file
  */
 function getPngName(file, directories) {
+    file = sanitize(file);
     let i = 1;
     const baseName = file;
     while (fs.existsSync(path.join(directories.characters, `${file}.png`))) {

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -890,6 +890,9 @@ async function importFromJson(uploadPath, { request }, preservedFileName) {
         jsonData = readFromV2(jsonData);
         jsonData.create_date = new Date().toISOString();
         jsonData.name = sanitize(jsonData.data?.name || jsonData.name);
+        if (jsonData.data?.name) {
+            jsonData.data.name = jsonData.name;
+        }
         const pngName = preservedFileName || getPngName(jsonData.name, request.user.directories);
         const char = JSON.stringify(jsonData);
         const result = await writeCharacterData(DEFAULT_AVATAR_PATH, char, pngName, request);
@@ -1403,9 +1406,21 @@ function sanitizeOnDiskFileName(fileName, directories) {
         return fileName;
     }
 
-    const newInternalName = getPngName(sanitizedName, directories);
-    const newFileName = `${newInternalName}.png`;
+    const oldChatsDir = path.join(directories.chats, nameWithoutExt);
+    const hasChats = fs.existsSync(oldChatsDir);
 
+    // Find a unique name where both the avatar file and chat directory (if applicable) don't conflict
+    const newInternalName = getUniqueName(sanitizedName, (name) =>
+        fs.existsSync(path.join(directories.characters, `${name}.png`)) ||
+        (hasChats && fs.existsSync(path.join(directories.chats, name))),
+    { nameBuilder: (base, i) => i === 0 ? base : `${base}${i}`, startIndex: 0 });
+
+    if (!newInternalName) {
+        console.error(`Failed to find a unique sanitized name for: ${fileName}`);
+        return fileName;
+    }
+
+    const newFileName = `${newInternalName}.png`;
     const oldFilePath = path.join(directories.characters, fileName);
     const newFilePath = path.join(directories.characters, newFileName);
 
@@ -1413,10 +1428,8 @@ function sanitizeOnDiskFileName(fileName, directories) {
         fs.renameSync(oldFilePath, newFilePath);
         console.info(`Sanitized character filename: "${fileName}" -> "${newFileName}"`);
 
-        const oldChatsDir = path.join(directories.chats, nameWithoutExt);
-        const newChatsDir = path.join(directories.chats, newInternalName);
-
-        if (fs.existsSync(oldChatsDir) && !fs.existsSync(newChatsDir)) {
+        if (hasChats) {
+            const newChatsDir = path.join(directories.chats, newInternalName);
             fs.renameSync(oldChatsDir, newChatsDir);
             console.info(`Renamed chat directory: "${nameWithoutExt}" -> "${newInternalName}"`);
         }
@@ -1436,13 +1449,8 @@ function sanitizeOnDiskFileName(fileName, directories) {
  */
 function getPngName(file, directories) {
     file = sanitize(file);
-    let i = 1;
-    const baseName = file;
-    while (fs.existsSync(path.join(directories.characters, `${file}.png`))) {
-        file = baseName + i;
-        i++;
-    }
-    return file;
+    return getUniqueName(file, (name) => fs.existsSync(path.join(directories.characters, `${name}.png`)),
+        { nameBuilder: (base, i) => i === 0 ? base : `${base}${i}`, startIndex: 0 }) ?? file;
 }
 
 /**


### PR DESCRIPTION
Character filenames were not consistently sanitized across all import paths, allowing characters with special characters (like backslashes) in their name to be saved with those characters in the filename. This breaks avatar loading, because the avatar is served via a URL — and characters like `\` in a URL path don't resolve correctly.

### What Changed

- **Added missing `sanitize()` call in the JSON V2 import path** — the direct bug fix
- **Added `sanitize()` as a safety net inside `getPngName`** — defense-in-depth against future oversights
- **Added `sanitizeOnDiskFileName` helper + integrated it into the `/all` endpoint** — fixes already-broken files on disk

### Why These Changes

A user reported that importing a character whose name contained a backslash (valid on Linux filesystems, not on Windows) resulted in the character being saved with that backslash in its `.png` filename. The character loaded fine in the UI and could be chatted with, but the **avatar image would not display** — because requesting `/characters/Maya \ Lisa.png` over HTTP doesn't work.

Investigation revealed that **every import path** (`importFromYaml`, `importFromCharX`, `importFromByaf`, `importFromPng`, and two of three branches in `importFromJson`) already called `sanitize()` on the character name before determining the filename. The **one exception** was the V2 spec branch of `importFromJson` — which is the most commonly used path for modern character cards. The name was passed directly to `getPngName` without sanitization.

This also raised the question: what happens if someone manually drops a file with a bad name into the characters folder on a Linux server? The `/all` endpoint reads filenames from disk as-is. If a file already has problematic characters, it would be returned to the frontend with a broken avatar URL — same symptom, different cause.

### How It Works

1. **Import fix**: The V2 spec branch of `importFromJson` now sanitizes the character name (via `sanitize-filename`) before using it to derive the output `.png` filename — matching what all other import paths already do.

2. **`getPngName` safety net**: This function is the central point that turns a character name into a unique filename. Adding `sanitize()` at the top ensures that even if a future import path forgets to sanitize, the filename will still be safe. Since `sanitize()` is idempotent, double-calling it from both the import function and `getPngName` is harmless.

3. **On-disk cleanup**: A new `sanitizeOnDiskFileName` helper checks each `.png` file during character list loading. If the filename differs from its sanitized version, it renames the file on disk and also renames the associated chats directory to keep them in sync. If the rename fails for any reason, the original filename is kept — no data is lost. This runs transparently on the first `/all` request and only affects files that actually need renaming.

### Impact

- Characters with special characters in their name will now always get a clean filename on import
- Existing broken files on disk are automatically fixed when the character list is loaded
- Avatar images will load correctly for affected characters
- Chat history is preserved through the rename (chats directory is moved along with the file)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).