### PR TITLE
OpenRouter: enable adaptive thinking and add xhigh/max verbosity for Claude 4.7

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2193,6 +2193,8 @@
                                                 <option data-i18n="openai_verbosity_low" value="low">Low</option>
                                                 <option data-i18n="openai_verbosity_medium" value="medium">Medium</option>
                                                 <option data-i18n="openai_verbosity_high" value="high">High</option>
+                                                <option data-i18n="openai_verbosity_xhigh" value="xhigh">XHigh</option>
+                                                <option data-i18n="openai_verbosity_max" value="max">Max</option>
                                             </select>
                                             <div class="toggle-description justifyLeft marginBot5" data-i18n="Constrains the verbosity of the model's response.">
                                                 Constrains the verbosity of the model's response.

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -248,6 +248,8 @@ export const verbosity_levels = {
     low: 'low',
     medium: 'medium',
     high: 'high',
+    xhigh: 'xhigh',
+    max: 'max',
 };
 
 export const tool_reasoning_modes = {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2224,6 +2224,7 @@ router.post('/generate', async function (request, response) {
                 plugins: getOpenRouterPlugins(request),
                 reasoning: {
                     exclude: !includeReasoning,
+                    ...(includeReasoning && { enabled: true }),
                 },
             };
 


### PR DESCRIPTION
## Summary
Two related changes that together enable adaptive thinking to work as expected on Anthropic Claude Opus 4.7 when routed through OpenRouter:

1. Send `reasoning.enabled: true` so adaptive thinking actually activates.
2. Expose `xhigh` and `max` verbosity levels so users can drive the effort high enough to guarantee thinking on simple prompts.

## Problem

When `Request model reasoning` is enabled in the UI on the OpenRouter source for an Anthropic Claude model, no extended thinking is produced. OpenRouter Activity dashboard reports `native_tokens_reasoning: 0` even though the user explicitly opted in.

### Root cause 1: `reasoning.enabled` is missing

Per OpenRouter's reasoning docs (https://openrouter.ai/docs/guides/best-practices/reasoning-tokens):
- `reasoning.enabled: true` is the explicit thinking opt-in switch.
- `reasoning.exclude` is a separate display toggle (whether reasoning text appears in the response).

The current OpenRouter branch only sets `reasoning: { exclude: !includeReasoning }`, never `enabled`. As a result, OpenRouter never activates thinking on the upstream Anthropic request for Claude 4.7 adaptive-thinking models.

Verified with `curl` against OpenRouter using `debug.echo_upstream_body`:
- `reasoning: { exclude: false }` only --> upstream body has no `thinking` block, `native_tokens_reasoning: 0`.
- `reasoning: { enabled: true }` --> upstream body contains `thinking: { type: "adaptive", display: "summarized" }`, `native_tokens_reasoning > 0`.

### Root cause 2: verbosity dropdown capped at `high`

Per the OpenRouter Claude 4.7 migration guide (https://openrouter.ai/docs/guides/evaluate-and-optimize/model-migrations/claude-4-7):

- `reasoning.effort` is ignored on Claude 4.7.
- `verbosity` maps to Anthropic's `output_config.effort` and is the only effort lever that actually applies.
Anthropic's effort scale is `low < medium < high < xhigh < max`. The dropdown currently exposes through `high` only. At `high` (the default), adaptive thinking may skip on prompts the model judges simple prompt. `xhigh` ("always thinks deeply", Opus 4.7-only) and `max` ("always thinks with no depth constraints") are the levels that guarantee thinking, and they were unreachable from the UI.

References

- OpenRouter Reasoning Tokens: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
- OpenRouter Claude 4.7 Migration: https://openrouter.ai/docs/guides/evaluate-and-optimize/model-migrations/claude-4-7
- Anthropic Adaptive Thinking: https://docs.anthropic.com/en/docs/build-with-claude/adaptive-thinking
- Anthropic Effort Parameter: https://platform.claude.com/docs/en/build-with-claude/effort

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
