### PR TITLE
Chat Completion: display API-reported completion token usage in message bubbles

### DIFF
--- a/public/global.d.ts
+++ b/public/global.d.ts
@@ -101,6 +101,8 @@ declare global {
         title?: string;
         isSmallSys?: boolean;
         token_count?: number;
+        /** Raw API-reported usage data (prompt_tokens, completion_tokens, etc.). Format varies by backend. */
+        api_usage?: object;
         /** When false, the message cannot be swiped. */
         swipeable?: boolean;
         overswipe_behavior?: OVERSWIPE_BEHAVIOR;

--- a/public/script.js
+++ b/public/script.js
@@ -107,6 +107,7 @@ import {
     openai_messages_count,
     chat_completion_sources,
     getChatCompletionModel,
+    getApiCompletionTokens,
     proxies,
     loadProxyPresets,
     selected_proxy,
@@ -2602,13 +2603,7 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
     messageElement.find('.ch_name .name_text').text(mes.name);
     messageElement.find('.timestamp').text(timestamp).attr('title', `${mes.extra?.api ? mes.extra.api + ' - ' : ''}${mes.extra?.model ?? ''}`);
     messageElement.find('.mesIDDisplay').text(`#${messageId}`);
-    const apiUsage = mes.extra?.api_usage;
-    if (apiUsage) {
-        const completion = apiUsage.completion_tokens ?? apiUsage.output_tokens ?? apiUsage.totalTokenCount ?? 0;
-        messageElement.find('.tokenCounterDisplay').text(`${completion}t`);
-    } else if (tokenCount) {
-        messageElement.find('.tokenCounterDisplay').text(`${tokenCount}t`);
-    }
+    tokenCount && messageElement.find('.tokenCounterDisplay').text(`${tokenCount}t`);
     mes.title && messageElement.attr('title', mes.title);
     timerValue && messageElement.find('.mes_timer').attr('title', timerTitle).text(timerValue);
     bookmarkLink && updateBookmarkDisplay(messageElement);
@@ -3642,10 +3637,17 @@ class StreamingProcessor {
             processedText = chat[messageId].mes;
 
             // Token count update.
-            const tokenCountText = this.reasoningHandler.reasoning + processedText;
-            const currentTokenCount = isFinal && power_user.message_token_count_enabled ? await getTokenCountAsync(tokenCountText, 0) : 0;
-            if (currentTokenCount) {
-                chat[messageId].extra.token_count = currentTokenCount;
+            if (isFinal && power_user.message_token_count_enabled) {
+                const apiTokens = getApiCompletionTokens(this.apiUsage);
+                if (apiTokens !== null) {
+                    chat[messageId].extra.token_count = apiTokens;
+                } else {
+                    const tokenCountText = this.reasoningHandler.reasoning + processedText;
+                    const localTokens = await getTokenCountAsync(tokenCountText, 0);
+                    if (localTokens) {
+                        chat[messageId].extra.token_count = localTokens;
+                    }
+                }
             }
 
             // Save API-reported usage from streaming
@@ -3654,12 +3656,9 @@ class StreamingProcessor {
             }
 
             if (this.messageTokenCounterDom instanceof HTMLElement) {
-                const apiUsage = chat[messageId].extra?.api_usage;
-                if (apiUsage) {
-                    const completion = apiUsage.completion_tokens ?? apiUsage.output_tokens ?? apiUsage.totalTokenCount ?? 0;
-                    this.messageTokenCounterDom.textContent = `${completion}t`;
-                } else if (currentTokenCount) {
-                    this.messageTokenCounterDom.textContent = `${currentTokenCount}t`;
+                const tokenCount = chat[messageId].extra?.token_count;
+                if (tokenCount) {
+                    this.messageTokenCounterDom.textContent = `${tokenCount}t`;
                 }
             }
 
@@ -3690,7 +3689,7 @@ class StreamingProcessor {
                 }
             }
 
-            const timePassed = formatGenerationTimer(this.timeStarted, currentTime, currentTokenCount, this.reasoningHandler.getDuration(), this.timeToFirstToken);
+            const timePassed = formatGenerationTimer(this.timeStarted, currentTime, chat[messageId].extra?.token_count, this.reasoningHandler.getDuration(), this.timeToFirstToken);
             if (this.messageTimerDom instanceof HTMLElement) {
                 this.messageTimerDom.textContent = timePassed.timerValue;
                 this.messageTimerDom.title = timePassed.timerTitle;
@@ -5452,7 +5451,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         let reasoning = extractReasoningFromData(data);
         let imageUrls = extractImagesFromData(data);
         const reasoningSignature = extractReasoningSignatureFromData(data);
-        const apiUsage = data?.usage ?? null;
+        const apiUsage = data?.usage ?? data?.usageMetadata ?? data?.meta?.tokens ?? data?.meta?.billed_units ?? null;
         kobold_horde_model = title;
 
         const swipes = extractMultiSwipes(data, type);
@@ -6643,8 +6642,13 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
                 lastMessage.extra.api_usage = apiUsage;
             }
             if (power_user.message_token_count_enabled) {
-                const tokenCountText = (reasoning || '') + lastMessage.mes;
-                lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
+                const apiTokens = getApiCompletionTokens(apiUsage);
+                if (apiTokens !== null) {
+                    lastMessage.extra.token_count = apiTokens;
+                } else {
+                    const tokenCountText = (reasoning || '') + lastMessage.mes;
+                    lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
+                }
             }
             const chat_id = (chat.length - 1);
             !fromStreaming && await eventSource.emit(event_types.MESSAGE_RECEIVED, chat_id, type);
@@ -6671,8 +6675,13 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
             lastMessage.extra.api_usage = apiUsage;
         }
         if (power_user.message_token_count_enabled) {
-            const tokenCountText = (reasoning || '') + lastMessage.mes;
-            lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
+            const apiTokens = getApiCompletionTokens(apiUsage);
+            if (apiTokens !== null) {
+                lastMessage.extra.token_count = apiTokens;
+            } else {
+                const tokenCountText = (reasoning || '') + lastMessage.mes;
+                lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
+            }
         }
         const chat_id = (chat.length - 1);
         !fromStreaming && await eventSource.emit(event_types.MESSAGE_RECEIVED, chat_id, type);
@@ -6696,8 +6705,13 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         }
         // We don't know if the reasoning duration extended, so we don't update it here on purpose.
         if (power_user.message_token_count_enabled) {
-            const tokenCountText = (reasoning || '') + lastMessage.mes;
-            lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
+            const apiTokens = getApiCompletionTokens(apiUsage);
+            if (apiTokens !== null) {
+                lastMessage.extra.token_count = apiTokens;
+            } else {
+                const tokenCountText = (reasoning || '') + lastMessage.mes;
+                lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
+            }
         }
         const chat_id = (chat.length - 1);
         !fromStreaming && await eventSource.emit(event_types.MESSAGE_RECEIVED, chat_id, type);
@@ -6725,8 +6739,13 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         newMessage.gen_finished = generationFinished;
 
         if (power_user.message_token_count_enabled) {
-            const tokenCountText = (reasoning || '') + newMessage.mes;
-            newMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
+            const apiTokens = getApiCompletionTokens(apiUsage);
+            if (apiTokens !== null) {
+                newMessage.extra.token_count = apiTokens;
+            } else {
+                const tokenCountText = (reasoning || '') + newMessage.mes;
+                newMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
+            }
         }
 
         if (apiUsage) {

--- a/public/script.js
+++ b/public/script.js
@@ -3639,7 +3639,9 @@ class StreamingProcessor {
             // Token count update.
             if (isFinal && power_user.message_token_count_enabled) {
                 const apiTokens = getApiCompletionTokens(this.apiUsage);
-                if (apiTokens !== null) {
+                if (apiTokens !== null && this.type === 'continue' && typeof chat[messageId].extra?.token_count === 'number') {
+                    chat[messageId].extra.token_count += apiTokens;
+                } else if (apiTokens !== null && this.type !== 'continue') {
                     chat[messageId].extra.token_count = apiTokens;
                 } else {
                     const tokenCountText = this.reasoningHandler.reasoning + processedText;
@@ -6676,8 +6678,8 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         }
         if (power_user.message_token_count_enabled) {
             const apiTokens = getApiCompletionTokens(apiUsage);
-            if (apiTokens !== null) {
-                lastMessage.extra.token_count = apiTokens;
+            if (apiTokens !== null && typeof lastMessage.extra.token_count === 'number') {
+                lastMessage.extra.token_count += apiTokens;
             } else {
                 const tokenCountText = (reasoning || '') + lastMessage.mes;
                 lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
@@ -6706,8 +6708,8 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         // We don't know if the reasoning duration extended, so we don't update it here on purpose.
         if (power_user.message_token_count_enabled) {
             const apiTokens = getApiCompletionTokens(apiUsage);
-            if (apiTokens !== null) {
-                lastMessage.extra.token_count = apiTokens;
+            if (apiTokens !== null && typeof lastMessage.extra.token_count === 'number') {
+                lastMessage.extra.token_count += apiTokens;
             } else {
                 const tokenCountText = (reasoning || '') + lastMessage.mes;
                 lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);

--- a/public/script.js
+++ b/public/script.js
@@ -2604,7 +2604,7 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
     messageElement.find('.mesIDDisplay').text(`#${messageId}`);
     const apiUsage = mes.extra?.api_usage;
     if (apiUsage) {
-        const completion = apiUsage.completion_tokens ?? apiUsage.output_tokens ?? apiUsage.candidatesTokenCount ?? 0;
+        const completion = apiUsage.completion_tokens ?? apiUsage.output_tokens ?? apiUsage.totalTokenCount ?? 0;
         messageElement.find('.tokenCounterDisplay').text(`${completion}t`);
     } else if (tokenCount) {
         messageElement.find('.tokenCounterDisplay').text(`${tokenCount}t`);
@@ -3656,7 +3656,7 @@ class StreamingProcessor {
             if (this.messageTokenCounterDom instanceof HTMLElement) {
                 const apiUsage = chat[messageId].extra?.api_usage;
                 if (apiUsage) {
-                    const completion = apiUsage.completion_tokens ?? apiUsage.output_tokens ?? apiUsage.candidatesTokenCount ?? 0;
+                    const completion = apiUsage.completion_tokens ?? apiUsage.output_tokens ?? apiUsage.totalTokenCount ?? 0;
                     this.messageTokenCounterDom.textContent = `${completion}t`;
                 } else if (currentTokenCount) {
                     this.messageTokenCounterDom.textContent = `${currentTokenCount}t`;

--- a/public/script.js
+++ b/public/script.js
@@ -2602,7 +2602,13 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
     messageElement.find('.ch_name .name_text').text(mes.name);
     messageElement.find('.timestamp').text(timestamp).attr('title', `${mes.extra?.api ? mes.extra.api + ' - ' : ''}${mes.extra?.model ?? ''}`);
     messageElement.find('.mesIDDisplay').text(`#${messageId}`);
-    tokenCount && messageElement.find('.tokenCounterDisplay').text(`${tokenCount}t`);
+    const apiUsage = mes.extra?.api_usage;
+    if (apiUsage) {
+        const completion = apiUsage.completion_tokens ?? apiUsage.output_tokens ?? apiUsage.candidatesTokenCount ?? 0;
+        messageElement.find('.tokenCounterDisplay').text(`${completion}t`);
+    } else if (tokenCount) {
+        messageElement.find('.tokenCounterDisplay').text(`${tokenCount}t`);
+    }
     mes.title && messageElement.attr('title', mes.title);
     timerValue && messageElement.find('.mes_timer').attr('title', timerTitle).text(timerValue);
     bookmarkLink && updateBookmarkDisplay(messageElement);
@@ -3524,6 +3530,8 @@ class StreamingProcessor {
         this.images = [];
         /** @type {string?} */
         this.reasoningSignature = null;
+        /** @type {object?} */
+        this.apiUsage = null;
     }
 
     /**
@@ -3638,7 +3646,19 @@ class StreamingProcessor {
             const currentTokenCount = isFinal && power_user.message_token_count_enabled ? await getTokenCountAsync(tokenCountText, 0) : 0;
             if (currentTokenCount) {
                 chat[messageId].extra.token_count = currentTokenCount;
-                if (this.messageTokenCounterDom instanceof HTMLElement) {
+            }
+
+            // Save API-reported usage from streaming
+            if (isFinal && this.apiUsage) {
+                chat[messageId].extra.api_usage = this.apiUsage;
+            }
+
+            if (this.messageTokenCounterDom instanceof HTMLElement) {
+                const apiUsage = chat[messageId].extra?.api_usage;
+                if (apiUsage) {
+                    const completion = apiUsage.completion_tokens ?? apiUsage.output_tokens ?? apiUsage.candidatesTokenCount ?? 0;
+                    this.messageTokenCounterDom.textContent = `${completion}t`;
+                } else if (currentTokenCount) {
                     this.messageTokenCounterDom.textContent = `${currentTokenCount}t`;
                 }
             }
@@ -3813,7 +3833,7 @@ class StreamingProcessor {
         try {
             const sw = new Stopwatch(1000 / power_user.streaming_fps);
             const timestamps = [];
-            for await (const { text, swipes, logprobs, toolCalls, state } of this.generator()) {
+            for await (const { text, swipes, logprobs, toolCalls, state, usage } of this.generator()) {
                 const now = Date.now();
                 timestamps.push(now);
                 if (!this.timeToFirstToken) {
@@ -3821,6 +3841,10 @@ class StreamingProcessor {
                 }
                 if (this.isStopped || this.abortController.signal.aborted) {
                     return this.result;
+                }
+
+                if (usage) {
+                    this.apiUsage = usage;
                 }
 
                 this.toolCalls = toolCalls;
@@ -5428,6 +5452,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         let reasoning = extractReasoningFromData(data);
         let imageUrls = extractImagesFromData(data);
         const reasoningSignature = extractReasoningSignatureFromData(data);
+        const apiUsage = data?.usage ?? null;
         kobold_horde_model = title;
 
         const swipes = extractMultiSwipes(data, type);
@@ -5469,9 +5494,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         } else {
             // Without streaming we'll be having a full message on continuation. Treat it as a last chunk.
             if (originalType !== 'continue') {
-                ({ type, getMessage } = await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature }));
+                ({ type, getMessage } = await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, apiUsage }));
             } else {
-                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, title, swipes, reasoning, imageUrls, reasoningSignature }));
+                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, apiUsage }));
             }
 
             // This relies on `saveReply` having been called to add the message to the chat, so it must be last.
@@ -6564,12 +6589,13 @@ async function processImageAttachment(message, { imageUrls }) {
  * @property {string} [reasoning] Message reasoning
  * @property {string[]} [imageUrls] Links to images
  * @property {string?} [reasoningSignature] Encrypted signature of the reasoning text
+ * @property {object?} [apiUsage] API-reported usage information (prompt_tokens, completion_tokens, etc.)
  *
  * @typedef {object} SaveReplyResult
  * @property {string} type Type of generation
  * @property {string} getMessage Generated message
  */
-export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrls = [], reasoningSignature = null }) {
+export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrls = [], reasoningSignature = null, apiUsage = null }) {
     // Backward compatibility
     if (arguments.length > 1 && typeof arguments[0] !== 'object') {
         console.trace('saveReply called with positional arguments. Please use an object instead.');
@@ -6613,6 +6639,9 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
             lastMessage.extra.reasoning_duration = null;
             lastMessage.extra.reasoning_signature = reasoningSignature;
             await processImageAttachment(lastMessage, { imageUrls });
+            if (apiUsage) {
+                lastMessage.extra.api_usage = apiUsage;
+            }
             if (power_user.message_token_count_enabled) {
                 const tokenCountText = (reasoning || '') + lastMessage.mes;
                 lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
@@ -6638,6 +6667,9 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.extra.reasoning_duration = null;
         lastMessage.extra.reasoning_signature = reasoningSignature;
         await processImageAttachment(lastMessage, { imageUrls });
+        if (apiUsage) {
+            lastMessage.extra.api_usage = apiUsage;
+        }
         if (power_user.message_token_count_enabled) {
             const tokenCountText = (reasoning || '') + lastMessage.mes;
             lastMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
@@ -6659,6 +6691,9 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.extra.reasoning += reasoning;
         lastMessage.extra.reasoning_signature = reasoningSignature;
         await processImageAttachment(lastMessage, { imageUrls });
+        if (apiUsage) {
+            lastMessage.extra.api_usage = apiUsage;
+        }
         // We don't know if the reasoning duration extended, so we don't update it here on purpose.
         if (power_user.message_token_count_enabled) {
             const tokenCountText = (reasoning || '') + lastMessage.mes;
@@ -6692,6 +6727,10 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         if (power_user.message_token_count_enabled) {
             const tokenCountText = (reasoning || '') + newMessage.mes;
             newMessage.extra.token_count = await getTokenCountAsync(tokenCountText, 0);
+        }
+
+        if (apiUsage) {
+            newMessage.extra.api_usage = apiUsage;
         }
 
         if (selected_group) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2745,6 +2745,7 @@ export async function createGenerationParameters(settings, model, type, messages
         'top_p': Number(settings.top_p_openai),
         'max_tokens': settings.openai_max_tokens,
         'stream': stream,
+        'stream_options': stream && [chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI, chat_completion_sources.NANOGPT, chat_completion_sources.AIMLAPI].includes(settings.chat_completion_source) ? { include_usage: true } : undefined,
         'logit_bias': logit_bias,
         'stop': getCustomStoppingStrings(openai_max_stop_strings),
         'chat_completion_source': settings.chat_completion_source,

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2745,7 +2745,6 @@ export async function createGenerationParameters(settings, model, type, messages
         'top_p': Number(settings.top_p_openai),
         'max_tokens': settings.openai_max_tokens,
         'stream': stream,
-        'stream_options': stream ? { include_usage: true } : undefined,
         'logit_bias': logit_bias,
         'stop': getCustomStoppingStrings(openai_max_stop_strings),
         'chat_completion_source': settings.chat_completion_source,

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3073,8 +3073,16 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
                 tryParseStreamingError(response, rawData);
                 const parsed = JSON.parse(rawData);
 
-                if (parsed.usage) {
-                    apiUsage = parsed.usage;
+                // Capture API usage from various SSE formats:
+                // OAI / Anthropic: parsed.usage (prompt_tokens/completion_tokens or input_tokens/output_tokens)
+                // Gemini:          parsed.usageMetadata (candidatesTokenCount etc.)
+                // Cohere v2:       parsed.meta.tokens (input_tokens/output_tokens)
+                const chunkUsage = parsed.usage
+                    || parsed.usageMetadata
+                    || parsed.meta?.tokens
+                    || null;
+                if (chunkUsage) {
+                    apiUsage = chunkUsage;
                 }
 
                 if (canMultiSwipe && Array.isArray(parsed?.choices) && parsed?.choices?.[0]?.index > 0) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2745,6 +2745,7 @@ export async function createGenerationParameters(settings, model, type, messages
         'top_p': Number(settings.top_p_openai),
         'max_tokens': settings.openai_max_tokens,
         'stream': stream,
+        'stream_options': stream ? { include_usage: true } : undefined,
         'logit_bias': logit_bias,
         'stop': getCustomStoppingStrings(openai_max_stop_strings),
         'chat_completion_source': settings.chat_completion_source,
@@ -3062,14 +3063,19 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
             let text = '';
             const swipes = [];
             const toolCalls = [];
+            let apiUsage = null;
             const state = { reasoning: '', images: [], signature: '', toolSignatures: {} };
             while (true) {
                 const { done, value } = await reader.read();
-                if (done) return;
+                if (done) break;
                 const rawData = value.data;
-                if (rawData === '[DONE]') return;
+                if (rawData === '[DONE]') break;
                 tryParseStreamingError(response, rawData);
                 const parsed = JSON.parse(rawData);
+
+                if (parsed.usage) {
+                    apiUsage = parsed.usage;
+                }
 
                 if (canMultiSwipe && Array.isArray(parsed?.choices) && parsed?.choices?.[0]?.index > 0) {
                     const swipeIndex = parsed.choices[0].index - 1;
@@ -3081,7 +3087,7 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
 
                 ToolManager.parseToolCalls(toolCalls, parsed, state.toolSignatures);
 
-                yield { text, swipes: swipes, logprobs: parseChatCompletionLogprobs(parsed), toolCalls: toolCalls, state: state };
+                yield { text, swipes: swipes, logprobs: parseChatCompletionLogprobs(parsed), toolCalls: toolCalls, state: state, usage: apiUsage };
             }
         };
     } else {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3121,6 +3121,23 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
 }
 
 /**
+ * Extracts the completion token count from API-reported usage data,
+ * normalizing across OAI, Claude, Gemini, and Cohere formats.
+ * @param {object|null} apiUsage - Raw API usage object from SSE chunk or response body
+ * @returns {number|null} - Completion token count, or null if not determinable
+ */
+export function getApiCompletionTokens(apiUsage) {
+    if (!apiUsage || typeof apiUsage !== 'object') return null;
+    if (typeof apiUsage.completion_tokens === 'number') return apiUsage.completion_tokens;
+    if (typeof apiUsage.output_tokens === 'number') return apiUsage.output_tokens;
+    if (typeof apiUsage.totalTokenCount === 'number' && typeof apiUsage.promptTokenCount === 'number') {
+        return apiUsage.totalTokenCount - apiUsage.promptTokenCount;
+    }
+    if (typeof apiUsage.candidatesTokenCount === 'number') return apiUsage.candidatesTokenCount;
+    return null;
+}
+
+/**
  * Extracts the reply from the response data from a chat completions-like source
  * @param {object} data Response data from the chat completions-like source
  * @param {object} state Additional state to keep track of

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1008,6 +1008,17 @@ async function sendCohereRequest(request, response) {
             }
             const generateResponseJson = await generateResponse.json();
             console.debug('Cohere response:', generateResponseJson);
+
+            // Map Cohere's meta.tokens / meta.billed_units to OAI-compatible usage format
+            const tokens = generateResponseJson?.meta?.tokens || generateResponseJson?.meta?.billed_units;
+            if (tokens) {
+                generateResponseJson.usage = {
+                    prompt_tokens: tokens.input_tokens || 0,
+                    completion_tokens: tokens.output_tokens || 0,
+                    total_tokens: (tokens.input_tokens || 0) + (tokens.output_tokens || 0),
+                };
+            }
+
             return response.send(generateResponseJson);
         }
     } catch (error) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1009,14 +1009,10 @@ async function sendCohereRequest(request, response) {
             const generateResponseJson = await generateResponse.json();
             console.debug('Cohere response:', generateResponseJson);
 
-            // Map Cohere's meta.tokens / meta.billed_units to OAI-compatible usage format
+            // Preserve Cohere's meta.tokens / meta.billed_units as api_usage for display
             const tokens = generateResponseJson?.meta?.tokens || generateResponseJson?.meta?.billed_units;
             if (tokens) {
-                generateResponseJson.usage = {
-                    prompt_tokens: tokens.input_tokens || 0,
-                    completion_tokens: tokens.output_tokens || 0,
-                    total_tokens: (tokens.input_tokens || 0) + (tokens.output_tokens || 0),
-                };
+                generateResponseJson.usage = tokens;
             }
 
             return response.send(generateResponseJson);

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -400,8 +400,8 @@ async function sendClaudeRequest(request, response) {
             const responseText = generateResponseJson?.content?.[0]?.text || '';
             console.debug('Claude response:', generateResponseJson);
 
-            // Wrap it back to OAI format + save the original content
-            const reply = { choices: [{ 'message': { 'content': responseText } }], content: generateResponseJson.content };
+            // Wrap it back to OAI format + save the original content and usage
+            const reply = { choices: [{ 'message': { 'content': responseText } }], content: generateResponseJson.content, usage: generateResponseJson.usage };
             return response.send(reply);
         }
     } catch (error) {
@@ -738,7 +738,7 @@ async function sendMakerSuiteRequest(request, response) {
             }
 
             // Wrap it back to OAI format (responseContent includes thought signatures in parts array)
-            const reply = { choices: [{ 'message': { 'content': responseText } }], responseContent };
+            const reply = { choices: [{ 'message': { 'content': responseText } }], responseContent, usage: generateResponseJson.usageMetadata };
             return response.send(reply);
         }
     } catch (error) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1008,13 +1008,6 @@ async function sendCohereRequest(request, response) {
             }
             const generateResponseJson = await generateResponse.json();
             console.debug('Cohere response:', generateResponseJson);
-
-            // Preserve Cohere's meta.tokens / meta.billed_units as api_usage for display
-            const tokens = generateResponseJson?.meta?.tokens || generateResponseJson?.meta?.billed_units;
-            if (tokens) {
-                generateResponseJson.usage = tokens;
-            }
-
             return response.send(generateResponseJson);
         }
     } catch (error) {


### PR DESCRIPTION
## Summary

Previously, SillyTavern never consumed the `usage` field from Chat Completion API responses. Token counts displayed in message bubbles were always computed by the local tokenizer, which may deviate from the API's actual billing count.

This becomes particularly important with providers like deepseek.com, where cache hits make input tokens nearly free — obtaining the real API-reported usage is essential for accurate cost tracking and for distinguishing cached from uncached tokens.

## Changes

**Streaming path:**
- Request `stream_options: { include_usage: true }` for OAI-compatible backends so the final SSE chunk includes usage data
- `streamData()` generator extracts `parsed.usage` from SSE chunks and yields it
- `StreamingProcessor` stores the usage and saves it to the message extra

**Non-streaming path:**
- `onSuccess()` extracts `data.usage` and passes it to `saveReply()`
- `saveReply()` stores API usage in `extra.api_usage` for all 4 message types (swipe, append, appendFinal, normal)

**Backend:**
- Claude non-streaming: preserve `generateResponseJson.usage` in the OAI-wrapped reply
- Gemini non-streaming: preserve `generateResponseJson.usageMetadata` in the OAI-wrapped reply

**Display:**
- Token count display format unchanged — still shows the message's token count (e.g. `150t`), but now sourced from API `completion_tokens` (or `output_tokens` / `candidatesTokenCount` depending on backend)
- Falls back to the local tokenizer count when API usage is unavailable
- Local tokenizer (`extra.token_count`) is fully preserved — it remains essential for PromptManager budget tracking, ChatCompletion budget checks, and other features
