### PR TITLE
fix: update backup archive to ignore migration secrets files

### DIFF
--- a/src/users.js
+++ b/src/users.js
@@ -1052,7 +1052,7 @@ export async function createBackupArchive(handle, response) {
     archive.pipe(response);
 
     // Append files from a sub-directory, putting its contents at the root of archive
-    const ignore = allowKeysExposure ? [] : [SECRETS_FILE];
+    const ignore = allowKeysExposure ? [] : [SECRETS_FILE, 'backups/secrets_migration_*.json'];
     archive.glob('**/*', {
         cwd: directories.root,
         follow: false,


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

A legacy secrets backup file (#4131)

Was missed in #5360 

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
