### PR TITLE
Fix: Disable Incomplete Pipe/Filter Tokenizing to Prevent Breaking Macros with Pipe Characters in Arguments

### DIFF
--- a/public/scripts/macros/engine/MacroLexer.js
+++ b/public/scripts/macros/engine/MacroLexer.js
@@ -214,11 +214,16 @@ const Def = {
             // Macro args allow nested macros
             enter(Tokens.Macro.Start, modes.macro_def),
 
+            // PIPE/FILTER FEATURE DISABLED: Lines below commented out until pipe/filter feature is fully implemented.
+            // Currently, having these active breaks macros that use | as a regular character in argument values (e.g., {{setvar::foo::|bar}})
+            // See: https://github.com/SillyTavern/SillyTavern/issues/5618
+            // TODO: Re-enable when filter flag (>) logic is properly implemented to conditionally enable pipe parsing
+
             // We allow escaped pipes to not start output modifiers. We need to capture this first, before the pipe
-            using(Tokens.Filter.EscapedPipe),
+            // using(Tokens.Filter.EscapedPipe),
 
             // If at any place during args writing there is a pipe, we lex it as an output identifier, and then continue with lex its args
-            enter(Tokens.Filter.Pipe, modes.macro_filter_modifer),
+            // enter(Tokens.Filter.Pipe, modes.macro_filter_modifer),
 
             using(Tokens.Args.DoubleColon),
             using(Tokens.Args.Colon),

--- a/tests/frontend/MacroLexer.e2e.js
+++ b/tests/frontend/MacroLexer.e2e.js
@@ -508,6 +508,49 @@ test.describe('MacroLexer', () => {
             expect(tokens).toEqual(expectedTokens);
         });
         // TODO: test invalid argument name identifiers
+
+        // REGRESSION TEST: https://github.com/SillyTavern/SillyTavern/issues/5618
+        // {{setvar::foo::|bar}} - pipe character should NOT be treated as Filter.Pipe (which breaks parsing)
+        test('should handle pipe character in argument values (issue #5618)', async ({ page }) => {
+            const input = '{{setvar::foo::|bar}}';
+            const tokens = await runLexerGetTokens(page, input);
+
+            const expectedTokens = [
+                { type: 'Macro.Start', text: '{{' },
+                { type: 'Macro.Identifier', text: 'setvar' },
+                { type: 'Args.DoubleColon', text: '::' },
+                { type: 'Identifier', text: 'foo' },
+                { type: 'Args.DoubleColon', text: '::' },
+                // Pipe is captured as Unknown (not Filter.Pipe), which allows the macro to parse correctly
+                { type: 'Unknown', text: '|' },
+                { type: 'Identifier', text: 'bar' },
+                { type: 'Macro.End', text: '}}' },
+            ];
+
+            expect(tokens).toEqual(expectedTokens);
+        });
+
+        // Test multiple pipes in argument values
+        test('should handle multiple pipe characters in argument values', async ({ page }) => {
+            const input = '{{setvar::key::a|b|c}}';
+            const tokens = await runLexerGetTokens(page, input);
+
+            const expectedTokens = [
+                { type: 'Macro.Start', text: '{{' },
+                { type: 'Macro.Identifier', text: 'setvar' },
+                { type: 'Args.DoubleColon', text: '::' },
+                { type: 'Identifier', text: 'key' },
+                { type: 'Args.DoubleColon', text: '::' },
+                { type: 'Identifier', text: 'a' },
+                { type: 'Unknown', text: '|' },
+                { type: 'Identifier', text: 'b' },
+                { type: 'Unknown', text: '|' },
+                { type: 'Identifier', text: 'c' },
+                { type: 'Macro.End', text: '}}' },
+            ];
+
+            expect(tokens).toEqual(expectedTokens);
+        });
     });
 
     test.describe('Macro Execution Modifiers', () => {
@@ -931,7 +974,8 @@ test.describe('MacroLexer', () => {
         });
     });
 
-    test.describe('Macro Output Modifiers', () => {
+    // SKIPPED: Pipe/filter feature temporarily disabled. See https://github.com/SillyTavern/SillyTavern/issues/5618
+    test.describe.skip('Macro Output Modifiers', () => {
         // {{macro | outputModifier}}
         test('should support output modifier without arguments', async ({ page }) => {
             const input = '{{macro | outputModifier}}';


### PR DESCRIPTION
Fixes a bug where macros containing `|` (pipe) characters in argument values were failing to parse correctly. The experimental pipe/filter feature was tokenizing `|` as a filter operator even when it was intended as regular content (e.g., for table formatting).

Filter pipe will be handled cleanly once that feature gets implemented. For now, we just don't use any of that.

Fixes #5618

### What Changed
- **Disabled pipe/filter tokenizing in the macro lexer** - The incomplete feature was unconditionally capturing `|` characters during macro argument parsing, breaking valid use cases
- **Added regression tests** - Two new test cases ensure pipe characters in argument values are handled correctly
- **Skipped related test suite** - The "Macro Output Modifiers" tests are temporarily disabled since the feature is not yet fully implemented

### Why These Changes
The issue was reported in #5618 where users couldn't use `|` in macro arguments like `{{setvar::foo::|bar}}` (for creating table-like formatting). The lexer was entering "filter mode" whenever it encountered a `|`, treating it as a pipe operator rather than regular argument content.

The pipe/filter feature was designed to work with a `>` flag (e.g., `{{>macro | filter}}`) to explicitly enable pipe parsing, but this conditional logic wasn't implemented. Until the feature is completed with proper flag detection, it's safer to disable the pipe tokenizing entirely.

### How It Works
- Before: `|` in macro arguments → `Filter.Pipe` token → parser error → macro renders as literal text
- After: `|` in macro arguments → `Unknown` token → parsed as regular content → macro executes correctly

### Impact
Users can now safely use `|` characters in macro arguments for formatting purposes (tables, separators, etc.) without the macro engine breaking. The planned pipe/filter feature can be re-implemented in the future with proper flag-gated logic.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).