### PR TITLE
feat: support reasoning effort for KoboldCpp via Chat Completions

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2495,18 +2495,25 @@ function getReasoningEffort(settings = null, model = null) {
     }
 
     function resolveReasoningEffort() {
+        const isKoboldCpp = settings.chat_completion_source === chat_completion_sources.CUSTOM && String(model).startsWith('koboldcpp/');
+
         switch (settings.reasoning_effort) {
             case reasoning_effort_types.auto:
                 return undefined;
             case reasoning_effort_types.min:
-                if (chat_completion_sources.OPENROUTER === settings.chat_completion_source && !settings.show_thoughts) {
+                if ((chat_completion_sources.OPENROUTER === settings.chat_completion_source || isKoboldCpp) && !settings.show_thoughts) {
                     return 'none';
+                }
+
+                if (isKoboldCpp) {
+                    return 'minimal';
                 }
 
                 return [chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source) && /^gpt-5/.test(model)
                     ? reasoning_effort_types.min
                     : reasoning_effort_types.low;
             case reasoning_effort_types.max:
+                if (isKoboldCpp) return 'xhigh';
                 return reasoning_effort_types.high;
             default:
                 return settings.reasoning_effort;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2501,7 +2501,7 @@ function getReasoningEffort(settings = null, model = null) {
             case reasoning_effort_types.auto:
                 return undefined;
             case reasoning_effort_types.min:
-                if ((chat_completion_sources.OPENROUTER === settings.chat_completion_source || isKoboldCpp) && !settings.show_thoughts) {
+                if (chat_completion_sources.OPENROUTER === settings.chat_completion_source && !settings.show_thoughts) {
                     return 'none';
                 }
 

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2395,7 +2395,7 @@ router.post('/generate', async function (request, response) {
 
         // A few of OpenAIs reasoning models support reasoning effort
         if (request.body.reasoning_effort && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.OPENAI].includes(request.body.chat_completion_source)) {
-            if (OPENAI_REASONING_EFFORT_MODELS.includes(request.body.model)) {
+            if (OPENAI_REASONING_EFFORT_MODELS.includes(request.body.model) || String(request.body.model).startsWith('koboldcpp/')) {
                 bodyParams['reasoning_effort'] = OPENAI_FIXED_REASONING_EFFORT[request.body.model] ?? OPENAI_REASONING_EFFORT_MAP[request.body.reasoning_effort] ?? request.body.reasoning_effort;
             }
         }


### PR DESCRIPTION
Closes #5489

## Summary
- Allow sending reasoning_effort to KoboldCpp on CUSTOM chat completions when model starts with koboldcpp/.
- Map UI values: min -> minimal, max -> xhigh.

## Testing
- npm run lint -- --quiet