### PR TITLE
Fix whitespace-only reasoning block controls

### DIFF
--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -551,7 +551,10 @@ export class ReasoningHandler {
         setDatasetProperty(this.messageReasoningDetailsDom, 'type', this.type);
 
         // Update the reasoning message
-        const reasoning = trimSpaces(this.reasoningDisplayText ?? this.reasoning);
+        const rawReasoning = this.reasoningDisplayText ?? this.reasoning;
+        const hasReasoningContent = Boolean(this.reasoningDisplayText || this.reasoning);
+        setDatasetProperty(this.messageReasoningDetailsDom, 'hasContent', hasReasoningContent ? 'true' : null);
+        const reasoning = trimSpaces(rawReasoning);
         const displayReasoning = messageFormatting(reasoning, '', false, false, messageId, {}, true);
 
         if (power_user.stream_fade_in) {
@@ -1198,8 +1201,8 @@ function setReasoningEventHandlers() {
 
     $(document).on('click', '.mes_reasoning_header', function (e) {
         const details = $(this).closest('.mes_reasoning_details');
-        // Along with the CSS rules to mark blocks not toggle-able when they are empty, prevent them from actually being toggled, or being edited
-        if (details.find('.mes_reasoning').is(':empty')) {
+        // Keep click behavior aligned with CSS: only blocks with backing content can toggle or enter edit mode.
+        if (details.attr('data-has-content') !== 'true') {
             e.preventDefault();
             return;
         }

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1234,6 +1234,10 @@ function setReasoningEventHandlers() {
             return;
         }
 
+        if (messageBlock.find('.reasoning_edit_textarea').length > 0) {
+            return;
+        }
+
         const reasoning = String(message?.extra?.reasoning ?? '');
         const chatElement = document.getElementById('chat');
         const textarea = document.createElement('textarea');
@@ -1317,6 +1321,10 @@ function setReasoningEventHandlers() {
         }
 
         const details = messageBlock.find('.mes_reasoning_details');
+        if (details.find('.reasoning_edit_textarea').length > 0) {
+            return;
+        }
+
         if (message.extra.reasoning && details.attr('data-has-content') === 'true') {
             toastr.info(t`Reasoning already exists.`, t`Edit Message`);
             return;

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -551,7 +551,12 @@ export class ReasoningHandler {
         setDatasetProperty(this.messageReasoningDetailsDom, 'type', this.type);
 
         // Update the reasoning message
-        const reasoning = trimSpaces(this.reasoningDisplayText ?? this.reasoning);
+        const rawReasoning = this.reasoningDisplayText ?? this.reasoning;
+        const reasoning = trimSpaces(rawReasoning);
+        // Keep whitespace-only saved reasoning editable without showing it as visible content.
+        const hasStoredReasoning = Boolean(this.reasoningDisplayText || this.reasoning);
+        const hasReasoningContent = Boolean(reasoning);
+        setDatasetProperty(this.messageReasoningDetailsDom, 'hasContent', hasReasoningContent ? 'true' : null);
         const displayReasoning = messageFormatting(reasoning, '', false, false, messageId, {}, true);
 
         if (power_user.stream_fade_in) {
@@ -563,7 +568,8 @@ export class ReasoningHandler {
         // Update tooltip for hidden reasoning edit
         /** @type {HTMLElement} */
         const button = this.messageDom.querySelector('.mes_edit_add_reasoning');
-        button.title = this.state === ReasoningState.Hidden ? t`Hidden reasoning - Add reasoning block` : t`Add reasoning block`;
+        const isHiddenLikeReasoning = this.state === ReasoningState.Hidden || (hasStoredReasoning && !hasReasoningContent);
+        button.title = isHiddenLikeReasoning ? t`Hidden reasoning - Add reasoning block` : t`Add reasoning block`;
 
         // Make sure that hidden reasoning headers are collapsed by default, to not show a useless edit button
         if (this.state === ReasoningState.Hidden) {
@@ -1198,8 +1204,8 @@ function setReasoningEventHandlers() {
 
     $(document).on('click', '.mes_reasoning_header', function (e) {
         const details = $(this).closest('.mes_reasoning_details');
-        // Along with the CSS rules to mark blocks not toggle-able when they are empty, prevent them from actually being toggled, or being edited
-        if (details.find('.mes_reasoning').is(':empty')) {
+        // Keep click behavior aligned with CSS: only blocks with backing content can toggle or enter edit mode.
+        if (details.attr('data-has-content') !== 'true') {
             e.preventDefault();
             return;
         }
@@ -1310,7 +1316,8 @@ function setReasoningEventHandlers() {
             return;
         }
 
-        if (message.extra.reasoning) {
+        const details = messageBlock.find('.mes_reasoning_details');
+        if (message.extra.reasoning && details.attr('data-has-content') === 'true') {
             toastr.info(t`Reasoning already exists.`, t`Edit Message`);
             return;
         }
@@ -1324,7 +1331,7 @@ function setReasoningEventHandlers() {
         }
 
         // Open the reasoning area so we can actually edit it
-        messageBlock.find('.mes_reasoning_details').attr('open', '');
+        details.attr('open', '');
         messageBlock.find('.mes_reasoning_edit').trigger('click');
         await saveChatConditional();
     });

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -74,13 +74,32 @@ function getMessageFromJquery(element) {
 }
 
 /**
+ * Collapses reasoning blocks that cannot be closed by their header.
+ * @param {JQuery<HTMLElement>} messageBlock Message block
+ */
+function closeReasoningDetailsWithoutContent(messageBlock) {
+    const details = messageBlock.find('.mes_reasoning_details');
+    if (details.attr('data-has-content') !== 'true') {
+        details.removeAttr('open');
+    }
+}
+
+/**
+ * Opens reasoning blocks only when they have visible content.
+ * @param {JQuery<HTMLElement>} details Reasoning details elements
+ */
+function openReasoningDetailsWithContent(details) {
+    details.filter('[data-has-content="true"]').attr('open', '');
+}
+
+/**
  * Toggles the auto-expand state of reasoning blocks.
  */
 function toggleReasoningAutoExpand() {
     const reasoningBlocks = document.querySelectorAll('details.mes_reasoning_details');
     reasoningBlocks.forEach((block) => {
         if (block instanceof HTMLDetailsElement) {
-            block.open = power_user.reasoning.auto_expand;
+            block.open = power_user.reasoning.auto_expand && block.dataset.hasContent === 'true';
         }
     });
 }
@@ -364,7 +383,7 @@ export class ReasoningHandler {
 
         this.updateDom(messageId);
 
-        if (power_user.reasoning.auto_expand && this.state !== ReasoningState.Hidden) {
+        if (power_user.reasoning.auto_expand && this.messageReasoningDetailsDom.dataset.hasContent === 'true') {
             this.messageReasoningDetailsDom.open = true;
         }
     }
@@ -555,7 +574,7 @@ export class ReasoningHandler {
         const reasoning = trimSpaces(rawReasoning);
         // Keep whitespace-only saved reasoning editable without showing it as visible content.
         const hasStoredReasoning = Boolean(this.reasoningDisplayText || this.reasoning);
-        const hasReasoningContent = Boolean(reasoning);
+        const hasReasoningContent = Boolean(String(rawReasoning ?? '').trim());
         setDatasetProperty(this.messageReasoningDetailsDom, 'hasContent', hasReasoningContent ? 'true' : null);
         const displayReasoning = messageFormatting(reasoning, '', false, false, messageId, {}, true);
 
@@ -940,8 +959,9 @@ function registerReasoningSlashCommands() {
             closeMessageEditor('reasoning');
             updateMessageBlock(messageId, message);
 
-            if (isTrueBoolean(String(args.collapse))) $(`#chat [mesid="${messageId}"] .mes_reasoning_details`).removeAttr('open');
-            if (isFalseBoolean(String(args.collapse))) $(`#chat [mesid="${messageId}"] .mes_reasoning_details`).attr('open', '');
+            const details = $(`#chat [mesid="${messageId}"] .mes_reasoning_details`);
+            if (isTrueBoolean(String(args.collapse))) details.removeAttr('open');
+            if (isFalseBoolean(String(args.collapse))) openReasoningDetailsWithContent(details);
             return message.extra.reasoning;
         },
     }));
@@ -1140,7 +1160,7 @@ function registerReasoningSlashCommands() {
         unnamedArgumentList: reasoningVisibilityArgs,
         callback: (_args, value) => {
             const details = getReasoningDetailsElements(value.toString());
-            if (details) details.attr('open', '');
+            if (details) openReasoningDetailsWithContent(details);
             return '';
         },
     }));
@@ -1157,7 +1177,7 @@ function registerReasoningSlashCommands() {
                 const $el = $(this);
                 if ($el.attr('open') !== undefined) {
                     $el.removeAttr('open');
-                } else {
+                } else if ($el.attr('data-has-content') === 'true') {
                     $el.attr('open', '');
                 }
             });
@@ -1275,6 +1295,7 @@ function setReasoningEventHandlers() {
         e.stopPropagation();
         e.preventDefault();
 
+        $('.mes_reasoning_details[open]:not([data-has-content="true"])').removeAttr('open');
         $('.mes_reasoning_details[open] .mes_reasoning_header').trigger('click');
     });
 
@@ -1291,11 +1312,13 @@ function setReasoningEventHandlers() {
         newReasoning = substituteParams(newReasoning);
         textarea.remove();
         if (newReasoning === message.extra.reasoning) {
+            closeReasoningDetailsWithoutContent(messageBlock);
             return;
         }
         updateReasoningFromValue(message, newReasoning);
         await saveChatConditional();
         updateMessageBlock(messageId, message);
+        closeReasoningDetailsWithoutContent(messageBlock);
 
         messageBlock.find('.mes_edit_done:visible').trigger('click');
         await eventSource.emit(event_types.MESSAGE_REASONING_EDITED, messageId);
@@ -1312,6 +1335,7 @@ function setReasoningEventHandlers() {
         messageBlock.find('.mes_reasoning_edit_cancel:visible').trigger('click');
 
         updateReasoningUI(messageBlock);
+        closeReasoningDetailsWithoutContent(messageBlock);
     });
 
     $(document).on('click', '.mes_edit_add_reasoning', async function () {

--- a/public/style.css
+++ b/public/style.css
@@ -466,7 +466,7 @@ input[type='checkbox']:focus-visible {
     align-items: baseline;
 }
 
-.mes:has(.mes_reasoning:empty) .mes_reasoning_header {
+.mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning_header {
     cursor: default;
 }
 
@@ -490,9 +490,9 @@ input[type='checkbox']:focus-visible {
 .mes_reasoning_details:not(:has(.reasoning_edit_textarea)) .mes_reasoning_actions .edit_button,
 .mes_block:has(.edit_textarea):has(.reasoning_edit_textarea) .mes_reasoning_actions,
 .mes.reasoning:not([data-reasoning-state="hidden"]) .mes_edit_add_reasoning,
-.mes:has(.mes_reasoning:empty) .mes_reasoning_arrow,
-.mes:has(.mes_reasoning:empty) .mes_reasoning,
-.mes:has(.mes_reasoning:empty) .mes_reasoning_copy {
+.mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning_arrow,
+.mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning,
+.mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning_copy {
     display: none;
 }
 
@@ -501,7 +501,7 @@ input[type='checkbox']:focus-visible {
 }
 
 /** If hidden reasoning should not be shown, we hide all blocks that don't have content */
-#chat:not([data-show-hidden-reasoning="true"]):not(:has(.reasoning_edit_textarea)) .mes:has(.mes_reasoning:empty) .mes_reasoning_details {
+#chat:not([data-show-hidden-reasoning="true"]):not(:has(.reasoning_edit_textarea)) .mes_reasoning_details:not([data-has-content="true"]) {
     display: none;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -466,7 +466,7 @@ input[type='checkbox']:focus-visible {
     align-items: baseline;
 }
 
-.mes:has(.mes_reasoning:empty) .mes_reasoning_header {
+.mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning_header {
     cursor: default;
 }
 
@@ -489,10 +489,10 @@ input[type='checkbox']:focus-visible {
 .mes_reasoning_details:has(.reasoning_edit_textarea) .mes_reasoning_actions .mes_button:not(.edit_button),
 .mes_reasoning_details:not(:has(.reasoning_edit_textarea)) .mes_reasoning_actions .edit_button,
 .mes_block:has(.edit_textarea):has(.reasoning_edit_textarea) .mes_reasoning_actions,
-.mes.reasoning:not([data-reasoning-state="hidden"]) .mes_edit_add_reasoning,
-.mes:has(.mes_reasoning:empty) .mes_reasoning_arrow,
-.mes:has(.mes_reasoning:empty) .mes_reasoning,
-.mes:has(.mes_reasoning:empty) .mes_reasoning_copy {
+.mes.reasoning:has(.mes_reasoning_details[data-has-content="true"]) .mes_edit_add_reasoning,
+.mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning_arrow,
+.mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning,
+.mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning_copy {
     display: none;
 }
 
@@ -500,8 +500,10 @@ input[type='checkbox']:focus-visible {
     background-color: color-mix(in srgb, var(--SmartThemeQuoteColor) 33%, var(--SmartThemeBlurTintColor) 66%);
 }
 
-/** If hidden reasoning should not be shown, we hide all blocks that don't have content */
-#chat:not([data-show-hidden-reasoning="true"]):not(:has(.reasoning_edit_textarea)) .mes:has(.mes_reasoning:empty) .mes_reasoning_details {
+/** If hidden reasoning should not be shown, we hide all blocks that don't have content,
+ * except the one currently being edited.
+ */
+#chat:not([data-show-hidden-reasoning="true"]) .mes_reasoning_details:not([data-has-content="true"]):not(:has(.reasoning_edit_textarea)) {
     display: none;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -490,6 +490,7 @@ input[type='checkbox']:focus-visible {
 .mes_reasoning_details:not(:has(.reasoning_edit_textarea)) .mes_reasoning_actions .edit_button,
 .mes_block:has(.edit_textarea):has(.reasoning_edit_textarea) .mes_reasoning_actions,
 .mes.reasoning:has(.mes_reasoning_details[data-has-content="true"]) .mes_edit_add_reasoning,
+.mes:has(.mes_reasoning_details .reasoning_edit_textarea) .mes_edit_add_reasoning,
 .mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning_arrow,
 .mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning,
 .mes_reasoning_details:not([data-has-content="true"]) .mes_reasoning_copy {

--- a/tests/frontend/ReasoningHiddenBlocks.e2e.js
+++ b/tests/frontend/ReasoningHiddenBlocks.e2e.js
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import { testSetup } from './frontent-test-utils.js';
+
+test.describe('Reasoning hidden blocks', () => {
+    test.beforeEach(testSetup.awaitST);
+
+    test('keeps unrelated hidden reasoning blocks hidden while another block is being edited', async ({ page }) => {
+        const result = await page.evaluate(() => {
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            chat.removeAttribute('data-show-hidden-reasoning');
+            chat.innerHTML = `
+                <div class="mes reasoning" mesid="1">
+                    <details class="mes_reasoning_details" data-has-content="false">
+                        <summary class="mes_reasoning_summary">
+                            <div class="mes_reasoning_header">
+                                <span class="mes_reasoning_header_title">Thought for some time</span>
+                            </div>
+                        </summary>
+                        <div class="mes_reasoning_actions">
+                            <button class="mes_button edit_button mes_reasoning_edit">Edit</button>
+                            <button class="mes_button mes_reasoning_edit_done">Done</button>
+                            <button class="mes_button mes_reasoning_edit_cancel">Cancel</button>
+                        </div>
+                        <div class="mes_reasoning"></div>
+                    </details>
+                </div>
+                <div class="mes reasoning" mesid="2">
+                    <details class="mes_reasoning_details" data-has-content="false">
+                        <summary class="mes_reasoning_summary">
+                            <div class="mes_reasoning_header">
+                                <span class="mes_reasoning_header_title">Thought for some time</span>
+                            </div>
+                        </summary>
+                        <div class="mes_reasoning_actions">
+                            <button class="mes_button edit_button mes_reasoning_edit">Edit</button>
+                            <button class="mes_button mes_reasoning_edit_done">Done</button>
+                            <button class="mes_button mes_reasoning_edit_cancel">Cancel</button>
+                        </div>
+                        <div class="mes_reasoning"></div>
+                    </details>
+                </div>
+            `;
+
+            const firstDetails = chat.querySelector('[mesid="1"] .mes_reasoning_details');
+            const secondDetails = chat.querySelector('[mesid="2"] .mes_reasoning_details');
+            if (!firstDetails || !secondDetails) {
+                throw new Error('Missing reasoning blocks');
+            }
+
+            const before = {
+                first: getComputedStyle(firstDetails).display,
+                second: getComputedStyle(secondDetails).display,
+            };
+
+            const textarea = document.createElement('textarea');
+            textarea.className = 'reasoning_edit_textarea';
+            textarea.value = ' ';
+            firstDetails.querySelector('.mes_reasoning').before(textarea);
+
+            const after = {
+                first: getComputedStyle(firstDetails).display,
+                second: getComputedStyle(secondDetails).display,
+                textarea: getComputedStyle(textarea).display,
+            };
+
+            return { before, after };
+        });
+
+        expect(result.before.first).toBe('none');
+        expect(result.before.second).toBe('none');
+        expect(result.after.first).not.toBe('none');
+        expect(result.after.second).toBe('none');
+        expect(result.after.textarea).not.toBe('none');
+    });
+});

--- a/tests/frontend/ReasoningHiddenBlocks.e2e.js
+++ b/tests/frontend/ReasoningHiddenBlocks.e2e.js
@@ -76,4 +76,104 @@ test.describe('Reasoning hidden blocks', () => {
         expect(result.after.second).toBe('none');
         expect(result.after.textarea).not.toBe('none');
     });
+
+    test('hides add reasoning button while hidden-like reasoning is being edited', async ({ page }) => {
+        const addReasoningDisplay = await page.evaluate(() => {
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            chat.removeAttribute('data-show-hidden-reasoning');
+            chat.innerHTML = `
+                <div class="mes reasoning" mesid="1" data-reasoning-state="done">
+                    <div class="mes_block">
+                        <div class="mes_edit_buttons" style="display: inline-flex;">
+                            <button class="mes_edit_add_reasoning menu_button">Add reasoning</button>
+                        </div>
+                        <details class="mes_reasoning_details" data-has-content="false" open>
+                            <summary class="mes_reasoning_summary">
+                                <div class="mes_reasoning_header">
+                                    <span class="mes_reasoning_header_title">Thought for some time</span>
+                                </div>
+                            </summary>
+                            <div class="mes_reasoning_actions">
+                                <button class="mes_button edit_button mes_reasoning_edit">Edit</button>
+                            </div>
+                            <textarea class="reasoning_edit_textarea">\n</textarea>
+                            <div class="mes_reasoning"></div>
+                        </details>
+                    </div>
+                </div>
+            `;
+
+            const addReasoning = chat.querySelector('.mes_edit_add_reasoning');
+            if (!addReasoning) {
+                throw new Error('Missing add reasoning button');
+            }
+
+            return getComputedStyle(addReasoning).display;
+        });
+
+        expect(addReasoningDisplay).toBe('none');
+    });
+
+    test('does not create duplicate reasoning editors when add is clicked repeatedly', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const reasoningModule = await import('/scripts/reasoning.js');
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo' });
+            chat.removeAttribute('data-show-hidden-reasoning');
+            chat.innerHTML = `
+                <div class="mes reasoning" mesid="0" data-reasoning-state="done">
+                    <div class="mes_block">
+                        <div class="mes_edit_buttons" style="display: inline-flex;">
+                            <div class="mes_edit_add_reasoning menu_button">Add reasoning</div>
+                        </div>
+                        <details class="mes_reasoning_details" data-has-content="false">
+                            <summary class="mes_reasoning_summary">
+                                <div class="mes_reasoning_header">
+                                    <span class="mes_reasoning_header_title">Thought for some time</span>
+                                </div>
+                                <div class="mes_reasoning_actions">
+                                    <div class="mes_button edit_button mes_reasoning_edit">Edit</div>
+                                </div>
+                            </summary>
+                            <div class="mes_reasoning"></div>
+                        </details>
+                    </div>
+                </div>
+            `;
+
+            const addReasoning = chat.querySelector('.mes_edit_add_reasoning');
+            if (!addReasoning) {
+                throw new Error('Missing add reasoning button');
+            }
+
+            addReasoning.click();
+            addReasoning.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            const textareas = chat.querySelectorAll('.reasoning_edit_textarea');
+            return {
+                addDisplay: getComputedStyle(addReasoning).display,
+                detailsOpen: chat.querySelector('.mes_reasoning_details')?.open,
+                textareaCount: textareas.length,
+                textareaValue: textareas[0]?.value,
+            };
+        });
+
+        expect(result.detailsOpen).toBe(true);
+        expect(result.addDisplay).toBe('none');
+        expect(result.textareaCount).toBe(1);
+        expect(result.textareaValue).toBe('\n');
+    });
 });

--- a/tests/frontend/ReasoningHiddenBlocks.e2e.js
+++ b/tests/frontend/ReasoningHiddenBlocks.e2e.js
@@ -1,6 +1,38 @@
 import { test, expect } from '@playwright/test';
 import { testSetup } from './frontent-test-utils.js';
 
+function createEditableReasoningMessageHtml({ detailsAttributes = 'data-has-content="false"', includeMessageContainers = false } = {}) {
+    const messageContainers = includeMessageContainers
+        ? `
+                        <div class="mes_text"></div>
+                        <div class="mes_media_wrapper"></div>
+                        <div class="mes_file_wrapper"></div>`
+        : '';
+
+    return `
+                <div class="mes reasoning" mesid="0" data-reasoning-state="done">
+                    <div class="mes_block">
+                        <div class="mes_edit_buttons" style="display: inline-flex;">
+                            <div class="mes_edit_add_reasoning menu_button">Add reasoning</div>
+                        </div>${messageContainers}
+                        <details class="mes_reasoning_details"${detailsAttributes ? ` ${detailsAttributes}` : ''}>
+                            <summary class="mes_reasoning_summary">
+                                <div class="mes_reasoning_header">
+                                    <span class="mes_reasoning_header_title">Thought for some time</span>
+                                </div>
+                                <div class="mes_reasoning_actions">
+                                    <div class="mes_button edit_button mes_reasoning_edit">Edit</div>
+                                    <div class="mes_reasoning_edit_done menu_button edit_button">Done</div>
+                                    <div class="mes_reasoning_edit_cancel menu_button edit_button">Cancel</div>
+                                </div>
+                            </summary>
+                            <div class="mes_reasoning"></div>
+                        </details>
+                    </div>
+                </div>
+            `;
+}
+
 test.describe('Reasoning hidden blocks', () => {
     test.beforeEach(testSetup.awaitST);
 
@@ -175,5 +207,408 @@ test.describe('Reasoning hidden blocks', () => {
         expect(result.addDisplay).toBe('none');
         expect(result.textareaCount).toBe(1);
         expect(result.textareaValue).toBe('\n');
+    });
+
+    test('close all collapses stale open hidden-like reasoning details', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const reasoningModule = await import('/scripts/reasoning.js');
+            reasoningModule.initReasoning();
+
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            chat.setAttribute('data-show-hidden-reasoning', 'true');
+            chat.innerHTML = `
+                <button class="mes_reasoning_close_all">Close all</button>
+                <div class="mes reasoning" mesid="0">
+                    <details class="mes_reasoning_details" data-has-content="false" open>
+                        <summary class="mes_reasoning_summary">
+                            <div class="mes_reasoning_header">
+                                <span class="mes_reasoning_header_title">Thought for some time</span>
+                            </div>
+                        </summary>
+                        <div class="mes_reasoning"></div>
+                    </details>
+                </div>
+                <div class="mes reasoning" mesid="1">
+                    <details class="mes_reasoning_details" data-has-content="true" open>
+                        <summary class="mes_reasoning_summary">
+                            <div class="mes_reasoning_header">
+                                <span class="mes_reasoning_header_title">Thought for some time</span>
+                            </div>
+                        </summary>
+                        <div class="mes_reasoning">visible reasoning</div>
+                    </details>
+                </div>
+            `;
+
+            const hiddenDetails = chat.querySelector('[mesid="0"] .mes_reasoning_details');
+            const visibleDetails = chat.querySelector('[mesid="1"] .mes_reasoning_details');
+            const closeAll = chat.querySelector('.mes_reasoning_close_all');
+            if (!hiddenDetails || !visibleDetails || !closeAll) {
+                throw new Error('Missing close-all test elements');
+            }
+
+            const before = {
+                hiddenOpen: hiddenDetails.open,
+                visibleOpen: visibleDetails.open,
+            };
+
+            closeAll.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            return {
+                before,
+                after: {
+                    hiddenOpen: hiddenDetails.open,
+                    visibleOpen: visibleDetails.open,
+                },
+            };
+        });
+
+        expect(result.before.hiddenOpen).toBe(true);
+        expect(result.before.visibleOpen).toBe(true);
+        expect(result.after.hiddenOpen).toBe(false);
+        expect(result.after.visibleOpen).toBe(false);
+    });
+
+    test('collapses whitespace-only reasoning after confirming edit with show hidden enabled', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const reasoningModule = await import('/scripts/reasoning.js');
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo' });
+            chat.setAttribute('data-show-hidden-reasoning', 'true');
+            chat.innerHTML = messageHtml;
+
+            const addReasoning = chat.querySelector('.mes_edit_add_reasoning');
+            if (!addReasoning) {
+                throw new Error('Missing add reasoning button');
+            }
+
+            addReasoning.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+            const details = chat.querySelector('.mes_reasoning_details');
+            const textarea = chat.querySelector('.reasoning_edit_textarea');
+            const beforeDone = {
+                detailsOpen: details?.open,
+                textareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+                textareaValue: textarea?.value,
+            };
+
+            chat.querySelector('.mes_reasoning_edit_done')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            return {
+                beforeDone,
+                afterDone: {
+                    detailsOpen: details?.open,
+                    textareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+                },
+            };
+        }, createEditableReasoningMessageHtml());
+
+        expect(result.beforeDone.detailsOpen).toBe(true);
+        expect(result.beforeDone.textareaCount).toBe(1);
+        expect(result.beforeDone.textareaValue).toBe('\n');
+        expect(result.afterDone.textareaCount).toBe(0);
+        expect(result.afterDone.detailsOpen).toBe(false);
+    });
+
+    test('collapses whitespace-only reasoning after canceling edit with show hidden enabled', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const reasoningModule = await import('/scripts/reasoning.js');
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo' });
+            chat.setAttribute('data-show-hidden-reasoning', 'true');
+            chat.innerHTML = messageHtml;
+
+            const addReasoning = chat.querySelector('.mes_edit_add_reasoning');
+            if (!addReasoning) {
+                throw new Error('Missing add reasoning button');
+            }
+
+            addReasoning.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+            const details = chat.querySelector('.mes_reasoning_details');
+            const beforeCancel = {
+                detailsOpen: details?.open,
+                textareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+            };
+
+            chat.querySelector('.mes_reasoning_edit_cancel')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            return {
+                beforeCancel,
+                afterCancel: {
+                    detailsOpen: details?.open,
+                    textareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+                },
+            };
+        }, createEditableReasoningMessageHtml());
+
+        expect(result.beforeCancel.detailsOpen).toBe(true);
+        expect(result.beforeCancel.textareaCount).toBe(1);
+        expect(result.afterCancel.textareaCount).toBe(0);
+        expect(result.afterCancel.detailsOpen).toBe(false);
+    });
+
+    test('keeps whitespace-only reasoning collapsed when auto-expand is enabled', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const [reasoningModule, powerUserModule] = await Promise.all([
+                import('/scripts/reasoning.js'),
+                import('/scripts/power-user.js'),
+            ]);
+            reasoningModule.initReasoning();
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo', gen_started: new Date().toISOString() });
+            chat.setAttribute('data-show-hidden-reasoning', 'true');
+            chat.innerHTML = messageHtml;
+
+            const previousAutoExpand = powerUserModule.power_user.reasoning.auto_expand;
+            powerUserModule.power_user.reasoning.auto_expand = true;
+            try {
+                reasoningModule.updateReasoningUI(chat.querySelector('.mes'));
+            } finally {
+                powerUserModule.power_user.reasoning.auto_expand = previousAutoExpand;
+            }
+
+            const details = chat.querySelector('.mes_reasoning_details');
+            return {
+                detailsOpen: details?.open,
+                hasContent: details?.getAttribute('data-has-content'),
+            };
+        }, createEditableReasoningMessageHtml({ detailsAttributes: '' }));
+
+        expect(result.hasContent).toBeNull();
+        expect(result.detailsOpen).toBe(false);
+    });
+
+    test('treats whitespace-only reasoning as hidden-like when trim spaces is disabled', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const [reasoningModule, powerUserModule] = await Promise.all([
+                import('/scripts/reasoning.js'),
+                import('/scripts/power-user.js'),
+            ]);
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo', gen_started: new Date().toISOString() });
+            chat.removeAttribute('data-show-hidden-reasoning');
+            chat.innerHTML = messageHtml;
+
+            const previousTrimSpaces = powerUserModule.power_user.trim_spaces;
+            try {
+                powerUserModule.power_user.trim_spaces = false;
+                reasoningModule.updateReasoningUI(chat.querySelector('.mes'));
+            } finally {
+                powerUserModule.power_user.trim_spaces = previousTrimSpaces;
+            }
+
+            const details = chat.querySelector('.mes_reasoning_details');
+            const beforeAddDisplay = details ? getComputedStyle(details).display : null;
+            const addReasoning = chat.querySelector('.mes_edit_add_reasoning');
+            addReasoning?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+            const textarea = chat.querySelector('.reasoning_edit_textarea');
+            return {
+                beforeAddDisplay,
+                afterAddDisplay: details ? getComputedStyle(details).display : null,
+                detailsOpen: details?.open,
+                hasContent: details?.getAttribute('data-has-content'),
+                textareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+                textareaValue: textarea?.value,
+            };
+        }, createEditableReasoningMessageHtml({ detailsAttributes: '' }));
+
+        expect(result.hasContent).toBeNull();
+        expect(result.beforeAddDisplay).toBe('none');
+        expect(result.afterAddDisplay).not.toBe('none');
+        expect(result.detailsOpen).toBe(true);
+        expect(result.textareaCount).toBe(1);
+        expect(result.textareaValue).toBe('\n');
+    });
+
+    test('does not expand whitespace-only reasoning through slash commands', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const [reasoningModule, slashCommandsModule] = await Promise.all([
+                import('/scripts/reasoning.js'),
+                import('/scripts/slash-commands.js'),
+            ]);
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo' });
+            chat.setAttribute('data-show-hidden-reasoning', 'true');
+            chat.innerHTML = messageHtml;
+
+            const details = chat.querySelector('.mes_reasoning_details');
+            await slashCommandsModule.executeSlashCommandsWithOptions('/reasoning-expand 0');
+            const afterExpand = details?.open;
+            await slashCommandsModule.executeSlashCommandsWithOptions('/reasoning-toggle 0');
+            const afterToggle = details?.open;
+
+            return {
+                afterExpand,
+                afterToggle,
+                hasContent: details?.getAttribute('data-has-content'),
+            };
+        }, createEditableReasoningMessageHtml());
+
+        expect(result.hasContent).toBe('false');
+        expect(result.afterExpand).toBe(false);
+        expect(result.afterToggle).toBe(false);
+    });
+
+    test('expands visible reasoning through slash commands', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const [reasoningModule, slashCommandsModule] = await Promise.all([
+                import('/scripts/reasoning.js'),
+                import('/scripts/slash-commands.js'),
+            ]);
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: 'visible reasoning' }, name: 'Ilo', mes: 'Foo' });
+            chat.innerHTML = messageHtml;
+
+            const details = chat.querySelector('.mes_reasoning_details');
+            await slashCommandsModule.executeSlashCommandsWithOptions('/reasoning-expand 0');
+            const afterExpand = details?.open;
+            await slashCommandsModule.executeSlashCommandsWithOptions('/reasoning-toggle 0');
+            const afterToggleClosed = details?.open;
+            await slashCommandsModule.executeSlashCommandsWithOptions('/reasoning-toggle 0');
+            const afterToggleOpen = details?.open;
+
+            return {
+                afterExpand,
+                afterToggleClosed,
+                afterToggleOpen,
+                hasContent: details?.getAttribute('data-has-content'),
+            };
+        }, createEditableReasoningMessageHtml({ detailsAttributes: 'data-has-content="true"' }));
+
+        expect(result.hasContent).toBe('true');
+        expect(result.afterExpand).toBe(true);
+        expect(result.afterToggleClosed).toBe(false);
+        expect(result.afterToggleOpen).toBe(true);
+    });
+
+    test('keeps reasoning expanded after changing whitespace-only reasoning to visible content', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const reasoningModule = await import('/scripts/reasoning.js');
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo' });
+            chat.setAttribute('data-show-hidden-reasoning', 'true');
+            chat.innerHTML = messageHtml;
+
+            chat.querySelector('.mes_edit_add_reasoning')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+            const textarea = chat.querySelector('.reasoning_edit_textarea');
+            textarea.value = 'visible reasoning';
+            chat.querySelector('.mes_reasoning_edit_done')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            const details = chat.querySelector('.mes_reasoning_details');
+            return {
+                detailsOpen: details?.open,
+                hasContent: details?.getAttribute('data-has-content'),
+                textareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+                reasoningText: chat.querySelector('.mes_reasoning')?.textContent,
+            };
+        }, createEditableReasoningMessageHtml({ includeMessageContainers: true }));
+
+        expect(result.textareaCount).toBe(0);
+        expect(result.hasContent).toBe('true');
+        expect(result.detailsOpen).toBe(true);
+        expect(result.reasoningText).toContain('visible reasoning');
+    });
+
+    test('collapses reasoning after changing whitespace-only reasoning to different whitespace', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const reasoningModule = await import('/scripts/reasoning.js');
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo' });
+            chat.setAttribute('data-show-hidden-reasoning', 'true');
+            chat.innerHTML = messageHtml;
+
+            chat.querySelector('.mes_edit_add_reasoning')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+            const textarea = chat.querySelector('.reasoning_edit_textarea');
+            textarea.value = '   ';
+            chat.querySelector('.mes_reasoning_edit_done')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            const details = chat.querySelector('.mes_reasoning_details');
+            return {
+                detailsOpen: details?.open,
+                hasContent: details?.getAttribute('data-has-content'),
+                textareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+            };
+        }, createEditableReasoningMessageHtml({ includeMessageContainers: true }));
+
+        expect(result.textareaCount).toBe(0);
+        expect(result.hasContent).toBeNull();
+        expect(result.detailsOpen).toBe(false);
     });
 });

--- a/tests/frontend/ReasoningHiddenBlocks.e2e.js
+++ b/tests/frontend/ReasoningHiddenBlocks.e2e.js
@@ -1,19 +1,30 @@
 import { test, expect } from '@playwright/test';
 import { testSetup } from './frontent-test-utils.js';
 
-function createEditableReasoningMessageHtml({ detailsAttributes = 'data-has-content="false"', includeMessageContainers = false } = {}) {
+function createEditableReasoningMessageHtml({ detailsAttributes = 'data-has-content="false"', includeMessageContainers = false, includeMessageEditControls = false } = {}) {
     const messageContainers = includeMessageContainers
         ? `
                         <div class="mes_text"></div>
                         <div class="mes_media_wrapper"></div>
                         <div class="mes_file_wrapper"></div>`
         : '';
+    const messageEditControls = includeMessageEditControls
+        ? `
+                            <div class="mes_edit_done menu_button edit_button">Done message</div>
+                            <div class="mes_edit_cancel menu_button edit_button">Cancel message</div>`
+        : '';
+    const messageButtons = includeMessageEditControls
+        ? `
+                        <div class="mes_buttons" style="display: flex;"></div>
+                        <div class="mes_bias"></div>`
+        : '';
 
     return `
                 <div class="mes reasoning" mesid="0" data-reasoning-state="done">
                     <div class="mes_block">
+                        ${messageButtons}
                         <div class="mes_edit_buttons" style="display: inline-flex;">
-                            <div class="mes_edit_add_reasoning menu_button">Add reasoning</div>
+                            <div class="mes_edit_add_reasoning menu_button">Add reasoning</div>${messageEditControls}
                         </div>${messageContainers}
                         <details class="mes_reasoning_details"${detailsAttributes ? ` ${detailsAttributes}` : ''}>
                             <summary class="mes_reasoning_summary">
@@ -369,6 +380,122 @@ test.describe('Reasoning hidden blocks', () => {
         expect(result.beforeCancel.textareaCount).toBe(1);
         expect(result.afterCancel.textareaCount).toBe(0);
         expect(result.afterCancel.detailsOpen).toBe(false);
+    });
+
+    test('collapses whitespace-only reasoning after confirming message edit with reasoning edit open', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const [reasoningModule, scriptModule] = await Promise.all([
+                import('/scripts/reasoning.js'),
+                import('/script.js'),
+            ]);
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo' });
+            chat.setAttribute('data-show-hidden-reasoning', 'true');
+            chat.innerHTML = messageHtml;
+
+            chat.querySelector('.mes_edit_add_reasoning')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+            await scriptModule.messageEdit(0);
+            await new Promise(resolve => setTimeout(resolve, 100));
+            const editTextarea = chat.querySelector('#curEditTextarea');
+            if (editTextarea) {
+                editTextarea.value = 'Foo edited';
+            }
+            const beforeDone = {
+                detailsOpen: chat.querySelector('.mes_reasoning_details')?.open,
+                reasoningTextareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+                messageTextareaCount: chat.querySelectorAll('#curEditTextarea').length,
+            };
+
+            chat.querySelector('.mes_edit_done')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            return {
+                beforeDone,
+                afterDone: {
+                    detailsOpen: chat.querySelector('.mes_reasoning_details')?.open,
+                    reasoningTextareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+                    messageTextareaCount: chat.querySelectorAll('#curEditTextarea').length,
+                    messageValue: context.chat[0]?.mes,
+                    reasoningValue: context.chat[0]?.extra?.reasoning,
+                },
+            };
+        }, createEditableReasoningMessageHtml({ includeMessageContainers: true, includeMessageEditControls: true }));
+
+        expect(result.beforeDone.detailsOpen).toBe(true);
+        expect(result.beforeDone.reasoningTextareaCount).toBe(1);
+        expect(result.beforeDone.messageTextareaCount).toBe(1);
+        expect(result.afterDone.reasoningTextareaCount).toBe(0);
+        expect(result.afterDone.messageTextareaCount).toBe(0);
+        expect(result.afterDone.detailsOpen).toBe(false);
+        expect(result.afterDone.messageValue).toBe('Foo edited');
+        expect(result.afterDone.reasoningValue).toBe('\n');
+    });
+
+    test('collapses whitespace-only reasoning after canceling message edit with reasoning edit open', async ({ page }) => {
+        const result = await page.evaluate(async (messageHtml) => {
+            const [reasoningModule, scriptModule] = await Promise.all([
+                import('/scripts/reasoning.js'),
+                import('/script.js'),
+            ]);
+            reasoningModule.initReasoning();
+
+            const context = window.SillyTavern.getContext();
+            const chat = document.getElementById('chat');
+            if (!chat) {
+                throw new Error('Missing #chat container');
+            }
+
+            context.chat.length = 0;
+            context.chat.push({ extra: { reasoning: '\n' }, name: 'Ilo', mes: 'Foo' });
+            chat.setAttribute('data-show-hidden-reasoning', 'true');
+            chat.innerHTML = messageHtml;
+
+            chat.querySelector('.mes_edit_add_reasoning')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+            await scriptModule.messageEdit(0);
+            await new Promise(resolve => setTimeout(resolve, 100));
+            const editTextarea = chat.querySelector('#curEditTextarea');
+            if (editTextarea) {
+                editTextarea.value = 'Foo should cancel';
+            }
+            const beforeCancel = {
+                detailsOpen: chat.querySelector('.mes_reasoning_details')?.open,
+                reasoningTextareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+                messageTextareaCount: chat.querySelectorAll('#curEditTextarea').length,
+            };
+
+            chat.querySelector('.mes_edit_cancel')?.click();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            return {
+                beforeCancel,
+                afterCancel: {
+                    detailsOpen: chat.querySelector('.mes_reasoning_details')?.open,
+                    reasoningTextareaCount: chat.querySelectorAll('.reasoning_edit_textarea').length,
+                    messageTextareaCount: chat.querySelectorAll('#curEditTextarea').length,
+                    messageValue: context.chat[0]?.mes,
+                    reasoningValue: context.chat[0]?.extra?.reasoning,
+                },
+            };
+        }, createEditableReasoningMessageHtml({ includeMessageContainers: true, includeMessageEditControls: true }));
+
+        expect(result.beforeCancel.detailsOpen).toBe(true);
+        expect(result.beforeCancel.reasoningTextareaCount).toBe(1);
+        expect(result.beforeCancel.messageTextareaCount).toBe(1);
+        expect(result.afterCancel.reasoningTextareaCount).toBe(0);
+        expect(result.afterCancel.messageTextareaCount).toBe(0);
+        expect(result.afterCancel.detailsOpen).toBe(false);
+        expect(result.afterCancel.messageValue).toBe('Foo');
+        expect(result.afterCancel.reasoningValue).toBe('\n');
     });
 
     test('keeps whitespace-only reasoning collapsed when auto-expand is enabled', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Treat whitespace-only saved reasoning, such as `"\n"`, as hidden-like in normal chat history when it renders no visible `.mes_reasoning` content.
- Keep the saved reasoning recoverable in message edit mode by exposing the reasoning edit/remove path instead of showing a normal collapsible reasoning block.
- Preserve existing visible reasoning and hidden/no-content reasoning behavior.

Fixes #5579.

## Test Plan

- `npm run lint`
- `npm run test:unit --prefix tests`
- `NODE_PATH=/home/dragonfsky/git/SillyTavern/node_modules /home/dragonfsky/git/SillyTavern/node_modules/.bin/eslint public/scripts/reasoning.js`
- `git diff --check`
- One-off Playwright/CSS check: visible reasoning still hides the add-reasoning edit button and keeps normal reasoning controls visible.
- One-off Playwright/CSS check: whitespace-only/no-visible reasoning hides the normal chat-history reasoning block while keeping the edit/remove entry available in message edit mode.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).