### PR TITLE
fix: add config toggle to disable HTTP keepAlive (Node 18 behavior)

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -43,7 +43,7 @@ port: 8000
 heartbeatInterval: 0
 # Enable HTTP/HTTPS keep-alive globally.
 # Disabling restores old Node 18 behavior, can help if ECONNRESET and other network errors occur.
-enableKeepAlive: true
+enableKeepAlive: false
 # -- SSL options --
 ssl:
   # Enable SSL/TLS encryption

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -41,9 +41,9 @@ port: 8000
 # Interval in seconds to write a heartbeat file. Set to 0 to disable.
 # This is used primarily for Docker healthchecks.
 heartbeatInterval: 0
-# Disable HTTP/HTTPS keep-alive globally.
-# Can help resolve connection issues with some proxies.
-disableKeepAlive: false
+# Enable HTTP/HTTPS keep-alive globally.
+# Disabling restores old Node 18 behavior, can help if ECONNRESET and other network errors occur.
+enableKeepAlive: true
 # -- SSL options --
 ssl:
   # Enable SSL/TLS encryption

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -41,6 +41,9 @@ port: 8000
 # Interval in seconds to write a heartbeat file. Set to 0 to disable.
 # This is used primarily for Docker healthchecks.
 heartbeatInterval: 0
+# Disable HTTP/HTTPS keep-alive globally.
+# Can help resolve connection issues with some proxies.
+disableKeepAlive: false
 # -- SSL options --
 ssl:
   # Enable SSL/TLS encryption

--- a/server.js
+++ b/server.js
@@ -8,7 +8,6 @@ console.log(`Node version: ${process.version}. Running in ${process.env.NODE_ENV
 const cliArgs = new CommandLineParser().parse(process.argv);
 globalThis.DATA_ROOT = cliArgs.dataRoot;
 globalThis.COMMAND_LINE_ARGS = cliArgs;
-
 process.chdir(serverDirectory);
 
 try {

--- a/server.js
+++ b/server.js
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import http from 'node:http';
-import https from 'node:https';
 import { CommandLineParser } from './src/command-line.js';
 import { serverDirectory } from './src/server-directory.js';
 
@@ -10,11 +8,6 @@ console.log(`Node version: ${process.version}. Running in ${process.env.NODE_ENV
 const cliArgs = new CommandLineParser().parse(process.argv);
 globalThis.DATA_ROOT = cliArgs.dataRoot;
 globalThis.COMMAND_LINE_ARGS = cliArgs;
-
-if (cliArgs.disableKeepAlive) {
-    http.globalAgent = new http.Agent({ keepAlive: false });
-    https.globalAgent = new https.Agent({ keepAlive: false });
-}
 
 process.chdir(serverDirectory);
 

--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import http from 'node:http';
+import https from 'node:https';
 import { CommandLineParser } from './src/command-line.js';
 import { serverDirectory } from './src/server-directory.js';
 
@@ -8,6 +10,12 @@ console.log(`Node version: ${process.version}. Running in ${process.env.NODE_ENV
 const cliArgs = new CommandLineParser().parse(process.argv);
 globalThis.DATA_ROOT = cliArgs.dataRoot;
 globalThis.COMMAND_LINE_ARGS = cliArgs;
+
+if (cliArgs.disableKeepAlive) {
+    http.globalAgent = new http.Agent({ keepAlive: false });
+    https.globalAgent = new https.Agent({ keepAlive: false });
+}
+
 process.chdir(serverDirectory);
 
 try {

--- a/src/command-line.js
+++ b/src/command-line.js
@@ -77,7 +77,7 @@ export class CommandLineParser {
             keyPassphrase: '',
             whitelistMode: true,
             basicAuthMode: false,
-            enableKeepAlive: true,
+            enableKeepAlive: false,
             requestProxyEnabled: false,
             requestProxyUrl: '',
             requestProxyBypass: [],

--- a/src/command-line.js
+++ b/src/command-line.js
@@ -31,7 +31,7 @@ import { initConfig } from './config-init.js';
  * @property {string} keyPassphrase SSL private key passphrase
  * @property {boolean} whitelistMode If enable whitelist mode
  * @property {boolean} basicAuthMode If enable basic authentication
- * @property {boolean} disableKeepAlive Disable HTTP/HTTPS keep-alive globally
+ * @property {boolean} enableKeepAlive Enable HTTP/HTTPS keep-alive globally
  * @property {boolean} requestProxyEnabled If enable outgoing request proxy
  * @property {string} requestProxyUrl Request proxy URL
  * @property {string[]} requestProxyBypass Request proxy bypass list
@@ -77,7 +77,7 @@ export class CommandLineParser {
             keyPassphrase: '',
             whitelistMode: true,
             basicAuthMode: false,
-            disableKeepAlive: false,
+            enableKeepAlive: true,
             requestProxyEnabled: false,
             requestProxyUrl: '',
             requestProxyBypass: [],
@@ -219,10 +219,10 @@ export class CommandLineParser {
                 default: null,
                 describe: 'Enables basic authentication',
             })
-            .option('disableKeepAlive', {
+            .option('enableKeepAlive', {
                 type: 'boolean',
                 default: null,
-                describe: 'Disable HTTP/HTTPS keep-alive globally',
+                describe: 'Enable HTTP/HTTPS keep-alive globally',
             })
             .option('requestProxyEnabled', {
                 type: 'boolean',
@@ -320,7 +320,7 @@ export class CommandLineParser {
             keyPassphrase: cliArguments.keyPassphrase ?? getConfigValue('ssl.keyPassphrase', defaultConfig.keyPassphrase),
             whitelistMode: cliArguments.whitelist ?? getConfigValue('whitelistMode', defaultConfig.whitelistMode, 'boolean'),
             basicAuthMode: cliArguments.basicAuthMode ?? getConfigValue('basicAuthMode', defaultConfig.basicAuthMode, 'boolean'),
-            disableKeepAlive: cliArguments.disableKeepAlive ?? getConfigValue('disableKeepAlive', defaultConfig.disableKeepAlive, 'boolean'),
+            enableKeepAlive: cliArguments.enableKeepAlive ?? getConfigValue('enableKeepAlive', defaultConfig.enableKeepAlive, 'boolean'),
             requestProxyEnabled: cliArguments.requestProxyEnabled ?? getConfigValue('requestProxy.enabled', defaultConfig.requestProxyEnabled, 'boolean'),
             requestProxyUrl: cliArguments.requestProxyUrl ?? getConfigValue('requestProxy.url', defaultConfig.requestProxyUrl),
             requestProxyBypass: cliArguments.requestProxyBypass ?? getConfigValue('requestProxy.bypass', defaultConfig.requestProxyBypass),

--- a/src/command-line.js
+++ b/src/command-line.js
@@ -31,6 +31,7 @@ import { initConfig } from './config-init.js';
  * @property {string} keyPassphrase SSL private key passphrase
  * @property {boolean} whitelistMode If enable whitelist mode
  * @property {boolean} basicAuthMode If enable basic authentication
+ * @property {boolean} disableKeepAlive Disable HTTP/HTTPS keep-alive globally
  * @property {boolean} requestProxyEnabled If enable outgoing request proxy
  * @property {string} requestProxyUrl Request proxy URL
  * @property {string[]} requestProxyBypass Request proxy bypass list
@@ -76,6 +77,7 @@ export class CommandLineParser {
             keyPassphrase: '',
             whitelistMode: true,
             basicAuthMode: false,
+            disableKeepAlive: false,
             requestProxyEnabled: false,
             requestProxyUrl: '',
             requestProxyBypass: [],
@@ -217,6 +219,11 @@ export class CommandLineParser {
                 default: null,
                 describe: 'Enables basic authentication',
             })
+            .option('disableKeepAlive', {
+                type: 'boolean',
+                default: null,
+                describe: 'Disable HTTP/HTTPS keep-alive globally',
+            })
             .option('requestProxyEnabled', {
                 type: 'boolean',
                 default: null,
@@ -313,6 +320,7 @@ export class CommandLineParser {
             keyPassphrase: cliArguments.keyPassphrase ?? getConfigValue('ssl.keyPassphrase', defaultConfig.keyPassphrase),
             whitelistMode: cliArguments.whitelist ?? getConfigValue('whitelistMode', defaultConfig.whitelistMode, 'boolean'),
             basicAuthMode: cliArguments.basicAuthMode ?? getConfigValue('basicAuthMode', defaultConfig.basicAuthMode, 'boolean'),
+            disableKeepAlive: cliArguments.disableKeepAlive ?? getConfigValue('disableKeepAlive', defaultConfig.disableKeepAlive, 'boolean'),
             requestProxyEnabled: cliArguments.requestProxyEnabled ?? getConfigValue('requestProxy.enabled', defaultConfig.requestProxyEnabled, 'boolean'),
             requestProxyUrl: cliArguments.requestProxyUrl ?? getConfigValue('requestProxy.url', defaultConfig.requestProxyUrl),
             requestProxyBypass: cliArguments.requestProxyBypass ?? getConfigValue('requestProxy.bypass', defaultConfig.requestProxyBypass),

--- a/src/request-proxy.js
+++ b/src/request-proxy.js
@@ -13,8 +13,9 @@ const LOG_HEADER = '[Request Proxy]';
  * @property {boolean} enabled Whether proxy is enabled.
  * @property {string} url Proxy URL.
  * @property {string[]} bypass List of URLs to bypass proxy.
+ * @property {boolean} [disableKeepAlive] Disable HTTP/HTTPS keep-alive.
  */
-export default function initRequestProxy({ enabled, url, bypass }) {
+export default function initRequestProxy({ enabled, url, bypass, disableKeepAlive }) {
     try {
         // No proxy is enabled, so return
         if (!enabled) {
@@ -39,7 +40,8 @@ export default function initRequestProxy({ enabled, url, bypass }) {
             process.env.no_proxy = bypass.join(',');
         }
 
-        const proxyAgent = new ProxyAgent();
+        const proxyAgentOptions = disableKeepAlive ? { keepAlive: false } : {};
+        const proxyAgent = new ProxyAgent(proxyAgentOptions);
         http.globalAgent = proxyAgent;
         https.globalAgent = proxyAgent;
 

--- a/src/request-proxy.js
+++ b/src/request-proxy.js
@@ -13,9 +13,9 @@ const LOG_HEADER = '[Request Proxy]';
  * @property {boolean} enabled Whether proxy is enabled.
  * @property {string} url Proxy URL.
  * @property {string[]} bypass List of URLs to bypass proxy.
- * @property {boolean} [disableKeepAlive] Disable HTTP/HTTPS keep-alive.
+ * @property {boolean} [enableKeepAlive] Enable HTTP/HTTPS keep-alive.
  */
-export default function initRequestProxy({ enabled, url, bypass, disableKeepAlive }) {
+export default function initRequestProxy({ enabled, url, bypass, enableKeepAlive }) {
     try {
         // No proxy is enabled, so return
         if (!enabled) {
@@ -40,7 +40,7 @@ export default function initRequestProxy({ enabled, url, bypass, disableKeepAliv
             process.env.no_proxy = bypass.join(',');
         }
 
-        const proxyAgentOptions = disableKeepAlive ? { keepAlive: false } : {};
+        const proxyAgentOptions =  enableKeepAlive ? { keepAlive: true } : { keepAlive: false };
         const proxyAgent = new ProxyAgent(proxyAgentOptions);
         http.globalAgent = proxyAgent;
         https.globalAgent = proxyAgent;

--- a/src/request-proxy.js
+++ b/src/request-proxy.js
@@ -13,7 +13,7 @@ const LOG_HEADER = '[Request Proxy]';
  * @property {boolean} enabled Whether proxy is enabled.
  * @property {string} url Proxy URL.
  * @property {string[]} bypass List of URLs to bypass proxy.
- * @property {boolean} [enableKeepAlive] Enable HTTP/HTTPS keep-alive.
+ * @property {boolean} enableKeepAlive Enable HTTP/HTTPS keep-alive.
  */
 export default function initRequestProxy({ enabled, url, bypass, enableKeepAlive }) {
     try {

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -5,6 +5,8 @@ import util from 'node:util';
 import net from 'node:net';
 import dns from 'node:dns';
 import process from 'node:process';
+import http from 'node:http';
+import https from 'node:https';
 
 import cors from 'cors';
 import { csrfSync } from 'csrf-sync';
@@ -92,6 +94,10 @@ if (!cliArgs.enableIPv6 && !cliArgs.enableIPv4) {
     console.error('error: You can\'t disable all internet protocols: at least IPv6 or IPv4 must be enabled.');
     process.exit(1);
 }
+
+// Set keep-alive preference for all HTTP/HTTPS requests.
+http.globalAgent = new http.Agent({ keepAlive: cliArgs.enableKeepAlive });
+https.globalAgent = new https.Agent({ keepAlive: cliArgs.enableKeepAlive });
 
 const app = express();
 app.use(helmet({
@@ -328,7 +334,7 @@ async function preSetupTasks() {
     });
 
     // Add request proxy.
-    initRequestProxy({ enabled: cliArgs.requestProxyEnabled, url: cliArgs.requestProxyUrl, bypass: cliArgs.requestProxyBypass, disableKeepAlive: cliArgs.disableKeepAlive });
+    initRequestProxy({ enabled: cliArgs.requestProxyEnabled, url: cliArgs.requestProxyUrl, bypass: cliArgs.requestProxyBypass, enableKeepAlive: cliArgs.enableKeepAlive });
 
     // Wait for frontend libs to compile
     await webpackMiddleware.runWebpackCompiler({ pruneCache: true });

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -328,7 +328,7 @@ async function preSetupTasks() {
     });
 
     // Add request proxy.
-    initRequestProxy({ enabled: cliArgs.requestProxyEnabled, url: cliArgs.requestProxyUrl, bypass: cliArgs.requestProxyBypass });
+    initRequestProxy({ enabled: cliArgs.requestProxyEnabled, url: cliArgs.requestProxyUrl, bypass: cliArgs.requestProxyBypass, disableKeepAlive: cliArgs.disableKeepAlive });
 
     // Wait for frontend libs to compile
     await webpackMiddleware.runWebpackCompiler({ pruneCache: true });


### PR DESCRIPTION
## Problem

In the `1.17.0` major version update, SillyTavern updated its minimum requirement to Node.js 20+ (moving away from Node 18, which reached EOL). While largely a seamless transition, this inadvertently inherited a networking change introduced in Node 19: HTTP/1.1 `keepAlive` is now set to `true` by default ([Node 19 release notes](https://nodejs.org/en/blog/announcements/v19-release-announce#https11-keepalive-by-default)).

This default behavior has resulted in `ECONNRESET` errors when routing requests through certain proxies. The primary example tested and observed was with NanoGPT. The root cause appears to be tied to how these specific network endpoints handle persistent connections.

## Fix

As discussed in [PR #5514 (comment)](https://github.com/SillyTavern/SillyTavern/pull/5514#issuecomment-4308509486), this commit introduces a new `disableKeepAlive` setting in `config.yaml` that allows users to revert the behavior and turn `keepAlive` off.

- **Implementation:** When `disableKeepAlive` is enabled via the config, the fix explicitly overrides `http.globalAgent` and `https.globalAgent` with new instances where `keepAlive: false`. This ensures the legacy behavior is applied globally across the application.
- **Default State:** `disableKeepAlive` is set to `false` by default. This preserves the standard Node 20+ behavior, leaving `keepAlive` active unless the user explicitly opts in to the fix.
- **Testing:** Local testing shows that enabling this toggle (setting `disableKeepAlive: true`) successfully alleviates the `ECONNRESET` proxy drops. Additional testing from other users also indicates this.
- **Additional Context:** The `request-proxies` logic was also modified to respect this new config behavior, though that specific pathway has not yet been thoroughly tested.

## Checklist

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).