### PR TITLE
Add Click-to-Edit Support for Reasoning Blocks

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -2288,11 +2288,14 @@ export function initChatUtilities() {
         await callGenericPopup(wrapper, POPUP_TYPE.TEXT, '', { wide: true, large: true });
     });
 
-    $(document).on('click', 'body .mes .mes_text', function () {
+    $(document).on('click', 'body .mes .mes_text, body .mes .mes_reasoning', function (event) {
         if (!power_user.click_to_edit) return;
         if (window.getSelection().toString()) return;
         if ($('.edit_textarea').length) return;
         $(this).closest('.mes').find('.mes_edit').trigger('click');
+        if ($(event.target).closest('.mes_reasoning').length) {
+            $('.reasoning_edit_textarea').trigger('focus');
+        }
     });
 
     $(document).on('click', '.open_media_overrides', openExternalMediaOverridesDialog);


### PR DESCRIPTION
Was noticing this when working on #5486. I myself never use the "Click to edit" feature, so I didn't realize this back then when we added reasoning support.

-----

The "click to edit" feature, which allows users to quickly edit messages by clicking on them, was not working for reasoning blocks even though they are editable like regular message text. This PR extends the existing click-to-edit functionality to include reasoning blocks for a consistent editing experience.

### What Changed
- Extended the click-to-edit handler to include `.mes_reasoning` elements alongside `.mes_text`
- Added auto-focus behavior that automatically focuses the reasoning textarea when clicking directly on a reasoning block

### Why This Was Needed
When the reasoning feature was introduced, the click-to-edit functionality was only applied to the main message text area (`.mes_text`). Reasoning blocks, despite being editable content, were overlooked in the original implementation. This created an inconsistent user experience where clicking on different parts of a message behaved differently.

### How It Works
The existing click handler now listens for clicks on both `.mes_text` and `.mes_reasoning` elements. When a click is detected on either element (and the user has click-to-edit enabled), it triggers the edit mode for that message. Additionally, if the click was specifically on a reasoning block, the reasoning textarea receives immediate focus so users can start typing right away.

### Impact
- Consistent editing behavior across all editable message content
- Faster workflow for users who frequently edit reasoning content
- No breaking changes to existing functionality

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).