### PR TITLE
Tabby: Prevent unwanted BOS token being added to all tokenizations.

### DIFF
--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -1093,7 +1093,7 @@ router.post('/remote/textgenerationwebui/encode', async function (request, respo
         switch (request.body.api_type) {
             case TEXTGEN_TYPES.TABBY:
                 url += '/v1/token/encode';
-                args.body = JSON.stringify({ 'text': text, 'add_bos_token': false });
+                args.body = JSON.stringify({ 'text': text, 'add_bos_token': false, 'encode_special_tokens': false });
                 break;
             case TEXTGEN_TYPES.KOBOLDCPP:
                 url += '/api/extra/tokencount';


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Despite https://github.com/SillyTavern/SillyTavern/commit/e19c4f7e19b68da86aa92fa867a71c5f361a5b88, Tabby still adds a BOS to every tokenization which likely breaks a host of things silently. Before the change it looks like this:

<img width="760" height="509" alt="Incorrect" src="https://github.com/user-attachments/assets/4e611ee9-550c-4759-9c91-804c5c3e01b3" />

You might think.. but what about the special tokens? Even with this setting disabled, they appear to encode just fine.
<img width="760" height="509" alt="Correct" src="https://github.com/user-attachments/assets/4d46dbf5-2b9b-436f-9fef-afca21d895c3" />

So what does the setting actually switch? unicode? I have no idea. This was tested on behemoth and the latest tabby/exllama3. I didn't test EXL2 but assumingly it works the same. Outside of string bans, you'd be banning or increasing probability of individual "words" and BOS doesn't belong, correct me if I'm wrong.

