### PR TITLE
Add rate limit to account reset

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -198,6 +198,8 @@ rateLimiting:
   accountsLoginMaxAttempts: 5
   # Set the maximum number of allowed failed account recovery attempts before rate limiting is applied. Set to 0 to disable rate limiting for account recovery.
   accountsRecoverMaxAttempts: 5
+  # Set the maximum number of allowed failed account reset attempts before rate limiting is applied. Set to 0 to disable rate limiting for account resets.
+  accountsResetMaxAttempts: 5
 # Set to true to enable support for real IPs in certain request headers for features like IP whitelisting, rate limiting and access logging.
 # Only change if you are sure that you use a correctly configured reverse proxy, otherwise this may lead to IP spoofing.
 forwardedHeaders:

--- a/public/scripts/templates/userReset.html
+++ b/public/scripts/templates/userReset.html
@@ -14,6 +14,6 @@
     </div>
     <div class="resetCodeBlock">
         <label data-i18n="Reset Code:" for="password">Reset Code:</label>
-        <input type="text" name="code" class="text_pole" placeholder="XXXX">
+        <input type="text" name="code" class="text_pole" placeholder="XXXXXX">
     </div>
 </form>

--- a/src/endpoints/users-private.js
+++ b/src/endpoints/users-private.js
@@ -4,15 +4,25 @@ import crypto from 'node:crypto';
 
 import storage from 'node-persist';
 import express from 'express';
+import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
 
 import { getUserAvatar, toKey, getPasswordHash, getPasswordSalt, createBackupArchive, ensurePublicDirectoriesExist, toAvatarKey, getAccountVersion } from '../users.js';
 import { SETTINGS_FILE } from '../constants.js';
 import { checkForNewContent, CONTENT_TYPES } from './content-manager.js';
 import { color, Cache, getConfigValue } from '../util.js';
+import { getIpAddress, retryAfter } from '../express-common.js';
 
+const RESET_POINTS = getConfigValue('rateLimiting.accountsResetMaxAttempts', 5, 'number');
+const PREFER_REAL_IP_HEADER = getConfigValue('rateLimiting.preferRealIpHeader', false, 'boolean');
 const RESET_CACHE = new Cache(5 * 60 * 1000);
 
+const generateResetCode = () => Array.from({ length: 6 }, () => crypto.randomInt(0, 10)).join('');
+
 export const router = express.Router();
+const resetLimiter = new RateLimiterMemory({
+    points: RESET_POINTS > 0 ? RESET_POINTS : Number.MAX_SAFE_INTEGER,
+    duration: 300,
+});
 
 router.post('/logout', async (request, response) => {
     try {
@@ -223,14 +233,27 @@ router.post('/change-name', async (request, response) => {
 
 router.post('/reset-step1', async (request, response) => {
     try {
-        const resetCode = String(crypto.randomInt(1000, 9999));
+        const ip = getIpAddress(request, PREFER_REAL_IP_HEADER);
+        const rateLimit = await resetLimiter.get(ip);
+
+        // Check for existing rate limits, but allow requesting a new code unless locked out
+        if (rateLimit !== null && rateLimit.consumedPoints > resetLimiter.points) {
+            throw rateLimit;
+        }
+
+        const resetCode = generateResetCode();
         console.log();
         console.log(color.magenta(`${request.user.profile.name}, your account reset code is: `) + color.red(resetCode));
         console.log();
         RESET_CACHE.set(request.user.profile.handle, resetCode);
         return response.sendStatus(204);
     } catch (error) {
-        console.error('Recover step 1 failed:', error);
+        if (error instanceof RateLimiterRes) {
+            console.error('Reset step 1 failed: Rate limited from', getIpAddress(request, PREFER_REAL_IP_HEADER));
+            return retryAfter(response, error).status(429).send({ error: 'Too many attempts. Try again later or contact your admin.' });
+        }
+
+        console.error('Reset step 1 failed:', error);
         return response.sendStatus(500);
     }
 });
@@ -238,19 +261,27 @@ router.post('/reset-step1', async (request, response) => {
 router.post('/reset-step2', async (request, response) => {
     try {
         if (!request.body.code) {
-            console.warn('Recover step 2 failed: Missing required fields');
+            console.warn('Reset step 2 failed: Missing required fields');
             return response.status(400).json({ error: 'Missing required fields' });
         }
 
         if (request.user.profile.password && request.user.profile.password !== getPasswordHash(request.body.password, request.user.profile.salt)) {
-            console.warn('Recover step 2 failed: Incorrect password');
+            console.warn('Reset step 2 failed: Incorrect password');
             return response.status(400).json({ error: 'Incorrect password' });
+        }
+
+        const ip = getIpAddress(request, PREFER_REAL_IP_HEADER);
+        const rateLimit = await resetLimiter.get(ip);
+
+        if (rateLimit !== null && rateLimit.consumedPoints > resetLimiter.points) {
+            throw rateLimit;
         }
 
         const code = RESET_CACHE.get(request.user.profile.handle);
 
         if (!code || code !== request.body.code) {
-            console.warn('Recover step 2 failed: Incorrect code');
+            await resetLimiter.consume(ip);
+            console.warn('Reset step 2 failed: Incorrect code');
             return response.status(400).json({ error: 'Incorrect code' });
         }
 
@@ -260,10 +291,16 @@ router.post('/reset-step2', async (request, response) => {
         await ensurePublicDirectoriesExist();
         await checkForNewContent([request.user.directories]);
 
+        await resetLimiter.delete(ip);
         RESET_CACHE.remove(request.user.profile.handle);
         return response.sendStatus(204);
     } catch (error) {
-        console.error('Recover step 2 failed:', error);
+        if (error instanceof RateLimiterRes) {
+            console.error('Reset step 2 failed: Rate limited from', getIpAddress(request, PREFER_REAL_IP_HEADER));
+            return retryAfter(response, error).status(429).send({ error: 'Too many attempts. Try again later or contact your admin.' });
+        }
+
+        console.error('Reset step 2 failed:', error);
         return response.sendStatus(500);
     }
 });


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Very similar functionality to account recover (evident by previously mislabeled console messages), but was missing rate limiting and now uses the same code length. Isn't critical since to perform a reset you need already be authenticated, but wouldn't hurt I guess.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
