### PR TITLE
Add message indicating that the 'Request mode reasoning' checkbox controls whether reasoning is generated at the source, for Deepseek API

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2147,6 +2147,9 @@
                                             <span data-i18n="Allows the model to return its thinking process.">
                                                 Allows the model to return its thinking process.
                                             </span>
+                                            <strong data-i18n="This setting enables or disables generation of reasoning at the source." data-source="deepseek">
+                                                This setting enables or disables generation of reasoning at the source.
+                                            </strong>
                                             <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter,deepseek">
                                                 This setting affects visibility only.
                                             </strong>

--- a/public/index.html
+++ b/public/index.html
@@ -2147,11 +2147,11 @@
                                             <span data-i18n="Allows the model to return its thinking process.">
                                                 Allows the model to return its thinking process.
                                             </span>
-                                            <strong data-i18n="This setting enables or disables generation of reasoning at the source." data-source="deepseek,zai,moonshot">
-                                                This setting enables or disables generation of reasoning at the source.
+                                            <strong data-i18n="This setting enables or disables reasoning generation by the model." data-source="deepseek,zai,moonshot">
+                                                This setting enables or disables reasoning generation by the model.
                                             </strong>
-                                            <strong data-i18n="When this setting is deactivated and the minimal reasoning effort set, reasoning will be disabled for models that support it. The behavior is model-dependent; certain providers may reject such requests." data-source="openrouter">
-                                                When this setting is deactivated and the minimal reasoning effort set, reasoning will be disabled for models that support it. The behavior is model-dependent; certain providers may reject such requests.
+                                            <strong data-i18n="When this setting is deactivated and the minimal reasoning effort is set, reasoning will be disabled for models that support it. The behavior is model-dependent; certain providers may reject such requests." data-source="openrouter">
+                                                When this setting is deactivated and the minimal reasoning effort is set, reasoning will be disabled for models that support it. The behavior is model-dependent; certain providers may reject such requests.
                                             </strong>
                                             <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter,deepseek">
                                                 This setting affects visibility only.

--- a/public/index.html
+++ b/public/index.html
@@ -2150,9 +2150,6 @@
                                             <strong data-i18n="This setting enables or disables reasoning generation by the model." data-source="deepseek,zai,moonshot">
                                                 This setting enables or disables reasoning generation by the model.
                                             </strong>
-                                            <strong data-i18n="When this setting is deactivated and the minimal reasoning effort is set, reasoning will be disabled for models that support it. The behavior is model-dependent; certain providers may reject such requests." data-source="openrouter">
-                                                When this setting is deactivated and the minimal reasoning effort is set, reasoning will be disabled for models that support it. The behavior is model-dependent; certain providers may reject such requests.
-                                            </strong>
                                             <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter,deepseek">
                                                 This setting affects visibility only.
                                             </strong>

--- a/public/index.html
+++ b/public/index.html
@@ -2150,6 +2150,9 @@
                                             <strong data-i18n="This setting enables or disables generation of reasoning at the source." data-source="deepseek,zai,moonshot">
                                                 This setting enables or disables generation of reasoning at the source.
                                             </strong>
+                                            <strong data-i18n="When this setting is deactivated and the minimal reasoning effort set, reasoning will be disabled for models that support it. The behavior is model-dependent; certain providers may reject such requests." data-source="openrouter">
+                                                When this setting is deactivated and the minimal reasoning effort set, reasoning will be disabled for models that support it. The behavior is model-dependent; certain providers may reject such requests.
+                                            </strong>
                                             <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter,deepseek">
                                                 This setting affects visibility only.
                                             </strong>

--- a/public/index.html
+++ b/public/index.html
@@ -2147,7 +2147,7 @@
                                             <span data-i18n="Allows the model to return its thinking process.">
                                                 Allows the model to return its thinking process.
                                             </span>
-                                            <strong data-i18n="This setting enables or disables generation of reasoning at the source." data-source="deepseek">
+                                            <strong data-i18n="This setting enables or disables generation of reasoning at the source." data-source="deepseek,zai,moonshot">
                                                 This setting enables or disables generation of reasoning at the source.
                                             </strong>
                                             <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter,deepseek">


### PR DESCRIPTION
Adds a small message for Deepseek API specifically indicating that the show-reasoning checkbox under AI Response Configuration controls whether or not reasoning is generated at the source, rather than simply whether it is returned.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
