### PR TITLE
Enhance Vectorize All process with error handling, retries and minor improvements

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -203,6 +203,7 @@ async function onVectorizeAllClick() {
         const batchSize = getBatchSize();
         const elapsedLog = [];
         let finished = false;
+        let initialPending = null; // total items pending at the start of this run — set on first sync return
         $('#vectorize_progress').show();
         $('#vectorize_progress_percent').text('0');
         $('#vectorize_progress_eta').text('...');
@@ -219,13 +220,18 @@ async function onVectorizeAllClick() {
             elapsedLog.push(elapsed);
             finished = remaining <= 0;
 
-            const total = getContext().chat.length;
-            const processed = total - remaining;
-            const processedPercent = Math.round((processed / total) * 100); // percentage of the work done
+            if (initialPending === null) {
+                initialPending = Math.max(0, remaining + batchSize);
+            }
+            const pending = Math.max(0, remaining);
+            const processed = Math.max(0, initialPending - pending);
+            const processedPercent = initialPending > 0
+                ? Math.min(100, Math.round((processed / initialPending) * 100))
+                : 100;
             const lastElapsed = elapsedLog.slice(-5); // last 5 elapsed times
             const averageElapsed = lastElapsed.reduce((a, b) => a + b, 0) / lastElapsed.length; // average time needed to process one item
             const pace = averageElapsed / batchSize; // time needed to process one item
-            const remainingTime = Math.round(pace * remaining / 1000);
+            const remainingTime = Math.round(pace * pending / 1000);
 
             $('#vectorize_progress_percent').text(processedPercent);
             $('#vectorize_progress_eta').text(remainingTime);

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -310,7 +310,7 @@ async function summarizeExtra(element) {
 
         if (apiResult.ok) {
             const data = await apiResult.json();
-            element.text = data.summary;
+            element.text = removeReasoningFromString(data.summary);
         }
     } catch (error) {
         console.log(error);
@@ -342,7 +342,7 @@ async function summarizeWebLLM(element) {
     }
 
     const messages = [{ role: 'system', content: settings.summary_prompt }, { role: 'user', content: element.text }];
-    element.text = await generateWebLlmChatPrompt(messages);
+    element.text = removeReasoningFromString(await generateWebLlmChatPrompt(messages));
 
     return true;
 }

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -77,6 +77,7 @@ const settings = {
     summarize_sent: false,
     summary_source: 'main',
     summary_prompt: 'Ignore previous instructions. Summarize the most important parts of the message. Limit yourself to 250 words or less. Your response should include nothing but the summary.',
+    summary_retries: 2,
     force_chunk_delimiter: '',
 
     // For chats
@@ -348,39 +349,55 @@ async function summarizeWebLLM(element) {
 }
 
 /**
- * Summarizes messages using the chosen method.
- * @param {HashedMessage[]} hashedMessages Array of hashed messages
+ * Runs one summarization attempt for a single element via the chosen endpoint.
+ * @param {HashedMessage} element
+ * @param {string} endpoint
+ * @returns {Promise<boolean>} Whether the attempt succeeded.
+ */
+async function summarizeOne(element, endpoint) {
+    switch (endpoint) {
+        case 'main':
+            return await summarizeMain(element);
+        case 'extras':
+            return await summarizeExtra(element);
+        case 'webllm':
+            return await summarizeWebLLM(element);
+        default:
+            throw new Error(`Unsupported summary endpoint: ${endpoint}`, { cause: 'summary_endpoint_invalid' });
+    }
+}
+
+/**
+ * Summarizes messages using the chosen method. Every returned element has been
+ * summarized (via live call or cache). Throws if any element fails after
+ * `settings.summary_retries` attempts.
+ * @param {HashedMessage[]} hashedMessages Array of hashed messages (mutated in place)
  * @param {string} endpoint Type of endpoint to use
  * @returns {Promise<HashedMessage[]>} Summarized messages
  */
 async function summarize(hashedMessages, endpoint = 'main') {
+    const maxAttempts = Math.max(1, Number(settings.summary_retries) || 1);
     for (const element of hashedMessages) {
         const cachedSummary = cachedSummaries.get(element.hash);
-        if (!cachedSummary) {
-            let success = true;
-            switch (endpoint) {
-                case 'main':
-                    success = await summarizeMain(element);
-                    break;
-                case 'extras':
-                    success = await summarizeExtra(element);
-                    break;
-                case 'webllm':
-                    success = await summarizeWebLLM(element);
-                    break;
-                default:
-                    console.error('Unsupported endpoint', endpoint);
-                    success = false;
-                    break;
-            }
-            if (success) {
-                cachedSummaries.set(element.hash, element.text);
-            } else {
-                break;
-            }
-        } else {
+        if (cachedSummary) {
             element.text = cachedSummary;
+            continue;
         }
+
+        let success = false;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            success = await summarizeOne(element, endpoint);
+            if (success) break;
+            console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} failed for hash ${element.hash}`);
+        }
+        if (!success) {
+            throw new Error(`Summarization failed after ${maxAttempts} attempt(s)`, { cause: 'summary_failed' });
+        }
+        cachedSummaries.set(element.hash, element.text);
+    }
+    return hashedMessages;
+}
+
     }
     return hashedMessages;
 }
@@ -450,6 +467,10 @@ async function synchronizeChat(batchSize = 5) {
                     return 'WebLLM extension is not installed or the model is not set.';
                 case 'account_id_missing':
                     return 'Workers AI account ID is required. Save it in the "API Connections" panel.';
+                case 'summary_endpoint_invalid':
+                    return 'Summarization endpoint is not supported.';
+                case 'summary_failed':
+                    return 'Summarization failed after the configured number of retries.';
                 default:
                     return 'Check server console for more details';
             }
@@ -1832,6 +1853,13 @@ export async function init() {
 
     $('#vectors_summary_prompt').val(settings.summary_prompt).on('input', () => {
         settings.summary_prompt = String($('#vectors_summary_prompt').val());
+        Object.assign(extension_settings.vectors, settings);
+        saveSettingsDebounced();
+    });
+
+    $('#vectors_summary_retries').val(settings.summary_retries).on('input', () => {
+        const parsed = Number($('#vectors_summary_retries').val());
+        settings.summary_retries = Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : 1;
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -388,9 +388,15 @@ async function summarizeOne(element, endpoint) {
  * `settings.summary_retries` attempts.
  * @param {HashedMessage[]} hashedMessages Array of hashed messages (mutated in place)
  * @param {string} endpoint Type of endpoint to use
+ * @param {Object} [options] Options for summarization behavior
+ * @param {boolean} [options.skipOnFailure=false] If true, tags failed elements with `summaryFailed = true` instead of throwing
  * @returns {Promise<HashedMessage[]>} Summarized messages
  */
-async function summarize(hashedMessages, endpoint = 'main') {
+async function summarize(hashedMessages, endpoint = 'main', options = {}) {
+    const { 
+        skipOnFailure = false 
+    } = options;
+
     const maxAttempts = Math.max(1, Number(settings.summary_retries) || 1);
     for (const element of hashedMessages) {
         const cachedSummary = cachedSummaries.get(element.hash);
@@ -411,45 +417,13 @@ async function summarize(hashedMessages, endpoint = 'main') {
             console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} failed for hash ${element.hash}`);
         }
         if (!success) {
+            if (skipOnFailure) {
+                console.warn(`Vectors: summarization exhausted ${maxAttempts} attempt(s) for hash ${element.hash} — marking for skip`);
+                element.summaryFailed = true;
+                continue;
+            }
+
             throw new Error(`Summarization failed after ${maxAttempts} attempt(s)`, { cause: 'summary_failed' });
-        }
-        cachedSummaries.set(element.hash, element.text);
-    }
-    return hashedMessages;
-}
-
-/**
- * Like {@link summarize} but tolerates per-element failure: after retries are
- * exhausted, the element is tagged with `summaryFailed = true` and its text is
- * left untouched. Fatal endpoint errors still propagate.
- * @param {HashedMessage[]} hashedMessages Array of hashed messages (mutated in place)
- * @param {string} endpoint Type of endpoint to use
- * @returns {Promise<HashedMessage[]>} The same array reference
- */
-async function summarizeSkipOnFailure(hashedMessages, endpoint = 'main') {
-    const maxAttempts = Math.max(1, Number(settings.summary_retries) || 1);
-    for (const element of hashedMessages) {
-        const cachedSummary = cachedSummaries.get(element.hash);
-        if (cachedSummary) {
-            element.text = cachedSummary;
-            continue;
-        }
-
-        let success = false;
-        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-            try {
-                success = await summarizeOne(element, endpoint);
-                if (success) break;
-            } catch (error) {
-                if (FATAL_CAUSES.has(error?.cause)) throw error;
-                console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} threw for hash ${element.hash}`, error);
-            }
-            console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} failed for hash ${element.hash}`);
-        }
-        if (!success) {
-            console.warn(`Vectors: summarization exhausted ${maxAttempts} attempt(s) for hash ${element.hash} — marking for skip`);
-            element.summaryFailed = true;
-            continue;
         }
         cachedSummaries.set(element.hash, element.text);
     }
@@ -492,7 +466,7 @@ async function synchronizeChat(batchSize = 5) {
             const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
             const toSummarize = minLength > 0 ? batch.filter(x => x.text.length >= minLength) : batch;
             if (toSummarize.length > 0) {
-                await summarizeSkipOnFailure(toSummarize, settings.summary_source);
+                await summarize(toSummarize, settings.summary_source, {skipOnFailure: true});
                 const failed = toSummarize.filter(x => x.summaryFailed);
                 if (failed.length > 0) {
                     for (const item of failed) skippedHashes.add(item.hash);
@@ -932,7 +906,7 @@ async function getQueryText(chat, initiator) {
         const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
         const toSummarize = minLength > 0 ? hashedMessages.filter(x => x.text.length >= minLength) : hashedMessages;
         if (toSummarize.length > 0) {
-            await summarizeSkipOnFailure(toSummarize, settings.summary_source);
+            await summarize(toSummarize, settings.summary_source, {skipOnFailure: true});
         }
     }
 

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -44,6 +44,7 @@ import { oai_settings } from '../../openai.js';
  * @property {string} text - The hashed message text
  * @property {number} hash - The hash used as the vector key
  * @property {number} index - The index of the message in the chat
+ * @property {boolean} [summaryFailed] - Whether summarization failed for this message (used internally to skip messages that fail summarization)
  */
 
 const MODULE_NAME = 'vectors';
@@ -393,8 +394,8 @@ async function summarizeOne(element, endpoint) {
  * @returns {Promise<HashedMessage[]>} Summarized messages
  */
 async function summarize(hashedMessages, endpoint = 'main', options = {}) {
-    const { 
-        skipOnFailure = false 
+    const {
+        skipOnFailure = false,
     } = options;
 
     const maxAttempts = Math.max(1, Number(settings.summary_retries) || 1);
@@ -452,6 +453,7 @@ async function synchronizeChat(batchSize = 5) {
             return -1;
         }
 
+        /** @type {HashedMessage[]} */
         const hashedMessages = context.chat.filter(x => settings.keep_hidden || !x.is_system).map(x => ({ text: String(substituteParams(x.mes)), hash: getStringHash(substituteParams(x.mes)), index: context.chat.indexOf(x) }));
         const hashesInCollection = await getSavedHashes(chatId);
 
@@ -466,7 +468,7 @@ async function synchronizeChat(batchSize = 5) {
             const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
             const toSummarize = minLength > 0 ? batch.filter(x => x.text.length >= minLength) : batch;
             if (toSummarize.length > 0) {
-                await summarize(toSummarize, settings.summary_source, {skipOnFailure: true});
+                await summarize(toSummarize, settings.summary_source, { skipOnFailure: true });
                 const failed = toSummarize.filter(x => x.summaryFailed);
                 if (failed.length > 0) {
                     for (const item of failed) skippedHashes.add(item.hash);
@@ -906,7 +908,7 @@ async function getQueryText(chat, initiator) {
         const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
         const toSummarize = minLength > 0 ? hashedMessages.filter(x => x.text.length >= minLength) : hashedMessages;
         if (toSummarize.length > 0) {
-            await summarize(toSummarize, settings.summary_source, {skipOnFailure: true});
+            await summarize(toSummarize, settings.summary_source, { skipOnFailure: true });
         }
     }
 

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -78,6 +78,7 @@ const settings = {
     summary_source: 'main',
     summary_prompt: 'Ignore previous instructions. Summarize the most important parts of the message. Limit yourself to 250 words or less. Your response should include nothing but the summary.',
     summary_retries: 2,
+    summary_threshold: 200,
     force_chunk_delimiter: '',
 
     // For chats
@@ -431,7 +432,16 @@ async function synchronizeChat(batchSize = 5) {
         const deletedHashes = hashesInCollection.filter(x => !hashedMessages.some(y => y.hash === x));
 
         if (settings.summarize) {
-            newVectorItems = await summarize(newVectorItems, settings.summary_source);
+            const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
+            const toSummarize = minLength > 0 ? batch.filter(x => x.text.length >= minLength) : batch;
+            if (toSummarize.length > 0) {
+                await summarizeSkipOnFailure(toSummarize, settings.summary_source);
+                const failed = toSummarize.filter(x => x.summaryFailed);
+                if (failed.length > 0) {
+                    for (const item of failed) skippedHashes.add(item.hash);
+                    batch = batch.filter(x => !x.summaryFailed);
+                }
+            }
         }
 
         if (newVectorItems.length > 0) {
@@ -854,7 +864,11 @@ async function getQueryText(chat, initiator) {
         .slice(0, settings.query);
 
     if (initiator === 'chat' && settings.enabled_chats && settings.summarize && settings.summarize_sent) {
-        hashedMessages = await summarize(hashedMessages, settings.summary_source);
+        const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
+        const toSummarize = minLength > 0 ? hashedMessages.filter(x => x.text.length >= minLength) : hashedMessages;
+        if (toSummarize.length > 0) {
+            await summarizeSkipOnFailure(toSummarize, settings.summary_source);
+        }
     }
 
     const queryText = hashedMessages.map(x => x.text).join('\n');
@@ -1860,6 +1874,13 @@ export async function init() {
     $('#vectors_summary_retries').val(settings.summary_retries).on('input', () => {
         const parsed = Number($('#vectors_summary_retries').val());
         settings.summary_retries = Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : 1;
+        Object.assign(extension_settings.vectors, settings);
+        saveSettingsDebounced();
+    });
+
+    $('#vectors_summary_threshold').val(settings.summary_threshold).on('input', () => {
+        const parsed = Number($('#vectors_summary_threshold').val());
+        settings.summary_threshold = Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : 0;
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -121,6 +121,10 @@ const settings = {
 const moduleWorker = new ModuleWorkerWrapper(synchronizeChat);
 const webllmProvider = new WebLlmVectorProvider();
 const cachedSummaries = new Map();
+/** Hashes skipped this Vectorize All session (summary or embed failure). Cleared on next Vectorize All click. */
+const skippedHashes = new Set();
+/** Error causes treated as fatal — abort Vectorize All rather than skip. */
+const FATAL_CAUSES = new Set(['api_key_missing', 'api_url_missing', 'api_model_missing', 'extras_module_missing', 'webllm_not_supported', 'summary_endpoint_invalid']);
 const vectorApiRequiresUrl = ['llamacpp', 'vllm', 'ollama', 'koboldcpp'];
 
 /**
@@ -201,6 +205,7 @@ async function onVectorizeAllClick() {
         // Clear all cached summaries to ensure that new ones are created
         // upon request of a full vectorise
         cachedSummaries.clear();
+        skippedHashes.clear();
 
         const batchSize = getBatchSize();
         const elapsedLog = [];
@@ -219,6 +224,12 @@ async function onVectorizeAllClick() {
             const startTime = Date.now();
             const remaining = await synchronizeChat(batchSize);
             const elapsed = Date.now() - startTime;
+
+            if (remaining === null) {
+                // synchronizeChat already surfaced a toast; bail out of the loop.
+                throw new Error('Vectorization aborted');
+            }
+
             elapsedLog.push(elapsed);
             finished = remaining <= 0;
 
@@ -241,6 +252,9 @@ async function onVectorizeAllClick() {
             if (chatId !== getCurrentChatId()) {
                 throw new Error('Chat changed');
             }
+        }
+        if (skippedHashes.size > 0) {
+            toastr.warning(`${skippedHashes.size} message(s) skipped due to errors. Click Vectorize All again to retry.`, 'Vectorization partial');
         }
     } catch (error) {
         console.error('Vectors: Failed to vectorize all', error);
@@ -387,8 +401,13 @@ async function summarize(hashedMessages, endpoint = 'main') {
 
         let success = false;
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-            success = await summarizeOne(element, endpoint);
-            if (success) break;
+            try {
+                success = await summarizeOne(element, endpoint);
+                if (success) break;
+            } catch (error) {
+                if (FATAL_CAUSES.has(error?.cause)) throw error;
+                console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} threw for hash ${element.hash}`, error);
+            }
             console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} failed for hash ${element.hash}`);
         }
         if (!success) {
@@ -399,6 +418,40 @@ async function summarize(hashedMessages, endpoint = 'main') {
     return hashedMessages;
 }
 
+/**
+ * Like {@link summarize} but tolerates per-element failure: after retries are
+ * exhausted, the element is tagged with `summaryFailed = true` and its text is
+ * left untouched. Fatal endpoint errors still propagate.
+ * @param {HashedMessage[]} hashedMessages Array of hashed messages (mutated in place)
+ * @param {string} endpoint Type of endpoint to use
+ * @returns {Promise<HashedMessage[]>} The same array reference
+ */
+async function summarizeSkipOnFailure(hashedMessages, endpoint = 'main') {
+    const maxAttempts = Math.max(1, Number(settings.summary_retries) || 1);
+    for (const element of hashedMessages) {
+        const cachedSummary = cachedSummaries.get(element.hash);
+        if (cachedSummary) {
+            element.text = cachedSummary;
+            continue;
+        }
+
+        let success = false;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                success = await summarizeOne(element, endpoint);
+                if (success) break;
+            } catch (error) {
+                if (FATAL_CAUSES.has(error?.cause)) throw error;
+                console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} threw for hash ${element.hash}`, error);
+            }
+            console.warn(`Vectors: summary attempt ${attempt}/${maxAttempts} failed for hash ${element.hash}`);
+        }
+        if (!success) {
+            console.warn(`Vectors: summarization exhausted ${maxAttempts} attempt(s) for hash ${element.hash} — marking for skip`);
+            element.summaryFailed = true;
+            continue;
+        }
+        cachedSummaries.set(element.hash, element.text);
     }
     return hashedMessages;
 }
@@ -428,8 +481,12 @@ async function synchronizeChat(batchSize = 5) {
         const hashedMessages = context.chat.filter(x => settings.keep_hidden || !x.is_system).map(x => ({ text: String(substituteParams(x.mes)), hash: getStringHash(substituteParams(x.mes)), index: context.chat.indexOf(x) }));
         const hashesInCollection = await getSavedHashes(chatId);
 
-        let newVectorItems = hashedMessages.filter(x => !hashesInCollection.includes(x.hash));
+        const newVectorItems = hashedMessages
+            .filter(x => !hashesInCollection.includes(x.hash))
+            .filter(x => !skippedHashes.has(x.hash));
         const deletedHashes = hashesInCollection.filter(x => !hashedMessages.some(y => y.hash === x));
+
+        let batch = newVectorItems.slice(0, batchSize);
 
         if (settings.summarize) {
             const minLength = Math.max(0, Number(settings.summary_threshold) || 0);
@@ -444,11 +501,19 @@ async function synchronizeChat(batchSize = 5) {
             }
         }
 
-        if (newVectorItems.length > 0) {
-            const chunkedBatch = splitByChunks(newVectorItems.slice(0, batchSize));
+        if (batch.length > 0) {
+            const chunkedBatch = splitByChunks(batch);
 
-            console.log(`Vectors: Found ${newVectorItems.length} new items. Processing ${batchSize}...`);
-            await insertVectorItems(chatId, chunkedBatch);
+            console.log(`Vectors: Found ${newVectorItems.length} new items. Processing ${batch.length}...`);
+            try {
+                await insertVectorItems(chatId, chunkedBatch);
+            } catch (insertError) {
+                if (FATAL_CAUSES.has(insertError?.cause)) {
+                    throw insertError;
+                }
+                console.warn('Vectors: insert failed for batch — marking for skip', insertError);
+                for (const item of batch) skippedHashes.add(item.hash);
+            }
         }
 
         if (deletedHashes.length > 0) {
@@ -490,7 +555,7 @@ async function synchronizeChat(batchSize = 5) {
 
         const message = getErrorMessage(error.cause);
         toastr.error(message, 'Vectorization failed', { preventDuplicates: true });
-        return -1;
+        return null;
     } finally {
         syncBlocked = false;
     }

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -121,10 +121,20 @@ const settings = {
 
 const moduleWorker = new ModuleWorkerWrapper(synchronizeChat);
 const webllmProvider = new WebLlmVectorProvider();
+/**
+ * Cache for storing summaries of messages by their hash.
+ * @type {Map<number, string>}
+ */
 const cachedSummaries = new Map();
-/** Hashes skipped this Vectorize All session (summary or embed failure). Cleared on next Vectorize All click. */
+/**
+ * Hashes skipped this Vectorize All session (summary or embed failure). Cleared on next Vectorize All click.
+ * @type {Set<number>}
+ */
 const skippedHashes = new Set();
-/** Error causes treated as fatal — abort Vectorize All rather than skip. */
+/**
+ * Error causes treated as fatal — abort Vectorize All rather than skip.
+ * @type {Set<string>}
+ */
 const FATAL_CAUSES = new Set(['account_id_missing', 'api_key_missing', 'api_url_missing', 'api_model_missing', 'extras_module_missing', 'webllm_not_supported', 'summary_endpoint_invalid']);
 const vectorApiRequiresUrl = ['llamacpp', 'vllm', 'ollama', 'koboldcpp'];
 
@@ -393,11 +403,7 @@ async function summarizeOne(element, endpoint) {
  * @param {boolean} [options.skipOnFailure=false] If true, tags failed elements with `summaryFailed = true` instead of throwing
  * @returns {Promise<HashedMessage[]>} Summarized messages
  */
-async function summarize(hashedMessages, endpoint = 'main', options = {}) {
-    const {
-        skipOnFailure = false,
-    } = options;
-
+async function summarize(hashedMessages, endpoint = 'main', { skipOnFailure = false } = {}) {
     const maxAttempts = Math.max(1, Number(settings.summary_retries) || 1);
     for (const element of hashedMessages) {
         const cachedSummary = cachedSummaries.get(element.hash);

--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -124,7 +124,7 @@ const cachedSummaries = new Map();
 /** Hashes skipped this Vectorize All session (summary or embed failure). Cleared on next Vectorize All click. */
 const skippedHashes = new Set();
 /** Error causes treated as fatal — abort Vectorize All rather than skip. */
-const FATAL_CAUSES = new Set(['api_key_missing', 'api_url_missing', 'api_model_missing', 'extras_module_missing', 'webllm_not_supported', 'summary_endpoint_invalid']);
+const FATAL_CAUSES = new Set(['account_id_missing', 'api_key_missing', 'api_url_missing', 'api_model_missing', 'extras_module_missing', 'webllm_not_supported', 'summary_endpoint_invalid']);
 const vectorApiRequiresUrl = ['llamacpp', 'vllm', 'ollama', 'koboldcpp'];
 
 /**

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -493,6 +493,11 @@
                         <label for="vectors_summary_prompt" title="Summary Prompt:">Summary Prompt:</label>
                         <small data-i18n="Only used when Main API or WebLLM Extension is selected.">Only used when Main API or WebLLM Extension is selected.</small>
                         <textarea id="vectors_summary_prompt" class="text_pole textarea_compact" rows="6" placeholder="This prompt will be sent to AI to request the summary generation."></textarea>
+
+                        <label for="vectors_summary_retries" title="Number of attempts per message before aborting vectorization.">
+                            <span data-i18n="Summarization retries per message">Summarization retries per message</span>
+                        </label>
+                        <input id="vectors_summary_retries" type="number" class="text_pole widthUnset" min="1" max="10" step="1" />
                     </div>
                 </div>
                 <small data-i18n="Old messages are vectorized gradually as you chat. To process all previous messages, click the button below.">

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -498,6 +498,11 @@
                             <span data-i18n="Summarization retries per message">Summarization retries per message</span>
                         </label>
                         <input id="vectors_summary_retries" type="number" class="text_pole widthUnset" min="1" max="10" step="1" />
+
+                        <label for="vectors_summary_threshold" title="Messages shorter than this (in characters) are embedded as-is without summarization. Set to 0 to always summarize.">
+                            <span data-i18n="Summarization min length (chars)">Summarization min length (chars)</span>
+                        </label>
+                        <input id="vectors_summary_threshold" type="number" class="text_pole widthUnset" min="0" step="1" />
                     </div>
                 </div>
                 <small data-i18n="Old messages are vectorized gradually as you chat. To process all previous messages, click the button below.">


### PR DESCRIPTION
## Why
  Running Vectorize All on large chats (thousands of messages) with summarization enabled has been fragile:
  - A single failed summary aborts the whole run, user must restart from scratch.
  - Transient provider errors (rate limits, 5xx) aren't retried.
  - The progress % and ETA are computed against chat.length, if there's a ton of system_message=true, will misalign
  - Extras and WebLLM summaries leak model reasoning blocks into the vector text.
  - Short messages are summarized unnecessarily (slow and useless (even harmful, if model hallucinates content)).


## Changes

1. Retry failed summaries with configurable attempts.
A new summary_retries setting (default: 2) has been added to the UI. The summarization logic attempts to process an element N times before failing. Importantly, failures are no longer swallowed; the system now explicitly throws an error once retries are exhausted.

2. Skip failed messages instead of aborting Vectorize All. 
The "Vectorize All" process is now more resilient. Previously, a single failed summary or embed call would abort the entire run, forcing a manual restart without clarifying if the error was transient or permanent.
Now, individual message failures are tolerated and marked as skipped, allowing the run to continue. Genuinely fatal errors, such as missing API keys or unsupported endpoints, still trigger an immediate abort to save time. Upon completion, a warning toast reports the number of skipped messages, allowing you to click "Vectorize All" again to retry only the failed items.

3. Fix Vectorize All progress % and ETA. 
Progress was processed / chat.length, but remaining only counts items actually pending for vectorization (filtered by is_system / keep_hidden). Denominator now captures the initial pending count on first sync and is used consistently, with ETA clamped against negative values.
 
4. Short Message Skip
A summary_threshold (default: 200 characters) is now available in the settings. Messages shorter than this limit will skip the summarization step entirely and be embedded in their original form. 

5. Accurate Progress Tracking
The progress percentage and ETA for Vectorize All are now calculated correctly.
 

## How to test

Progress/ETA 
  1. Purge vectors on a chat with a number of is_system=true / hidden messages.
  2. Click Vectorize All.
  3. Observe that the percentage starts near 0 and climbs monotonically, and ETA is a sensible positive number.

Summary Retries
  1. In Vector Storage settings, set Summarization retries per message to 3.
  2. Temporarily misconfigure the summary endpoint (e.g. bad URL) and trigger a summary.
  3. Observe 3 attempts logged in the console, then a summary_failed toast.

Short Message Skip threshold 
  1. Set Summarization min length to 200.
  2. Vectorize a chat containing both short (< 200 char) and long messages.
  3. Confirm only the long messages produce summary calls (network tab), while short ones are embedded directly.

Skip on failure
  1. If using Main API for summaries, set the OpenAI/compat model name to something the endpoint rejects (e.g.
    model-that-does-not-exist).
  2. Click Vectorize All on a ~100 message chat.
  3. The run should complete through to the end (not abort) and show a warning toast: N message(s) skipped due to
  errors. Click Vectorize All again to retry.

<img width="451" height="291" alt="image" src="https://github.com/user-attachments/assets/6a70aece-11db-4098-b1e5-affdde7ca4ea" />


## Checklist:

- [ X ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
