### PR TITLE
Fix reasoning prefill auto parse

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3636,13 +3636,12 @@ class StreamingProcessor {
             includeUserPromptBias = false;
         }
 
-        if (this.reasoningHandler.reasoning.startsWith(power_user.reasoning.prefix)){
+        if (this.reasoningHandler.reasoning.startsWith(power_user.reasoning.prefix)) {
             if (this.reasoningHandler.reasoning.includes(power_user.reasoning.suffix)) {
                 let reParse = this.reasoningHandler.reasoning + text;
-                ({reasoning: this.reasoningHandler.reasoning, content: text} =
-                    parseReasoningFromString(reParse) ?? {reasoning: this.reasoningHandler.reasoning, content: text});
-            }
-            else {
+                ({ reasoning: this.reasoningHandler.reasoning, content: text } =
+                    parseReasoningFromString(reParse) ?? { reasoning: this.reasoningHandler.reasoning, content: text });
+            } else {
                 this.reasoningHandler.reasoning = this.reasoningHandler.reasoning.slice(power_user.reasoning.prefix.length);
             }
             includeUserPromptBias = false;

--- a/public/script.js
+++ b/public/script.js
@@ -5470,18 +5470,16 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         if (isContinue) {
             continue_mag = promptReasoning.removePrefix(continue_mag);
             getMessage = continue_mag + getMessage;
-        }
-        else if (reasoning && power_user.user_prompt_bias) {
+        } else if (reasoning && power_user.user_prompt_bias) {
             reasoning = substituteParams(power_user.user_prompt_bias) + reasoning;
             includeUserPromptBias = false;
         }
 
-        if (reasoning.startsWith(power_user.reasoning.prefix)){
+        if (reasoning.startsWith(power_user.reasoning.prefix)) {
             if (reasoning.includes(power_user.reasoning.suffix)) {
                 let reParse = reasoning + getMessage;
-                ({reasoning, content: getMessage} = parseReasoningFromString(reParse) ?? {reasoning, content: getMessage});
-            }
-            else {
+                ({ reasoning, content: getMessage } = parseReasoningFromString(reParse) ?? { reasoning, content: getMessage });
+            } else {
                 reasoning = reasoning.slice(power_user.reasoning.prefix.length);
             }
             includeUserPromptBias = false;

--- a/public/script.js
+++ b/public/script.js
@@ -269,7 +269,7 @@ import { initServerHistory } from './scripts/server-history.js';
 import { initSettingsSearch } from './scripts/setting-search.js';
 import { initBulkEdit } from './scripts/bulk-edit.js';
 import { getContext } from './scripts/st-context.js';
-import { extractReasoningFromData, extractReasoningSignatureFromData, initReasoning, parseReasoningInSwipes, PromptReasoning, ReasoningHandler, removeReasoningFromString, updateReasoningUI } from './scripts/reasoning.js';
+import { extractReasoningFromData, extractReasoningSignatureFromData, initReasoning, parseReasoningFromString, parseReasoningInSwipes, PromptReasoning, ReasoningHandler, removeReasoningFromString, updateReasoningUI } from './scripts/reasoning.js';
 import { accountStorage } from './scripts/util/AccountStorage.js';
 import { initWelcomeScreen, openPermanentAssistantChat, openPermanentAssistantCard, getPermanentAssistantAvatar } from './scripts/welcome-screen.js';
 import { initDataMaid } from './scripts/data-maid.js';
@@ -5466,13 +5466,26 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
 
         const swipes = extractMultiSwipes(data, type);
 
-        messageChunk = cleanUpMessage({
-            getMessage: getMessage,
-            isImpersonate: isImpersonate,
-            isContinue: isContinue,
-            displayIncompleteSentences: false,
-        });
+        let includeUserPromptBias = true;
+        if (isContinue) {
+            continue_mag = promptReasoning.removePrefix(continue_mag);
+            getMessage = continue_mag + getMessage;
+        }
+        else if (reasoning && power_user.user_prompt_bias) {
+            reasoning = substituteParams(power_user.user_prompt_bias) + reasoning;
+            includeUserPromptBias = false;
+        }
 
+        if (reasoning.startsWith(power_user.reasoning.prefix)){
+            if (reasoning.includes(power_user.reasoning.suffix)) {
+                let reParse = reasoning + getMessage;
+                ({reasoning, content: getMessage} = parseReasoningFromString(reParse) ?? {reasoning, content: getMessage});
+            }
+            else {
+                reasoning = reasoning.slice(power_user.reasoning.prefix.length);
+            }
+            includeUserPromptBias = false;
+        }
 
         reasoning = getRegexedString(reasoning, regex_placement.REASONING);
 
@@ -5480,10 +5493,13 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             reasoning = reasoning.trim();
         }
 
-        if (isContinue) {
-            continue_mag = promptReasoning.removePrefix(continue_mag);
-            getMessage = continue_mag + getMessage;
-        }
+        messageChunk = cleanUpMessage({
+            getMessage: getMessage,
+            isImpersonate: isImpersonate,
+            isContinue: isContinue,
+            displayIncompleteSentences: false,
+            includeUserPromptBias: includeUserPromptBias,
+        });
 
         //Formating
         const displayIncomplete = type === 'quiet' && !quietToLoud;
@@ -5492,6 +5508,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             isImpersonate: isImpersonate,
             isContinue: isContinue,
             displayIncompleteSentences: displayIncomplete,
+            includeUserPromptBias: includeUserPromptBias,
         });
 
         if (isImpersonate) {

--- a/public/script.js
+++ b/public/script.js
@@ -269,7 +269,7 @@ import { initServerHistory } from './scripts/server-history.js';
 import { initSettingsSearch } from './scripts/setting-search.js';
 import { initBulkEdit } from './scripts/bulk-edit.js';
 import { getContext } from './scripts/st-context.js';
-import { extractReasoningFromData, extractReasoningSignatureFromData, initReasoning, parseReasoningFromString, parseReasoningInSwipes, PromptReasoning, ReasoningHandler, removeReasoningFromString, updateReasoningUI } from './scripts/reasoning.js';
+import { extractReasoningFromData, extractReasoningSignatureFromData, initReasoning, parseReasoningFromString, parseReasoningInSwipes, PromptReasoning, ReasoningHandler, ReasoningState, ReasoningType, removeReasoningFromString, updateReasoningUI } from './scripts/reasoning.js';
 import { accountStorage } from './scripts/util/AccountStorage.js';
 import { initWelcomeScreen, openPermanentAssistantChat, openPermanentAssistantCard, getPermanentAssistantAvatar } from './scripts/welcome-screen.js';
 import { initDataMaid } from './scripts/data-maid.js';
@@ -3272,7 +3272,7 @@ export function getExtensionPromptMaxDepth() {
  * @param {boolean} [wrap] Wrap start and end with a separator
  * @returns {Promise<string>} Extension prompt
  */
-export async function getExtensionPrompt(position = extension_prompt_types.IN_PROMPT, depth = undefined, separator = '\n', role = undefined, wrap = true) {
+export async function getExtensionPrompt(position = extension_prompt_types.IN_PROMPT, depth = undefined, separator = '\n\n', role = undefined, wrap = true) {
     const filterByFunction = async (prompt) => {
         const hasFilter = typeof prompt.filter === 'function';
         if (hasFilter && !await prompt.filter()) {
@@ -3630,12 +3630,37 @@ class StreamingProcessor {
             }
         }
 
+        let includeUserPromptBias = true;
+        if (this.reasoningHandler.type == ReasoningType.Model && this.reasoningHandler.state != ReasoningState.None) {
+            this.reasoningHandler.reasoning = substituteParams(power_user.user_prompt_bias) + this.reasoningHandler.reasoning;
+            includeUserPromptBias = false;
+        }
+
+        if (this.reasoningHandler.reasoning.startsWith(power_user.reasoning.prefix)){
+            if (this.reasoningHandler.reasoning.includes(power_user.reasoning.suffix)) {
+                let reParse = this.reasoningHandler.reasoning + text;
+                ({reasoning: this.reasoningHandler.reasoning, content: text} =
+                    parseReasoningFromString(reParse) ?? {reasoning: this.reasoningHandler.reasoning, content: text});
+            }
+            else {
+                this.reasoningHandler.reasoning = this.reasoningHandler.reasoning.slice(power_user.reasoning.prefix.length);
+            }
+            includeUserPromptBias = false;
+        }
+
+        this.reasoningHandler.reasoning = getRegexedString(this.reasoningHandler.reasoning, regex_placement.REASONING);
+
+        if (power_user.trim_spaces) {
+            this.reasoningHandler.reasoning = this.reasoningHandler.reasoning.trim();
+        }
+
         let processedText = cleanUpMessage({
             getMessage: text,
             isImpersonate: isImpersonate,
             isContinue: isContinue,
             displayIncompleteSentences: !isFinal,
             stoppingStrings: this.stoppingStrings,
+            includeUserPromptBias: includeUserPromptBias,
         });
 
         const charsToBalance = ['*', '"', '```', '~~~'];

--- a/public/script.js
+++ b/public/script.js
@@ -3631,7 +3631,9 @@ class StreamingProcessor {
         }
 
         let includeUserPromptBias = true;
-        if (this.reasoningHandler.type == ReasoningType.Model || this.reasoningHandler.state != ReasoningState.None) {
+        let parsedBias = substituteParams(power_user.user_prompt_bias);
+        if ((this.reasoningHandler.type == ReasoningType.Model && this.reasoningHandler.state != ReasoningState.None) ||
+                parsedBias.startsWith(power_user.reasoning.prefix)) {
             this.reasoningHandler.reasoning = substituteParams(power_user.user_prompt_bias) + this.reasoningHandler.reasoning;
             includeUserPromptBias = false;
         }

--- a/public/script.js
+++ b/public/script.js
@@ -3630,7 +3630,7 @@ class StreamingProcessor {
             }
         }
 
-        let includeUserPromptBias = this.reasoningHandler.state == ReasoningState.None || this.reasoningHandler.type == ReasoningType.Parsed;
+        let includeUserPromptBias = !isContinue && (this.reasoningHandler.state == ReasoningState.None || this.reasoningHandler.type == ReasoningType.Parsed);
         let parsedBias = substituteParams(power_user.user_prompt_bias);
         if (!includeUserPromptBias && this.reasoningHandler.type == ReasoningType.Model) {
             this.reasoningHandler.reasoning = substituteParams(parsedBias) + this.reasoningHandler.reasoning;

--- a/public/script.js
+++ b/public/script.js
@@ -3631,7 +3631,7 @@ class StreamingProcessor {
         }
 
         let includeUserPromptBias = true;
-        if (this.reasoningHandler.type == ReasoningType.Model && this.reasoningHandler.state != ReasoningState.None) {
+        if (this.reasoningHandler.type == ReasoningType.Model || this.reasoningHandler.state != ReasoningState.None) {
             this.reasoningHandler.reasoning = substituteParams(power_user.user_prompt_bias) + this.reasoningHandler.reasoning;
             includeUserPromptBias = false;
         }

--- a/public/script.js
+++ b/public/script.js
@@ -3630,13 +3630,13 @@ class StreamingProcessor {
             }
         }
 
-        let includeUserPromptBias = true;
+        let includeUserPromptBias = this.reasoningHandler.state == ReasoningState.None || this.reasoningHandler.type == ReasoningType.Parsed;
         let parsedBias = substituteParams(power_user.user_prompt_bias);
-        if (this.reasoningHandler.type == ReasoningType.Model && this.reasoningHandler.state != ReasoningState.None) {
+        if (!includeUserPromptBias && this.reasoningHandler.type == ReasoningType.Model) {
             this.reasoningHandler.reasoning = substituteParams(parsedBias) + this.reasoningHandler.reasoning;
             includeUserPromptBias = false;
-        } else if (this.reasoningHandler.state == ReasoningState.None && parsedBias == power_user.reasoning.prefix) {
-            let reasoning = parsedBias + this.reasoningHandler.reasoning;
+        } else if (includeUserPromptBias && parsedBias.trim() == power_user.reasoning.prefix) {
+            let reasoning = (parsedBias + this.reasoningHandler.reasoning).slice(power_user.reasoning.prefix.length);
             includeUserPromptBias = !this.reasoningHandler.updateReasoning(messageId, reasoning);
         }
 

--- a/public/script.js
+++ b/public/script.js
@@ -3632,10 +3632,12 @@ class StreamingProcessor {
 
         let includeUserPromptBias = true;
         let parsedBias = substituteParams(power_user.user_prompt_bias);
-        if ((this.reasoningHandler.type == ReasoningType.Model && this.reasoningHandler.state != ReasoningState.None) ||
-                parsedBias.startsWith(power_user.reasoning.prefix)) {
-            this.reasoningHandler.reasoning = substituteParams(power_user.user_prompt_bias) + this.reasoningHandler.reasoning;
+        if (this.reasoningHandler.type == ReasoningType.Model && this.reasoningHandler.state != ReasoningState.None) {
+            this.reasoningHandler.reasoning = substituteParams(parsedBias) + this.reasoningHandler.reasoning;
             includeUserPromptBias = false;
+        } else if (this.reasoningHandler.state == ReasoningState.None && parsedBias == power_user.reasoning.prefix) {
+            let reasoning = parsedBias + this.reasoningHandler.reasoning;
+            includeUserPromptBias = !this.reasoningHandler.updateReasoning(messageId, reasoning);
         }
 
         if (this.reasoningHandler.reasoning.startsWith(power_user.reasoning.prefix)) {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -318,8 +318,15 @@ export class ReasoningHandler {
      * @param {PromptReasoning} promptReasoning Prompt reasoning object
      */
     initContinue(promptReasoning) {
-        this.reasoning = promptReasoning.prefixReasoning;
         this.state = promptReasoning.prefixIncomplete ? ReasoningState.None : ReasoningState.Done;
+        if (this.state == ReasoningState.Done) {
+            this.reasoning = promptReasoning.prefixReasoningFormatted;
+            this.type = ReasoningType.Parsed;
+            this.#parsingReasoningMesStartIndex = this.reasoning.length;
+            promptReasoning.prefixIncomplete = true;
+        } else {
+            this.reasoning = promptReasoning.prefixReasoning;
+        }
         this.startTime = this.initialTime;
         this.endTime = promptReasoning.prefixDuration ? new Date(this.initialTime.getTime() + promptReasoning.prefixDuration) : null;
     }

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -292,9 +292,9 @@ export class ReasoningHandler {
         this.reasoning = '';
         /** @type {string?} The reasoning output display in case of translate or other */
         this.reasoningDisplayText = null;
-        /** @type {Date?} When the reasoning started */
+        /** @type {Date|null} When the reasoning started */
         this.startTime = null;
-        /** @type {Date?} When the reasoning ended */
+        /** @type {Date|null} When the reasoning ended */
         this.endTime = null;
 
         /** @type {Date} Initial starting time of the generation */
@@ -398,7 +398,7 @@ export class ReasoningHandler {
     /**
      * Gets the duration of the reasoning in milliseconds.
      *
-     * @returns {number?} The duration in milliseconds, or null if the start or end time is not set
+     * @returns {number|null} The duration in milliseconds, or null if the start or end time is not set
      */
     getDuration() {
         if (this.startTime && this.endTime) {
@@ -441,7 +441,7 @@ export class ReasoningHandler {
         if (persist) {
             // Build and save the reasoning data to message extras
             extra.reasoning = this.reasoning;
-            extra.reasoning_duration = this.getDuration() ?? undefined;
+            extra.reasoning_duration = this.getDuration();
             extra.reasoning_type = (this.#isParsingReasoning || this.#parsingReasoningMesStartIndex) ? ReasoningType.Parsed : ReasoningType.Model;
         }
 

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -426,7 +426,7 @@ export class ReasoningHandler {
 
         this.reasoning = getRegexedString(trimSpaces(reasoning) ?? '', regex_placement.REASONING);
 
-        this.type = (this.#isParsingReasoning || this.#parsingReasoningMesStartIndex) ? ReasoningType.Parsed : ReasoningType.Model;
+        this.type = (this.#isParsingReasoning || this.#parsingReasoningMesStartIndex) ? ReasoningType.Parsed : reasoning ? ReasoningType.Model : null;
 
         if (reasoningChanged && this.type == ReasoningType.Model && this.state == ReasoningState.None)
             this.state = this.reasoning ? ReasoningState.Thinking : ReasoningState.Done;

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -480,8 +480,8 @@ export class ReasoningHandler {
         if (!power_user.reasoning.auto_parse || !power_user.reasoning.prefix || !power_user.reasoning.suffix)
             return mesChanged;
 
-        // If we already have native model reasoning, don't auto-parse the reconstructed text
-        if (this.type === ReasoningType.Model) {
+        // If we already have native model reasoning, don't auto-parse reconstructed text
+        if (this.type === ReasoningType.Model && this.state !== ReasoningState.None) {
             return mesChanged;
         }
 

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1467,7 +1467,7 @@ export function getReasoningTemplateByName(name) {
  * @param {Object} options Optional arguments
  * @param {boolean} [options.strict=true] Whether the reasoning block **has** to be at the beginning of the provided string (excluding whitespaces), or can be anywhere in it
  * @param {ReasoningTemplate} template Optional reasoning template to use instead of power_user.reasoning
- * @returns {ParsedReasoning|null} Parsed reasoning block and message content
+ * @returns {ParsedReasoning|null} Parsed reasoning block and message content, or null if no reasoning block was found
  */
 export function parseReasoningFromString(str, { strict = true } = {}, template = null) {
     template = template ?? power_user.reasoning;  // if no template given, use the currently selected template
@@ -1488,10 +1488,12 @@ export function parseReasoningFromString(str, { strict = true } = {}, template =
             return '';
         });
 
-        if (didReplace) {
-            reasoning = trimSpaces(reasoning);
-            content = trimSpaces(content);
+        if (!didReplace) {
+            return null;
         }
+
+        reasoning = trimSpaces(reasoning);
+        content = trimSpaces(content);
 
         return { reasoning, content };
     } catch (error) {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -477,9 +477,7 @@ export class ReasoningHandler {
      * @returns {boolean} Whether the message has changed after reasoning parsing
      */
     #autoParseReasoningFromMessage(messageId, mesChanged, promptReasoning) {
-        if (!power_user.reasoning.auto_parse)
-            return;
-        if (!power_user.reasoning.prefix || !power_user.reasoning.suffix)
+        if (!power_user.reasoning.auto_parse || !power_user.reasoning.prefix || !power_user.reasoning.suffix)
             return mesChanged;
 
         /** @type {ChatMessage} */

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -480,6 +480,11 @@ export class ReasoningHandler {
         if (!power_user.reasoning.auto_parse || !power_user.reasoning.prefix || !power_user.reasoning.suffix)
             return mesChanged;
 
+        // If we already have native model reasoning, don't auto-parse the reconstructed text
+        if (this.type === ReasoningType.Model) {
+            return mesChanged;
+        }
+
         /** @type {ChatMessage} */
         const message = chat[messageId];
         if (!message) return mesChanged;

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -292,9 +292,9 @@ export class ReasoningHandler {
         this.reasoning = '';
         /** @type {string?} The reasoning output display in case of translate or other */
         this.reasoningDisplayText = null;
-        /** @type {Date} When the reasoning started */
+        /** @type {Date?} When the reasoning started */
         this.startTime = null;
-        /** @type {Date} When the reasoning ended */
+        /** @type {Date?} When the reasoning ended */
         this.endTime = null;
 
         /** @type {Date} Initial starting time of the generation */
@@ -303,13 +303,13 @@ export class ReasoningHandler {
         this.#isHiddenReasoningModel = isHiddenReasoningModel();
 
         // Cached DOM elements for reasoning
-        /** @type {HTMLElement} Main message DOM element `.mes` */
+        /** @type {HTMLElement?} Main message DOM element `.mes` */
         this.messageDom = null;
-        /** @type {HTMLDetailsElement} Reasoning details DOM element `.mes_reasoning_details` */
+        /** @type {HTMLDetailsElement?} Reasoning details DOM element `.mes_reasoning_details` */
         this.messageReasoningDetailsDom = null;
-        /** @type {HTMLElement} Reasoning content DOM element `.mes_reasoning` */
+        /** @type {HTMLElement?} Reasoning content DOM element `.mes_reasoning` */
         this.messageReasoningContentDom = null;
-        /** @type {HTMLElement} Reasoning header DOM element `.mes_reasoning_header_title` */
+        /** @type {HTMLElement?} Reasoning header DOM element `.mes_reasoning_header_title` */
         this.messageReasoningHeaderDom = null;
     }
 
@@ -415,24 +415,26 @@ export class ReasoningHandler {
             return false;
         }
 
-        reasoning = allowReset ? reasoning ?? this.reasoning : reasoning || this.reasoning;
-        reasoning = trimSpaces(reasoning);
-
         // Ensure the chat extra exists
         if (!chat[messageId].extra) {
             chat[messageId].extra = {};
         }
         const extra = chat[messageId].extra;
 
+        reasoning = allowReset ? reasoning ?? this.reasoning : reasoning || this.reasoning;
         const reasoningChanged = extra.reasoning !== reasoning;
-        this.reasoning = getRegexedString(reasoning ?? '', regex_placement.REASONING);
+
+        this.reasoning = getRegexedString(trimSpaces(reasoning) ?? '', regex_placement.REASONING);
 
         this.type = (this.#isParsingReasoning || this.#parsingReasoningMesStartIndex) ? ReasoningType.Parsed : ReasoningType.Model;
+
+        if (reasoningChanged && this.type == ReasoningType.Model && this.state == ReasoningState.None)
+            this.state = this.reasoning ? ReasoningState.Thinking : ReasoningState.Done;
 
         if (persist) {
             // Build and save the reasoning data to message extras
             extra.reasoning = this.reasoning;
-            extra.reasoning_duration = this.getDuration();
+            extra.reasoning_duration = this.getDuration() ?? undefined;
             extra.reasoning_type = (this.#isParsingReasoning || this.#parsingReasoningMesStartIndex) ? ReasoningType.Parsed : ReasoningType.Model;
         }
 
@@ -489,7 +491,7 @@ export class ReasoningHandler {
         const message = chat[messageId];
         if (!message) return mesChanged;
 
-        const parseTarget = promptReasoning?.prefixIncomplete ? (promptReasoning.prefixReasoningFormatted + message.mes) : message.mes;
+        const parseTarget = promptReasoning?.prefixIncomplete ? (promptReasoning.prefixReasoningFormatted + message.mes) : message.mes ?? '';
 
         // If we are done with reasoning parse, we just split the message correctly so the reasoning doesn't show up inside of it.
         if (this.#parsingReasoningMesStartIndex) {


### PR DESCRIPTION
This PR fixes two bugs in the reasoning system when backends provide native `reasoning_content` fields:

## Auto-parse Content Dropping Bug

**Problem:** When backends return identical `reasoning_content` and `content`, SillyTavern reconstructs `<think>` tags then auto-parses them again, causing message content to disappear.

**Fix:** Skip auto-parsing when reasoning comes from native API (`ReasoningType.Model`).

**Files:** `public/scripts/reasoning.js`

## Prefill Contamination Bug  

**Problem:** Reasoning prefills (like `"<think>\n"`) appear in message content instead of reasoning.

**Fix:** Unified reasoning prefix handling that separates reasoning from content correctly.

**Files:** `public/script.js`

## Additional Edge Case Fixes

**Type Safety & Null Handling:**
- Fixed nullable type annotations for DOM elements and timing properties that can be null
- Added null safety for message content parsing and duration handling
- Prevented undefined values from being stored in reasoning extras

**Enhanced Prefill Processing:**
- Improved `user_prompt_bias` handling for native model reasoning to prevent double-inclusion
- Added logic to strip reasoning prefixes that leak into message content  
- Enhanced re-parsing when reasoning contains both prefix and suffix markers
- Added precise control over bias inclusion with `includeUserPromptBias` flag

**Reasoning State Management:**
- Better state transitions for `ReasoningType.Model` when reasoning is provided natively
- Improved reasoning state handling to prevent incorrect state persistence

**Files:** `public/scripts/reasoning.js`, `public/script.js`

Both the core fixes and edge case handling ensure native reasoning APIs work without content corruption, contamination, or state management issues.

## Tests Run

| Prefill | Streaming | Non-Streaming | Continue Streaming | Continue Non-Streaming |
| --- | :---: | :---: | :---: | :---: |
| `null` | ✓ | ✓ | ✓ | ✓ |
| `{{prefix}}` | ✓ | ✓ | ✓ | ✓ |
| `{{prefix}}\n` | ✓ | ✓ | ✓ | ✓ |
| `{{prefix}}\nOk, so the user` | ✓ | ✓ | reasoning: finished:✓/continuing:✓ | ✓ |

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
