### PR TITLE
Fix: Prevent crash in cachingAtDepthForOpenRouterClaude on empty content from trailing tool calls

### DIFF
--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1040,7 +1040,7 @@ export function cachingAtDepthForOpenRouterClaude(messages, cachingAtDepth, ttl)
                         text: content,
                         cache_control: { type: 'ephemeral', ttl: ttl },
                     }];
-                } else if (content !== null && typeof content !== 'undefined' && content.length > 0) {
+                } else if (content?.length > 0) {
                     const contentPartCount = content.length;
                     content[contentPartCount - 1].cache_control = {
                         type: 'ephemeral',

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1040,7 +1040,7 @@ export function cachingAtDepthForOpenRouterClaude(messages, cachingAtDepth, ttl)
                         text: content,
                         cache_control: { type: 'ephemeral', ttl: ttl },
                     }];
-                } else {
+                } else if (content !== null && typeof content !== 'undefined' && content.length > 0) {
                     const contentPartCount = content.length;
                     content[contentPartCount - 1].cache_control = {
                         type: 'ephemeral',


### PR DESCRIPTION
**Describe the bug**
When using OpenRouter with Claude models and Prompt Caching enabled, SillyTavern crashes with a fatal error (`Cannot read properties of undefined (reading 'length')` in `prompt-converters.js`). 

Generation failed TypeError: Cannot read properties of undefined (reading 'length')
    at cachingAtDepthForOpenRouterClaude (file:///C:/git/SillyTavern/src/prompt-converters.js:1044:54)
    at file:///C:/git/SillyTavern/src/endpoints/backends/chat-completions.js:2292:25
    at Layer.handle [as handle_request] (C:\git\SillyTavern\node_modules\express\lib\router\layer.js:95:5)
    at next (C:\git\SillyTavern\node_modules\express\lib\router\route.js:149:13)
    at Route.dispatch (C:\git\SillyTavern\node_modules\express\lib\router\route.js:119:3)
    at Layer.handle [as handle_request] (C:\git\SillyTavern\node_modules\express\lib\router\layer.js:95:5)
    at C:\git\SillyTavern\node_modules\express\lib\router\index.js:284:15
    at router.process_params (C:\git\SillyTavern\node_modules\express\lib\router\index.js:346:12)
    at next (C:\git\SillyTavern\node_modules\express\lib\router\index.js:280:10)
    at router.handle (C:\git\SillyTavern\node_modules\express\lib\router\index.js:175:3)

This happens when the LLM generates narrative text that is immediately followed by a tool call at the very end of the response (tool is set to `stealth: false`). SillyTavern's internal handling of this trailing tool call creates a state where the message `content` being evaluated by the caching algorithm is `undefined` or `null`. The algorithm then attempts to access `.length` on it, causing the backend to crash with a 502 Bad Gateway.

**To Reproduce**
1. Enable OpenRouter Claude Caching (enableSystemPromptCache=true, cachingAtDepth=2 in my case).
2. Use a model/prompt that triggers a tool call at the very end of its response (after generating narrative text).
3. The server crashes during the next(!) completion request when calculating cache breakpoints for the chat history.

**What this PR does**
Updates the condition in `cachingAtDepthForOpenRouterClaude` to safely handle `null` or `undefined` message content. 


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
