### PR TITLE
feat: add Adaptive-P controls for oobabooga

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1400,7 +1400,7 @@
                                         <input class="neo-range-input" type="number" min="0" max="20" step="1" data-for="max_tokens_second_textgenerationwebui" id="max_tokens_second_counter_textgenerationwebui">
                                     </div>
 
-                                    <div data-tg-type="koboldcpp, llamacpp, tabby" id="adaptive_p_block" class="wide100p">
+                                    <div data-tg-type="koboldcpp, llamacpp, ooba, tabby" id="adaptive_p_block" class="wide100p">
                                         <h4 class="wide100p textAlignCenter">
                                             <label data-i18n="Adaptive-P">Adaptive-P</label>
                                             <a href="https://github.com/MrJackSpade/adaptive-p-docs" target="_blank">
@@ -1835,6 +1835,7 @@
                                             <div data-name="xtc" draggable="true"><span>XTC</span><small></small></div>
                                             <div data-name="encoder_repetition_penalty" draggable="true"><span>Encoder Repetition Penalty</span><small></small></div>
                                             <div data-name="no_repeat_ngram" draggable="true"><span>No Repeat Ngram</span><small></small></div>
+                                            <div data-name="adaptive_p" draggable="true"><span>Adaptive-P</span><small></small></div>
                                         </div>
                                         <div id="textgenerationwebui_default_order" class="menu_button menu_button_icon">
                                             <span data-i18n="Load default order">Load default order</span>

--- a/public/index.html
+++ b/public/index.html
@@ -1831,11 +1831,11 @@
                                             <div data-name="tfs" draggable="true"><span>Tail Free Sampling</span><small></small></div>
                                             <div data-name="top_a" draggable="true"><span>Top A</span><small></small></div>
                                             <div data-name="min_p" draggable="true"><span>Min P</span><small></small></div>
+                                            <div data-name="adaptive_p" draggable="true"><span>Adaptive-P</span><small></small></div>
                                             <div data-name="mirostat" draggable="true"><span>Mirostat</span><small></small></div>
                                             <div data-name="xtc" draggable="true"><span>XTC</span><small></small></div>
                                             <div data-name="encoder_repetition_penalty" draggable="true"><span>Encoder Repetition Penalty</span><small></small></div>
                                             <div data-name="no_repeat_ngram" draggable="true"><span>No Repeat Ngram</span><small></small></div>
-                                            <div data-name="adaptive_p" draggable="true"><span>Adaptive-P</span><small></small></div>
                                         </div>
                                         <div id="textgenerationwebui_default_order" class="menu_button menu_button_icon">
                                             <span data-i18n="Load default order">Load default order</span>

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -93,11 +93,11 @@ const OOBA_DEFAULT_ORDER = [
     'tfs',
     'top_a',
     'min_p',
+    'adaptive_p',
     'mirostat',
     'xtc',
     'encoder_repetition_penalty',
     'no_repeat_ngram',
-    'adaptive_p',
 ];
 export const APHRODITE_DEFAULT_ORDER = [
     'dry',

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -97,6 +97,7 @@ const OOBA_DEFAULT_ORDER = [
     'xtc',
     'encoder_repetition_penalty',
     'no_repeat_ngram',
+    'adaptive_p',
 ];
 export const APHRODITE_DEFAULT_ORDER = [
     'dry',


### PR DESCRIPTION
## Summary
- show the Adaptive-P settings for the oobabooga/text-generation-webui backend
- include `adaptive_p` in the default oobabooga sampler priority order
- add Adaptive-P to the draggable oobabooga sampler priority UI

## Testing
- npm run lint

Closes #5262