### PR TITLE
fix: reasoning and tool calling prompt logic

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1028,7 +1028,7 @@ async function populateChatHistory(messages, prompts, chatCompletion, type = nul
                 }
                 return clone;
             });
-            const toolCallMessage = await Message.createAsync(chatMessage.role, undefined, 'toolCall-' + chatMessage.identifier);
+            const toolCallMessage = await Message.createAsync(chatMessage.role, chatMessage.content, 'toolCall-' + chatMessage.identifier);
             const toolResultMessages = await Promise.all(invocations.slice().reverse().map((invocation) => Message.createAsync('tool', invocation.result || '[No content]', invocation.id)));
             await toolCallMessage.setToolCalls(invocations, includeSignature, includeToolReasoning);
             if (chatCompletion.canAffordAll([toolCallMessage, ...toolResultMessages])) {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -756,7 +756,7 @@ export class PromptReasoning {
             this.prefixDuration = duration;
             this.prefixIncomplete = false;
         }
-        return `${formattedReasoning}${content}`;
+        return `${formattedReasoning}${content ?? ''}`;
     }
 
     /**


### PR DESCRIPTION
Closes #5516

## Summary
Fixes two edge cases when "Add to prompts" is enabled for reasoning:
1. Tool calls were dropped from the message if reasoning was added, because `Message.createAsync` was called with `undefined` content for tool-call messages, discarding the `mes` text. Now it uses `chatMessage.content`, preserving the text/reasoning.
2. When the original message text was empty, the reasoning text was concatenated with `undefined`, producing `"<reasoning>undefined"`. Now it falls back to an empty string.

## Testing
- Enabled "Add to prompts" and verified that tool calls aren't dropped and empty messages aren't suffixed with `"undefined"`.
- `npm run lint -- --quiet` (Passed)

## Checklist:
- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).