### PR TITLE
Fix KoboldCpp vector hash deletion

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -1125,11 +1125,12 @@ function throwIfSourceInvalid() {
  * @returns {Promise<void>}
  */
 async function deleteVectorItems(collectionId, hashes) {
+    const args = await getAdditionalArgs([]);
     const response = await fetch('/api/vector/delete', {
         method: 'POST',
         headers: getRequestHeaders(),
         body: JSON.stringify({
-            ...getVectorsRequestBody(),
+            ...getVectorsRequestBody(args),
             collectionId: collectionId,
             hashes: hashes,
             source: settings.source,


### PR DESCRIPTION
Fixes #5496

## Summary
- Include provider-specific request args when deleting vector hashes.
- Ensures KoboldCpp delete requests include the current model, so deletion targets the same model-scoped vector index used by list/insert.

## Testing
- npm run lint -- --quiet
- git diff --check

## Reviewer notes
To verify manually, enable chat vectorization with KoboldCpp, vectorize a message, edit it, and confirm the old hash is removed instead of remaining as stale context.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).