### PR TITLE
add macro support for image caption extension prompt (multimodal)

### DIFF
--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -320,6 +320,8 @@ async function captionMultimodal(base64Img, externalPrompt) {
         }
         prompt = String(customPrompt).trim();
     }
+    //added macro stuff to prompt
+    prompt = substituteParamsExtended(prompt);
 
     const caption = await getMultimodalCaption(base64Img, prompt);
     return { caption };

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -1,6 +1,6 @@
 import { ensureImageFormatSupported, getBase64Async, getFileExtension, isTrueBoolean, saveBase64AsFile } from '../../utils.js';
 import { getContext, getApiUrl, doExtrasFetch, extension_settings, modules, renderExtensionTemplateAsync } from '../../extensions.js';
-import { appendMediaToMessage, chat_metadata, eventSource, event_types, getRequestHeaders, saveChatConditional, saveSettingsDebounced, substituteParamsExtended } from '../../../script.js';
+import { appendMediaToMessage, chat_metadata, eventSource, event_types, getRequestHeaders, saveChatConditional, saveSettingsDebounced, substituteParams } from '../../../script.js';
 import { getMessageTimeStamp } from '../../RossAscends-mods.js';
 import { SECRET_KEYS, secret_state } from '../../secrets.js';
 import { getMultimodalCaption } from '../shared.js';
@@ -99,7 +99,7 @@ async function wrapCaptionTemplate(caption) {
         template += ' {{caption}}';
     }
 
-    let messageText = substituteParamsExtended(template, { caption: caption });
+    let messageText = substituteParams(template, { dynamicMacros: { caption: caption } });
 
     if (extension_settings.caption.refine_mode) {
         messageText = await Popup.show.input(
@@ -321,7 +321,7 @@ async function captionMultimodal(base64Img, externalPrompt) {
         prompt = String(customPrompt).trim();
     }
     //added macro stuff to prompt
-    prompt = substituteParamsExtended(prompt);
+    prompt = substituteParams(prompt);
 
     const caption = await getMultimodalCaption(base64Img, prompt);
     return { caption };

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -320,7 +320,7 @@ async function captionMultimodal(base64Img, externalPrompt) {
         }
         prompt = String(customPrompt).trim();
     }
-    //added macro stuff to prompt
+
     prompt = substituteParams(prompt);
 
     const caption = await getMultimodalCaption(base64Img, prompt);


### PR DESCRIPTION
## Changes:

Updated to use `substituteParams`

Simple addition to `captionMultimodal` allowing the usage of st macros in the image captioning prompt.

(previously would send the macros unchanged)

<details><summary>Before</summary>
<img width="800" height="663" alt="image" src="https://github.com/user-attachments/assets/499269c8-42e4-45f1-b530-4fba6b499000" />
</details>
<details><summary>After</summary>
<img width="793" height="274" alt="image" src="https://github.com/user-attachments/assets/ff322f72-78f7-4d85-a891-453a13dc0f94" />
</details>

## Checklist:
- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).