### PR TITLE
feat: add getWorldInfoNames() to getContext() for WorldInfo enumeration.

### DIFF
--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -104,7 +104,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { timestampToMoment, uuidv4, importFromExternalUrl } from './utils.js';
 import { addGlobalVariable, addLocalVariable, decrementGlobalVariable, decrementLocalVariable, deleteGlobalVariable, deleteLocalVariable, existsGlobalVariable, existsLocalVariable, getGlobalVariable, getLocalVariable, incrementGlobalVariable, incrementLocalVariable, setGlobalVariable, setLocalVariable } from './variables.js';
-import { convertCharacterBook, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList } from './world-info.js';
+import { convertCharacterBook, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList, world_names } from './world-info.js';
 import { ChatCompletionService, TextCompletionService } from './custom-request.js';
 import { ConnectionManagerRequestService } from './extensions/shared.js';
 import { updateReasoningUI, parseReasoningFromString, getReasoningTemplateByName } from './reasoning.js';
@@ -279,6 +279,7 @@ export function getContext() {
         updateWorldInfoList,
         convertCharacterBook,
         getWorldInfoPrompt,
+        getWorldInfoNames: () => [...world_names],
         CONNECT_API_MAP,
         getTextGenServer,
         extractMessageFromData,

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -279,7 +279,7 @@ export function getContext() {
         updateWorldInfoList,
         convertCharacterBook,
         getWorldInfoPrompt,
-        getWorldInfoNames: () => [...world_names],
+        getWorldInfoNames: () => Array.isArray(world_names) ? [...world_names] : [],
         CONNECT_API_MAP,
         getTextGenServer,
         extractMessageFromData,


### PR DESCRIPTION
This pull request makes a small update to the `st-context.js` module by exposing the list of world info names through the context API. This allows other parts of the application to easily access the available world names.

- Context API enhancement:
  * Added a `getWorldInfoNames` function to the context, which returns a copy of the `world_names` array. This provides consumers of the context with direct access to the list of world info names.
  * Imported `world_names` from `world-info.js` to support the new context function.


## Checklist:

- [x ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).