### PR TITLE
fix: Don't apply layout hack in Firefox Mobile while editing text

### DIFF
--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -72,6 +72,14 @@ function applyBrowserFixes() {
 
     if (isMobile()) {
         const fixFunkyPositioning = () => {
+            if (isFirefox()) {
+                const active = document.activeElement;
+                if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+                    // The positioning hack below breaks GBoard candidate replacement
+                    // in Firefox Mobile on Android.
+                    return;
+                }
+            }
             console.debug('[Mobile] Device viewport change detected.');
             document.documentElement.style.position = 'fixed';
             requestAnimationFrame(() => document.documentElement.style.position = '');


### PR DESCRIPTION
This fixes the following bug in Firefox Mobile on Android:

**Steps to reproduce:**

1. Swipe a word into the chat input edit field in Firefox Mobile on Android, for examples "Test".
2. In GBoard (default Android keyboard), tap on a different suggestion, for examples "Rest".

**Expected behavior:** The word "Test" is replaced with "Rest".

**Actual behavior:** The word becomes "TestRest".

I confirmed with bisecting that the commit f897a4ab1a0ca87e4afa50dfb3e926de057ec6ea introduced the issue.

This change fixes the issue by disabling the layout hack while editing text. Disabling the layout hack is limited to Firefox Mobile because

* I could not reproduce the bug in Chrome on Android
* This way, if it causes a new bug, only Firefox Mobile users are affected

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
