### PR TITLE
fix: prevent modal jumping on mobile when viewport is scaled

### DIFF
--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -32,6 +32,14 @@ dialog {
     --popup-animation-speed: var(--animation-duration-slow);
 }
 
+.popup.popup--viewport-positioned[open] {
+    position: fixed;
+    top: var(--popup-top, 50%);
+    left: var(--popup-left, 50%);
+    margin: 0;
+    transform: var(--popup-transform, translate(-50%, -50%));
+}
+
 /** Popup styles applied to the main popup */
 .popup--animation-fast {
     --popup-animation-speed: var(--animation-duration);

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -36,6 +36,8 @@ dialog {
     position: fixed;
     top: var(--popup-top, 50%);
     left: var(--popup-left, 50%);
+    right: auto;
+    bottom: auto;
     margin: 0;
     transform: var(--popup-transform, translate(-50%, -50%));
 }

--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -183,7 +183,8 @@ export class Popup {
     /** @type {boolean} */ #isClosingPrevented;
     /** @type {number} */ #lastEscapePress = 0;
     /** @type {boolean} */ #isShowingForceCloseConfirm = false;
-    /** @type {() => void} */ #viewportPositionListener = () => this.#updateViewportPosition();
+    /** @type {number?} */ #viewportPositionFrame = null;
+    /** @type {() => void} */ #viewportPositionListener = () => this.#scheduleViewportPositionUpdate();
 
     /**
      * Constructs a new Popup object with the given text content, type, inputValue, and options
@@ -862,10 +863,27 @@ export class Popup {
 
     #disableViewportPositionTracking() {
         this.dlg.classList.remove('popup--viewport-positioned');
+
+        if (this.#viewportPositionFrame !== null) {
+            cancelAnimationFrame(this.#viewportPositionFrame);
+            this.#viewportPositionFrame = null;
+        }
+
         window.visualViewport?.removeEventListener('resize', this.#viewportPositionListener);
         window.visualViewport?.removeEventListener('scroll', this.#viewportPositionListener);
         window.removeEventListener('resize', this.#viewportPositionListener);
         window.removeEventListener('orientationchange', this.#viewportPositionListener);
+    }
+
+    #scheduleViewportPositionUpdate() {
+        if (this.#viewportPositionFrame !== null) {
+            return;
+        }
+
+        this.#viewportPositionFrame = requestAnimationFrame(() => {
+            this.#viewportPositionFrame = null;
+            this.#updateViewportPosition();
+        });
     }
 
     #updateViewportPosition() {

--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -183,6 +183,7 @@ export class Popup {
     /** @type {boolean} */ #isClosingPrevented;
     /** @type {number} */ #lastEscapePress = 0;
     /** @type {boolean} */ #isShowingForceCloseConfirm = false;
+    /** @type {() => void} */ #viewportPositionListener = () => this.#updateViewportPosition();
 
     /**
      * Constructs a new Popup object with the given text content, type, inputValue, and options
@@ -677,7 +678,9 @@ export class Popup {
         // Run opening animation
         this.dlg.setAttribute('opening', '');
 
+        this.#enableViewportPositionTracking();
         this.dlg.showModal();
+        this.#updateViewportPosition();
 
         // We need to fix the toastr to be present inside this dialog
         fixToastrForDialogs();
@@ -816,6 +819,7 @@ export class Popup {
         runAfterAnimation(this.dlg, async () => {
             // Call the close on the dialog
             this.dlg.close();
+            this.#disableViewportPositionTracking();
 
             // Run a possible custom handler right before DOM removal
             if (this.onClose) {
@@ -841,6 +845,45 @@ export class Popup {
 
             this.#resolver(this.value);
         });
+    }
+
+    #enableViewportPositionTracking() {
+        if (!window.visualViewport) {
+            return;
+        }
+
+        this.dlg.classList.add('popup--viewport-positioned');
+        this.#updateViewportPosition();
+        window.visualViewport.addEventListener('resize', this.#viewportPositionListener);
+        window.visualViewport.addEventListener('scroll', this.#viewportPositionListener);
+        window.addEventListener('resize', this.#viewportPositionListener);
+        window.addEventListener('orientationchange', this.#viewportPositionListener);
+    }
+
+    #disableViewportPositionTracking() {
+        this.dlg.classList.remove('popup--viewport-positioned');
+        window.visualViewport?.removeEventListener('resize', this.#viewportPositionListener);
+        window.visualViewport?.removeEventListener('scroll', this.#viewportPositionListener);
+        window.removeEventListener('resize', this.#viewportPositionListener);
+        window.removeEventListener('orientationchange', this.#viewportPositionListener);
+    }
+
+    #updateViewportPosition() {
+        const viewport = window.visualViewport;
+
+        // Do not constantly reposition the modal if the user is zoomed in (scale !== 1).
+        // This prevents the modal from jumping wildly due to coordinate miscalculations
+        // when panning or focusing an input on mobile browsers (especially Chrome Android).
+        if (viewport && Math.abs(viewport.scale - 1) > 0.01) {
+            return;
+        }
+
+        const left = viewport ? viewport.offsetLeft + viewport.width / 2 : window.innerWidth / 2;
+        const top = viewport ? viewport.offsetTop + viewport.height / 2 : window.innerHeight / 2;
+
+        this.dlg.style.setProperty('--popup-left', `${left}px`);
+        this.dlg.style.setProperty('--popup-top', `${top}px`);
+        this.dlg.style.setProperty('--popup-transform', 'translate(-50%, -50%)');
     }
 
     /**


### PR DESCRIPTION
Potentially addresses #5515

## Summary

This PR is a proposed mitigation for #5515, based on the Android Chrome / Termux recordings from the issue.

On Android Chrome, opening the soft keyboard or entering a zoomed visual viewport appears to make the browser's native dialog positioning unstable. This PR explicitly positions the popup relative to `visualViewport`, and avoids repositioning while `visualViewport.scale !== 1` so the popup does not chase the zoomed viewport.

Viewport position updates are also batched with `requestAnimationFrame` to avoid fighting rapid soft-keyboard / viewport layout changes.

## Testing

- Tried to reproduce on macOS, iOS, and Chrome DevTools mobile emulation, but could not reproduce the original issue reliably.
- `npm run lint` passed.
- Needs confirmation from an affected Android Chrome / Termux environment.

## Checklist:
- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).