### PR TITLE
fix: skip parsed reasoning tokens in continue prefill (fixes #5506)

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -269,7 +269,7 @@ import { initServerHistory } from './scripts/server-history.js';
 import { initSettingsSearch } from './scripts/setting-search.js';
 import { initBulkEdit } from './scripts/bulk-edit.js';
 import { getContext } from './scripts/st-context.js';
-import { extractReasoningFromData, extractReasoningSignatureFromData, initReasoning, parseReasoningInSwipes, PromptReasoning, ReasoningHandler, removeReasoningFromString, updateReasoningUI } from './scripts/reasoning.js';
+import { extractReasoningFromData, extractReasoningSignatureFromData, initReasoning, parseReasoningInSwipes, PromptReasoning, ReasoningHandler, ReasoningType, removeReasoningFromString, updateReasoningUI } from './scripts/reasoning.js';
 import { accountStorage } from './scripts/util/AccountStorage.js';
 import { initWelcomeScreen, openPermanentAssistantChat, openPermanentAssistantCard, getPermanentAssistantAvatar } from './scripts/welcome-screen.js';
 import { initDataMaid } from './scripts/data-maid.js';
@@ -4475,13 +4475,18 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         // In group chats, only include reasoning from the currently generating character
         const isOtherGroupMember = selected_group && coreChat[i].name !== name2;
 
+        // Parsed reasoning was extracted from message text (e.g. Gemma 4 with --reasoning off).
+        // Re-adding the reasoning tokens to the continue prefill causes the model to repeat them
+        // at the start of the continuation. Skip reasoning for parsed type on the prefix message.
+        const skipReasoningForPrefix = isPrefix && coreChat[i].extra?.reasoning_type === ReasoningType.Parsed;
+
         coreChat[i] = {
             ...coreChat[i],
             mes: isOtherGroupMember
                 ? coreChat[i].mes
                 : promptReasoning.addToMessage(
                     coreChat[i].mes,
-                    getRegexedString(
+                    skipReasoningForPrefix ? '' : getRegexedString(
                         String(coreChat[i].extra?.reasoning ?? ''),
                         regex_placement.REASONING,
                         { isPrompt: true, depth: depth },


### PR DESCRIPTION
## Problem

When using Gemma 4 via llama.cpp with `--reasoning off` and Chat Completion API, clicking **Continue** with the **continue prefill** option enabled caused `<|channel>thought <channel|>` to appear in the message text before the new continuation.

**Root cause:** When SillyTavern's auto-parse extracts reasoning tokens from the message text (setting `reasoning_type = 'Parsed'`), it stores the reasoning in `message.extra.reasoning` and strips it from `message.mes`. During a continue-with-prefill operation, `addToMessage()` re-adds those tokens as `{prefix}{reasoning}{suffix}` at the front of the prefill message. Models that embed thinking tokens in text (rather than via a separate API field) see this as a cue to output more reasoning tokens at the start of their continuation.

## Fix

Skip adding reasoning tokens to the continue prefill when `reasoning_type === 'Parsed'`. This type means the reasoning was extracted from embedded text tokens, not from a dedicated API reasoning field. The model should continue from the response content without being prompted to re-emit reasoning tokens.

Model-sourced reasoning (`reasoning_type === 'Model'`, from API fields like DeepSeek's `reasoning_content` or Claude's thinking blocks) is unaffected and still included in the continue prefill.

## Changes

- `public/script.js`: Import `ReasoningType` from reasoning module; check `reasoning_type` before building the reasoning string for the continue prefix message.