### PR TITLE
Refactor getUniqueName utility for allowBaseName option

### DIFF
--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -94,7 +94,7 @@ async function getBookmarkName({ isReplace = false, forceName = null } = {}) {
         return `${cleanName} - ${bookmarkNameToken}${i}`;
     }
     const existingChats = await getExistingChatNames();
-    const suggestedName = getUniqueName(mainChatName, (x) => existingChats.includes(x), { nameBuilder: buildCheckpointName });
+    const suggestedName = getUniqueName(mainChatName, (x) => existingChats.includes(x), { nameBuilder: buildCheckpointName, startIndex: 1 });
 
     const body = await renderTemplateAsync('createCheckpoint', { isReplace: isReplace, suggestedName: suggestedName });
     let name = forceName ?? await Popup.show.input('Create Checkpoint', body, suggestedName);
@@ -212,7 +212,7 @@ export async function createBranch(mesId, { swipeId = null } = {}) {
         return `${cleanName} - Branch #${i}`;
     }
     const existingChats = await getExistingChatNames();
-    const name = getUniqueName(mainChatName, (x) => existingChats.includes(x), { nameBuilder: buildBranchName });
+    const name = getUniqueName(mainChatName, (x) => existingChats.includes(x), { nameBuilder: buildBranchName, startIndex: 1 });
     if (!name) {
         console.error('Could not generate a unique branch name.');
         toastr.error('Could not generate a unique branch name.', 'Branch creation failed');

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -696,9 +696,14 @@ export function isElementInViewport(el) {
  * @param {number} [options.maxTries=1000] The maximum number of tries to find a unique name. Default is 1000.
  * @param {number} [options.startIndex=1] The index to start with when building the name. Default is 1.
  *        When set to 0, the intention is to also check if the basename (without applied index) is free.
+ * @param {boolean} [options.allowBaseName=true] Whether to allow the base name to be returned if it's unique. Default is true.
  * @returns {string|null} A unique name. Null if no unique name could be found in `maxTries`.
  */
-export function getUniqueName(baseName, exists, { nameBuilder = null, maxTries = 1000, startIndex = 1 } = {}) {
+export function getUniqueName(baseName, exists, { nameBuilder = null, maxTries = 1000, startIndex = 1, allowBaseName = true } = {}) {
+    if (allowBaseName && !exists(baseName)) {
+        return baseName;
+    }
+
     nameBuilder ??= (baseName, i) => i === 0 ? baseName : `${baseName} (${i})`;
     let i = startIndex;
     let name;

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -692,18 +692,12 @@ export function isElementInViewport(el) {
  * @param {{ (name: string): boolean; }} exists Function to check if name exists.
  * @param {Object} [options] The options.
  * @param {((baseName: string, i: number) => string)|null} [options.nameBuilder=null] Function to build the name.
- *        Starts with the index provided by `startIndex` (default is 1). If not provided, uses "${baseName} (${i})".
+ *        Starts with the index provided by `startIndex` (default is 0). If not provided, uses `baseName` for index 0 and "${baseName} (${i})" for higher indices.
  * @param {number} [options.maxTries=1000] The maximum number of tries to find a unique name. Default is 1000.
- * @param {number} [options.startIndex=1] The index to start with when building the name. Default is 1.
- *        When set to 0, the intention is to also check if the basename (without applied index) is free.
- * @param {boolean} [options.allowBaseName=true] Whether to allow the base name to be returned if it's unique. Default is true.
+ * @param {number} [options.startIndex=0] The index to start with when building the name. Default is 0.
  * @returns {string|null} A unique name. Null if no unique name could be found in `maxTries`.
  */
-export function getUniqueName(baseName, exists, { nameBuilder = null, maxTries = 1000, startIndex = 1, allowBaseName = true } = {}) {
-    if (allowBaseName && !exists(baseName)) {
-        return baseName;
-    }
-
+export function getUniqueName(baseName, exists, { nameBuilder = null, maxTries = 1000, startIndex = 0 } = {}) {
     nameBuilder ??= (baseName, i) => i === 0 ? baseName : `${baseName} (${i})`;
     let i = startIndex;
     let name;


### PR DESCRIPTION
I checked all core caller sites. We have two (branch, checkpoint) where an appended index suffix by default is required/makes sense.
For any other existing or future caller, allowing base name by default makes the most sense.

Fixes #5600

### Copilot Summary
This pull request updates the logic for generating unique names for bookmarks and branches. The main change is to ensure that the naming process now starts from index 1 instead of 0 when suggesting new names, which avoids suggesting the base name without a suffix when it might already exist. This improves consistency and prevents name collisions.

**Unique name generation improvements:**

* Changed the default `startIndex` parameter in `getUniqueName` from 1 to 0, but updated all usage sites for bookmarks and branches to explicitly pass `startIndex: 1`, ensuring that generated names always have a suffix and avoid potential collisions with existing base names. (`public/scripts/utils.js`, `public/scripts/bookmarks.js`) [[1]](diffhunk://#diff-5dd7af59de2d856cc772e718a0d6eb14d74efae71eaf64230666fcf636caaba6L695-R700) [[2]](diffhunk://#diff-2f40fb199f4496965a62f579caf8e676756ffcb664d04826b498f5e1c4c562a1L97-R97) [[3]](diffhunk://#diff-2f40fb199f4496965a62f579caf8e676756ffcb664d04826b498f5e1c4c562a1L215-R215)

* Updated documentation in `getUniqueName` to clarify the new default behavior and how the `startIndex` parameter affects name generation. (`public/scripts/utils.js`)

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).
