### PR TITLE
Filter Gemma 4 continue thought channel marker

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6238,6 +6238,15 @@ export function extractMessageFromData(data, activeApi = null) {
     return Array.isArray(result) ? result.map(x => x.text).filter(x => x).join('') : result;
 }
 
+function stripGemma4ContinueThoughtChannel(text, isContinue) {
+    const model = String(getChatCompletionModel(oai_settings) || '').toLowerCase();
+    if (!isContinue || main_api !== 'openai' || oai_settings.chat_completion_source !== chat_completion_sources.CUSTOM || !model.includes('gemma-4')) {
+        return text;
+    }
+
+    return text.replace(/<\|channel\|?>thought\s*<\|?channel\|>\s*/i, '');
+}
+
 /**
  * Extracts JSON from the response data.
  * @param {object} data Response data
@@ -6377,6 +6386,8 @@ export function cleanUpMessage({ getMessage, isImpersonate, isContinue, displayI
     if (!getMessage) {
         return '';
     }
+
+    getMessage = stripGemma4ContinueThoughtChannel(getMessage, isContinue);
 
     // Add the prompt bias before anything else
     if (

--- a/public/script.js
+++ b/public/script.js
@@ -6238,13 +6238,21 @@ export function extractMessageFromData(data, activeApi = null) {
     return Array.isArray(result) ? result.map(x => x.text).filter(x => x).join('') : result;
 }
 
-function stripGemma4ContinueThoughtChannel(text, isContinue) {
-    const model = String(getChatCompletionModel(oai_settings) || '').toLowerCase();
-    if (!isContinue || main_api !== 'openai' || oai_settings.chat_completion_source !== chat_completion_sources.CUSTOM || !model.includes('gemma-4')) {
+/**
+ * Strips leaked thought-channel markers from continue responses.
+ * Handles patterns like <|channel>thought <channel|> used by some models.
+ * @param {string} text Response text
+ * @param {boolean} isContinue Whether this is a continue generation
+ * @returns {string} Cleaned text
+ */
+function stripThoughtChannelMarkers(text, isContinue) {
+    // Only apply to continue generations on OpenAI-compatible APIs
+    if (!isContinue || main_api !== 'openai') {
         return text;
     }
 
-    return text.replace(/<\|channel\|?>thought\s*<\|?channel\|>\s*/i, '');
+    // Remove common thought-channel leak patterns
+    return text.replace(/<\|channel\|?>thought\s*<\|?channel\|>\s*/gi, '');
 }
 
 /**
@@ -6387,7 +6395,8 @@ export function cleanUpMessage({ getMessage, isImpersonate, isContinue, displayI
         return '';
     }
 
-    getMessage = stripGemma4ContinueThoughtChannel(getMessage, isContinue);
+    // Strip leaked thought-channel markers from continue responses
+    getMessage = stripThoughtChannelMarkers(getMessage, isContinue);
 
     // Add the prompt bias before anything else
     if (


### PR DESCRIPTION
Fixes #5506

## Summary
- Remove the leaked Gemma 4 thought-channel marker from continued responses.
- Scope the cleanup to continue generations on OpenAI-compatible custom sources using Gemma 4 models, so other models and normal generations are unaffected.

## Testing
- npm run lint -- --quiet
- git diff --check
- Manual regex smoke check for both reported marker spellings

## Reviewer notes
To verify manually, use a Gemma 4 model through an OpenAI-compatible custom endpoint, enable continue prefill, continue an assistant message, and confirm `<|channel>thought <channel|>` is not inserted into the saved text.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).