### PR TITLE
chore: Sync NanoGPT providers: Tensorix, and Xiaomi

### DIFF
--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -259,6 +259,10 @@ const NANOGPT_PROVIDERS = [
         'label': 'Neuralwatt',
     },
     {
+        "id": "tensorix",
+        "label": "Tensorix"
+    },
+    {
         'id': 'nextbit',
         'label': 'NextBit',
     },
@@ -309,6 +313,10 @@ const NANOGPT_PROVIDERS = [
     {
         'id': 'wandb',
         'label': 'Weights & Biases',
+    },
+    {
+        "id": "xiaomi",
+        "label": "Xiaomi"
     },
     {
         'id': 'zai',

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -259,8 +259,8 @@ const NANOGPT_PROVIDERS = [
         'label': 'Neuralwatt',
     },
     {
-        "id": "tensorix",
-        "label": "Tensorix"
+        'id': 'tensorix',
+        'label': 'Tensorix',
     },
     {
         'id': 'nextbit',
@@ -315,8 +315,8 @@ const NANOGPT_PROVIDERS = [
         'label': 'Weights & Biases',
     },
     {
-        "id": "xiaomi",
-        "label": "Xiaomi"
+        'id': 'xiaomi',
+        'label': 'Xiaomi',
     },
     {
         'id': 'zai',


### PR DESCRIPTION
##Summary
Synced the NanoGPT provider list adding missing providers to `public\scripts\textgen-models.js`. 

##Note
To keep compatibility with the upstream list Tensorix is out of alphabetical order.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
