### PR TITLE
fix: resolve nested markdown emphasis breaking formatting

### DIFF
--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -437,6 +437,12 @@ export function fixMarkdown(text, forDisplay) {
 
     // Iterate through the matches and replace adjacent spaces immediately beside formatting characters
     let newText = text;
+
+    // Fix nested emphasis: *text *nested* text* -> *text **nested** text*
+    // Handles the common LLM artifact where it tries to put *action* inside an *action block*
+    const nestedEmphasisRegex = /(^|[^\w*])\*([^*\n]+?)\s+\*([^*\n]+?)\*\s+([^*\n]+?)\*([^\w*]|$)/g;
+    newText = newText.replace(nestedEmphasisRegex, '$1*$2 **$3** $4*$5');
+
     for (let i = matches.length - 1; i >= 0; i--) {
         let matchText = matches[i][0];
         let replacementText = matchText.replace(/(\*|_)([\t \u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]+)|([\t \u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]+)(\*|_)/g, '$1$4');


### PR DESCRIPTION
Fixes #5500

## Summary
- Fixes an issue where nested emphasis markers (e.g., `*...Some Text *Nested Emphasis Text* More text...*`) break the Markdown parser.
- Modifies `fixMarkdown` to detect this specific LLM artifact pattern and automatically convert the inner single asterisks into double asterisks (`**`), allowing `showdown.js` to correctly render it as bold text inside italics.
- Uses a strict regex that only triggers when spaces and word boundaries properly isolate the inner emphasis, preventing unintended replacements.

## Testing
- `npm run lint -- --quiet` (Passed)
- Manual regex testing against standard markdown structures and edge cases.

## Reviewer notes
- This relies on the user having the "Auto-fix generated Markdown" setting enabled, as it plugs directly into `fixMarkdown`.
- To verify manually, enable the setting, paste `*...Some Text *Nested Emphasis Text* More text...*` into a chat response, and observe it successfully render.

## Checklist:
- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).