### PR TITLE
Enhance Vectorize All process with error handling and retries and minor improvments

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -203,6 +203,7 @@ async function onVectorizeAllClick() {
         const batchSize = getBatchSize();
         const elapsedLog = [];
         let finished = false;
+        let initialPending = null; // total items pending at the start of this run — set on first sync return
         $('#vectorize_progress').show();
         $('#vectorize_progress_percent').text('0');
         $('#vectorize_progress_eta').text('...');
@@ -219,13 +220,18 @@ async function onVectorizeAllClick() {
             elapsedLog.push(elapsed);
             finished = remaining <= 0;
 
-            const total = getContext().chat.length;
-            const processed = total - remaining;
-            const processedPercent = Math.round((processed / total) * 100); // percentage of the work done
+            if (initialPending === null) {
+                initialPending = Math.max(0, remaining + batchSize);
+            }
+            const pending = Math.max(0, remaining);
+            const processed = Math.max(0, initialPending - pending);
+            const processedPercent = initialPending > 0
+                ? Math.min(100, Math.round((processed / initialPending) * 100))
+                : 100;
             const lastElapsed = elapsedLog.slice(-5); // last 5 elapsed times
             const averageElapsed = lastElapsed.reduce((a, b) => a + b, 0) / lastElapsed.length; // average time needed to process one item
             const pace = averageElapsed / batchSize; // time needed to process one item
-            const remainingTime = Math.round(pace * remaining / 1000);
+            const remainingTime = Math.round(pace * pending / 1000);
 
             $('#vectorize_progress_percent').text(processedPercent);
             $('#vectorize_progress_eta').text(remainingTime);

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -310,7 +310,7 @@ async function summarizeExtra(element) {
 
         if (apiResult.ok) {
             const data = await apiResult.json();
-            element.text = data.summary;
+            element.text = removeReasoningFromString(data.summary);
         }
     } catch (error) {
         console.log(error);
@@ -342,7 +342,7 @@ async function summarizeWebLLM(element) {
     }
 
     const messages = [{ role: 'system', content: settings.summary_prompt }, { role: 'user', content: element.text }];
-    element.text = await generateWebLlmChatPrompt(messages);
+    element.text = removeReasoningFromString(await generateWebLlmChatPrompt(messages));
 
     return true;
 }

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -77,6 +77,7 @@ const settings = {
     summarize_sent: false,
     summary_source: 'main',
     summary_prompt: 'Ignore previous instructions. Summarize the most important parts of the message. Limit yourself to 250 words or less. Your response should include nothing but the summary.',
+    summary_retries: 2,
     force_chunk_delimiter: '',
 
     // For chats
@@ -348,39 +349,55 @@ async function summarizeWebLLM(element) {
 }
 
 /**
- * Summarizes messages using the chosen method.
- * @param {HashedMessage[]} hashedMessages Array of hashed messages
+ * Runs one summarization attempt for a single element via the chosen endpoint.
+ * @param {HashedMessage} element
+ * @param {string} endpoint
+ * @returns {Promise<boolean>} Whether the attempt succeeded.
+ */
+async function summarizeOne(element, endpoint) {
+    switch (endpoint) {
+        case 'main':
+            return await summarizeMain(element);
+        case 'extras':
+            return await summarizeExtra(element);
+        case 'webllm':
+            return await summarizeWebLLM(element);
+        default:
+            throw new Error(`Unsupported summary endpoint: ${endpoint}`, { cause: 'summary_endpoint_invalid' });
+    }
+}
+
+/**
+ * Summarizes messages using the chosen method. Every returned element has been
+ * summarized (via live call or cache). Throws if any element fails after
+ * `settings.summary_retries` attempts.
+ * @param {HashedMessage[]} hashedMessages Array of hashed messages (mutated in place)
  * @param {string} endpoint Type of endpoint to use
  * @returns {Promise<HashedMessage[]>} Summarized messages
  */
 async function summarize(hashedMessages, endpoint = 'main') {
+    const maxAttempts = Math.max(1, Number(settings.summary_retries) || 1);
     for (const element of hashedMessages) {
         const cachedSummary = cachedSummaries.get(element.hash);
-        if (!cachedSummary) {
-            let success = true;
-            switch (endpoint) {
-                case 'main':
-                    success = await summarizeMain(element);
-                    break;
-                case 'extras':
-                    success = await summarizeExtra(element);
-                    break;
-                case 'webllm':
-                    success = await summarizeWebLLM(element);
-                    break;
-                default:
-                    console.error('Unsupported endpoint', endpoint);
-                    success = false;
-                    break;
-            }
-            if (success) {
-                cachedSummaries.set(element.hash, element.text);
-            } else {
-                break;
-            }
-        } else {
+        if (cachedSummary) {
             element.text = cachedSummary;
+            continue;
         }
+
+        let success = false;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            success = await summarizeOne(element, endpoint);
+            if (success) break;
+            console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} failed for hash ${element.hash}`);
+        }
+        if (!success) {
+            throw new Error(`Summarization failed after ${maxAttempts} attempt(s)`, { cause: 'summary_failed' });
+        }
+        cachedSummaries.set(element.hash, element.text);
+    }
+    return hashedMessages;
+}
+
     }
     return hashedMessages;
 }
@@ -450,6 +467,10 @@ async function synchronizeChat(batchSize = 5) {
                     return 'WebLLM extension is not installed or the model is not set.';
                 case 'account_id_missing':
                     return 'Workers AI account ID is required. Save it in the "API Connections" panel.';
+                case 'summary_endpoint_invalid':
+                    return 'Summarization endpoint is not supported.';
+                case 'summary_failed':
+                    return 'Summarization failed after the configured number of retries.';
                 default:
                     return 'Check server console for more details';
             }
@@ -1832,6 +1853,13 @@ export async function init() {
 
     $('#vectors_summary_prompt').val(settings.summary_prompt).on('input', () => {
         settings.summary_prompt = String($('#vectors_summary_prompt').val());
+        Object.assign(extension_settings.vectors, settings);
+        saveSettingsDebounced();
+    });
+
+    $('#vectors_summary_retries').val(settings.summary_retries).on('input', () => {
+        const parsed = Number($('#vectors_summary_retries').val());
+        settings.summary_retries = Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : 1;
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -121,6 +121,10 @@ const settings = {
 const moduleWorker = new ModuleWorkerWrapper(synchronizeChat);
 const webllmProvider = new WebLlmVectorProvider();
 const cachedSummaries = new Map();
+/** Hashes skipped this Vectorize All session (summary or embed failure). Cleared on next Vectorize All click. */
+const skippedHashes = new Set();
+/** Error causes treated as fatal — abort Vectorize All rather than skip. */
+const FATAL_CAUSES = new Set(['api_key_missing', 'api_url_missing', 'api_model_missing', 'extras_module_missing', 'webllm_not_supported', 'summary_endpoint_invalid']);
 const vectorApiRequiresUrl = ['llamacpp', 'vllm', 'ollama', 'koboldcpp'];
 
 /**
@@ -201,6 +205,7 @@ async function onVectorizeAllClick() {
         // Clear all cached summaries to ensure that new ones are created
         // upon request of a full vectorise
         cachedSummaries.clear();
+        skippedHashes.clear();
 
         const batchSize = getBatchSize();
         const elapsedLog = [];
@@ -219,6 +224,12 @@ async function onVectorizeAllClick() {
             const startTime = Date.now();
             const remaining = await synchronizeChat(batchSize);
             const elapsed = Date.now() - startTime;
+
+            if (remaining === null) {
+                // synchronizeChat already surfaced a toast; bail out of the loop.
+                throw new Error('Vectorization aborted');
+            }
+
             elapsedLog.push(elapsed);
             finished = remaining <= 0;
 
@@ -241,6 +252,9 @@ async function onVectorizeAllClick() {
             if (chatId !== getCurrentChatId()) {
                 throw new Error('Chat changed');
             }
+        }
+        if (skippedHashes.size > 0) {
+            toastr.warning(`${skippedHashes.size} message(s) skipped due to errors. Click Vectorize All again to retry.`, 'Vectorization partial');
         }
     } catch (error) {
         console.error('Vectors: Failed to vectorize all', error);
@@ -399,6 +413,35 @@ async function summarize(hashedMessages, endpoint = 'main') {
     return hashedMessages;
 }
 
+/**
+ * Like {@link summarize} but tolerates per-element failure: after retries are
+ * exhausted, the element is tagged with `summaryFailed = true` and its text is
+ * left untouched. Fatal endpoint errors still propagate.
+ * @param {HashedMessage[]} hashedMessages Array of hashed messages (mutated in place)
+ * @param {string} endpoint Type of endpoint to use
+ * @returns {Promise<HashedMessage[]>} The same array reference
+ */
+async function summarizeSkipOnFailure(hashedMessages, endpoint = 'main') {
+    const maxAttempts = Math.max(1, Number(settings.summary_retries) || 1);
+    for (const element of hashedMessages) {
+        const cachedSummary = cachedSummaries.get(element.hash);
+        if (cachedSummary) {
+            element.text = cachedSummary;
+            continue;
+        }
+
+        let success = false;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            success = await summarizeOne(element, endpoint);
+            if (success) break;
+            console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} failed for hash ${element.hash}`);
+        }
+        if (!success) {
+            console.warn(`Vectors: summarization exhausted ${maxAttempts} attempt(s) for hash ${element.hash} — marking for skip`);
+            element.summaryFailed = true;
+            continue;
+        }
+        cachedSummaries.set(element.hash, element.text);
     }
     return hashedMessages;
 }
@@ -428,8 +471,12 @@ async function synchronizeChat(batchSize = 5) {
         const hashedMessages = context.chat.filter(x => settings.keep_hidden || !x.is_system).map(x => ({ text: String(substituteParams(x.mes)), hash: getStringHash(substituteParams(x.mes)), index: context.chat.indexOf(x) }));
         const hashesInCollection = await getSavedHashes(chatId);
 
-        let newVectorItems = hashedMessages.filter(x => !hashesInCollection.includes(x.hash));
+        const newVectorItems = hashedMessages
+            .filter(x => !hashesInCollection.includes(x.hash))
+            .filter(x => !skippedHashes.has(x.hash));
         const deletedHashes = hashesInCollection.filter(x => !hashedMessages.some(y => y.hash === x));
+
+        let batch = newVectorItems.slice(0, batchSize);
 
         if (settings.summarize) {
             const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
@@ -444,11 +491,19 @@ async function synchronizeChat(batchSize = 5) {
             }
         }
 
-        if (newVectorItems.length > 0) {
-            const chunkedBatch = splitByChunks(newVectorItems.slice(0, batchSize));
+        if (batch.length > 0) {
+            const chunkedBatch = splitByChunks(batch);
 
-            console.log(`Vectors: Found ${newVectorItems.length} new items. Processing ${batchSize}...`);
-            await insertVectorItems(chatId, chunkedBatch);
+            console.log(`Vectors: Found ${newVectorItems.length} new items. Processing ${batch.length}...`);
+            try {
+                await insertVectorItems(chatId, chunkedBatch);
+            } catch (insertError) {
+                if (FATAL_CAUSES.has(insertError?.cause)) {
+                    throw insertError;
+                }
+                console.warn('Vectors: insert failed for batch — marking for skip', insertError);
+                for (const item of batch) skippedHashes.add(item.hash);
+            }
         }
 
         if (deletedHashes.length > 0) {
@@ -490,7 +545,7 @@ async function synchronizeChat(batchSize = 5) {
 
         const message = getErrorMessage(error.cause);
         toastr.error(message, 'Vectorization failed', { preventDuplicates: true });
-        return -1;
+        return null;
     } finally {
         syncBlocked = false;
     }

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -78,6 +78,7 @@ const settings = {
     summary_source: 'main',
     summary_prompt: 'Ignore previous instructions. Summarize the most important parts of the message. Limit yourself to 250 words or less. Your response should include nothing but the summary.',
     summary_retries: 2,
+    summary_threshold: 200,
     force_chunk_delimiter: '',
 
     // For chats
@@ -431,7 +432,16 @@ async function synchronizeChat(batchSize = 5) {
         const deletedHashes = hashesInCollection.filter(x => !hashedMessages.some(y => y.hash === x));
 
         if (settings.summarize) {
-            newVectorItems = await summarize(newVectorItems, settings.summary_source);
+            const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
+            const toSummarize = minLength > 0 ? batch.filter(x => x.text.length >= minLength) : batch;
+            if (toSummarize.length > 0) {
+                await summarizeSkipOnFailure(toSummarize, settings.summary_source);
+                const failed = toSummarize.filter(x => x.summaryFailed);
+                if (failed.length > 0) {
+                    for (const item of failed) skippedHashes.add(item.hash);
+                    batch = batch.filter(x => !x.summaryFailed);
+                }
+            }
         }
 
         if (newVectorItems.length > 0) {
@@ -854,7 +864,11 @@ async function getQueryText(chat, initiator) {
         .slice(0, settings.query);
 
     if (initiator === 'chat' && settings.enabled_chats && settings.summarize && settings.summarize_sent) {
-        hashedMessages = await summarize(hashedMessages, settings.summary_source);
+        const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
+        const toSummarize = minLength > 0 ? hashedMessages.filter(x => x.text.length >= minLength) : hashedMessages;
+        if (toSummarize.length > 0) {
+            await summarizeSkipOnFailure(toSummarize, settings.summary_source);
+        }
     }
 
     const queryText = hashedMessages.map(x => x.text).join('\n');
@@ -1860,6 +1874,13 @@ export async function init() {
     $('#vectors_summary_retries').val(settings.summary_retries).on('input', () => {
         const parsed = Number($('#vectors_summary_retries').val());
         settings.summary_retries = Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : 1;
+        Object.assign(extension_settings.vectors, settings);
+        saveSettingsDebounced();
+    });
+
+    $('#vectors_summary_threshold').val(settings.summary_threshold).on('input', () => {
+        const parsed = Number($('#vectors_summary_threshold').val());
+        settings.summary_threshold = Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : 0;
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -493,6 +493,11 @@
                         <label for="vectors_summary_prompt" title="Summary Prompt:">Summary Prompt:</label>
                         <small data-i18n="Only used when Main API or WebLLM Extension is selected.">Only used when Main API or WebLLM Extension is selected.</small>
                         <textarea id="vectors_summary_prompt" class="text_pole textarea_compact" rows="6" placeholder="This prompt will be sent to AI to request the summary generation."></textarea>
+
+                        <label for="vectors_summary_retries" title="Number of attempts per message before aborting vectorization.">
+                            <span data-i18n="Summarization retries per message">Summarization retries per message</span>
+                        </label>
+                        <input id="vectors_summary_retries" type="number" class="text_pole widthUnset" min="1" max="10" step="1" />
                     </div>
                 </div>
                 <small data-i18n="Old messages are vectorized gradually as you chat. To process all previous messages, click the button below.">

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -498,6 +498,11 @@
                             <span data-i18n="Summarization retries per message">Summarization retries per message</span>
                         </label>
                         <input id="vectors_summary_retries" type="number" class="text_pole widthUnset" min="1" max="10" step="1" />
+
+                        <label for="vectors_summary_threshold" title="Messages shorter than this (in characters) are embedded as-is without summarization. Set to 0 to always summarize.">
+                            <span data-i18n="Summarization min length (chars)">Summarization min length (chars)</span>
+                        </label>
+                        <input id="vectors_summary_threshold" type="number" class="text_pole widthUnset" min="0" step="1" />
                     </div>
                 </div>
                 <small data-i18n="Old messages are vectorized gradually as you chat. To process all previous messages, click the button below.">


### PR DESCRIPTION
## Why
  Running Vectorize All on large chats (thousands of messages) with summarization enabled has been fragile:
  - A single failed summary aborts the whole run, user must restart from scratch.
  - The progress % and ETA 
  - Extras and WebLLM summaries leak model reasoning blocks into the vector text.
  - Short messages are summarized unnecessarily (slow and useless (even harmful, if model hallucinates content)).


## Changes

1. Retry failed summaries with configurable attempts

## Checklist:

- [ X ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
