### PR TITLE
feat: add DeepSeek V4 model support with thinking mode and reasoning effort

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2135,7 +2135,7 @@
                                             </strong>
                                         </div>
                                     </div>
-                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt">
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt,deepseek">
                                         <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
                                             <label for="openai_reasoning_effort">
                                                 <span data-i18n="Reasoning Effort">Reasoning Effort</span>
@@ -3735,9 +3735,11 @@
                             <div>
                                 <h4 data-i18n="DeepSeek Model">DeepSeek Model</h4>
                                 <select id="model_deepseek_select">
-                                    <option value="deepseek-chat">deepseek-chat</option>
+                                    <option value="deepseek-v4-flash">deepseek-v4-flash</option>
+                                    <option value="deepseek-v4-pro">deepseek-v4-pro</option>
+                                    <option value="deepseek-chat">deepseek-chat (deprecated)</option>
+                                    <option value="deepseek-reasoner">deepseek-reasoner (deprecated)</option>
                                     <option value="deepseek-coder">deepseek-coder</option>
-                                    <option value="deepseek-reasoner">deepseek-reasoner</option>
                                 </select>
                             </div>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -3735,9 +3735,7 @@
                             <div>
                                 <h4 data-i18n="DeepSeek Model">DeepSeek Model</h4>
                                 <select id="model_deepseek_select">
-                                    <option value="deepseek-chat">deepseek-chat</option>
-                                    <option value="deepseek-coder">deepseek-coder</option>
-                                    <option value="deepseek-reasoner">deepseek-reasoner</option>
+                                    <option value="" data-i18n="-- Connect to the API --">-- Connect to the API --</option>
                                 </select>
                             </div>
                         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -2130,7 +2130,7 @@
                                             <span data-i18n="Allows the model to return its thinking process.">
                                                 Allows the model to return its thinking process.
                                             </span>
-                                            <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter">
+                                            <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter,deepseek">
                                                 This setting affects visibility only.
                                             </strong>
                                         </div>
@@ -3735,11 +3735,9 @@
                             <div>
                                 <h4 data-i18n="DeepSeek Model">DeepSeek Model</h4>
                                 <select id="model_deepseek_select">
-                                    <option value="deepseek-v4-flash">deepseek-v4-flash</option>
-                                    <option value="deepseek-v4-pro">deepseek-v4-pro</option>
-                                    <option value="deepseek-chat">deepseek-chat (deprecated)</option>
-                                    <option value="deepseek-reasoner">deepseek-reasoner (deprecated)</option>
+                                    <option value="deepseek-chat">deepseek-chat</option>
                                     <option value="deepseek-coder">deepseek-coder</option>
+                                    <option value="deepseek-reasoner">deepseek-reasoner</option>
                                 </select>
                             </div>
                         </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2512,6 +2512,7 @@ function getReasoningEffort(settings = null, model = null) {
         chat_completion_sources.COMETAPI,
         chat_completion_sources.ELECTRONHUB,
         chat_completion_sources.CHUTES,
+        chat_completion_sources.DEEPSEEK,
     ];
 
     if (!reasoningEffortSources.includes(settings.chat_completion_source)) {
@@ -2519,6 +2520,17 @@ function getReasoningEffort(settings = null, model = null) {
     }
 
     function resolveReasoningEffort() {
+        if (settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
+            switch (settings.reasoning_effort) {
+                case reasoning_effort_types.auto:
+                    return undefined;
+                case reasoning_effort_types.max:
+                    return reasoning_effort_types.max;
+                default:
+                    return reasoning_effort_types.high;
+            }
+        }
+
         switch (settings.reasoning_effort) {
             case reasoning_effort_types.auto:
                 return undefined;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2488,6 +2488,17 @@ function getReasoningEffort(settings = null, model = null) {
     settings = settings ?? oai_settings;
     model = model ?? getChatCompletionModel(settings);
 
+    if (settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
+        switch (settings.reasoning_effort) {
+            case reasoning_effort_types.auto:
+                return undefined;
+            case reasoning_effort_types.max:
+                return reasoning_effort_types.max;
+            default:
+                return reasoning_effort_types.high;
+        }
+    }
+
     // These sources expect the effort as string.
     const reasoningEffortSources = [
         chat_completion_sources.OPENAI,
@@ -5624,8 +5635,8 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
         if (oai_settings.max_context_unlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
-        } else if (['deepseek-reasoner', 'deepseek-chat'].includes(oai_settings.deepseek_model)) {
-            $('#openai_max_context').attr('max', max_128k);
+        } else if (/^deepseek-v4/.test(oai_settings.deepseek_model) || ['deepseek-reasoner', 'deepseek-chat'].includes(oai_settings.deepseek_model)) {
+            $('#openai_max_context').attr('max', max_1mil);
         } else if (oai_settings.deepseek_model == 'deepseek-coder') {
             $('#openai_max_context').attr('max', max_16k);
         } else {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2088,31 +2088,18 @@ function saveModelList(data) {
     }
 
     if (oai_settings.chat_completion_source == chat_completion_sources.DEEPSEEK) {
-        const legacyDeepSeekModels = [
-            { id: 'deepseek-chat', deprecated: '2026/07/24' },
-            { id: 'deepseek-reasoner', deprecated: '2026/07/24' },
-        ];
-        const deepSeekModels = [...model_list];
-        for (const legacyModel of legacyDeepSeekModels) {
-            if (!deepSeekModels.some(model => model.id === legacyModel.id)) {
-                deepSeekModels.push(legacyModel);
-            }
-        }
-
         $('#model_deepseek_select').empty();
-        deepSeekModels.forEach((model) => {
-            const deprecatedInfo = legacyDeepSeekModels.find(legacyModel => legacyModel.id === model.id)?.deprecated;
-            const label = deprecatedInfo ? `${model.id} (deprecated ${deprecatedInfo})` : model.id;
+        model_list.forEach((model) => {
             $('#model_deepseek_select').append(
                 $('<option>', {
                     value: model.id,
-                    text: label,
+                    text: model.id,
                 }));
         });
 
-        const selectedModel = deepSeekModels.find(model => model.id === oai_settings.deepseek_model);
-        if (deepSeekModels.length > 0 && (!selectedModel || !oai_settings.deepseek_model)) {
-            oai_settings.deepseek_model = deepSeekModels[0].id;
+        const selectedModel = model_list.find(model => model.id === oai_settings.deepseek_model);
+        if (model_list.length > 0 && (!selectedModel || !oai_settings.deepseek_model)) {
+            oai_settings.deepseek_model = model_list[0].id;
         }
 
         $('#model_deepseek_select').val(oai_settings.deepseek_model).trigger('change');
@@ -4134,6 +4121,7 @@ function migrateChatCompletionSettings(settings) {
         { oldKey: 'claude_use_sysprompt', oldValue: true, newKey: 'use_sysprompt', newValue: true },
         { oldKey: 'use_makersuite_sysprompt', oldValue: true, newKey: 'use_sysprompt', newValue: true },
         { oldKey: 'mistralai_model', oldValue: /^(mistral-medium|mistral-small)$/, newKey: 'mistralai_model', newValue: (settings.mistralai_model + '-latest') },
+        { oldKey: 'deepseek_model', oldValue: /^deepseek-(chat|reasoner)$/, newKey: 'deepseek_model', newValue: 'deepseek-v4-flash' },
     ];
 
     for (const migration of migrateMap) {
@@ -5646,18 +5634,8 @@ async function onModelChange() {
     }
 
     if (oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
-        if (oai_settings.max_context_unlocked) {
-            $('#openai_max_context').attr('max', unlocked_max);
-        } else if (/^deepseek-v4/.test(oai_settings.deepseek_model)) {
-            $('#openai_max_context').attr('max', max_1mil);
-        } else if (['deepseek-chat','deepseek-reasoner'].includes(oai_settings.deepseek_model)) {
-            $('#openai_max_context').attr('max', max_128k);
-        } else if (oai_settings.deepseek_model == 'deepseek-coder') {
-            $('#openai_max_context').attr('max', max_16k);
-        } else {
-            $('#openai_max_context').attr('max', max_64k);
-        }
-
+        const maxContext = oai_settings.max_context_unlocked ? unlocked_max : max_1mil;
+        $('#openai_max_context').attr('max', maxContext);
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
         $('#temp_openai').attr('max', oai_max_temp).val(oai_settings.temp_openai).trigger('input');

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2488,17 +2488,6 @@ function getReasoningEffort(settings = null, model = null) {
     settings = settings ?? oai_settings;
     model = model ?? getChatCompletionModel(settings);
 
-    if (settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
-        switch (settings.reasoning_effort) {
-            case reasoning_effort_types.auto:
-                return undefined;
-            case reasoning_effort_types.max:
-                return reasoning_effort_types.max;
-            default:
-                return reasoning_effort_types.high;
-        }
-    }
-
     // These sources expect the effort as string.
     const reasoningEffortSources = [
         chat_completion_sources.OPENAI,

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -446,7 +446,7 @@ const default_settings = {
     electronhub_sort_models: 'alphabetically',
     electronhub_group_models: false,
     nanogpt_model: 'gpt-4o-mini',
-    deepseek_model: 'deepseek-v4-flash',
+    deepseek_model: 'deepseek-chat',
     aimlapi_model: 'chatgpt-4o-latest',
     xai_model: 'grok-3-beta',
     pollinations_model: 'openai',
@@ -2088,23 +2088,20 @@ function saveModelList(data) {
     }
 
     if (oai_settings.chat_completion_source == chat_completion_sources.DEEPSEEK) {
-        const knownDeepSeekModels = [
-            { id: 'deepseek-v4-flash' },
-            { id: 'deepseek-v4-pro' },
+        const legacyDeepSeekModels = [
             { id: 'deepseek-chat', deprecated: '2026/07/24' },
             { id: 'deepseek-reasoner', deprecated: '2026/07/24' },
-            { id: 'deepseek-coder' },
         ];
-        const mergedModels = [...model_list];
-        for (const known of knownDeepSeekModels) {
-            if (!mergedModels.some(m => m.id === known.id)) {
-                mergedModels.push(known);
+        const deepSeekModels = [...model_list];
+        for (const legacyModel of legacyDeepSeekModels) {
+            if (!deepSeekModels.some(model => model.id === legacyModel.id)) {
+                deepSeekModels.push(legacyModel);
             }
         }
 
         $('#model_deepseek_select').empty();
-        mergedModels.forEach((model) => {
-            const deprecatedInfo = knownDeepSeekModels.find(k => k.id === model.id)?.deprecated;
+        deepSeekModels.forEach((model) => {
+            const deprecatedInfo = legacyDeepSeekModels.find(legacyModel => legacyModel.id === model.id)?.deprecated;
             const label = deprecatedInfo ? `${model.id} (deprecated ${deprecatedInfo})` : model.id;
             $('#model_deepseek_select').append(
                 $('<option>', {
@@ -2113,9 +2110,9 @@ function saveModelList(data) {
                 }));
         });
 
-        const selectedModel = mergedModels.find(model => model.id === oai_settings.deepseek_model);
-        if (mergedModels.length > 0 && (!selectedModel || !oai_settings.deepseek_model)) {
-            oai_settings.deepseek_model = mergedModels[0].id;
+        const selectedModel = deepSeekModels.find(model => model.id === oai_settings.deepseek_model);
+        if (deepSeekModels.length > 0 && (!selectedModel || !oai_settings.deepseek_model)) {
+            oai_settings.deepseek_model = deepSeekModels[0].id;
         }
 
         $('#model_deepseek_select').val(oai_settings.deepseek_model).trigger('change');
@@ -5651,8 +5648,10 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
         if (oai_settings.max_context_unlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
-        } else if (/^deepseek-v4/.test(oai_settings.deepseek_model) || ['deepseek-reasoner', 'deepseek-chat'].includes(oai_settings.deepseek_model)) {
+        } else if (/^deepseek-v4/.test(oai_settings.deepseek_model)) {
             $('#openai_max_context').attr('max', max_1mil);
+        } else if (['deepseek-chat','deepseek-reasoner'].includes(oai_settings.deepseek_model)) {
+            $('#openai_max_context').attr('max', max_128k);
         } else if (oai_settings.deepseek_model == 'deepseek-coder') {
             $('#openai_max_context').attr('max', max_16k);
         } else {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -446,7 +446,7 @@ const default_settings = {
     electronhub_sort_models: 'alphabetically',
     electronhub_group_models: false,
     nanogpt_model: 'gpt-4o-mini',
-    deepseek_model: 'deepseek-chat',
+    deepseek_model: 'deepseek-v4-flash',
     aimlapi_model: 'chatgpt-4o-latest',
     xai_model: 'grok-3-beta',
     pollinations_model: 'openai',
@@ -2088,18 +2088,34 @@ function saveModelList(data) {
     }
 
     if (oai_settings.chat_completion_source == chat_completion_sources.DEEPSEEK) {
+        const knownDeepSeekModels = [
+            { id: 'deepseek-v4-flash' },
+            { id: 'deepseek-v4-pro' },
+            { id: 'deepseek-chat', deprecated: '2026/07/24' },
+            { id: 'deepseek-reasoner', deprecated: '2026/07/24' },
+            { id: 'deepseek-coder' },
+        ];
+        const mergedModels = [...model_list];
+        for (const known of knownDeepSeekModels) {
+            if (!mergedModels.some(m => m.id === known.id)) {
+                mergedModels.push(known);
+            }
+        }
+
         $('#model_deepseek_select').empty();
-        model_list.forEach((model) => {
+        mergedModels.forEach((model) => {
+            const deprecatedInfo = knownDeepSeekModels.find(k => k.id === model.id)?.deprecated;
+            const label = deprecatedInfo ? `${model.id} (deprecated ${deprecatedInfo})` : model.id;
             $('#model_deepseek_select').append(
                 $('<option>', {
                     value: model.id,
-                    text: model.id,
+                    text: label,
                 }));
         });
 
-        const selectedModel = model_list.find(model => model.id === oai_settings.deepseek_model);
-        if (model_list.length > 0 && (!selectedModel || !oai_settings.deepseek_model)) {
-            oai_settings.deepseek_model = model_list[0].id;
+        const selectedModel = mergedModels.find(model => model.id === oai_settings.deepseek_model);
+        if (mergedModels.length > 0 && (!selectedModel || !oai_settings.deepseek_model)) {
+            oai_settings.deepseek_model = mergedModels[0].id;
         }
 
         $('#model_deepseek_select').val(oai_settings.deepseek_model).trigger('change');

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -446,7 +446,7 @@ const default_settings = {
     electronhub_sort_models: 'alphabetically',
     electronhub_group_models: false,
     nanogpt_model: 'gpt-4o-mini',
-    deepseek_model: 'deepseek-chat',
+    deepseek_model: 'deepseek-v4-flash',
     aimlapi_model: 'chatgpt-4o-latest',
     xai_model: 'grok-3-beta',
     pollinations_model: 'openai',

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4122,7 +4122,7 @@ function migrateChatCompletionSettings(settings) {
         { oldKey: 'claude_use_sysprompt', oldValue: true, newKey: 'use_sysprompt', newValue: true },
         { oldKey: 'use_makersuite_sysprompt', oldValue: true, newKey: 'use_sysprompt', newValue: true },
         { oldKey: 'mistralai_model', oldValue: /^(mistral-medium|mistral-small)$/, newKey: 'mistralai_model', newValue: (settings.mistralai_model + '-latest') },
-        { oldKey: 'deepseek_model', oldValue: /^deepseek-(chat|reasoner)$/, newKey: 'deepseek_model', newValue: 'deepseek-v4-flash' },
+        { oldKey: 'deepseek_model', oldValue: /^deepseek-(chat|reasoner|coder)$/, newKey: 'deepseek_model', newValue: 'deepseek-v4-flash' },
     ];
 
     for (const migration of migrateMap) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1073,9 +1073,9 @@ async function sendDeepSeekRequest(request, response) {
             request.body.messages.push(message);
         }
 
-        const processedMessages = addAssistantPrefix(postProcessPrompt(request.body.messages, PROMPT_PROCESSING_TYPE.SEMI_TOOLS, getPromptNames(request)), bodyParams.tools, 'prefix');
+        const processedMessages = postProcessPrompt(request.body.messages, PROMPT_PROCESSING_TYPE.SEMI_TOOLS, getPromptNames(request));
         const isV4Model = /^deepseek-v4/.test(request.body.model);
-        const usesPrefixCompletion = processedMessages.some(message => message.prefix);
+        const usesPrefixCompletion = processedMessages.some(message => message.role === 'assistant' && message.prefix === true);
 
         if (/-reasoner/.test(request.body.model) || isV4Model) {
             addReasoningContentToToolCalls(processedMessages);

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -79,8 +79,7 @@ const API_AI21 = 'https://api.ai21.com/studio/v1';
 const API_CHUTES = 'https://llm.chutes.ai/v1';
 const API_ELECTRONHUB = 'https://api.electronhub.ai/v1';
 const API_NANOGPT = 'https://nano-gpt.com/api/v1';
-const API_DEEPSEEK = 'https://api.deepseek.com';
-const API_DEEPSEEK_BETA = 'https://api.deepseek.com/beta';
+const API_DEEPSEEK = 'https://api.deepseek.com/beta';
 const API_XAI = 'https://api.x.ai/v1';
 const API_AIMLAPI = 'https://api.aimlapi.com/v1';
 const API_POLLINATIONS = 'https://gen.pollinations.ai/v1';
@@ -1027,6 +1026,7 @@ async function sendCohereRequest(request, response) {
  * @param {express.Response} response Express response
  */
 async function sendDeepSeekRequest(request, response) {
+    const apiUrl = new URL(request.body.reverse_proxy || API_DEEPSEEK).toString();
     const apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.DEEPSEEK, request.body.secret_id);
 
     if (!apiKey && !request.body.reverse_proxy) {
@@ -1073,9 +1073,8 @@ async function sendDeepSeekRequest(request, response) {
             request.body.messages.push(message);
         }
 
-        const processedMessages = postProcessPrompt(request.body.messages, PROMPT_PROCESSING_TYPE.SEMI_TOOLS, getPromptNames(request));
+        const processedMessages = addAssistantPrefix(postProcessPrompt(request.body.messages, PROMPT_PROCESSING_TYPE.SEMI_TOOLS, getPromptNames(request)), bodyParams.tools, 'prefix');
         const isV4Model = /^deepseek-v4/.test(request.body.model);
-        const usesPrefixCompletion = processedMessages.some(message => message.role === 'assistant' && message.prefix === true);
 
         if (/-reasoner/.test(request.body.model) || isV4Model) {
             addReasoningContentToToolCalls(processedMessages);
@@ -1088,8 +1087,6 @@ async function sendDeepSeekRequest(request, response) {
                 bodyParams['reasoning_effort'] = request.body.reasoning_effort;
             }
         }
-
-        const apiUrl = new URL(request.body.reverse_proxy || (usesPrefixCompletion ? API_DEEPSEEK_BETA : API_DEEPSEEK)).toString();
 
         const requestBody = {
             'messages': processedMessages,
@@ -1787,7 +1784,7 @@ router.post('/status', async function (request, statusResponse) {
             headers = {};
             queryParams = { detailed: true };
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.DEEPSEEK) {
-            apiUrl = new URL(request.body.reverse_proxy || API_DEEPSEEK).toString();
+            apiUrl = new URL(request.body.reverse_proxy || API_DEEPSEEK.replace('/beta', '')).toString();
             apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.DEEPSEEK, request.body.secret_id);
             headers = {};
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.XAI) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1074,18 +1074,10 @@ async function sendDeepSeekRequest(request, response) {
         }
 
         const processedMessages = addAssistantPrefix(postProcessPrompt(request.body.messages, PROMPT_PROCESSING_TYPE.SEMI_TOOLS, getPromptNames(request)), bodyParams.tools, 'prefix');
-        const isV4Model = /^deepseek-v4/.test(request.body.model);
+        addReasoningContentToToolCalls(processedMessages);
 
-        if (/-reasoner/.test(request.body.model) || isV4Model) {
-            addReasoningContentToToolCalls(processedMessages);
-        }
-
-        if (isV4Model) {
-            bodyParams['thinking'] = { type: request.body.include_reasoning ? 'enabled' : 'disabled' };
-
-            if (request.body.include_reasoning && request.body.reasoning_effort) {
-                bodyParams['reasoning_effort'] = request.body.reasoning_effort;
-            }
+        if (request.body.include_reasoning && request.body.reasoning_effort) {
+            bodyParams['reasoning_effort'] = request.body.reasoning_effort;
         }
 
         const requestBody = {
@@ -1099,8 +1091,10 @@ async function sendDeepSeekRequest(request, response) {
             'top_p': request.body.top_p,
             'stop': request.body.stop,
             'seed': request.body.seed,
+            'thinking': { type: request.body.include_reasoning ? 'enabled' : 'disabled' },
             ...bodyParams,
         };
+
 
         const config = {
             method: 'POST',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1095,7 +1095,6 @@ async function sendDeepSeekRequest(request, response) {
             ...bodyParams,
         };
 
-
         const config = {
             method: 'POST',
             headers: {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -79,7 +79,8 @@ const API_AI21 = 'https://api.ai21.com/studio/v1';
 const API_CHUTES = 'https://llm.chutes.ai/v1';
 const API_ELECTRONHUB = 'https://api.electronhub.ai/v1';
 const API_NANOGPT = 'https://nano-gpt.com/api/v1';
-const API_DEEPSEEK = 'https://api.deepseek.com/beta';
+const API_DEEPSEEK = 'https://api.deepseek.com';
+const API_DEEPSEEK_BETA = 'https://api.deepseek.com/beta';
 const API_XAI = 'https://api.x.ai/v1';
 const API_AIMLAPI = 'https://api.aimlapi.com/v1';
 const API_POLLINATIONS = 'https://gen.pollinations.ai/v1';
@@ -1026,7 +1027,6 @@ async function sendCohereRequest(request, response) {
  * @param {express.Response} response Express response
  */
 async function sendDeepSeekRequest(request, response) {
-    const apiUrl = new URL(request.body.reverse_proxy || API_DEEPSEEK).toString();
     const apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.DEEPSEEK, request.body.secret_id);
 
     if (!apiKey && !request.body.reverse_proxy) {
@@ -1074,10 +1074,22 @@ async function sendDeepSeekRequest(request, response) {
         }
 
         const processedMessages = addAssistantPrefix(postProcessPrompt(request.body.messages, PROMPT_PROCESSING_TYPE.SEMI_TOOLS, getPromptNames(request)), bodyParams.tools, 'prefix');
+        const isV4Model = /^deepseek-v4/.test(request.body.model);
+        const usesPrefixCompletion = processedMessages.some(message => message.prefix);
 
-        if (/-reasoner/.test(request.body.model)) {
+        if (/-reasoner/.test(request.body.model) || isV4Model) {
             addReasoningContentToToolCalls(processedMessages);
         }
+
+        if (isV4Model) {
+            bodyParams['thinking'] = { type: request.body.include_reasoning ? 'enabled' : 'disabled' };
+
+            if (request.body.include_reasoning && request.body.reasoning_effort) {
+                bodyParams['reasoning_effort'] = request.body.reasoning_effort;
+            }
+        }
+
+        const apiUrl = new URL(request.body.reverse_proxy || (usesPrefixCompletion ? API_DEEPSEEK_BETA : API_DEEPSEEK)).toString();
 
         const requestBody = {
             'messages': processedMessages,
@@ -1775,7 +1787,7 @@ router.post('/status', async function (request, statusResponse) {
             headers = {};
             queryParams = { detailed: true };
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.DEEPSEEK) {
-            apiUrl = new URL(request.body.reverse_proxy || API_DEEPSEEK.replace('/beta', '')).toString();
+            apiUrl = new URL(request.body.reverse_proxy || API_DEEPSEEK).toString();
             apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.DEEPSEEK, request.body.secret_id);
             headers = {};
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.XAI) {


### PR DESCRIPTION
## Summary

Add support for DeepSeek V4 models (`deepseek-v4-flash`, `deepseek-v4-pro`) with thinking mode and reasoning effort control.

## Changes

### Backend (`src/endpoints/backends/chat-completions.js`)
- Detect V4 models (`/^deepseek-v4/`) and send `thinking` parameter (`enabled`/`disabled`) based on the "Request model reasoning" toggle
- Send `reasoning_effort` (`high`/`max`) when thinking mode is enabled
- Include V4 models in `addReasoningContentToToolCalls` for proper tool call handling

### Frontend (`public/scripts/openai.js`)
- Map DeepSeek reasoning effort values: `auto` → omitted, `max` → `max`, all others → `high` (per API docs)
- Update context limit to 1M tokens for V4 and legacy models
- Merge known DeepSeek models with API-returned list so all models appear in dropdown
- Mark `deepseek-chat` and `deepseek-reasoner` as deprecated (2026/07/24)
- Default model changed to `deepseek-v4-flash`

### UI (`public/index.html`)
- Add `deepseek-v4-flash` and `deepseek-v4-pro` to static model selector
- Add `deepseek` to the Reasoning Effort dropdown's `data-source` so the control is visible
- Mark deprecated models in the static options

## Testing

1. Select DeepSeek as chat completion source
2. Verify all 5 models appear in dropdown (v4-flash, v4-pro, chat, reasoner, coder)
3. Select `deepseek-v4-flash` or `deepseek-v4-pro`
4. Toggle "Request model reasoning" → verify thinking mode works
5. Change Reasoning Effort between High/Maximum → verify effort level is respected
6. Test with deprecated models to confirm they still work normally