### PR TITLE
Increase Top K max value from 200 to 500 for text generation WebU

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1269,8 +1269,8 @@
                                             <span data-i18n="Top K">Top K</span>
                                             <div class="fa-solid fa-circle-info opacity50p" title="Top K sets a maximum amount of top tokens that can be chosen from.&#13;E.g Top K is 20, this means only the 20 highest ranking tokens will be kept (regardless of their probabilities being diverse or limited).&#13;Set to 0 (or -1, depending on your backend) to disable." data-i18n="[title]Top_K_desc"></div>
                                         </small>
-                                        <input class="neo-range-slider" type="range" id="top_k_textgenerationwebui" name="volume" min="-1" max="200" step="1">
-                                        <input class="neo-range-input" type="number" min="-1" max="200" step="1" data-for="top_k_textgenerationwebui" id="top_k_counter_textgenerationwebui">
+                                        <input class="neo-range-slider" type="range" id="top_k_textgenerationwebui" name="volume" min="-1" max="500" step="1">
+                                        <input class="neo-range-input" type="number" min="-1" max="500" step="1" data-for="top_k_textgenerationwebui" id="top_k_counter_textgenerationwebui">
                                     </div>
                                     <div data-tg-samplers="top_p" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>


### PR DESCRIPTION
This pull request increases the maximum allowed value for the "Top K" parameter in the UI from 200 to 500. This change enables users to select a wider range of top tokens for text generation.

- UI improvements:
  * Increased the `max` value for both the range slider and number input for `top_k_textgenerationwebui` from 200 to 500 in `public/index.html`.

Closes #5408 

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).