### PR TITLE
Fix mobile lag from inactive autocomplete resize handlers

### DIFF
--- a/public/scripts/autocomplete/AutoComplete.js
+++ b/public/scripts/autocomplete/AutoComplete.js
@@ -126,9 +126,17 @@ export class AutoComplete {
         });
         textarea.addEventListener('blur', () => this.hide());
         if (isFloating) {
-            textarea.addEventListener('scroll', () => this.updateFloatingPositionDebounced());
+            textarea.addEventListener('scroll', () => {
+                if (this.isActive) {
+                    this.updateFloatingPositionDebounced();
+                }
+            });
         }
-        window.addEventListener('resize', () => this.updatePositionDebounced());
+        window.addEventListener('resize', () => {
+            if (this.isActive) {
+                this.updatePositionDebounced();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## What changed

Autocomplete instances now skip scroll/resize repositioning work when they are not active.

## Why

Each autocomplete instance registers resize listeners. On mobile browsers, opening or closing the virtual keyboard triggers viewport resize events. Previously, inactive autocomplete instances still ran positioning logic during those resizes, causing unnecessary layout work.

This could make the chat input bar lag or take too long to return to its correct position on Android/Termux.

Fixes #5570.

## How to test

1. Open SillyTavern on Android/Termux in a mobile browser.
2. Open a long chat.
3. Focus the chat input, then close the virtual keyboard.
4. Confirm the input bar returns to its normal position without the previous delay.
5. Confirm slash command and macro autocomplete still appears and repositions normally when active.

## Notes

This is intentionally scoped to avoiding inactive autocomplete work. It does not change autocomplete behavior while the popup is active.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).