### PR TITLE
Fix group chat reasoning "mind reading" — only include reasoning from the currently generating character

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4470,18 +4470,24 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     for (let i = coreChat.length - 1; i >= 0; i--) {
         const depth = coreChat.length - i - (isContinue ? 2 : 1);
         const isPrefix = isContinue && i === coreChat.length - 1;
+
+        // In group chats, only include reasoning from the currently generating character
+        const isOtherGroupMember = selected_group && coreChat[i].name !== name2;
+
         coreChat[i] = {
             ...coreChat[i],
-            mes: promptReasoning.addToMessage(
-                coreChat[i].mes,
-                getRegexedString(
-                    String(coreChat[i].extra?.reasoning ?? ''),
-                    regex_placement.REASONING,
-                    { isPrompt: true, depth: depth },
+            mes: isOtherGroupMember
+                ? coreChat[i].mes
+                : promptReasoning.addToMessage(
+                    coreChat[i].mes,
+                    getRegexedString(
+                        String(coreChat[i].extra?.reasoning ?? ''),
+                        regex_placement.REASONING,
+                        { isPrompt: true, depth: depth },
+                    ),
+                    isPrefix,
+                    coreChat[i].extra?.reasoning_duration,
                 ),
-                isPrefix,
-                coreChat[i].extra?.reasoning_duration,
-            ),
         };
         if (promptReasoning.isLimitReached()) {
             break;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -604,8 +604,10 @@ function setOpenAIMessages(chat) {
         const originApi = chat[j]?.extra?.api;
         const originModel = chat[j]?.extra?.model;
         const isSameModel = originApi === currentApi && originModel === currentModel;
-        const signature = isSameModel ? chat[j]?.extra?.reasoning_signature : null;
-        const reasoning = isSameModel ? String(chat[j]?.extra?.reasoning ?? '') : '';
+        // In group chats, only include reasoning from the currently generating character
+        const isOtherGroupMember = selected_group && chat[j].name !== name2;
+        const signature = isSameModel && !isOtherGroupMember ? chat[j]?.extra?.reasoning_signature : null;
+        const reasoning = isSameModel && !isOtherGroupMember ? String(chat[j]?.extra?.reasoning ?? '') : '';
 
         // Remove reasoning metadata from invocations if the API/model don't match
         if (Array.isArray(invocations) && invocations.length > 0) {


### PR DESCRIPTION
In group chats, reasoning/thinking blocks from all characters were being sent back to the model in the prompt context, regardless of which character was currently generating. This effectively let characters "read the minds" of other group members. This fix ensures only the currently speaking character's own reasoning is included in the prompt.

Fixes #3508

### What Changed

- **Text Completion path** (`script.js`): The `PromptReasoning.addToMessage` loop now skips messages from other group members, leaving their content untouched without reasoning prepended.
- **Chat Completion path** (`openai.js`): The native `reasoning` and `signature` fields are cleared for messages belonging to other group members, preventing their thinking blocks from being sent via the API.

Both paths use the same guard: check if we're in a group chat and the message author isn't the character currently being generated for.

### Why These Changes

When "Add reasoning to prompts" is enabled, the system iterates through recent messages and injects their reasoning blocks back into the prompt. In 1:1 chats this is fine — there's only one character. But in group chats, this meant Character B would receive Character A's inner thoughts in its prompt context, leading to unintended "mind reading."

The decision was made to fix this as a **default behavior change** rather than adding a new toggle, for several reasons:

- This is a **bug**, not a missing feature. Cross-character reasoning leaking is wrong for the vast majority of use cases. The fix should be the default, not opt-in behind a setting.
- A separate toggle would add **UI complexity for a near-zero audience**. Even in non-roleplay pipeline/agent scenarios, each agent typically should only see its own chain-of-thought.
- The existing `max_additions` setting already controls how many reasoning blocks are sent — a second group-specific count would be confusing and redundant.
- If demand for a "share all reasoning" option ever materializes, it can be added later. Shipping the sane default first follows YAGNI.

### Impact

Group chat users with "Add reasoning to prompts" enabled will no longer experience characters referencing or being influenced by other characters' private reasoning. Non-group chats are completely unaffected.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).