### PR TITLE
fix: resolve nested markdown emphasis formatting via showdown extension

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -216,6 +216,7 @@ import {
 import { initSecrets, readSecretState } from './scripts/secrets.js';
 import { markdownExclusionExt } from './scripts/showdown-exclusion.js';
 import { markdownUnderscoreExt } from './scripts/showdown-underscore.js';
+import { markdownNestedEmphasisExt } from './scripts/showdown-nested-emphasis.js';
 import { NOTE_MODULE_NAME, initAuthorsNote, metadata_keys, setFloatingPrompt, shouldWIAddPrompt } from './scripts/authors-note.js';
 import { registerPromptManagerMigration } from './scripts/PromptManager.js';
 import { getRegexedString, regex_placement } from './scripts/extensions/regex/engine.js';
@@ -527,7 +528,7 @@ export function reloadMarkdownProcessor() {
         simpleLineBreaks: true,
         strikethrough: true,
         disableForced4SpacesIndentedSublists: true,
-        extensions: [markdownUnderscoreExt()],
+        extensions: [markdownUnderscoreExt(), markdownNestedEmphasisExt()],
     });
 
     // Inject the dinkus extension after creating the converter

--- a/public/scripts/showdown-nested-emphasis.js
+++ b/public/scripts/showdown-nested-emphasis.js
@@ -1,0 +1,39 @@
+// Showdown extension that prevents parsing breakage when single asterisks are nested.
+// It converts `*... *inner* ...*` into `*... **inner** ...*` before Showdown processes it.
+
+export const markdownNestedEmphasisExt = () => {
+    try {
+        if (!canUseLookbehind()) {
+            console.log('Showdown-nested-emphasis extension: Lookbehind not supported. Skipping.');
+            return [];
+        }
+
+        return [{
+            type: 'lang',
+            filter: function (text) {
+                const regex = /(?<=^|\W|_)\*(?!\s)([^*]+?)\*(?!\s)([^*]+?)(?<!\s)\*([^*]+?)(?<!\s)\*(?=\W|_|$)/g;
+                let newText = text;
+                let previousText = '';
+
+                while (newText !== previousText) {
+                    previousText = newText;
+                    newText = newText.replace(regex, '*$1**$2**$3*');
+                }
+
+                return newText;
+            },
+        }];
+    } catch (e) {
+        console.error('Error in Showdown-nested-emphasis extension:', e);
+        return [];
+    }
+};
+
+function canUseLookbehind() {
+    try {
+        new RegExp('(?<=a)(?<!b)');
+        return true;
+    } catch (e) {
+        return false;
+    }
+}


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

**Reason for change:**
This addresses issue #5500. Currently, nesting emphasis markers (e.g., `*...Some Text *Nested Emphasis Text* More text...*`) completely breaks the Markdown parser, causing the entire block to render as unformatted plain text.

*Note: In a previous attempt (#5511), I mistakenly placed this logic inside the deprecated `fixMarkdown` function. Taking Cohee's feedback into account, I have completely rewritten the approach to use the correct native method.*

**What was done:**
- Instead of relying on any deprecated toggles, I created a native `showdown.js` extension (`markdownNestedEmphasisExt`) and registered it alongside `markdownUnderscoreExt`.
- During the `lang` phase, the extension detects nested single asterisks and converts the inner `*...*` into `**...**` (bold) before Showdown attempts to parse it.
- This prevents parsing breakage and natively supports nested formatting (bold inside italic) as suggested by the issue reporter.
- Included a `canUseLookbehind()` safety check so that older browsers lacking lookbehind regex support will silently skip this extension rather than crashing the chat render.

**How to test:**
1. Send a message containing nested emphasis, for example: `*...Some Text *Nested Emphasis Text* More text...*`
2. Verify that it now renders properly without breaking the markdown parser (the outer text should be italicized, and the inner text should be bold).
