### PR TITLE
Add runner container for frontend tests

### DIFF
--- a/docker/docker-compose.tests.yml
+++ b/docker/docker-compose.tests.yml
@@ -1,0 +1,23 @@
+services:
+  playwright-tests:
+    image: mcr.microsoft.com/playwright:v1.56.1-noble
+    network_mode: host
+    working_dir: /workspace/tests
+    environment:
+      - CI=1
+      - ST_BASE_URL=http://host.docker.internal:8000
+      - PLAYWRIGHT_TEST_ARGS=
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    volumes:
+      - ..:/workspace
+      - st_tests_node_modules:/workspace/tests/node_modules
+      - st_tests_npm_cache:/root/.npm
+      - st_tests_playwright_cache:/ms-playwright
+    command: >-
+      bash -lc "npm ci && if [ -n \"$$PLAYWRIGHT_TEST_ARGS\" ]; then npm run test:e2e -- $$PLAYWRIGHT_TEST_ARGS; else npm run test:e2e; fi"
+
+volumes:
+  st_tests_node_modules:
+  st_tests_npm_cache:
+  st_tests_playwright_cache:


### PR DESCRIPTION
Given the lack of a discrete Playwright runner for the frontend tests, this commit adds a discrete Dockerfile that can be used to run through all of the UI tests.

Given the note https://github.com/SillyTavern/SillyTavern/pull/5610#issuecomment-4424496459, this is a discrete PR for a container to run frontend tests

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
