### PR TITLE
Fix emitted event type in note-position command

### DIFF
--- a/public/scripts/authors-note.js
+++ b/public/scripts/authors-note.js
@@ -96,7 +96,7 @@ function setNotePositionCommand(_, text) {
             return;
         }
 
-        $(`input[name="extension_floating_position"][value="${position}"]`).prop('checked', true).trigger('input');
+        $(`input[name="extension_floating_position"][value="${position}"]`).prop('checked', true).trigger('input').trigger('change');
         toastr.info(t`Author's Note position updated`);
     }
     return Object.keys(validPositions).find(key => validPositions[key] == chat_metadata[metadata_keys.position]);


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Unlike other Authors Note fields, position uses 'change' for update tracking, while a script command callback only emits a synthetic 'input' event, so the proper UI handler never calls.

Fixes #5606

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
