### PR TITLE
feat: add option to disable fallback expression on AI generation

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -592,8 +592,11 @@ async function moduleWorker({ newChat = false } = {}) {
         const force = !!context.groupId;
 
         // Character won't be angry on you for swiping
-        if (currentLastMessage.mes == '...' && expressionsList.includes(extension_settings.expressions.fallback_expression)) {
-            expression = extension_settings.expressions.fallback_expression;
+        if (currentLastMessage.mes == '...') {
+            const fallback = extension_settings.expressions.disableFallback ? null : extension_settings.expressions.fallback_expression;
+            if (fallback === null || expressionsList.includes(fallback)) {
+                expression = fallback;
+            }
         }
 
         await sendExpressionCall(spriteFolderName, expression, { force: force, vnMode: vnMode });
@@ -1013,9 +1016,11 @@ function onTextGenSettingsReady(args) {
  * @returns {Promise<string?>} - The label of the expression.
  */
 export async function getExpressionLabel(text, expressionsApi = extension_settings.expressions.api, { filterAvailable = null, customPrompt = null } = {}) {
+    const fallback = extension_settings.expressions.disableFallback ? null : extension_settings.expressions.fallback_expression;
+
     // Return if text is undefined, saving a costly fetch request
     if ((!modules.includes('classify') && expressionsApi == EXPRESSION_API.extras) || !text) {
-        return extension_settings.expressions.fallback_expression;
+        return fallback;
     }
 
     if (extension_settings.expressions.translate && typeof globalThis.translate === 'function') {
@@ -1050,7 +1055,7 @@ export async function getExpressionLabel(text, expressionsApi = extension_settin
                     await waitUntilCondition(() => online_status !== 'no_connection', 3000, 250);
                 } catch (error) {
                     console.warn('No LLM connection. Using fallback expression', error);
-                    return extension_settings.expressions.fallback_expression;
+                    return fallback;
                 }
 
                 const expressionsList = await getExpressionsList({ filterAvailable: filterAvailable });
@@ -1077,7 +1082,7 @@ export async function getExpressionLabel(text, expressionsApi = extension_settin
             case EXPRESSION_API.webllm: {
                 if (!isWebLlmSupported()) {
                     console.warn('WebLLM is not supported. Using fallback expression');
-                    return extension_settings.expressions.fallback_expression;
+                    return fallback;
                 }
 
                 const expressionsList = await getExpressionsList({ filterAvailable: filterAvailable });
@@ -1121,7 +1126,7 @@ export async function getExpressionLabel(text, expressionsApi = extension_settin
     } catch (error) {
         toastr.error('Could not classify expression. Check the console or your backend for more information.');
         console.error(error);
-        return extension_settings.expressions.fallback_expression;
+        return fallback;
     }
 }
 
@@ -2138,6 +2143,11 @@ function migrateSettings() {
         extension_settings.expressions.promptType = PROMPT_TYPE.raw;
         saveSettingsDebounced();
     }
+
+    if (extension_settings.expressions.disableFallback === undefined) {
+        extension_settings.expressions.disableFallback = false;
+        saveSettingsDebounced();
+    }
 }
 
 export async function init() {
@@ -2179,6 +2189,10 @@ export async function init() {
         });
         $('#expressions_filter_available').prop('checked', extension_settings.expressions.filterAvailable).on('input', function () {
             extension_settings.expressions.filterAvailable = !!$(this).prop('checked');
+            saveSettingsDebounced();
+        });
+        $('#expression_disable_fallback').prop('checked', extension_settings.expressions.disableFallback).on('input', function () {
+            extension_settings.expressions.disableFallback = !!$(this).prop('checked');
             saveSettingsDebounced();
         });
         $('#expression_override_cleanup_button').on('click', onClickExpressionOverrideRemoveAllButton);

--- a/public/scripts/extensions/expressions/settings.html
+++ b/public/scripts/extensions/expressions/settings.html
@@ -60,6 +60,10 @@
                 <label for="expression_fallback" data-i18n="Default / Fallback Expression">Default / Fallback Expression</label>
                 <small data-i18n="Set the default and fallback expression being used when no matching expression is found.">Set the default and fallback expression being used when no matching expression is found.</small>
                 <select id="expression_fallback" class="flex1 margin0"></select>
+                <label class="checkbox_label m-t-1" for="expression_disable_fallback" title="Disable using the default/fallback expression when no match is found" data-i18n="[title]Disable using the default/fallback expression when no match is found">
+                    <input id="expression_disable_fallback" type="checkbox">
+                    <span data-i18n="Disable fallback expression">Disable fallback expression</span>
+                </label>
             </div>
             <div class="expression_custom_block m-b-1 m-t-1">
                 <label for="expression_custom" data-i18n="Custom Expressions">Custom Expressions</label>


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

**Reason for change:**
This addresses the feature request #5547 (which has the `👍 Approved` label). 
Users who utilize Quick Reply Scripts or Regex to dynamically set character expressions find their expressions immediately overwritten by the default fallback expression as soon as AI generation starts (when the message content temporarily becomes `...`), or when classification fails. This forces them to add artificial 2-second delays to bypass the generation state.

**What was done:**
- Added a "Disable fallback expression" checkbox beneath the fallback expression selector in the Character Expressions extension settings.
- When enabled, the extension will return `null` instead of forcing the `fallback_expression` during the generation wait state (`currentLastMessage.mes == '...'`) and when the classification API fails or returns empty.
- When disabled (default behavior), the original fallback logic remains completely intact.
- Missing sprite image resolution logic is untouched.

**How to test:**
1. Open the Character Expressions settings and check the new "Disable fallback expression" box.
2. Manually set a character expression (e.g. using a slash command `/emote joy`).
3. Send a message to trigger AI generation.
4. Verify that while the AI is generating (`...`), the previously set `joy` expression is NOT forcefully overwritten by the fallback expression.
