### PR TITLE
Bulk extension field updates via merge-attributes with UNSET_VALUE sentinel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -549,6 +549,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
             "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/core": "^0.22.12"
             }
@@ -1010,6 +1011,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
             "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/core": "1.6.0",
                 "@jimp/types": "1.6.0",
@@ -1041,6 +1043,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
             "integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1136,6 +1139,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
             "integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1172,6 +1176,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
             "integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12",
                 "tinycolor2": "^1.6.0"
@@ -1215,6 +1220,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
             "integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1302,6 +1308,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
             "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1314,6 +1321,7 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
             "integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1914,6 +1922,7 @@
             "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -2603,6 +2612,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3222,6 +3232,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -4556,6 +4567,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -8113,6 +8125,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -9130,6 +9143,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -549,7 +549,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
             "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/core": "^0.22.12"
             }
@@ -1011,7 +1010,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
             "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/core": "1.6.0",
                 "@jimp/types": "1.6.0",
@@ -1043,7 +1041,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
             "integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1139,7 +1136,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
             "integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1176,7 +1172,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
             "integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12",
                 "tinycolor2": "^1.6.0"
@@ -1220,7 +1215,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
             "integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1308,7 +1302,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
             "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1321,7 +1314,6 @@
             "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
             "integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jimp/utils": "^0.22.12"
             },
@@ -1922,7 +1914,6 @@
             "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -2612,7 +2603,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3232,7 +3222,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -4567,7 +4556,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -8125,7 +8113,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -9143,7 +9130,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -3,7 +3,7 @@ import { DOMPurify, Popper } from '../lib.js';
 import { eventSource, event_types, saveSettings, saveSettingsDebounced, getRequestHeaders, animation_duration, CLIENT_VERSION } from '../script.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup } from './popup.js';
 import { renderTemplate, renderTemplateAsync } from './templates.js';
-import { delay, equalsIgnoreCaseAndAccents, isSubsetOf, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';
+import { delay, deleteValueByPath, equalsIgnoreCaseAndAccents, isSubsetOf, sanitizeSelector, setValueByPath, versionCompare } from './utils.js';
 import { getContext } from './st-context.js';
 import { isAdmin } from './user.js';
 import { addLocaleData, getCurrentLocale, t } from './i18n.js';
@@ -1840,6 +1840,18 @@ export async function runGenerationInterceptors(chat, contextSize, type) {
 }
 
 /**
+ * Sentinel value that signals a field should be completely removed (unset)
+ * from the character card rather than being set to any value. Pass this as
+ * the `value` argument to {@link writeExtensionField} or
+ * {@link writeExtensionFieldBulk} to delete the key entirely.
+ *
+ * Using `null` as a value will set the field to `null` (the key remains).
+ * Using this sentinel will delete the key from the character card.
+ * @type {string}
+ */
+export const UNSET_VALUE = '__@@UNSET@@__';
+
+/**
  * Writes a field to the character's data extensions object.
  * @param {number|string} characterId Index in the character array
  * @param {string} key Field name
@@ -1853,13 +1865,23 @@ export async function writeExtensionField(characterId, key, value) {
         console.warn('Character not found', characterId);
         return;
     }
-    const path = `data.extensions.${key}`;
-    setValueByPath(character, path, value);
+    const extensionPath = `data.extensions.${key}`;
+    const isUnset = value === UNSET_VALUE;
+
+    if (isUnset) {
+        deleteValueByPath(character, extensionPath);
+    } else {
+        setValueByPath(character, extensionPath, value);
+    }
 
     // Process JSON data
     if (character.json_data) {
         const jsonData = JSON.parse(character.json_data);
-        setValueByPath(jsonData, path, value);
+        if (isUnset) {
+            deleteValueByPath(jsonData, extensionPath);
+        } else {
+            setValueByPath(jsonData, extensionPath, value);
+        }
         character.json_data = JSON.stringify(jsonData);
 
         // Make sure the data doesn't get lost when saving the current character
@@ -1886,6 +1908,106 @@ export async function writeExtensionField(characterId, key, value) {
     if (!mergeResponse.ok) {
         console.error('Failed to save extension field', mergeResponse.statusText);
     }
+}
+
+/**
+ * @typedef {object} BulkExtensionFieldResult
+ * @property {string[]} updated  Avatar filenames that were successfully updated
+ * @property {string[]} skipped  Avatar filenames skipped (filter didn't match or unreadable)
+ * @property {string[]} failed   Avatar filenames where the update failed
+ */
+
+/**
+ * Writes (or deletes) an extension field for multiple characters in a single
+ * bulk request. Unlike {@link writeExtensionField}, this sends one API call
+ * for all characters, and the server processes them in parallel.
+ *
+ * When `value` is {@link UNSET_VALUE} the extension key is **deleted** from
+ * each matching character card. Passing `null` sets the field to `null`
+ * (the key is preserved).
+ *
+ * @param {string[]|null} avatars Avatar filenames to update. Pass `null` or an
+ *   empty array to target **all** characters in the user's character directory.
+ * @param {string} key Extension field name (e.g. "greeting_tools")
+ * @param {any} value Field value, `null` to set null, or
+ *   {@link UNSET_VALUE} to delete the key entirely
+ * @param {object} [options={}] Optional settings
+ * @param {string} [options.filterPath] Dot-path filter — the server will only
+ *   update characters where this path exists and is non-null. Useful when the
+ *   frontend has shallow character data and cannot pre-filter.
+ *   Defaults to `data.extensions.<key>` when unsetting, so deletion requests
+ *   automatically skip characters that don't have the field.
+ * @returns {Promise<BulkExtensionFieldResult>} Summary of the bulk operation
+ */
+export async function writeExtensionFieldBulk(avatars, key, value, { filterPath } = {}) {
+    const context = getContext();
+    const extensionPath = `data.extensions.${key}`;
+    const isUnset = value === UNSET_VALUE;
+
+    // Build the server request
+    const requestBody = {
+        avatars: Array.isArray(avatars) && avatars.length > 0 ? avatars : [],
+        data: {
+            data: {
+                extensions: {
+                    [key]: value,
+                },
+            },
+        },
+    };
+
+    // Default filter: when unsetting, only touch characters that have the field
+    const resolvedFilterPath = filterPath ?? (isUnset ? extensionPath : undefined);
+    if (resolvedFilterPath) {
+        requestBody.filter = { path: resolvedFilterPath };
+    }
+
+    const mergeResponse = await fetch('/api/characters/merge-attributes', {
+        method: 'POST',
+        headers: getRequestHeaders(),
+        body: JSON.stringify(requestBody),
+    });
+
+    if (!mergeResponse.ok) {
+        console.error('Bulk extension field update failed', mergeResponse.statusText);
+        return { updated: [], skipped: [], failed: [] };
+    }
+
+    /** @type {BulkExtensionFieldResult} */
+    const result = await mergeResponse.json();
+
+    // Sync in-memory character objects for successfully updated characters
+    const updatedSet = new Set(result.updated);
+    for (const character of context.characters) {
+        if (!character || !updatedSet.has(character.avatar)) continue;
+
+        if (isUnset) {
+            deleteValueByPath(character, extensionPath);
+        } else {
+            setValueByPath(character, extensionPath, value);
+        }
+
+        // Keep json_data in sync
+        if (character.json_data) {
+            const jsonData = JSON.parse(character.json_data);
+            if (isUnset) {
+                deleteValueByPath(jsonData, extensionPath);
+            } else {
+                setValueByPath(jsonData, extensionPath, value);
+            }
+            character.json_data = JSON.stringify(jsonData);
+        }
+    }
+
+    // If the currently active character was updated, sync the hidden input
+    if (context.characterId !== undefined) {
+        const activeChar = context.characters[context.characterId];
+        if (activeChar && updatedSet.has(activeChar.avatar) && activeChar.json_data) {
+            $('#character_json_data').val(activeChar.json_data);
+        }
+    }
+
+    return result;
 }
 
 /**

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1933,10 +1933,11 @@ export async function writeExtensionField(characterId, key, value) {
  *   {@link UNSET_VALUE} to delete the key entirely
  * @param {object} [options={}] Optional settings
  * @param {string} [options.filterPath] Dot-path filter — the server will only
- *   update characters where this path exists and is non-null. Useful when the
- *   frontend has shallow character data and cannot pre-filter.
+ *   update characters where this path is present and not `undefined`;
+ *   `null` still counts as a match. Useful when the frontend has shallow
+ *   character data and cannot pre-filter.
  *   Defaults to `data.extensions.<key>` when unsetting, so deletion requests
- *   automatically skip characters that don't have the field.
+ *   automatically skip characters where the field is missing/`undefined`.
  * @returns {Promise<BulkExtensionFieldResult>} Summary of the bulk operation
  */
 export async function writeExtensionFieldBulk(avatars, key, value, { filterPath } = {}) {

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -77,7 +77,9 @@ import {
     renderExtensionTemplate,
     renderExtensionTemplateAsync,
     saveMetadataDebounced,
+    UNSET_VALUE,
     writeExtensionField,
+    writeExtensionFieldBulk,
 } from './extensions.js';
 import { groups, openGroupChat, selected_group, unshallowGroupMembers } from './group-chats.js';
 import { addLocaleData, getCurrentLocale, t, translate } from './i18n.js';
@@ -202,6 +204,7 @@ export function getContext() {
         generateRaw,
         generateRawData,
         writeExtensionField,
+        writeExtensionFieldBulk,
         getThumbnailUrl,
         selectCharacterById,
         messageFormatting,
@@ -295,6 +298,9 @@ export function getContext() {
         openThirdPartyExtensionMenu,
         symbols: {
             ignore: IGNORE_SYMBOL,
+        },
+        constants: {
+            unset: UNSET_VALUE,
         },
     };
 }

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2062,6 +2062,23 @@ export function setValueByPath(obj, path, value) {
 }
 
 /**
+ * Deletes a value from a nested object at the given dot-separated path.
+ * @param {object} obj Object to delete from
+ * @param {string} path Dot-separated key path (e.g. "data.extensions.myKey")
+ */
+export function deleteValueByPath(obj, path) {
+    const keyParts = path.split('.');
+    let current = obj;
+    for (let i = 0; i < keyParts.length - 1; i++) {
+        if (!current || typeof current !== 'object') return;
+        current = current[keyParts[i]];
+    }
+    if (current && typeof current === 'object') {
+        delete current[keyParts[keyParts.length - 1]];
+    }
+}
+
+/**
  * Flashes the given HTML element via CSS flash animation for a defined period
  * @param {JQuery<HTMLElement>} element - The element to flash
  * @param {number} timespan - A number in milliseconds how the flash should last (default is 2000ms.  Multiples of 1000ms work best, as they end with the flash animation being at 100% opacity)

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1322,7 +1322,7 @@ router.post('/merge-attributes', getFileNameValidationFunction('avatar'), async 
             let targetAvatars;
             if (avatars.length > 0) {
                 for (const avatar of avatars) {
-                    if (typeof avatar !== 'string' || forbiddenRegExp.test(avatar)) {
+                    if (typeof avatar !== 'string' || forbiddenRegExp.test(avatar) || path.extname(avatar).toLowerCase() !== '.png') {
                         return response.status(400).send({ message: `Invalid avatar filename: ${avatar}` });
                     }
                 }
@@ -1330,7 +1330,7 @@ router.post('/merge-attributes', getFileNameValidationFunction('avatar'), async 
             } else {
                 // Empty array → scan all characters in the directory
                 const files = fs.readdirSync(request.user.directories.characters);
-                targetAvatars = files.filter(file => file.endsWith('.png'));
+                targetAvatars = files.filter(file => path.extname(file).toLowerCase() === '.png');
             }
 
             const updated = [];

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -13,7 +13,7 @@ import { Jimp, JimpMime } from '../jimp.js';
 import storage from 'node-persist';
 
 import { AVATAR_WIDTH, AVATAR_HEIGHT, DEFAULT_AVATAR_PATH } from '../constants.js';
-import { default as validateAvatarUrlMiddleware, getFileNameValidationFunction } from '../middleware/validateFileName.js';
+import { default as validateAvatarUrlMiddleware, getFileNameValidationFunction, forbiddenRegExp } from '../middleware/validateFileName.js';
 import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements } from '../util.js';
 import { TavernCardValidator } from '../validator/TavernCardValidator.js';
 import { parse, read, write } from '../character-card-parser.js';
@@ -1321,7 +1321,6 @@ router.post('/merge-attributes', getFileNameValidationFunction('avatar'), async 
             // Determine which avatar files to process
             let targetAvatars;
             if (avatars.length > 0) {
-                const forbiddenRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
                 for (const avatar of avatars) {
                     if (typeof avatar !== 'string' || forbiddenRegExp.test(avatar)) {
                         return response.status(400).send({ message: `Invalid avatar filename: ${avatar}` });

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1314,8 +1314,8 @@ router.post('/merge-attributes', getFileNameValidationFunction('avatar'), async 
         if (Array.isArray(request.body.avatars)) {
             const { avatars, data, filter } = request.body;
 
-            if (!data || typeof data !== 'object') {
-                return response.status(400).send({ message: 'No update data provided.' });
+            if (!_.isPlainObject(data)) {
+                return response.status(400).send({ message: 'No valid update data provided.' });
             }
 
             // Determine which avatar files to process

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1220,45 +1220,179 @@ router.post('/edit-attribute', validateAvatarUrlMiddleware, async function (requ
 });
 
 /**
+ * Sentinel value that signals a field should be completely removed (unset)
+ * from the character card rather than being set to any value. Use this in
+ * the merge payload wherever a key should be deleted.
+ *
+ * Both the server and the frontend share this constant so that callers can
+ * explicitly opt into deletion without overloading `null`.
+ * @type {string}
+ */
+const UNSET_SENTINEL = '__@@UNSET@@__';
+
+/** Maximum number of characters processed in parallel during bulk merge */
+const BULK_MERGE_CONCURRENCY = 10;
+
+/**
+ * Recursively walks `source` and removes any key from `target` whose
+ * corresponding value in `source` equals the {@link UNSET_SENTINEL}.
+ * Called after {@link deepMerge} so that the sentinel gets replaced by
+ * an actual key deletion.
+ * @param {object} target The merged character object to clean up
+ * @param {object} source The original update payload (pre-merge clone)
+ */
+function processUnsetSentinels(target, source) {
+    for (const key of Object.keys(source)) {
+        if (source[key] === UNSET_SENTINEL) {
+            _.unset(target, key);
+        } else if (_.isPlainObject(source[key]) && _.isPlainObject(target[key])) {
+            processUnsetSentinels(target[key], source[key]);
+        }
+    }
+}
+
+/**
+ * Reads a character card, applies a merge update (with sentinel-based
+ * unsetting), validates the result, and writes it back.
+ * @param {string} avatarPath Full path to the character PNG
+ * @param {string} avatar     Avatar filename (e.g. "char.png")
+ * @param {object} updateData The merge payload to apply
+ * @param {import("express").Request} request Express request object
+ * @returns {Promise<{ok: boolean, error?: string}>}
+ */
+async function mergeCharacterUpdate(avatarPath, avatar, updateData, request) {
+    const pngStringData = await readCharacterData(avatarPath);
+    if (!pngStringData) {
+        return { ok: false, error: 'Invalid character file' };
+    }
+
+    let character = JSON.parse(pngStringData);
+
+    const update = _.cloneDeep(updateData);
+    _.unset(update, 'json_data');
+    _.unset(character, 'json_data');
+
+    character = deepMerge(character, update);
+    processUnsetSentinels(character, update);
+
+    const validator = new TavernCardValidator(character);
+    //Accept either V1 or V2.
+    if (!validator.validate()) {
+        return { ok: false, error: validator.lastValidationError ?? 'Validation failed' };
+    }
+
+    const targetImg = avatar.replace('.png', '');
+    await writeCharacterData(avatarPath, JSON.stringify(character), targetImg, request);
+    return { ok: true };
+}
+
+/**
  * Handle a POST request to edit character properties.
  *
- * Merges the request body with the selected character and
- * validates the result against TavernCard V2 specification.
+ * Operates in two modes depending on the request body:
  *
- * @param {Object} request - The HTTP request object.
- * @param {Object} response - The HTTP response object.
+ * **Single mode** (default behavior) — when `avatar` (string) is present:
+ *   Merges the request body with the selected character and validates the
+ *   result against TavernCard V2 specification.
  *
+ * **Bulk mode** — when `avatars` (array) is present:
+ *   Applies the same merge to multiple characters in parallel. Supports:
+ *   - An explicit list of avatars, or all characters when the array is empty
+ *   - An optional server-side `filter` so only characters where a given
+ *     JSON path exists and is non-null are updated
+ *
+ * In both modes, any value equal to the sentinel `__@@UNSET@@__` will cause
+ * that key to be **deleted** from the character card instead of being set.
+ *
+ * @param {import("express").Request} request - The HTTP request object
+ * @param {import("express").Response} response - The HTTP response object
  * @returns {void}
- * */
+ */
 router.post('/merge-attributes', getFileNameValidationFunction('avatar'), async function (request, response) {
     try {
+        // ── Bulk mode: avatars array is present ──────────────────
+        if (Array.isArray(request.body.avatars)) {
+            const { avatars, data, filter } = request.body;
+
+            if (!data || typeof data !== 'object') {
+                return response.status(400).send({ message: 'No update data provided.' });
+            }
+
+            // Determine which avatar files to process
+            let targetAvatars;
+            if (avatars.length > 0) {
+                const forbiddenRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
+                for (const avatar of avatars) {
+                    if (typeof avatar !== 'string' || forbiddenRegExp.test(avatar)) {
+                        return response.status(400).send({ message: `Invalid avatar filename: ${avatar}` });
+                    }
+                }
+                targetAvatars = avatars;
+            } else {
+                // Empty array → scan all characters in the directory
+                const files = fs.readdirSync(request.user.directories.characters);
+                targetAvatars = files.filter(file => file.endsWith('.png'));
+            }
+
+            const updated = [];
+            const skipped = [];
+            const failed = [];
+
+            /**
+             * Process a single character in bulk: read, filter, merge, validate, write.
+             * @param {string} avatar Avatar filename
+             */
+            const processOne = async (avatar) => {
+                const avatarPath = path.join(request.user.directories.characters, avatar);
+
+                try {
+                    // Apply optional server-side filter before reading the full card
+                    if (filter && typeof filter.path === 'string') {
+                        const pngStringData = await readCharacterData(avatarPath);
+                        if (!pngStringData) {
+                            skipped.push(avatar);
+                            return;
+                        }
+                        const character = JSON.parse(pngStringData);
+                        const existingValue = _.get(character, filter.path);
+                        if (existingValue === undefined || existingValue === null) {
+                            skipped.push(avatar);
+                            return;
+                        }
+                    }
+
+                    const result = await mergeCharacterUpdate(avatarPath, avatar, data, request);
+                    if (result.ok) {
+                        updated.push(avatar);
+                    } else {
+                        console.warn(`Bulk merge failed for ${avatar}:`, result.error);
+                        failed.push(avatar);
+                    }
+                } catch (error) {
+                    console.error(`Bulk merge failed for ${avatar}:`, error);
+                    failed.push(avatar);
+                }
+            };
+
+            // Process in parallel with a concurrency limit
+            for (let i = 0; i < targetAvatars.length; i += BULK_MERGE_CONCURRENCY) {
+                const batch = targetAvatars.slice(i, i + BULK_MERGE_CONCURRENCY);
+                await Promise.allSettled(batch.map(processOne));
+            }
+
+            return response.send({ updated, skipped, failed });
+        }
+
+        // ── Single mode (default behavior) ───────────────────────
         const update = request.body;
         const avatarPath = path.join(request.user.directories.characters, update.avatar);
 
-        const pngStringData = await readCharacterData(avatarPath);
-
-        if (!pngStringData) {
-            console.error('Error: invalid character file.');
-            return response.status(400).send('Error: invalid character file.');
-        }
-
-        let character = JSON.parse(pngStringData);
-
-        _.unset(update, 'json_data');
-        _.unset(character, 'json_data');
-
-        character = deepMerge(character, update);
-
-        const validator = new TavernCardValidator(character);
-        const targetImg = (update.avatar).replace('.png', '');
-
-        //Accept either V1 or V2.
-        if (validator.validate()) {
-            await writeCharacterData(avatarPath, JSON.stringify(character), targetImg, request);
+        const result = await mergeCharacterUpdate(avatarPath, update.avatar, update, request);
+        if (result.ok) {
             response.sendStatus(200);
         } else {
-            console.warn(validator.lastValidationError);
-            response.status(400).send({ message: `Validation failed for ${character.name}`, error: validator.lastValidationError });
+            console.warn(result.error);
+            response.status(400).send({ message: `Validation failed for ${update.avatar}`, error: result.error });
         }
     } catch (exception) {
         response.status(500).send({ message: 'Unexpected error while saving character.', error: exception.toString() });

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1355,7 +1355,7 @@ router.post('/merge-attributes', getFileNameValidationFunction('avatar'), async 
                         }
                         const character = JSON.parse(pngStringData);
                         const existingValue = _.get(character, filter.path);
-                        if (existingValue === undefined || existingValue === null) {
+                        if (existingValue === undefined) {
                             skipped.push(avatar);
                             return;
                         }

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1258,15 +1258,20 @@ function processUnsetSentinels(target, source) {
  * @param {string} avatar     Avatar filename (e.g. "char.png")
  * @param {object} updateData The merge payload to apply
  * @param {import("express").Request} request Express request object
- * @returns {Promise<{ok: boolean, error?: string}>}
+ * @param {((data: any) => boolean) | null} [shouldSkip] Optional function to determine if a character should be skipped based on its original data (used for bulk merge filtering)
+ * @returns {Promise<{ok: boolean, error?: string, skipped?: boolean}>} Result of the merge operation, including any validation error
  */
-async function mergeCharacterUpdate(avatarPath, avatar, updateData, request) {
+async function mergeCharacterUpdate(avatarPath, avatar, updateData, request, shouldSkip = null) {
     const pngStringData = await readCharacterData(avatarPath);
     if (!pngStringData) {
         return { ok: false, error: 'Invalid character file' };
     }
 
     let character = JSON.parse(pngStringData);
+
+    if (typeof shouldSkip === 'function' && shouldSkip(character)) {
+        return { ok: false, skipped: true };
+    }
 
     const update = _.cloneDeep(updateData);
     _.unset(update, 'json_data');
@@ -1345,24 +1350,22 @@ router.post('/merge-attributes', getFileNameValidationFunction('avatar'), async 
                 const avatarPath = path.join(request.user.directories.characters, avatar);
 
                 try {
-                    // Apply optional server-side filter before reading the full card
+                    /** @type {(character: object) => boolean} */
+                    let shouldSkip = () => false;
+
+                    // Apply optional server-side filter before updating the card
                     if (filter && typeof filter.path === 'string') {
-                        const pngStringData = await readCharacterData(avatarPath);
-                        if (!pngStringData) {
-                            skipped.push(avatar);
-                            return;
-                        }
-                        const character = JSON.parse(pngStringData);
-                        const existingValue = _.get(character, filter.path);
-                        if (existingValue === undefined) {
-                            skipped.push(avatar);
-                            return;
-                        }
+                        shouldSkip = (character) => {
+                            const value = _.get(character, filter.path);
+                            return value === undefined;
+                        };
                     }
 
-                    const result = await mergeCharacterUpdate(avatarPath, avatar, data, request);
+                    const result = await mergeCharacterUpdate(avatarPath, avatar, data, request, shouldSkip);
                     if (result.ok) {
                         updated.push(avatar);
+                    } else if (result.skipped) {
+                        skipped.push(avatar);
                     } else {
                         console.warn(`Bulk merge failed for ${avatar}:`, result.error);
                         failed.push(avatar);

--- a/src/middleware/validateFileName.js
+++ b/src/middleware/validateFileName.js
@@ -1,5 +1,7 @@
 import path from 'node:path';
 
+export const forbiddenRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
+
 /**
  * Checks if an object has a toString method.
  * @param {object} o Object to check
@@ -23,7 +25,6 @@ export function getFileNameValidationFunction(fieldName) {
     */
     return function validateAvatarUrlMiddleware(req, res, next) {
         if (req.body && fieldName in req.body && (typeof req.body[fieldName] === 'string' || hasToString(req.body[fieldName]))) {
-            const forbiddenRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
             if (forbiddenRegExp.test(req.body[fieldName])) {
                 console.error('An error occurred while validating the request body', {
                     handle: req.user.profile.handle,


### PR DESCRIPTION
Extensions that store data inside character cards currently have no efficient way to update or clean that data across many characters at once. Each character requires its own API round-trip to `/merge-attributes`, which makes cleanup routines painfully slow — especially when hundreds or thousands of characters are involved, and even more so when shallow character loading is enabled (where the frontend doesn't even know which characters have the field set).

This PR extends the existing `/merge-attributes` endpoint to support bulk operations and introduces a sentinel-based mechanism for explicitly deleting keys from character cards.

### What Changed

- **Bulk mode for `/merge-attributes`** — The existing endpoint now accepts an `avatars` array in the request body to trigger bulk mode. When present, the server applies the same merge update to all targeted characters in parallel (batches of 10). Passing an empty array scans all characters in the directory automatically. Single-mode behavior (sending a single `avatar` string) is completely unchanged.

- **Server-side filtering** — Bulk requests can include an optional `filter` with a dot-path. The server checks each character card and only updates those where the specified path exists and is non-null. This solves the shallow-character problem: the frontend doesn't need to know which characters have a given field — it lets the server figure it out by reading the actual card data from disk.

- **`UNSET_VALUE` sentinel for key deletion** — A shared sentinel constant (`'__@@UNSET@@__'`) that explicitly signals "delete this key from the character card." This replaces the previous ambiguity around `null` — now `null` means "set the field to null" (the key stays), while `UNSET_VALUE` means "remove the key entirely." Supported in both `writeExtensionField` (single) and `writeExtensionFieldBulk` (bulk).

- **`writeExtensionFieldBulk` frontend utility** — A new exported function in `extensions.js` that wraps the bulk endpoint. Handles request construction, smart default filtering for deletion, and keeps all in-memory character objects in sync after the server responds.

- **`deleteValueByPath` utility** — A new general-purpose utility in `utils.js` (counterpart to the existing `setValueByPath`) for deleting nested object keys by dot-path.

- **Shared `mergeCharacterUpdate` helper on the backend** — The read → merge → validate → write logic was extracted into a reusable function used by both single and bulk mode, reducing duplication within the endpoint.

### Why These Changes

The immediate motivation is extension cleanup routines. When an extension stores per-character metadata (e.g. greeting titles, index maps), uninstalling or cleaning the extension needs to strip that data from every character card. With the previous approach, each character required its own HTTP request and file write — this could take minutes for large libraries and had to be artificially time-budgeted to avoid blocking the UI.

The shallow character loading feature made this worse: when enabled, the frontend only has minimal character data loaded, so it can't even determine which characters need updating without unshallowing each one first.

A secondary concern was the `null` ambiguity — extensions might legitimately want to set a field to `null` without deleting the key, which wasn't possible when `null` was overloaded to mean "delete."

### How It Works

The endpoint detects the mode based on the request body shape:
- `avatar` (string) present → single mode, same as before
- `avatars` (array) present → bulk mode

In bulk mode, characters are processed in parallel batches. An optional `filter.path` lets the server skip characters that don't match a condition (e.g. "only touch characters that have `data.extensions.greeting_tools` set"). The response returns three arrays — `updated`, `skipped`, and `failed` — giving the caller full visibility into what happened.

The sentinel approach for deletion is straightforward: when the server encounters the sentinel string after deep-merging, it `_.unset()`s that key from the character. The frontend utility handles the same logic for in-memory state.

### Impact

- Extensions can now clean up per-character data with a single API call instead of hundreds
- Shallow character loading is no longer a blocker for bulk operations
- Setting `null` and deleting a key are now distinct, explicit operations
- The existing single-character merge behavior is fully preserved

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).