### PR TITLE
Fix json schema use for openAI compat CUSTOM endpoints in several use paths

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3239,7 +3239,7 @@ export function getExtensionPromptMaxDepth() {
  * @param {boolean} [wrap] Wrap start and end with a separator
  * @returns {Promise<string>} Extension prompt
  */
-export async function getExtensionPrompt(position = extension_prompt_types.IN_PROMPT, depth = undefined, separator = '\n', role = undefined, wrap = true) {
+export async function getExtensionPrompt(position = extension_prompt_types.IN_PROMPT, depth = undefined, separator = '\n\n', role = undefined, wrap = true) {
     const filterByFunction = async (prompt) => {
         const hasFilter = typeof prompt.filter === 'function';
         if (hasFilter && !await prompt.filter()) {
@@ -4290,7 +4290,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     if (selected_group && !is_group_generating) {
         if (!dryRun) {
             // Returns the promise that generateGroupWrapper returns; resolves when generation is done
-            return generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage });
+            return generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, jsonSchema });
         }
 
         const characterIndexMap = new Map(characters.map((char, index) => [char.avatar, index]));

--- a/public/script.js
+++ b/public/script.js
@@ -5330,7 +5330,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 streamingProcessor.firstMessageText = '';
             }
 
-            streamingProcessor.generator = await sendStreamingRequest(type, generate_data);
+            streamingProcessor.generator = await sendStreamingRequest(type, generate_data, { jsonSchema });
 
             hideSwipeButtons();
             let getMessage = await streamingProcessor.generate();

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2319,6 +2319,16 @@ router.post('/generate', async function (request, response) {
             mergeObjectWithYaml(bodyParams, request.body.custom_include_body);
             mergeObjectWithYaml(headers, request.body.custom_include_headers);
             embedOpenRouterMedia(request.body.messages, { audio: true, video: false });
+            if (request.body.json_schema) {
+                bodyParams['response_format'] = {
+                    type: 'json_schema',
+                    json_schema: {
+                        name: request.body.json_schema.name,
+                        strict: request.body.json_schema.strict ?? true,
+                        schema: request.body.json_schema.value,
+                    },
+                };
+            }
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.PERPLEXITY) {
             apiUrl = API_PERPLEXITY;
             apiKey = readSecret(request.user.directories, SECRET_KEYS.PERPLEXITY, request.body.secret_id);


### PR DESCRIPTION
Fixes three code paths where jsonSchema was silently dropped before reaching the upstream LLM provider:

- [X] `sendStreamingRequest` missing options (script.js:5333): The call inside `Generate` passed no options argument, so `jsonSchema` was always null inside `sendStreamingRequest` and never forwarded to `sendOpenAIRequest` for streaming generations.
- [X] `CUSTOM` source missing `json_schema` translation (chat-completions.js): Every other chat completion source translated `request.body.json_schema` into a `response_format` block before forwarding the request upstream. The `CUSTOM` source handler had no such translation, so structured output requests to custom OpenAI-compatible endpoints were sent without the schema.
- [X] Group chat dropping `jsonSchema` (script.js:4293): In a group chat, `Generate` intercepts and delegates to `generateGroupWrapper`, passing a `params` object that did not include `jsonSchema`. Because `generateGroupWrapper` spreads params back into the recursive `Generate` call, `jsonSchema` was always `null` by the time the request was assembled.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
