### PR TITLE
prompt-manager: add 'Chat' meta-trigger

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7305,6 +7305,7 @@
                                     <span data-i18n="Triggers">Triggers</span>
                                 </label>
                                 <select id="completion_prompt_manager_popup_entry_form_injection_trigger" class="text_pole" name="injection_trigger" multiple>
+                                    <option data-i18n="Chat" value="chat" title="Any user-driven chat turn (Normal + Continue + Swipe + Regenerate). Skipped for Quiet/Impersonate calls.">Chat</option>
                                     <option data-i18n="Normal" value="normal">Normal</option>
                                     <option data-i18n="Continue" value="continue">Continue</option>
                                     <option data-i18n="Impersonate" value="impersonate">Impersonate</option>
@@ -7312,8 +7313,8 @@
                                     <option data-i18n="Regenerate" value="regenerate">Regenerate</option>
                                     <option data-i18n="Quiet" value="quiet">Quiet</option>
                                 </select>
-                                <div class="text_muted" data-i18n="Filter to specific generation types.">
-                                    Filter to specific generation types.
+                                <div class="text_muted" data-i18n="Filter to specific generation types. 'Chat' is a shortcut for Normal+Continue+Swipe+Regenerate.">
+                                    Filter to specific generation types. 'Chat' is a shortcut for Normal+Continue+Swipe+Regenerate.
                                 </div>
                             </div>
                         </div>

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -32,6 +32,12 @@ const DEFAULT_DEPTH = 4;
 const DEFAULT_ORDER = 100;
 
 /**
+ * Generation types that count as a real user-driven chat turn. The 'chat' meta-trigger expands
+ * to this set so a prompt can opt out of Quiet/Impersonate without listing each chat type.
+ */
+const CHAT_GENERATION_TYPES = new Set(['normal', 'continue', 'swipe', 'regenerate']);
+
+/**
  * @enum {number}
  */
 export const INJECTION_POSITION = {
@@ -1549,7 +1555,11 @@ class PromptManager {
     shouldTrigger(prompt, generationType) {
         if (!Array.isArray(prompt?.injection_trigger)) return true;
         if (!prompt.injection_trigger.length) return true;
-        return prompt.injection_trigger.includes(generationType);
+        if (prompt.injection_trigger.includes(generationType)) return true;
+        // Meta-trigger: 'chat' matches any user-driven chat turn.
+        // Lets a prompt opt out of Quiet/Impersonate without listing four triggers individually.
+        if (prompt.injection_trigger.includes('chat') && CHAT_GENERATION_TYPES.has(generationType)) return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a new `Chat` option at the top of the prompt manager's **Triggers** dropdown. It expands to `{normal, continue, swipe, regenerate}` in `shouldTrigger()`, so a single selection covers every user-driven chat turn.

## Why

To opt a prompt out of `quiet` and `impersonate` calls today, you have to manually select each of the four chat-like generation types every time you edit a prompt entry. The new `Chat` shortcut makes that a one-click choice.

## Behaviour

- Pure additive: existing prompts and trigger lists are unchanged.
- `chat` is a meta-trigger — `shouldTrigger()` returns `true` if `injection_trigger.includes('chat')` and the current generation type is one of `normal`, `continue`, `swipe`, `regenerate`.
- `Quiet` and `Impersonate` remain explicit, separate triggers.

## Files changed

- `public/scripts/PromptManager.js` — define `CHAT_GENERATION_TYPES` set; expand the meta-trigger in `shouldTrigger()`.
- `public/index.html` — add the `Chat` option to the trigger `<select>`; update the helper text.

Total: **+14 / -3** across 2 files.

## Test plan

- [x] Linted with `npx eslint`.
- [x] Confirmed in browser: editing a prompt entry and selecting only `Chat` results in the prompt firing on a regular chat send / continue / swipe / regenerate but **not** on `Quiet` (e.g. an extension calling `generateQuietPrompt`).
- [x] Pre-existing prompts with no triggers, or with the previous individual triggers, behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)