### PR TITLE
feat: improve structured output JSON extraction robustness

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6248,10 +6248,53 @@ export function extractJsonFromData(data, { mainApi = null, chatCompletionSource
     chatCompletionSource = chatCompletionSource ?? oai_settings.chat_completion_source;
 
     const tryParse = (/** @type {string} */ value) => {
+        if (typeof value !== 'string') {
+            return;
+        }
+
+        let normalizedValue = value.trim();
+
+        if (normalizedValue.startsWith('```')) {
+            normalizedValue = normalizedValue.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
+        }
+
         try {
-            return JSON.parse(value);
+            return JSON.parse(normalizedValue);
         } catch (e) {
-            console.debug('Failed to parse content as JSON.', e);
+            try {
+                let repairedValue = normalizedValue;
+                const quoteCount = (repairedValue.match(/"/g) || []).length;
+                const escapedQuoteCount = (repairedValue.match(/\\"/g) || []).length;
+                const actualQuoteCount = quoteCount - escapedQuoteCount;
+
+                if (actualQuoteCount % 2 !== 0) {
+                    repairedValue += '"';
+                }
+
+                const openBraces = (repairedValue.match(/\{/g) || []).length;
+                const closeBraces = (repairedValue.match(/\}/g) || []).length;
+                const missingBraces = openBraces - closeBraces;
+
+                const openBrackets = (repairedValue.match(/\[/g) || []).length;
+                const closeBrackets = (repairedValue.match(/\]/g) || []).length;
+                const missingBrackets = openBrackets - closeBrackets;
+
+                // Simple heuristic: close brackets first, then braces.
+                // Works for common cases like `{"key": ["value1", "value2` or `{"key": "value`
+                if (missingBrackets > 0) {
+                    repairedValue += ']'.repeat(missingBrackets);
+                }
+
+                if (missingBraces > 0) {
+                    repairedValue += '}'.repeat(missingBraces);
+                }
+
+                const result = JSON.parse(repairedValue);
+                console.debug('Successfully repaired and parsed truncated JSON.');
+                return result;
+            } catch (repairError) {
+                console.debug('Failed to parse content as JSON.', e);
+            }
         }
     };
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

**Reason for change:**
This PR aims to address #5569. In some cases (e.g., due to `max_tokens` or stop strings), structured output JSON can arrive slightly truncated or wrapped in markdown blocks, causing `extractJsonFromData` to silently fail and fall back to an empty object.

**What was done:**
Instead of adding the `jsonrepair` library dependency as suggested in the original issue (which might be too heavy and could increase the maintenance burden), I opted for a lightweight, dependency-free heuristic repair inside `tryParse`:
1. It safely strips markdown fenced code blocks (e.g., ` ```json ... ``` `).
2. If the initial `JSON.parse` fails, it counts unmatched quotes, brackets `[`, and braces `{`, and attempts to append them to the end of the string.
3. If the repair attempt still fails, it safely falls back to the existing behavior (returning `undefined`), ensuring no regressions for standard JSON outputs.

**How to test:**
1. Generate a structured output response using a model.
2. Manually test or simulate a response wrapped in ` ```json ... ``` `.
3. Simulate a response abruptly cut off at the end (e.g., missing closing brackets `]}` or quotes `"`).
4. Verify that the truncated JSON is now successfully recovered instead of defaulting to `{}`.

If this lightweight approach is not preferred or if you'd rather strictly enforce perfect JSON from the models, I completely understand. Thanks for reviewing!
