### PR TITLE
Update/Turn expression-set-fallback into expression-fallback

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -2344,7 +2344,6 @@ export async function init() {
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'expression-fallback',
-        aliases: ['expression-set-fallback'],
         callback: setFallBackExpressionSlashCommand,
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -2350,7 +2350,7 @@ export async function init() {
             SlashCommandArgument.fromProps({
                 description: 'expression label to set',
                 typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
+                isRequired: false,
                 enumProvider: () => [
                     new SlashCommandEnumValue('#none', 'Sets the fallback expression to no image'),
                     new SlashCommandEnumValue('#emoji', 'Sets the fallback expression to emojis'),
@@ -2358,7 +2358,25 @@ export async function init() {
                 ],
             }),
         ],
-        helpString: 'Force sets the expression fallback for all characters.',
+        helpString: `
+            <div>
+                Gets the currently selected expression fallback for all characters.<br />
+                If a valid expression label is sent, it will be set as the new fallback.
+            </div>
+            <div>
+                <strong>Example:</strong>
+                <ul>
+                    <li>
+                        <pre><code>/expression-fallback | /echo</code></pre>
+                        <small>Returns the currently selected fallback.</small>
+                    </li>
+                    <li>
+                        <pre><code>/expression-fallback admiration</code></pre>
+                        <small>Sets a new expression as fallback.</small>
+                    </li>
+                </ul>
+            </div>
+        `,
         returns: 'The currently set expression label after setting it.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -792,6 +792,8 @@ async function setSpriteSlashCommand({ type }, searchTerm) {
 function setFallBackExpressionSlashCommand(args, expressionName) {
     expressionName = expressionName.trim().toLowerCase();
 
+    if (!expressionName) return extension_settings?.expressions?.fallback_expression || '';
+
     const select = /** @type {HTMLSelectElement} */(document.getElementById('expression_fallback'));
     const fallbackExpressions = Array
         .from(select?.options || [])
@@ -2341,7 +2343,8 @@ export async function init() {
         returns: 'The currently set expression label after setting it.',
     }));
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'expression-set-fallback',
+        name: 'expression-fallback',
+        aliases: ['expression-set-fallback'],
         callback: setFallBackExpressionSlashCommand,
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({


### PR DESCRIPTION
Turn `expression-set-fallback` into `expression-fallback`
> Makes the extension a getter and setter instead of a setter only.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
