### PR TITLE
Fix example names ignoring setting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1915,6 +1915,13 @@
                                                     Prepend character names to message contents.
                                                 </small>
                                             </label>
+                                            <label class="checkbox_label flexWrap alignItemsCenter" for="character_names_none_except_examples">
+                                                <input type="radio" id="character_names_none_except_examples" name="character_names" value="3">
+                                                <span data-i18n="None (Except Examples)">None (Except Examples)</span>
+                                                <small class="flexBasis100p" data-i18n="character_names_none_except_examples">
+                                                    Never add name prefixes to messages, but always include them in example dialogues.
+                                                </small>
+                                            </label>
                                             <!-- Hidden input for loading radio buttons from presets. Don't remove! -->
                                             <input type="hidden" id="names_behavior" class="displayNone" />
                                         </div>
@@ -4333,6 +4340,7 @@
                                     </small>
                                     <select id="instruct_names_behavior">
                                         <option value="none" data-i18n="Never">Never</option>
+                                        <option value="none_except_examples" data-i18n="Never (Except Examples)">Never (Except Examples)</option>
                                         <option value="force" data-i18n="Groups and Past Personas">Groups and Past Personas</option>
                                         <option value="always" data-i18n="Always">Always</option>
                                     </select>

--- a/public/script.js
+++ b/public/script.js
@@ -111,6 +111,7 @@ import {
     loadProxyPresets,
     selected_proxy,
     initOpenAI,
+    character_names_behavior,
 } from './scripts/openai.js';
 
 import {
@@ -4806,9 +4807,10 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     let oaiMessageExamples = [];
 
     if (main_api === 'openai') {
-        let appendNamesForGroup = !!selected_group && [names_behavior_types.ALWAYS, names_behavior_types.FORCE].includes(power_user.instruct.names_behavior);
+        const appendNamesForGroup = !!selected_group && [character_names_behavior.DEFAULT, character_names_behavior.CONTENT, character_names_behavior.NONE_EXCEPT_EXAMPLES].includes(oai_settings.names_behavior);
+        const alwaysAppendNames = oai_settings.names_behavior === character_names_behavior.NONE_EXCEPT_EXAMPLES;
         oaiMessages = setOpenAIMessages(coreChat);
-        oaiMessageExamples = setOpenAIMessageExamples(mesExamplesArray, appendNamesForGroup);
+        oaiMessageExamples = setOpenAIMessageExamples(mesExamplesArray, appendNamesForGroup, alwaysAppendNames);
     }
 
     // hack for regeneration of the first message

--- a/public/script.js
+++ b/public/script.js
@@ -229,6 +229,7 @@ import {
     formatInstructModeExamples,
     formatInstructModeStoryString,
     getInstructStoppingSequences,
+    names_behavior_types,
 } from './scripts/instruct-mode.js';
 import { initLocales, t } from './scripts/i18n.js';
 import { getFriendlyTokenizerName, getTokenCount, getTokenCountAsync, initTokenizers, saveTokenCache } from './scripts/tokenizers.js';
@@ -4805,8 +4806,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     let oaiMessageExamples = [];
 
     if (main_api === 'openai') {
+        let appendNamesForGroup = selected_group && [names_behavior_types.ALWAYS, names_behavior_types.FORCE].includes(power_user.instruct.names_behavior);
         oaiMessages = setOpenAIMessages(coreChat);
-        oaiMessageExamples = setOpenAIMessageExamples(mesExamplesArray);
+        oaiMessageExamples = setOpenAIMessageExamples(mesExamplesArray, appendNamesForGroup);
     }
 
     // hack for regeneration of the first message

--- a/public/script.js
+++ b/public/script.js
@@ -230,7 +230,6 @@ import {
     formatInstructModeExamples,
     formatInstructModeStoryString,
     getInstructStoppingSequences,
-    names_behavior_types,
 } from './scripts/instruct-mode.js';
 import { initLocales, t } from './scripts/i18n.js';
 import { getFriendlyTokenizerName, getTokenCount, getTokenCountAsync, initTokenizers, saveTokenCache } from './scripts/tokenizers.js';

--- a/public/script.js
+++ b/public/script.js
@@ -4806,7 +4806,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     let oaiMessageExamples = [];
 
     if (main_api === 'openai') {
-        let appendNamesForGroup = selected_group && [names_behavior_types.ALWAYS, names_behavior_types.FORCE].includes(power_user.instruct.names_behavior);
+        let appendNamesForGroup = !!selected_group && [names_behavior_types.ALWAYS, names_behavior_types.FORCE].includes(power_user.instruct.names_behavior);
         oaiMessages = setOpenAIMessages(coreChat);
         oaiMessageExamples = setOpenAIMessageExamples(mesExamplesArray, appendNamesForGroup);
     }

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -18,6 +18,7 @@ export const names_behavior_types = {
     NONE: 'none',
     FORCE: 'force',
     ALWAYS: 'always',
+    NONE_EXCEPT_EXAMPLES: 'none_except_examples',
 };
 
 const controls = [
@@ -515,8 +516,8 @@ export function formatInstructModeExamples(mesExamplesArray, name1, name2) {
         return mesExamplesArray.map(x => x.replace(/<START>\n/i, blockHeading));
     }
 
-    const includeNames = power_user.instruct.names_behavior === names_behavior_types.ALWAYS;
-    const includeGroupNames = !!selected_group && [names_behavior_types.ALWAYS, names_behavior_types.FORCE].includes(power_user.instruct.names_behavior);
+    const includeNames = [names_behavior_types.ALWAYS, names_behavior_types.NONE_EXCEPT_EXAMPLES].includes(power_user.instruct.names_behavior);
+    const includeGroupNames = !!selected_group && [names_behavior_types.ALWAYS, names_behavior_types.FORCE, names_behavior_types.NONE_EXCEPT_EXAMPLES].includes(power_user.instruct.names_behavior);
 
     let inputPrefix = power_user.instruct.input_sequence || '';
     let outputPrefix = power_user.instruct.output_sequence || '';

--- a/public/scripts/instruct-mode.js
+++ b/public/scripts/instruct-mode.js
@@ -516,7 +516,7 @@ export function formatInstructModeExamples(mesExamplesArray, name1, name2) {
     }
 
     const includeNames = power_user.instruct.names_behavior === names_behavior_types.ALWAYS;
-    const includeGroupNames = selected_group && [names_behavior_types.ALWAYS, names_behavior_types.FORCE].includes(power_user.instruct.names_behavior);
+    const includeGroupNames = !!selected_group && [names_behavior_types.ALWAYS, names_behavior_types.FORCE].includes(power_user.instruct.names_behavior);
 
     let inputPrefix = power_user.instruct.input_sequence || '';
     let outputPrefix = power_user.instruct.output_sequence || '';

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -741,7 +741,11 @@ export function parseExampleIntoIndividual(messageExampleString, appendNamesForG
         // join different newlines (we split them by \n and join by \n)
         // remove char name
         // strip to remove extra spaces
-        let parsed_msg = cur_msg_lines.join('\n').replace(name + ':', '').trim();
+        let parsed_msg = cur_msg_lines.join('\n');
+        if (!!name) {
+            parsed_msg = parsed_msg.replace(name + ':', '').trim()
+        }
+        parsed_msg = parsed_msg.trim();
 
         if (appendNamesForGroup && selected_group && ['example_user', 'example_assistant'].includes(system_name)) {
             parsed_msg = `${name}: ${parsed_msg}`;
@@ -782,6 +786,8 @@ export function parseExampleIntoIndividual(messageExampleString, appendNamesForG
         add_msg(name1, 'system', 'example_user');
     } else if (in_bot) {
         add_msg(botName, 'system', 'example_assistant');
+    } else {
+        add_msg(null, 'system', 'example_assistant');
     }
     return result;
 }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -742,8 +742,8 @@ export function parseExampleIntoIndividual(messageExampleString, appendNamesForG
         // remove char name
         // strip to remove extra spaces
         let parsed_msg = cur_msg_lines.join('\n');
-        if (!!name) {
-            parsed_msg = parsed_msg.replace(name + ':', '').trim()
+        if (name) {
+            parsed_msg = parsed_msg.replace(name + ':', '').trim();
         }
         parsed_msg = parsed_msg.trim();
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -202,11 +202,12 @@ export const chat_completion_sources = {
     MINIMAX: 'minimax',
 };
 
-const character_names_behavior = {
+export const character_names_behavior = {
     NONE: -1,
     DEFAULT: 0,
     COMPLETION: 1,
     CONTENT: 2,
+    NONE_EXCEPT_EXAMPLES: 3,
 };
 
 const continue_postfix_types = {
@@ -606,6 +607,8 @@ function setOpenAIMessages(chat) {
                 break;
             case character_names_behavior.COMPLETION:
                 break;
+            case character_names_behavior.NONE_EXCEPT_EXAMPLES:
+                break;
             default:
                 break;
         }
@@ -651,15 +654,16 @@ function setOpenAIMessages(chat) {
  * Formats chat examples into chat completion messages.
  * @param {string[]} mesExamplesArray - Array containing all examples.
  * @param {boolean} appendNamesForGroup - Whether to append the character name for group chats
+ * @param {boolean} alwaysAppendNames - Whether to append names in all examples regardless of group status
  * @returns {object[]} - Array containing all examples formatted for chat completion.
  */
-function setOpenAIMessageExamples(mesExamplesArray, appendNamesForGroup = true) {
+function setOpenAIMessageExamples(mesExamplesArray, appendNamesForGroup = true, alwaysAppendNames = false) {
     // get a nice array of all blocks of all example messages = array of arrays (important!)
     const examples = [];
     for (let item of mesExamplesArray) {
         // remove <START> {Example Dialogue:} and replace \r\n with just \n
         let replaced = item.replace(/<START>/i, '{Example Dialogue:}').replace(/\r/gm, '');
-        let parsed = parseExampleIntoIndividual(replaced, appendNamesForGroup);
+        let parsed = parseExampleIntoIndividual(replaced, appendNamesForGroup, alwaysAppendNames);
         // add to the example message blocks array
         examples.push(parsed);
     }
@@ -724,9 +728,10 @@ function setupChatCompletionPromptManager(openAiSettings) {
  * Parses the example messages into individual messages.
  * @param {string} messageExampleString - The string containing the example messages
  * @param {boolean} appendNamesForGroup - Whether to append the character name for group chats
+ * @param {boolean} alwaysAppendNames - Whether to append names in all examples regardless of group status
  * @returns {Message[]} Array of message objects
  */
-export function parseExampleIntoIndividual(messageExampleString, appendNamesForGroup = true) {
+export function parseExampleIntoIndividual(messageExampleString, appendNamesForGroup = true, alwaysAppendNames = false) {
     const groupBotNames = getGroupNames().map(name => `${name}:`);
 
     let result = []; // array of msgs
@@ -747,7 +752,7 @@ export function parseExampleIntoIndividual(messageExampleString, appendNamesForG
         }
         parsed_msg = parsed_msg.trim();
 
-        if (appendNamesForGroup && selected_group && ['example_user', 'example_assistant'].includes(system_name)) {
+        if ((alwaysAppendNames || (appendNamesForGroup && selected_group)) && ['example_user', 'example_assistant'].includes(system_name)) {
             parsed_msg = `${name}: ${parsed_msg}`;
         }
 
@@ -4365,6 +4370,9 @@ function setNamesBehaviorControls() {
         case character_names_behavior.CONTENT:
             $('#character_names_content').prop('checked', true);
             break;
+        case character_names_behavior.NONE_EXCEPT_EXAMPLES:
+            $('#character_names_none_except_examples').prop('checked', true);
+            break;
     }
 
     const checkedItemText = $('input[name="character_names"]:checked ~ span').text().trim();
@@ -7052,6 +7060,12 @@ export function initOpenAI() {
 
     $('#character_names_content').on('input', function () {
         oai_settings.names_behavior = character_names_behavior.CONTENT;
+        setNamesBehaviorControls();
+        saveSettingsDebounced();
+    });
+
+    $('#character_names_none_except_examples').on('input', function () {
+        oai_settings.names_behavior = character_names_behavior.NONE_EXCEPT_EXAMPLES;
         setNamesBehaviorControls();
         saveSettingsDebounced();
     });

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -650,15 +650,16 @@ function setOpenAIMessages(chat) {
 /**
  * Formats chat examples into chat completion messages.
  * @param {string[]} mesExamplesArray - Array containing all examples.
+ * @param {boolean} appendNamesForGroup - Whether to append the character name for group chats
  * @returns {object[]} - Array containing all examples formatted for chat completion.
  */
-function setOpenAIMessageExamples(mesExamplesArray) {
+function setOpenAIMessageExamples(mesExamplesArray, appendNamesForGroup = true) {
     // get a nice array of all blocks of all example messages = array of arrays (important!)
     const examples = [];
     for (let item of mesExamplesArray) {
         // remove <START> {Example Dialogue:} and replace \r\n with just \n
         let replaced = item.replace(/<START>/i, '{Example Dialogue:}').replace(/\r/gm, '');
-        let parsed = parseExampleIntoIndividual(replaced, true);
+        let parsed = parseExampleIntoIndividual(replaced, appendNamesForGroup);
         // add to the example message blocks array
         examples.push(parsed);
     }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -787,7 +787,7 @@ export function parseExampleIntoIndividual(messageExampleString, appendNamesForG
     } else if (in_bot) {
         add_msg(botName, 'system', 'example_assistant');
     } else {
-        add_msg(null, 'system', 'example_assistant');
+        add_msg(null, 'system', 'system');
     }
     return result;
 }


### PR DESCRIPTION
Force example formatting to follow chat completion settings.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
