### PR TITLE
Add character metadata attributes to expression images

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -254,6 +254,8 @@ async function visualNovelSetCharacterSprites(vnContainer, spriteFolderName, exp
         img.attr('data-sprite-folder-name', spriteFolderName);
         img.attr('data-expression', expression);
         img.attr('data-sprite-filename', spriteFile?.fileName || null);
+        img.attr('data-avatar-key', avatar);
+        img.attr('data-character-name', character.name);
         img.attr('title', expression);
 
         if (spriteFile) console.info(`Expression set for group member ${character.name}`, { expression: spriteFile.expression, file: spriteFile.fileName });
@@ -1515,6 +1517,8 @@ async function setExpression(spriteFolderName, expression, { force = false, over
             }
         }
 
+        const character = /** @type {Character} */ (characters[this_chid]);
+
         //only swap expressions when necessary
         if (prevExpressionSrc !== spriteFile.imageSrc
             && !img.hasClass('expression-animating')) {
@@ -1529,6 +1533,8 @@ async function setExpression(spriteFolderName, expression, { force = false, over
             expressionClone.attr('data-sprite-folder-name', spriteFolderName);
             expressionClone.attr('data-expression', expression);
             expressionClone.attr('data-sprite-filename', spriteFile.fileName);
+            expressionClone.attr('data-avatar-key', character.avatar);
+            expressionClone.attr('data-character-name', character.name);
             expressionClone.attr('title', expression);
             //add invisible clone to html
             expressionClone.appendTo($('#expression-holder'));
@@ -1617,6 +1623,8 @@ function setDefaultEmojiForImage(img, expression) {
     img.attr('src', defImgUrl);
     img.attr('data-expression', expression);
     img.attr('data-sprite-filename', null);
+    img.attr('data-avatar-key', null);
+    img.attr('data-character-name', null);
     img.attr('title', expression);
     img.addClass('default');
 }
@@ -1630,6 +1638,8 @@ function setNoneForImage(img, expression) {
     img.attr('src', '');
     img.attr('data-expression', expression);
     img.attr('data-sprite-filename', null);
+    img.attr('data-avatar-key', null);
+    img.attr('data-character-name', null);
     img.attr('title', expression);
     img.removeClass('default');
 }


### PR DESCRIPTION
This is mostly for convenience on Custom CSS or any extension customizing expressions.
Easier to target specific expression images this way.


This pull request enhances the way character information is handled in the expressions extension by consistently attaching more metadata to sprite image elements. The main focus is on adding the character's avatar key and name as data attributes, which will make it easier to reference and manipulate character sprites in the UI and scripts.

**Enhancements to sprite image metadata:**

- Added `data-avatar-key` and `data-character-name` attributes to sprite image elements when setting or cloning expressions, ensuring that each sprite image is tagged with its corresponding character's avatar and name. [[1]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR257-R258) [[2]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR1536-R1537)
- Set `data-avatar-key` and `data-character-name` to `null` when resetting images to their default emoji or to none, maintaining consistency in the data attributes and preventing stale data. [[1]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR1626-R1627) [[2]](diffhunk://#diff-4781b50050a28c9122e8c7cb7a7b41f0d0e483d9075fa386cdc98ed71b807a2bR1641-R1642)

**Code maintainability:**

- Introduced a local `character` variable in the `setExpression` function for easier and clearer access to character properties when updating image attributes.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).