### PR TITLE
feat: support xhigh reasoning for OpenAI models

### DIFF
--- a/public/scripts/openai-reasoning.js
+++ b/public/scripts/openai-reasoning.js
@@ -1,0 +1,19 @@
+const openaiXHighReasoningEffortModel = /^gpt-5\.(?:[2-9]|\d{2,})(?:$|-(?:\d{4}-\d{2}-\d{2}|chat-latest|mini(?:-\d{4}-\d{2}-\d{2})?|nano(?:-\d{4}-\d{2}-\d{2})?))$/;
+
+/**
+ * Models that only accept a single fixed reasoning effort value.
+ * These models accept reasoning_effort, but not xhigh, so the broader family
+ * regex must not opt them into the frontend Maximum -> xhigh mapping.
+ * @type {Readonly<Record<string, string>>}
+ */
+export const OPENAI_FIXED_REASONING_EFFORT = Object.freeze({
+    'gpt-5.3-chat-latest': 'medium',
+});
+
+/**
+ * @param {string} model Model name
+ * @returns {boolean} True when the OpenAI Chat Completions model supports xhigh reasoning effort
+ */
+export function supportsOpenAIXHighReasoningEffort(model) {
+    return !Object.hasOwn(OPENAI_FIXED_REASONING_EFFORT, model) && openaiXHighReasoningEffortModel.test(model);
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -81,6 +81,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
 import { syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
+import { supportsOpenAIXHighReasoningEffort } from './openai-reasoning.js';
 
 export {
     openai_messages_count,
@@ -2594,6 +2595,9 @@ function getReasoningEffort(settings = null, model = null) {
 
                 return reasoning_effort_types.low;
             case reasoning_effort_types.max:
+                if ([chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source)) {
+                    return supportsOpenAIXHighReasoningEffort(model) ? 'xhigh' : reasoning_effort_types.high;
+                }
                 return reasoning_effort_types.high;
             default:
                 return settings.reasoning_effort;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,8 @@
+import {
+    OPENAI_FIXED_REASONING_EFFORT,
+    supportsOpenAIXHighReasoningEffort,
+} from '../public/scripts/openai-reasoning.js';
+
 export const PUBLIC_DIRECTORIES = {
     images: 'public/img/',
     backups: 'backups/',
@@ -493,13 +498,24 @@ export const OPENAI_REASONING_EFFORT_MAP = {
     min: 'minimal',
 };
 
+export { OPENAI_FIXED_REASONING_EFFORT };
+
 /**
- * Models that only accept a single fixed reasoning effort value.
- * @type {Record<string, string>}
+ * @param {string} model Model name
+ * @param {string} reasoningEffort Reasoning effort
+ * @returns {string|undefined} Reasoning effort supported by OpenAI
  */
-export const OPENAI_FIXED_REASONING_EFFORT = {
-    'gpt-5.3-chat-latest': 'medium',
-};
+export function getOpenAIReasoningEffort(model, reasoningEffort) {
+    if (!OPENAI_REASONING_EFFORT_MODELS.includes(model) && !supportsOpenAIXHighReasoningEffort(model)) {
+        return undefined;
+    }
+
+    if (OPENAI_FIXED_REASONING_EFFORT[model]) {
+        return OPENAI_FIXED_REASONING_EFFORT[model];
+    }
+
+    return OPENAI_REASONING_EFFORT_MAP[reasoningEffort] ?? reasoningEffort;
+}
 
 export const NANOGPT_REASONING_EFFORT_MAP = {
     min: 'none',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -10,6 +10,7 @@ import {
     AZURE_OPENAI_KEYS,
     CHAT_COMPLETION_SOURCES,
     GEMINI_SAFETY,
+    getOpenAIReasoningEffort,
     NANOGPT_REASONING_EFFORT_MAP,
     OPENAI_FIXED_REASONING_EFFORT,
     OPENAI_REASONING_EFFORT_MAP,
@@ -1685,9 +1686,7 @@ async function sendAzureOpenAIRequest(request, response) {
     }
 
     // Do not send reasoning effort to models which do not support it
-    apiRequestBody['reasoning_effort'] = OPENAI_REASONING_EFFORT_MODELS.includes(request.body.model)
-        ? OPENAI_FIXED_REASONING_EFFORT[request.body.model] ?? OPENAI_REASONING_EFFORT_MAP[request.body.reasoning_effort] ?? request.body.reasoning_effort
-        : undefined;
+    apiRequestBody['reasoning_effort'] = getOpenAIReasoningEffort(request.body.model, request.body.reasoning_effort);
 
     const controller = new AbortController();
     request.socket.removeAllListeners('close');
@@ -2499,7 +2498,12 @@ router.post('/generate', async function (request, response) {
 
         // A few of OpenAIs reasoning models support reasoning effort
         if (request.body.reasoning_effort && [CHAT_COMPLETION_SOURCES.CUSTOM, CHAT_COMPLETION_SOURCES.OPENAI].includes(request.body.chat_completion_source)) {
-            if (OPENAI_REASONING_EFFORT_MODELS.includes(request.body.model)) {
+            if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.OPENAI) {
+                const reasoningEffort = getOpenAIReasoningEffort(request.body.model, request.body.reasoning_effort);
+                if (reasoningEffort) {
+                    bodyParams['reasoning_effort'] = reasoningEffort;
+                }
+            } else if (OPENAI_REASONING_EFFORT_MODELS.includes(request.body.model)) {
                 bodyParams['reasoning_effort'] = OPENAI_FIXED_REASONING_EFFORT[request.body.model] ?? OPENAI_REASONING_EFFORT_MAP[request.body.reasoning_effort] ?? request.body.reasoning_effort;
             }
             if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM && /^koboldcpp\/(.+)$/.test(request.body.model)) {

--- a/tests/openai-reasoning-effort.test.js
+++ b/tests/openai-reasoning-effort.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    OPENAI_FIXED_REASONING_EFFORT as SERVER_OPENAI_FIXED_REASONING_EFFORT,
+    getOpenAIReasoningEffort,
+} from '../src/constants.js';
+import {
+    OPENAI_FIXED_REASONING_EFFORT as FRONTEND_OPENAI_FIXED_REASONING_EFFORT,
+    supportsOpenAIXHighReasoningEffort,
+} from '../public/scripts/openai-reasoning.js';
+
+describe('OpenAI xhigh reasoning effort support', () => {
+    test('detects GPT-5.2 and newer chat-completions models by pattern on frontend', () => {
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.2')).toBe(true);
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.4-mini')).toBe(true);
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.5-2026-04-23')).toBe(true);
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.6-nano')).toBe(true);
+    });
+
+    test('does not opt in earlier, fixed-effort, pro, or codex models by pattern', () => {
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5')).toBe(false);
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.1')).toBe(false);
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.3-chat-latest')).toBe(false);
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.2-codex')).toBe(false);
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.3-codex')).toBe(false);
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.4-pro')).toBe(false);
+        expect(supportsOpenAIXHighReasoningEffort('gpt-5.4-pro-2026-03-05')).toBe(false);
+    });
+
+    test('keeps OpenRouter-hosted models out of OpenAI xhigh detection', () => {
+        expect(supportsOpenAIXHighReasoningEffort('openai/gpt-5.2')).toBe(false);
+    });
+
+    test('shares fixed effort exceptions between frontend detection and backend guard', () => {
+        expect(FRONTEND_OPENAI_FIXED_REASONING_EFFORT).toBe(SERVER_OPENAI_FIXED_REASONING_EFFORT);
+    });
+});
+
+describe('getOpenAIReasoningEffort', () => {
+    test('passes through frontend-resolved provider effort values for supported models', () => {
+        expect(getOpenAIReasoningEffort('gpt-5.2', 'xhigh')).toBe('xhigh');
+        expect(getOpenAIReasoningEffort('gpt-5.4-mini', 'xhigh')).toBe('xhigh');
+        expect(getOpenAIReasoningEffort('gpt-5.5-2026-04-23', 'xhigh')).toBe('xhigh');
+        expect(getOpenAIReasoningEffort('gpt-5.6-nano', 'xhigh')).toBe('xhigh');
+        expect(getOpenAIReasoningEffort('gpt-5.1', 'high')).toBe('high');
+    });
+
+    test('keeps fixed effort overrides and unsupported models unchanged', () => {
+        expect(getOpenAIReasoningEffort('gpt-5.3-chat-latest', 'xhigh')).toBe('medium');
+        expect(getOpenAIReasoningEffort('gpt-4o', 'high')).toBeUndefined();
+    });
+
+    test('does not opt in pro or codex models for the Chat Completions API', () => {
+        expect(getOpenAIReasoningEffort('gpt-5.2-codex', 'xhigh')).toBeUndefined();
+        expect(getOpenAIReasoningEffort('gpt-5.3-codex', 'xhigh')).toBeUndefined();
+        expect(getOpenAIReasoningEffort('gpt-5.4-pro', 'xhigh')).toBeUndefined();
+        expect(getOpenAIReasoningEffort('gpt-5.4-pro-2026-03-05', 'xhigh')).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Closes #5325

## Summary
- Map the existing `Maximum` reasoning effort to `xhigh` for OpenAI and Azure OpenAI GPT-5.2+ Chat Completions models via a regex-based frontend check.
- Keep older OpenAI reasoning models on their existing `Maximum` -> `high` behavior.
- Keep fixed-effort aliases such as `gpt-5.3-chat-latest` out of the `xhigh` frontend mapping.
- Exclude `pro` and `codex` model names from this Chat Completions path, since those require Responses API support.
- Keep the backend as a guard so unsupported OpenAI models do not receive `reasoning_effort`.

## Test Plan
- `git diff --check`
- `npm --prefix tests run test:unit -- openai-reasoning-effort.test.js --runInBand`
- `npm --prefix tests run test:unit -- --runInBand`
- `npm run lint`
- `npm --prefix tests run lint`

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).