### PR TITLE
Support for additional thinking, effort parameters of updated Deepsee…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2135,7 +2135,7 @@
                                             </strong>
                                         </div>
                                     </div>
-                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt">
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt,deepseek">
                                         <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
                                             <label for="openai_reasoning_effort">
                                                 <span data-i18n="Reasoning Effort">Reasoning Effort</span>

--- a/public/index.html
+++ b/public/index.html
@@ -2130,7 +2130,7 @@
                                             <span data-i18n="Allows the model to return its thinking process.">
                                                 Allows the model to return its thinking process.
                                             </span>
-                                            <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter">
+                                            <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter,deepseek">
                                                 This setting affects visibility only.
                                             </strong>
                                         </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2501,6 +2501,7 @@ function getReasoningEffort(settings = null, model = null) {
         chat_completion_sources.COMETAPI,
         chat_completion_sources.ELECTRONHUB,
         chat_completion_sources.CHUTES,
+        chat_completion_sources.DEEPSEEK,
     ];
 
     if (!reasoningEffortSources.includes(settings.chat_completion_source)) {
@@ -2520,6 +2521,9 @@ function getReasoningEffort(settings = null, model = null) {
                     ? reasoning_effort_types.min
                     : reasoning_effort_types.low;
             case reasoning_effort_types.max:
+                if (settings.chat_completion_source === chat_completion_sources.DEEPSEEK) {
+                    return reasoning_effort_types.max;
+                }
                 return reasoning_effort_types.high;
             default:
                 return settings.reasoning_effort;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1095,6 +1095,11 @@ async function sendDeepSeekRequest(request, response) {
             ...bodyParams,
         };
 
+        // DeepSeek requires thinking to be enabled when reasoning_effort is set
+        if (requestBody.thinking?.type === 'disabled') {
+            delete requestBody.reasoning_effort;
+        }
+
         const config = {
             method: 'POST',
             headers: {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1090,6 +1090,8 @@ async function sendDeepSeekRequest(request, response) {
             'top_p': request.body.top_p,
             'stop': request.body.stop,
             'seed': request.body.seed,
+            'reasoning_effort': request.body.reasoning_effort,
+            'thinking': request.body.include_reasoning ? { type: 'enabled' } : { type: 'disabled' },
             ...bodyParams,
         };
 


### PR DESCRIPTION
Support for additional thinking, effort parameters of updated Deepseek Api
## Why

DeepSeek’s latest API update introduces Thinking Mode, which changes how responses are generated and controlled.  `thinking` and `reasoning-effort` parameters controls the API behavior now. Previously `thinking` is trigger by changing models, e.g. `deepseek-chat` and `deepseek-reasoner`.

This PR lets users make use of the new parameters and still be able to trigger reasoning / non-reasoning

## Changes
- **`public/index.html`** — Added `deepseek` to the `data-source` attribute of the "Reasoning Effort" dropdown, making the control visible when DeepSeek is selected as the chat completion source.

- **`public/scripts/openai.js`** — Added `chat_completion_sources.DEEPSEEK` to the `reasoningEffortSources` array in `getReasoningEffort()`, ensuring DeepSeek gets the proper effort value. When maximum is selected as the reasoning effort, DeepSeek now receives "max" while all other sources continue to receive "high".

- **`src/endpoints/backends/chat-completions.js`** — Added two new fields to the DeepSeek request body: `reasoning_effort` (passthrough from `request.body.reasoning_effort`) and `thinking` (derived from `request.body.include_reasoning` — maps to `{type: "enabled"}` when true, `{type: "disabled"}` when false).

In short, request parameters `thinking` and `reasoning_effort` of requests sent to Deepseek can now be configured in the AI Response Configuration tab

## How to Test

1. **Select DeepSeek as the chat completion source**


2. Check the existence of reasoning, effort options in Chat Completion / AI Responses config
<img width="455" height="97" alt="image" src="https://github.com/user-attachments/assets/499e9e63-a122-4a52-98f2-4d3d8445b9f1" />


3. Send chat message and capture outgoing requests via browser Devtools. Request payload fields should equal selected options
<img width="413" height="396" alt="image" src="https://github.com/user-attachments/assets/c3cbcebf-2535-4e17-a0f6-1f60782c663c" /> 
<img width="415" height="364" alt="image" src="https://github.com/user-attachments/assets/b77c6a48-a18a-4af7-ba42-6f59f1fed030" />

4. Input with without reasoning should not have reasoning displayed
<img width="966" height="210" alt="image" src="https://github.com/user-attachments/assets/f820444a-5fc9-4920-ad38-5f6440a36442" />

Input with reasoning should have reasoning displayed
<img width="952" height="204" alt="image" src="https://github.com/user-attachments/assets/b54e8966-03d1-4ba6-9a75-353c139d806e" />


## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
