### PR TITLE
Add Slug Parameter to Action Loader for Programmatic Identification

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -717,6 +717,7 @@ async function firstLoadInit() {
     initLoaderOverlay.appendChild(splashMessage);
 
     const initLoaderHandle = loader.show({
+        slug: 'app-init',
         toastMode: loader.ToastMode.NONE,
         overlayContent: initLoaderOverlay,
     });
@@ -10592,6 +10593,7 @@ export async function renameGroupOrCharacterChat({ characterId, groupId, oldFile
     }
 
     const loaderHandle = showLoader ? loader.show({
+        slug: 'chat-rename',
         title: t`Rename Chat`,
         message: t`Renaming chat…`,
         toastMode: loader.ToastMode.STATIC,
@@ -11196,6 +11198,7 @@ jQuery(async function () {
         $('#select_chat_cross').trigger('click');
 
         const loaderHandle = loader.show({
+            slug: 'chat-delete',
             title: t`Delete Chat`,
             message: t`Deleting chat…`,
             toastMode: loader.ToastMode.STATIC,

--- a/public/scripts/BulkEditOverlay.js
+++ b/public/scripts/BulkEditOverlay.js
@@ -848,6 +848,7 @@ class BulkEditOverlay {
                 const deleteChats = checkbox.prop('checked') ?? false;
 
                 const loaderHandle = loader.show({
+                    slug: 'bulk-delete',
                     title: t`Bulk Delete`,
                     message: t`Deleting ${characterIds.length} character(s)…`,
                     toastMode: loader.ToastMode.STATIC,

--- a/public/scripts/action-loader-slashcommands.js
+++ b/public/scripts/action-loader-slashcommands.js
@@ -1,4 +1,4 @@
-import { ActionLoaderToastMode, getActiveLoaderHandles, getLoaderHandleById, hideActionLoader, showActionLoader } from './action-loader.js';
+import { ActionLoaderToastMode, getActiveLoaderHandles, getLoaderHandleById, loader } from './action-loader.js';
 import { t } from './i18n.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { SlashCommandNamedArgument, ARGUMENT_TYPE, SlashCommandArgument } from './slash-commands/SlashCommandArgument.js';
@@ -116,6 +116,12 @@ export function registerActionLoaderSlashCommands() {
                 typeList: [ARGUMENT_TYPE.STRING],
             }),
             SlashCommandNamedArgument.fromProps({
+                name: 'slug',
+                description: 'Unique slug for the loader (to identify it easily via code or CSS)',
+                typeList: [ARGUMENT_TYPE.STRING],
+                defaultValue: 'slash-wrap',
+            }),
+            SlashCommandNamedArgument.fromProps({
                 name: 'stopTooltip',
                 description: 'Tooltip text for the stop button (only used when toast=stoppable)',
                 typeList: [ARGUMENT_TYPE.STRING],
@@ -148,7 +154,8 @@ export function registerActionLoaderSlashCommands() {
             const title = args.title ? String(args.title) : '';
             const stopTooltip = String(args.stopTooltip ?? t`Stop`);
 
-            const loader = showActionLoader({
+            const actionLoader = loader.show({
+                slug: typeof args.slug === 'string' ? String(args.slug) : 'slash-wrap',
                 blocking,
                 toastMode,
                 message,
@@ -162,7 +169,7 @@ export function registerActionLoaderSlashCommands() {
                 const result = await closureCopy.execute();
                 return result.pipe;
             } finally {
-                await loader.hide();
+                await actionLoader.hide();
             }
         },
     }));
@@ -232,6 +239,12 @@ export function registerActionLoaderSlashCommands() {
                 typeList: [ARGUMENT_TYPE.STRING],
             }),
             SlashCommandNamedArgument.fromProps({
+                name: 'slug',
+                description: 'Unique slug for the loader (to identify it easily via code or CSS)',
+                typeList: [ARGUMENT_TYPE.STRING],
+                defaultValue: 'slash-show',
+            }),
+            SlashCommandNamedArgument.fromProps({
                 name: 'stopTooltip',
                 description: 'Tooltip text for the stop button (only used when toast=stoppable)',
                 typeList: [ARGUMENT_TYPE.STRING],
@@ -258,7 +271,8 @@ export function registerActionLoaderSlashCommands() {
             const title = args.title ? String(args.title) : '';
             const stopTooltip = String(args.stopTooltip ?? t`Stop`);
 
-            const handle = showActionLoader({
+            const handle = loader.show({
+                slug: typeof args.slug === 'string' ? String(args.slug) : 'slash-show',
                 blocking,
                 toastMode,
                 message,
@@ -307,7 +321,7 @@ export function registerActionLoaderSlashCommands() {
             }
 
             // No handle provided - hide all active loaders
-            const result = await hideActionLoader();
+            const result = await loader.hide();
             return result ? 'true' : 'false';
         },
     }));

--- a/public/scripts/action-loader.js
+++ b/public/scripts/action-loader.js
@@ -33,7 +33,7 @@ export const ActionLoaderToastMode = {
  * @typedef {object} ActionLoaderOptions
  * @property {boolean} [blocking=true] - Whether to show the blocking overlay. Set to false for non-blocking toast-only loaders.
  * @property {ActionLoaderToastMode} [toastMode='stoppable'] - Toast display mode
- * @property {string} [slug=null] - Unique slug for the loader (to identify it easy via code or CSS)
+ * @property {string} [slug=null] - Unique slug for the loader to identify it easily via code or CSS
  * @property {string} [message='Generating...'] - The message to display in the toast
  * @property {string} [title] - Optional title for the toast notification
  * @property {string} [stopTooltip='Stop'] - Tooltip text for the stop button
@@ -109,7 +109,7 @@ export class ActionLoaderHandle {
      * @param {object} options - Configuration options
      * @param {boolean} [options.blocking=true] - Whether to show blocking overlay
      * @param {ActionLoaderToastMode} [options.toastMode] - Toast display mode
-     * @param {string} [options.slug] - Unique slug for the loader (to identify it easy via code or CSS)
+     * @param {string|null} [options.slug] - Unique slug for the loader (to identify it easily via code or CSS)
      * @param {string} [options.message='Generating...'] - Message to display in the toast
      * @param {string} [options.title] - Title for the toast notification
      * @param {string} [options.stopTooltip='Stop'] - Tooltip for the stop button
@@ -239,7 +239,7 @@ export class ActionLoaderHandle {
     }
 
     /**
-     * The unique slug for this loader handle. (to identify it easy via code or CSS)
+     * The unique slug for this loader handle, used to identify it easily via code or CSS.
      * @returns {string|null}
      */
     get slug() {

--- a/public/scripts/action-loader.js
+++ b/public/scripts/action-loader.js
@@ -33,6 +33,7 @@ export const ActionLoaderToastMode = {
  * @typedef {object} ActionLoaderOptions
  * @property {boolean} [blocking=true] - Whether to show the blocking overlay. Set to false for non-blocking toast-only loaders.
  * @property {ActionLoaderToastMode} [toastMode='stoppable'] - Toast display mode
+ * @property {string} [slug=null] - Unique slug for the loader (to identify it easy via code or CSS)
  * @property {string} [message='Generating...'] - The message to display in the toast
  * @property {string} [title] - Optional title for the toast notification
  * @property {string} [stopTooltip='Stop'] - Tooltip text for the stop button
@@ -83,7 +84,10 @@ export class ActionLoaderHandle {
     }
 
     /** @type {string} Unique identifier for this handle */
-    id;
+    #id;
+
+    /** @type {string|null} Unique slug for the loader */
+    #slug = null;
 
     /** @type {JQuery<HTMLElement>|null} The toast element for this loader */
     #toast = null;
@@ -105,6 +109,7 @@ export class ActionLoaderHandle {
      * @param {object} options - Configuration options
      * @param {boolean} [options.blocking=true] - Whether to show blocking overlay
      * @param {ActionLoaderToastMode} [options.toastMode] - Toast display mode
+     * @param {string} [options.slug] - Unique slug for the loader (to identify it easy via code or CSS)
      * @param {string} [options.message='Generating...'] - Message to display in the toast
      * @param {string} [options.title] - Title for the toast notification
      * @param {string} [options.stopTooltip='Stop'] - Tooltip for the stop button
@@ -116,6 +121,7 @@ export class ActionLoaderHandle {
     constructor({
         blocking = true,
         toastMode = ActionLoaderToastMode.STOPPABLE,
+        slug = null,
         message = t`Generating...`,
         title = '',
         stopTooltip = t`Stop`,
@@ -129,7 +135,8 @@ export class ActionLoaderHandle {
             return;
         }
 
-        this.id = generateLoaderId();
+        this.#id = generateLoaderId();
+        this.#slug = slug;
         this.#blocking = blocking;
         this.#onStop = onStop;
         this.#onHide = onHide;
@@ -163,6 +170,12 @@ export class ActionLoaderHandle {
     #createToast(message, title, toastMode, stopTooltip) {
         const toastContent = document.createElement('div');
         toastContent.className = 'action-loader-toast';
+
+        if (this.#slug) {
+            toastContent.dataset.slug = this.#slug;
+        }
+        toastContent.dataset.loaderId = this.#id;
+        toastContent.dataset.blocking = this.#blocking.toString();
 
         const messageSpan = document.createElement('span');
         messageSpan.className = 'action-loader-message';
@@ -215,6 +228,22 @@ export class ActionLoaderHandle {
         if (this.#blocking && !hasBlockingLoaders()) {
             await hideOverlay();
         }
+    }
+
+    /**
+     * The unique identifier for this loader handle.
+     * @returns {string}
+     */
+    get id() {
+        return this.#id;
+    }
+
+    /**
+     * The unique slug for this loader handle. (to identify it easy via code or CSS)
+     * @returns {string|null}
+     */
+    get slug() {
+        return this.#slug;
     }
 
     /**

--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -700,6 +700,7 @@ export function initBookmarks() {
         }
 
         const loaderHandle = loader.show({
+            slug: 'chat-load',
             title: t`Chat History`,
             message: t`Loading chat…`,
             toastMode: loader.ToastMode.STATIC,

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -5301,6 +5301,7 @@ async function generateMediaSwipe(mediaAttachment, message, onStart, onComplete,
         // Show non-blocking stoppable toast for this generation
         loaderHandle = loader.show({
             blocking: false,
+            slug: `${MODULE_NAME}-image-generation`,
             title: t`Image Generation`,
             message: t`Generating an image...`,
             onStop: stopListener,

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -3061,6 +3061,7 @@ async function generatePicture(initiator, args, trigger, message, callback) {
         // Show non-blocking stoppable toast for this generation
         loaderHandle = loader.show({
             blocking: false,
+            slug: `${MODULE_NAME}-image-generation`,
             title: t`Image Generation`,
             message: t`Generating an image...`,
             onStop: stopListener,

--- a/public/scripts/loader.js
+++ b/public/scripts/loader.js
@@ -28,6 +28,7 @@ export function showLoader() {
 
     // Create a blocking loader with no toast (matches old behavior)
     legacyLoaderHandle = loader.show({
+        slug: 'legacy-loader',
         blocking: true,
         toastMode: loader.ToastMode.NONE,
     });


### PR DESCRIPTION
This PR adds a `slug` parameter to the action loader system, enabling developers to programmatically identify and target specific loaders via code or CSS selectors.

### What Changed
- Added optional `slug` parameter to `ActionLoaderOptions` for unique loader identification
- Updated `ActionLoaderHandle` class to store and expose the slug via a getter
- Added `data-slug` attribute to loader toast elements for CSS targeting
- Updated slash command handlers (`slash-wrap` and `slash-show`) to accept and use the slug parameter
- Updated existing loader usages in core files (bookmarks, legacy loader) to use descriptive slugs

### Why These Changes
Previously, action loaders could only be identified by their internal ID, which was auto-generated and not predictable. This made it difficult to:
- Target specific loaders with CSS for styling
- Programmatically identify and interact with particular loaders in extensions
- Differentiate between multiple active loaders in complex scenarios

The slug parameter provides a stable, human-readable identifier that developers can control.

### How It Works
The slug is an optional string parameter passed when creating a loader. If provided, it:
- Gets stored in the loader handle's private state
- Gets exposed via a getter property for programmatic access
- Gets added as a `data-slug` attribute on the toast DOM element
- Can be used in CSS selectors like `[data-slug="chat-load"]` for styling

Slash commands now accept a `slug` argument with sensible defaults (`slash-wrap` and `slash-show`).

### Impact
This change enables:
- CSS-based styling of specific loaders without relying on auto-generated IDs
- Easier programmatic identification of loaders in extensions and custom code
- Better maintainability for complex UI interactions involving multiple loaders
- Backward compatibility - the slug is optional, so existing code continues to work

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).