### PR TITLE
Auto-sanitize existing character filenames on disk during character list loading

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1454,7 +1454,8 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
 router.post('/all', async function (request, response) {
     try {
         const files = fs.readdirSync(request.user.directories.characters);
-        const pngFiles = files.filter(file => file.endsWith('.png'));
+        const pngFiles = files.filter(file => file.endsWith('.png'))
+            .map(file => sanitizeOnDiskFileName(file, request.user.directories));
         const processingPromises = pngFiles.map(file => processCharacter(file, request.user.directories, { shallow: useShallowCharacters }));
         const data = (await Promise.all(processingPromises)).filter(c => c.name);
         return response.send(data);
@@ -1521,6 +1522,56 @@ router.post('/chats', validateAvatarUrlMiddleware, async function (request, resp
         return response.send({ error: true });
     }
 });
+
+/**
+ * Checks if a character file on disk has an unsanitized filename and renames it if needed.
+ * Also renames the associated chats directory to keep them in sync.
+ * @param {string} fileName The original filename (e.g. "Maya \ Lisa.png")
+ * @param {import('../users.js').UserDirectoryList} directories User directories
+ * @returns {string} The sanitized filename, or the original if no change was needed
+ */
+function sanitizeOnDiskFileName(fileName, directories) {
+    const nameWithoutExt = path.parse(fileName).name;
+    const sanitizedName = sanitize(nameWithoutExt);
+
+    if (sanitizedName === nameWithoutExt) {
+        return fileName;
+    }
+
+    const oldChatsDir = path.join(directories.chats, nameWithoutExt);
+    const hasChats = fs.existsSync(oldChatsDir);
+
+    // Find a unique name where both the avatar file and chat directory (if applicable) don't conflict
+    const newInternalName = getUniqueName(sanitizedName, (name) =>
+        fs.existsSync(path.join(directories.characters, `${name}.png`)) ||
+        (hasChats && fs.existsSync(path.join(directories.chats, name))),
+    { nameBuilder: (base, i) => i === 0 ? base : `${base}${i}`, startIndex: 0 });
+
+    if (!newInternalName) {
+        console.error(`Failed to find a unique sanitized name for: ${fileName}`);
+        return fileName;
+    }
+
+    const newFileName = `${newInternalName}.png`;
+    const oldFilePath = path.join(directories.characters, fileName);
+    const newFilePath = path.join(directories.characters, newFileName);
+
+    try {
+        fs.renameSync(oldFilePath, newFilePath);
+        console.info(`Sanitized character filename: "${fileName}" -> "${newFileName}"`);
+
+        if (hasChats) {
+            const newChatsDir = path.join(directories.chats, newInternalName);
+            fs.renameSync(oldChatsDir, newChatsDir);
+            console.info(`Renamed chat directory: "${nameWithoutExt}" -> "${newInternalName}"`);
+        }
+    } catch (err) {
+        console.error(`Failed to sanitize character filename: ${fileName}`, err);
+        return fileName;
+    }
+
+    return newFileName;
+}
 
 /**
  * Gets the name for the uploaded PNG file.


### PR DESCRIPTION
Adds an automatic cleanup step that detects and renames character files with unsanitized filenames on disk. This runs transparently when the character list is loaded and fixes already-broken files that were created before the import-time sanitization fix.

Supersedes #5469 (splitting different fixes)

#### What Changed
- **New `sanitizeOnDiskFileName()` helper** — checks each character PNG file during list loading. If the filename differs from its sanitized version, the file is renamed on disk. The associated chats directory is also renamed to keep everything in sync.
- **Integrated into the `/all` endpoint** — the sanitization runs as a `.map()` step on the file list, so it happens transparently on first load and only affects files that actually need renaming.

#### How It Works
1. When the character list is requested, each `.png` filename is compared against its sanitized version
2. If they differ, a unique new name is generated (checking for collisions against both existing avatar files and chat directories)
3. The avatar file and its associated chats directory are renamed together
4. If anything goes wrong during rename, the original filename is kept — no data is lost
5. Files that are already clean pass through with zero overhead (early return on string equality check)

#### Why This Is Separate
This is split from the import-time fix (see companion PR) because it's more invasive — it modifies files on disk during application startup. It needs careful testing across different scenarios: name collisions, missing chat directories, filesystem permission issues, large character libraries, etc. The import-time fix prevents the problem going forward; this one cleans up existing damage.

#### Impact
- Existing characters with broken filenames (e.g. from past imports without sanitization) are automatically fixed
- Chat history is preserved through the rename
- Avatars that previously failed to load due to bad filenames will start working

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).