### PR TITLE
feat: add confirmation dialog when branching

### DIFF
--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -452,6 +452,14 @@ export async function branchChat(mesId, { swipeId = null } = {}) {
         return null;
     }
 
+    const confirm = await Popup.show.confirm(t`Create Branch`, `<p>${t`Create a new branch from this message?`}</p>`, {
+        okButton: t`Create`,
+        cancelButton: t`Cancel`,
+    });
+    if (!confirm) {
+        return null;
+    }
+
     const fileName = await createBranch(mesId, { swipeId });
     if (!fileName) {
         return null;


### PR DESCRIPTION
## Summary:
When trying to copy a message or editing to the message for the message card, it's very easy to accidentally click the `branch` button next to it. Previously, there was no confirmation step, meaning every misclick required me to go back to the main chat and delete the unwanted branch. 

To fix this UX issue, I added a secondary confirmation step to the "Create Branch" button to prevent accidental clicks.

## Image Demo:
<img width="360" height="100" alt="image" src="https://github.com/user-attachments/assets/30743b8e-ab91-4c6d-b908-0183d1328d11" />
<img width="926" height="327" alt="image" src="https://github.com/user-attachments/assets/78ed5457-746f-4120-ad97-88c9aa2d3dea" />


## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
