### PR TITLE
feat: split tokenizer settings into counting and encoding tokenizers

### DIFF
--- a/default/content/settings.json
+++ b/default/content/settings.json
@@ -85,7 +85,8 @@
         "trusted_workers_only": false
     },
     "power_user": {
-        "tokenizer": 99,
+        "counting_tokenizer": 99,
+        "encoding_tokenizer": 99,
         "token_padding": 64,
         "collapse_newlines": false,
         "pin_examples": false,

--- a/public/index.html
+++ b/public/index.html
@@ -4529,51 +4529,11 @@
                                 <label for="counting_tokenizer">
                                     <small data-i18n="Counting Tokenizer">Counting Tokenizer</small>
                                 </label>
-                                <select id="counting_tokenizer">
-                                    <option value="99">Best match (recommended)</option>
-                                    <option value="0">None / Estimated</option>
-                                    <option value="1">GPT-2</option>
-                                    <!-- Option #2 was a legacy GPT-2/3 tokenizer -->
-                                    <option value="3">Llama 1/2</option>
-                                    <option value="12">Llama 3</option>
-                                    <option value="13">Gemma / Gemini</option>
-                                    <option value="14">Jamba</option>
-                                    <option value="15">Qwen2</option>
-                                    <option value="16">Command-R</option>
-                                    <option value="19">Command-A</option>
-                                    <option value="4">NerdStash (NovelAI Clio)</option>
-                                    <option value="5">NerdStash v2 (NovelAI Kayra)</option>
-                                    <option value="7">Mistral V1</option>
-                                    <option value="17">Mistral Nemo</option>
-                                    <option value="8">Yi</option>
-                                    <option value="11">Claude 1/2</option>
-                                    <option value="18">DeepSeek V3</option>
-                                    <option value="6">API (WebUI / koboldcpp)</option>
-                                </select>
+                                <select id="counting_tokenizer"></select>
                                 <label for="encoding_tokenizer">
                                     <small data-i18n="Encoding Tokenizer">Encoding Tokenizer</small>
                                 </label>
-                                <select id="encoding_tokenizer">
-                                    <option value="99">Best match (recommended)</option>
-                                    <option value="0">None / Estimated</option>
-                                    <option value="1">GPT-2</option>
-                                    <!-- Option #2 was a legacy GPT-2/3 tokenizer -->
-                                    <option value="3">Llama 1/2</option>
-                                    <option value="12">Llama 3</option>
-                                    <option value="13">Gemma / Gemini</option>
-                                    <option value="14">Jamba</option>
-                                    <option value="15">Qwen2</option>
-                                    <option value="16">Command-R</option>
-                                    <option value="19">Command-A</option>
-                                    <option value="4">NerdStash (NovelAI Clio)</option>
-                                    <option value="5">NerdStash v2 (NovelAI Kayra)</option>
-                                    <option value="7">Mistral V1</option>
-                                    <option value="17">Mistral Nemo</option>
-                                    <option value="8">Yi</option>
-                                    <option value="11">Claude 1/2</option>
-                                    <option value="18">DeepSeek V3</option>
-                                    <option value="6">API (WebUI / koboldcpp)</option>
-                                </select>
+                                <select id="encoding_tokenizer"></select>
                             </div>
                             <div class="range-block flex-container flexnowrap" name="tokenPaddingBlock">
                                 <div class="range-block-title justifyLeft">

--- a/public/index.html
+++ b/public/index.html
@@ -4519,14 +4519,41 @@
                             </label>
                         </div>
 
-                        <div name="tokenizerSettingsBlock" data-cc-null>
+                        <div name="tokenizerSettingsBlock">
                             <div name="tokenizerSelectorBlock">
                                 <h4 class="standoutHeader"><span data-i18n="Tokenizer">Tokenizer</span>
                                     <a href="https://docs.sillytavern.app/usage/prompts/tokenizer/" class="notes-link" target="_blank">
                                         <span class="fa-solid fa-circle-question note-link-span"></span>
                                     </a>
                                 </h4>
-                                <select id="tokenizer">
+                                <label for="counting_tokenizer">
+                                    <small data-i18n="Counting Tokenizer">Counting Tokenizer</small>
+                                </label>
+                                <select id="counting_tokenizer">
+                                    <option value="99">Best match (recommended)</option>
+                                    <option value="0">None / Estimated</option>
+                                    <option value="1">GPT-2</option>
+                                    <!-- Option #2 was a legacy GPT-2/3 tokenizer -->
+                                    <option value="3">Llama 1/2</option>
+                                    <option value="12">Llama 3</option>
+                                    <option value="13">Gemma / Gemini</option>
+                                    <option value="14">Jamba</option>
+                                    <option value="15">Qwen2</option>
+                                    <option value="16">Command-R</option>
+                                    <option value="19">Command-A</option>
+                                    <option value="4">NerdStash (NovelAI Clio)</option>
+                                    <option value="5">NerdStash v2 (NovelAI Kayra)</option>
+                                    <option value="7">Mistral V1</option>
+                                    <option value="17">Mistral Nemo</option>
+                                    <option value="8">Yi</option>
+                                    <option value="11">Claude 1/2</option>
+                                    <option value="18">DeepSeek V3</option>
+                                    <option value="6">API (WebUI / koboldcpp)</option>
+                                </select>
+                                <label for="encoding_tokenizer">
+                                    <small data-i18n="Encoding Tokenizer">Encoding Tokenizer</small>
+                                </label>
+                                <select id="encoding_tokenizer">
                                     <option value="99">Best match (recommended)</option>
                                     <option value="0">None / Estimated</option>
                                     <option value="1">GPT-2</option>

--- a/public/scripts/extensions/token-counter/index.js
+++ b/public/scripts/extensions/token-counter/index.js
@@ -2,7 +2,7 @@ import { main_api } from '../../../script.js';
 import { getContext } from '../../extensions.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
-import { getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, tokenizerSettings } from '../../tokenizers.js';
+import { getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, tokenizer_settings } from '../../tokenizers.js';
 import { resetScrollHeight, debounce } from '../../utils.js';
 import { debounce_timeout } from '../../constants.js';
 import { POPUP_TYPE, callGenericPopup } from '../../popup.js';
@@ -10,7 +10,7 @@ import { renderExtensionTemplateAsync } from '../../extensions.js';
 import { t } from '../../i18n.js';
 
 async function doTokenCounter() {
-    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, tokenizerSettings.ENCODING);
+    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, tokenizer_settings.ENCODING);
     const html = await renderExtensionTemplateAsync('token-counter', 'window', { tokenizerName });
 
     const dialog = $(html);

--- a/public/scripts/extensions/token-counter/index.js
+++ b/public/scripts/extensions/token-counter/index.js
@@ -2,7 +2,7 @@ import { main_api } from '../../../script.js';
 import { getContext } from '../../extensions.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
-import { getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, tokenizers } from '../../tokenizers.js';
+import { getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, tokenizerSettings } from '../../tokenizers.js';
 import { resetScrollHeight, debounce } from '../../utils.js';
 import { debounce_timeout } from '../../constants.js';
 import { POPUP_TYPE, callGenericPopup } from '../../popup.js';
@@ -10,13 +10,13 @@ import { renderExtensionTemplateAsync } from '../../extensions.js';
 import { t } from '../../i18n.js';
 
 async function doTokenCounter() {
-    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api);
+    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, tokenizerSettings.ENCODING);
     const html = await renderExtensionTemplateAsync('token-counter', 'window', { tokenizerName });
 
     const dialog = $(html);
     const countDebounced = debounce(async () => {
         const text = String($('#token_counter_textarea').val());
-        const ids = main_api == 'openai' ? getTextTokens(tokenizers.OPENAI, text) : getTextTokens(tokenizerId, text);
+        const ids = getTextTokens(tokenizerId, text);
 
         if (Array.isArray(ids) && ids.length > 0) {
             $('#token_counter_ids').text(`[${ids.join(', ')}]`);

--- a/public/scripts/extensions/token-counter/index.js
+++ b/public/scripts/extensions/token-counter/index.js
@@ -10,7 +10,7 @@ import { renderExtensionTemplateAsync } from '../../extensions.js';
 import { t } from '../../i18n.js';
 
 async function doTokenCounter() {
-    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, tokenizer_settings.ENCODING);
+    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, { target: tokenizer_settings.ENCODING });
     const html = await renderExtensionTemplateAsync('token-counter', 'window', { tokenizerName });
 
     const dialog = $(html);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -67,7 +67,7 @@ import {
     textValueMatcher,
     uuidv4,
 } from './utils.js';
-import { countTokensOpenAIAsync, getTokenizerModel } from './tokenizers.js';
+import { countTokensOpenAIAsync, getEncodingTokenizerType, getTokenizerModel, getTokenizerModelForType, tokenizers } from './tokenizers.js';
 import { isMobile } from './RossAscends-mods.js';
 import { saveLogprobsForActiveMessage } from './logprobs.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
@@ -3315,22 +3315,44 @@ function parseOpenAITextLogprobs(logprobs) {
 }
 
 async function calculateLogitBias() {
-    const body = JSON.stringify(oai_settings.bias_presets[oai_settings.bias_preset_selected]);
-    let result = {};
-
     try {
-        const reply = await fetch(`/api/backends/chat-completions/bias?model=${getTokenizerModel()}`, {
+        const tokenizerModel = getLogitBiasTokenizerModel();
+
+        if (!tokenizerModel) {
+            return {};
+        }
+
+        const reply = await fetch(`/api/backends/chat-completions/bias?model=${encodeURIComponent(tokenizerModel)}`, {
             method: 'POST',
             headers: getRequestHeaders(),
-            body,
+            body: JSON.stringify(oai_settings.bias_presets[oai_settings.bias_preset_selected]),
         });
 
-        result = await reply.json();
+        if (!reply.ok) {
+            console.warn('Failed to calculate logit bias:', reply.status, reply.statusText);
+            return {};
+        }
+
+        return await reply.json();
     } catch (err) {
-        result = {};
         console.error(err);
+        return {};
     }
-    return result;
+}
+
+function getLogitBiasTokenizerModel() {
+    const tokenizerType = getEncodingTokenizerType();
+
+    if ([tokenizers.NONE, tokenizers.API_CURRENT].includes(tokenizerType)) {
+        return null;
+    }
+
+    const tokenizerModel = tokenizerType === tokenizers.BEST_MATCH
+        ? getTokenizerModel()
+        : getTokenizerModelForType(tokenizerType);
+
+    // Match the legacy Chat Completion /bias endpoint behavior.
+    return tokenizerModel === 'claude' ? null : tokenizerModel;
 }
 
 class TokenHandler {
@@ -7258,6 +7280,7 @@ export function initOpenAI() {
     $('#openai_logit_bias_preset').on('change', onLogitBiasPresetChange);
     $('#openai_logit_bias_new_preset').on('click', createNewLogitBiasPreset);
     $('#openai_logit_bias_new_entry').on('click', createNewLogitBiasEntry);
+    $('#encoding_tokenizer').on('change', () => biasCache = undefined);
     $('#openai_logit_bias_import_file').on('input', onLogitBiasPresetImportFileChange);
     $('#openai_preset_import_file').on('input', onPresetImportFileChange);
     $('#export_oai_preset').on('click', onExportPresetClick);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -67,7 +67,7 @@ import {
     textValueMatcher,
     uuidv4,
 } from './utils.js';
-import { countTokensOpenAIAsync, getEncodingTokenizerType, getTokenizerModel, getTokenizerModelForType, tokenizers } from './tokenizers.js';
+import { countTokensOpenAIAsync, getEncodingTokenizerType, getTokenizerModel, tokenizers } from './tokenizers.js';
 import { isMobile } from './RossAscends-mods.js';
 import { saveLogprobsForActiveMessage } from './logprobs.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
@@ -3347,9 +3347,7 @@ function getLogitBiasTokenizerModel() {
         return null;
     }
 
-    const tokenizerModel = tokenizerType === tokenizers.BEST_MATCH
-        ? getTokenizerModel()
-        : getTokenizerModelForType(tokenizerType);
+    const tokenizerModel = getTokenizerModel(tokenizerType);
 
     // Match the legacy Chat Completion /bias endpoint behavior.
     return tokenizerModel === 'claude' ? null : tokenizerModel;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3347,7 +3347,7 @@ function getLogitBiasTokenizerModel() {
         return null;
     }
 
-    const tokenizerModel = getTokenizerModel(tokenizerType);
+    const tokenizerModel = getTokenizerModel({ tokenizerType });
 
     // Match the legacy Chat Completion /bias endpoint behavior.
     return tokenizerModel === 'claude' ? null : tokenizerModel;

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -115,7 +115,8 @@ export const persona_description_positions = _persona_description_positions;
 
 export const power_user = {
     charListGrid: false,
-    tokenizer: tokenizers.BEST_MATCH,
+    counting_tokenizer: tokenizers.BEST_MATCH,
+    encoding_tokenizer: tokenizers.BEST_MATCH,
     token_padding: 64,
     collapse_newlines: false,
     pin_examples: false,
@@ -1551,6 +1552,28 @@ function getExampleMessagesBehavior() {
 }
 
 //MARK: loadPowerUser
+
+/**
+ * Normalizes persisted tokenizer settings to options selectable in the UI.
+ * @param {unknown} tokenizer Tokenizer setting value.
+ * @returns {number} Normalized tokenizer setting value.
+ */
+function normalizePowerUserTokenizer(tokenizer) {
+    const tokenizerType = Number(tokenizer);
+
+    // Option #2 was a legacy GPT-2/3 tokenizer setting and is no longer selectable.
+    if (tokenizerType === tokenizers.OPENAI) {
+        return tokenizers.GPT2;
+    }
+
+    if (!Number.isInteger(tokenizerType)) {
+        return tokenizers.BEST_MATCH;
+    }
+
+    const hasOption = $(`#counting_tokenizer option[value="${tokenizerType}"], #encoding_tokenizer option[value="${tokenizerType}"]`).length > 0;
+    return hasOption ? tokenizerType : tokenizers.BEST_MATCH;
+}
+
 export async function loadPowerUserSettings(settings, data) {
     const defaultStscript = JSON.parse(JSON.stringify(power_user.stscript));
     // Load from settings.json
@@ -1562,6 +1585,16 @@ export async function loadPowerUserSettings(settings, data) {
         if (Object.hasOwn(settings.power_user, 'auto_sort_tags') && !Object.hasOwn(settings.power_user, 'tag_sort_mode')) {
             settings.power_user.tag_sort_mode = settings.power_user.auto_sort_tags ? tag_sort_mode.ALPHABETICAL : tag_sort_mode.MANUAL;
             delete settings.power_user.auto_sort_tags;
+        }
+        if (Object.hasOwn(settings.power_user, 'tokenizer')) {
+            const tokenizer = normalizePowerUserTokenizer(settings.power_user.tokenizer);
+            if (typeof settings.power_user.counting_tokenizer !== 'number') {
+                settings.power_user.counting_tokenizer = tokenizer;
+            }
+            if (typeof settings.power_user.encoding_tokenizer !== 'number') {
+                settings.power_user.encoding_tokenizer = tokenizer;
+            }
+            delete settings.power_user.tokenizer;
         }
         Object.assign(power_user, settings.power_user);
     }
@@ -1626,9 +1659,8 @@ export async function loadPowerUserSettings(settings, data) {
         power_user.chat_width = 50;
     }
 
-    if (power_user.tokenizer === tokenizers.LEGACY) {
-        power_user.tokenizer = tokenizers.GPT2;
-    }
+    power_user.counting_tokenizer = normalizePowerUserTokenizer(power_user.counting_tokenizer);
+    power_user.encoding_tokenizer = normalizePowerUserTokenizer(power_user.encoding_tokenizer);
 
     // Clean up old/legacy settings
     if (power_user.import_card_tags !== undefined) {
@@ -1681,7 +1713,8 @@ export async function loadPowerUserSettings(settings, data) {
     $('#auto_scroll_chat_to_bottom').prop('checked', power_user.auto_scroll_chat_to_bottom);
     $('#bogus_folders').prop('checked', power_user.bogus_folders);
     $('#zoomed_avatar_magnification').prop('checked', power_user.zoomed_avatar_magnification);
-    $(`#tokenizer option[value="${power_user.tokenizer}"]`).prop('selected', true);
+    $(`#counting_tokenizer option[value="${power_user.counting_tokenizer}"]`).prop('selected', true);
+    $(`#encoding_tokenizer option[value="${power_user.encoding_tokenizer}"]`).prop('selected', true);
     $(`#send_on_enter option[value=${power_user.send_on_enter}]`).prop('selected', true);
     $('#confirm_message_delete').prop('checked', power_user.confirm_message_delete !== undefined ? !!power_user.confirm_message_delete : true);
     $('#spoiler_free_mode').prop('checked', power_user.spoiler_free_mode);
@@ -3624,14 +3657,20 @@ jQuery(() => {
         saveSettingsDebounced();
     });
 
-    $('#tokenizer').on('change', function () {
+    $('#counting_tokenizer').on('change', function () {
         const value = $(this).find(':selected').val();
-        power_user.tokenizer = Number(value);
-        BIAS_CACHE.clear();
+        power_user.counting_tokenizer = Number(value);
         saveSettingsDebounced();
 
         // Trigger character editor re-tokenize
         forceCharacterEditorTokenize();
+    });
+
+    $('#encoding_tokenizer').on('change', function () {
+        const value = $(this).find(':selected').val();
+        power_user.encoding_tokenizer = Number(value);
+        BIAS_CACHE.clear();
+        saveSettingsDebounced();
     });
 
     $('#send_on_enter').on('change', function () {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -46,7 +46,7 @@ import {
 } from './instruct-mode.js';
 
 import { getTagsList, tag_import_setting, tag_map, tag_sort_mode, tags } from './tags.js';
-import { tokenizers } from './tokenizers.js';
+import { initTokenizerSelects, isSelectableTokenizer, tokenizers } from './tokenizers.js';
 import { BIAS_CACHE } from './logit-bias.js';
 import { renderTemplateAsync } from './templates.js';
 
@@ -1570,12 +1570,13 @@ function normalizePowerUserTokenizer(tokenizer) {
         return tokenizers.BEST_MATCH;
     }
 
-    const hasOption = $(`#counting_tokenizer option[value="${tokenizerType}"], #encoding_tokenizer option[value="${tokenizerType}"]`).length > 0;
-    return hasOption ? tokenizerType : tokenizers.BEST_MATCH;
+    return isSelectableTokenizer(tokenizerType) ? tokenizerType : tokenizers.BEST_MATCH;
 }
 
 export async function loadPowerUserSettings(settings, data) {
     const defaultStscript = JSON.parse(JSON.stringify(power_user.stscript));
+    initTokenizerSelects();
+
     // Load from settings.json
     if (settings.power_user !== undefined) {
         // Migrate old preference to a new setting

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -74,7 +74,7 @@ import { chat_completion_sources, MINIMAX_ENDPOINT, oai_settings, POLLINATIONS_E
 import { user_avatar } from './personas.js';
 import { addEphemeralStoppingString, chat_styles, context_presets, flushEphemeralStoppingStrings, playMessageSound, power_user } from './power-user.js';
 import { SERVER_INPUTS, textgen_types, textgenerationwebui_settings } from './textgen-settings.js';
-import { decodeTextTokens, getAvailableTokenizers, getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, selectTokenizer, tokenizerSettings } from './tokenizers.js';
+import { decodeTextTokens, getAvailableTokenizers, getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, selectTokenizer, tokenizer_settings } from './tokenizers.js';
 import { debounce, delay, equalsIgnoreCaseAndAccents, findChar, getCharIndex, isFalseBoolean, isTrueBoolean, onlyUnique, regexFromString, showFontAwesomePicker, stringToRange, trimToEndSentence, trimToStartSentence, waitUntilCondition } from './utils.js';
 import { registerVariableCommands, resolveVariable } from './variables.js';
 import { registerActionLoaderSlashCommands } from './action-loader-slashcommands.js';
@@ -3182,8 +3182,8 @@ export function initDefaultSlashCommands() {
                 name: 'target',
                 description: t`tokenizer setting to update`,
                 typeList: [ARGUMENT_TYPE.STRING],
-                defaultValue: tokenizerSettings.BOTH,
-                enumList: [tokenizerSettings.COUNTING, tokenizerSettings.ENCODING, tokenizerSettings.BOTH],
+                defaultValue: tokenizer_settings.BOTH,
+                enumList: [tokenizer_settings.COUNTING, tokenizer_settings.ENCODING, tokenizer_settings.BOTH],
                 forceEnum: true,
             }),
         ],
@@ -3996,7 +3996,7 @@ async function trimTokensCallback(arg, value) {
         return value;
     }
 
-    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, tokenizerSettings.ENCODING);
+    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, tokenizer_settings.ENCODING);
     console.debug('Requesting tokenization for /trimtokens command', tokenizerName);
 
     try {
@@ -6800,13 +6800,13 @@ async function setApiUrlCallback({ api = null, connect = 'true', quiet = 'false'
 }
 
 async function selectTokenizerCallback(_, name) {
-    const target = [tokenizerSettings.COUNTING, tokenizerSettings.ENCODING].includes(_.target)
+    const target = [tokenizer_settings.COUNTING, tokenizer_settings.ENCODING].includes(_.target)
         ? _.target
-        : tokenizerSettings.BOTH;
+        : tokenizer_settings.BOTH;
 
     if (!name) {
-        const counting = getFriendlyTokenizerName(main_api, tokenizerSettings.COUNTING).tokenizerKey;
-        const encoding = getFriendlyTokenizerName(main_api, tokenizerSettings.ENCODING).tokenizerKey;
+        const counting = getFriendlyTokenizerName(main_api, tokenizer_settings.COUNTING).tokenizerKey;
+        const encoding = getFriendlyTokenizerName(main_api, tokenizer_settings.ENCODING).tokenizerKey;
         return `counting=${counting}, encoding=${encoding}`;
     }
 

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3197,10 +3197,7 @@ export function initDefaultSlashCommands() {
         ],
         helpString: `
             <div>
-                ${t`Selects counting and/or encoding tokenizer by name. Gets the current tokenizers if no name is provided.`}
-            </div>
-            <div>
-                ${t`When getting, returns <code>counting=&lt;name&gt;, encoding=&lt;name&gt;</code>.`}
+                ${t`Selects counting and/or encoding tokenizer by name. Gets the current counting tokenizer if no name is provided.`}
             </div>
             <div>
                 ${t`Use <code>target=counting</code>, <code>target=encoding</code>, or <code>target=both</code> to choose which setting to update.`}
@@ -6805,9 +6802,7 @@ async function selectTokenizerCallback(_, name) {
         : tokenizer_settings.BOTH;
 
     if (!name) {
-        const counting = getFriendlyTokenizerName(main_api, { target: tokenizer_settings.COUNTING }).tokenizerKey;
-        const encoding = getFriendlyTokenizerName(main_api, { target: tokenizer_settings.ENCODING }).tokenizerKey;
-        return `counting=${counting}, encoding=${encoding}`;
+        return getAvailableTokenizers().find(tokenizer => tokenizer.tokenizerId === power_user.counting_tokenizer)?.tokenizerKey ?? '';
     }
 
     const tokenizers = getAvailableTokenizers();

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -6796,9 +6796,9 @@ async function setApiUrlCallback({ api = null, connect = 'true', quiet = 'false'
     return textgenerationwebui_settings.server_urls[type] ?? '';
 }
 
-async function selectTokenizerCallback(_, name) {
-    const target = [tokenizer_settings.COUNTING, tokenizer_settings.ENCODING].includes(_.target)
-        ? _.target
+async function selectTokenizerCallback(args, name) {
+    const target = [tokenizer_settings.COUNTING, tokenizer_settings.ENCODING].includes(args.target)
+        ? args.target
         : tokenizer_settings.BOTH;
 
     if (!name) {

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3200,7 +3200,13 @@ export function initDefaultSlashCommands() {
                 ${t`Selects counting and/or encoding tokenizer by name. Gets the current tokenizers if no name is provided.`}
             </div>
             <div>
+                ${t`When getting, returns <code>counting=&lt;name&gt;, encoding=&lt;name&gt;</code>.`}
+            </div>
+            <div>
                 ${t`Use <code>target=counting</code>, <code>target=encoding</code>, or <code>target=both</code> to choose which setting to update.`}
+            </div>
+            <div>
+                ${t`When setting <code>target=both</code>, provide one tokenizer name to apply to both settings.`}
             </div>
             <div>
                 <strong>${t`Available tokenizers:`}</strong>

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -74,7 +74,7 @@ import { chat_completion_sources, MINIMAX_ENDPOINT, oai_settings, POLLINATIONS_E
 import { user_avatar } from './personas.js';
 import { addEphemeralStoppingString, chat_styles, context_presets, flushEphemeralStoppingStrings, playMessageSound, power_user } from './power-user.js';
 import { SERVER_INPUTS, textgen_types, textgenerationwebui_settings } from './textgen-settings.js';
-import { decodeTextTokens, getAvailableTokenizers, getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, selectTokenizer } from './tokenizers.js';
+import { decodeTextTokens, getAvailableTokenizers, getFriendlyTokenizerName, getTextTokens, getTokenCountAsync, selectTokenizer, tokenizerSettings } from './tokenizers.js';
 import { debounce, delay, equalsIgnoreCaseAndAccents, findChar, getCharIndex, isFalseBoolean, isTrueBoolean, onlyUnique, regexFromString, showFontAwesomePicker, stringToRange, trimToEndSentence, trimToStartSentence, waitUntilCondition } from './utils.js';
 import { registerVariableCommands, resolveVariable } from './variables.js';
 import { registerActionLoaderSlashCommands } from './action-loader-slashcommands.js';
@@ -3177,6 +3177,16 @@ export function initDefaultSlashCommands() {
         name: 'tokenizer',
         callback: selectTokenizerCallback,
         returns: t`current tokenizer`,
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'target',
+                description: t`tokenizer setting to update`,
+                typeList: [ARGUMENT_TYPE.STRING],
+                defaultValue: tokenizerSettings.BOTH,
+                enumList: [tokenizerSettings.COUNTING, tokenizerSettings.ENCODING, tokenizerSettings.BOTH],
+                forceEnum: true,
+            }),
+        ],
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: t`tokenizer name`,
@@ -3187,7 +3197,10 @@ export function initDefaultSlashCommands() {
         ],
         helpString: `
             <div>
-                ${t`Selects tokenizer by name. Gets the current tokenizer if no name is provided.`}
+                ${t`Selects counting and/or encoding tokenizer by name. Gets the current tokenizers if no name is provided.`}
+            </div>
+            <div>
+                ${t`Use <code>target=counting</code>, <code>target=encoding</code>, or <code>target=both</code> to choose which setting to update.`}
             </div>
             <div>
                 <strong>${t`Available tokenizers:`}</strong>
@@ -3977,7 +3990,7 @@ async function trimTokensCallback(arg, value) {
         return value;
     }
 
-    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api);
+    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, tokenizerSettings.ENCODING);
     console.debug('Requesting tokenization for /trimtokens command', tokenizerName);
 
     try {
@@ -6781,8 +6794,14 @@ async function setApiUrlCallback({ api = null, connect = 'true', quiet = 'false'
 }
 
 async function selectTokenizerCallback(_, name) {
+    const target = [tokenizerSettings.COUNTING, tokenizerSettings.ENCODING].includes(_.target)
+        ? _.target
+        : tokenizerSettings.BOTH;
+
     if (!name) {
-        return getAvailableTokenizers().find(tokenizer => tokenizer.tokenizerId === power_user.tokenizer)?.tokenizerKey ?? '';
+        const counting = getFriendlyTokenizerName(main_api, tokenizerSettings.COUNTING).tokenizerKey;
+        const encoding = getFriendlyTokenizerName(main_api, tokenizerSettings.ENCODING).tokenizerKey;
+        return `counting=${counting}, encoding=${encoding}`;
     }
 
     const tokenizers = getAvailableTokenizers();
@@ -6796,7 +6815,7 @@ async function selectTokenizerCallback(_, name) {
 
     /** @type {import('./tokenizers.js').Tokenizer} */
     const foundTokenizer = result[0].item;
-    selectTokenizer(foundTokenizer.tokenizerId);
+    selectTokenizer(foundTokenizer.tokenizerId, target);
 
     return foundTokenizer.tokenizerKey;
 }

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -3996,7 +3996,7 @@ async function trimTokensCallback(arg, value) {
         return value;
     }
 
-    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, tokenizer_settings.ENCODING);
+    const { tokenizerName, tokenizerId } = getFriendlyTokenizerName(main_api, { target: tokenizer_settings.ENCODING });
     console.debug('Requesting tokenization for /trimtokens command', tokenizerName);
 
     try {
@@ -6805,8 +6805,8 @@ async function selectTokenizerCallback(_, name) {
         : tokenizer_settings.BOTH;
 
     if (!name) {
-        const counting = getFriendlyTokenizerName(main_api, tokenizer_settings.COUNTING).tokenizerKey;
-        const encoding = getFriendlyTokenizerName(main_api, tokenizer_settings.ENCODING).tokenizerKey;
+        const counting = getFriendlyTokenizerName(main_api, { target: tokenizer_settings.COUNTING }).tokenizerKey;
+        const encoding = getFriendlyTokenizerName(main_api, { target: tokenizer_settings.ENCODING }).tokenizerKey;
         return `counting=${counting}, encoding=${encoding}`;
     }
 
@@ -6821,7 +6821,7 @@ async function selectTokenizerCallback(_, name) {
 
     /** @type {import('./tokenizers.js').Tokenizer} */
     const foundTokenizer = result[0].item;
-    selectTokenizer(foundTokenizer.tokenizerId, target);
+    selectTokenizer(foundTokenizer.tokenizerId, { target });
 
     return foundTokenizer.tokenizerKey;
 }

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -99,7 +99,7 @@ import { SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { tag_map, tags, importTags } from './tags.js';
 import { getTextGenServer, textgenerationwebui_settings } from './textgen-settings.js';
-import { tokenizers, getTextTokens, getTokenCount, getTokenCountAsync, getTokenizerModel, tokenizerSettings } from './tokenizers.js';
+import { tokenizers, getTextTokens, getTokenCount, getTokenCountAsync, getTokenizerModel, tokenizer_settings } from './tokenizers.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { timestampToMoment, uuidv4, importFromExternalUrl } from './utils.js';
@@ -145,7 +145,7 @@ export function getContext() {
         sendGenerationRequest,
         stopGeneration,
         tokenizers,
-        tokenizerSettings,
+        tokenizer_settings,
         getTextTokens,
         /** @deprecated Use getTokenCountAsync instead */
         getTokenCount,

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -99,7 +99,7 @@ import { SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { tag_map, tags, importTags } from './tags.js';
 import { getTextGenServer, textgenerationwebui_settings } from './textgen-settings.js';
-import { tokenizers, getTextTokens, getTokenCount, getTokenCountAsync, getTokenizerModel } from './tokenizers.js';
+import { tokenizers, getTextTokens, getTokenCount, getTokenCountAsync, getTokenizerModel, tokenizerSettings } from './tokenizers.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { timestampToMoment, uuidv4, importFromExternalUrl } from './utils.js';
@@ -145,6 +145,7 @@ export function getContext() {
         sendGenerationRequest,
         stopGeneration,
         tokenizers,
+        tokenizerSettings,
         getTextTokens,
         /** @deprecated Use getTokenCountAsync instead */
         getTokenCount,

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -24,7 +24,7 @@ import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPri
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
 import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, updateOpenRouterProvidersWarning } from './textgen-models.js';
-import { ENCODE_TOKENIZERS, TEXTGEN_TOKENIZERS, TOKENIZER_SUPPORTED_KEY, getTextTokens, getTokenizerBestMatch, tokenizers } from './tokenizers.js';
+import { TOKENIZER_SUPPORTED_KEY, getEncodingTokenizerType, getTextTokens, getTokenizerBestMatch, tokenizers } from './tokenizers.js';
 import { AbortReason } from './util/AbortReason.js';
 import { getSortableDelay, onlyUnique, arraysEqual, isObject } from './utils.js';
 
@@ -406,17 +406,19 @@ function convertPresets(presets) {
 }
 
 function getTokenizerForTokenIds() {
+    const encodingTokenizer = getEncodingTokenizerType();
+
+    if (encodingTokenizer === tokenizers.NONE) {
+        return tokenizers.NONE;
+    }
+
+    if (encodingTokenizer !== tokenizers.BEST_MATCH) {
+        return encodingTokenizer;
+    }
+
     const bestMatchTokenizer = getTokenizerBestMatch('textgenerationwebui');
     if (bestMatchTokenizer === tokenizers.API_TEXTGENERATIONWEBUI) {
         return tokenizers.API_CURRENT;
-    }
-
-    if (power_user.tokenizer === tokenizers.API_CURRENT && TEXTGEN_TOKENIZERS.includes(textgenerationwebui_settings.type)) {
-        return tokenizers.API_CURRENT;
-    }
-
-    if (ENCODE_TOKENIZERS.includes(power_user.tokenizer)) {
-        return power_user.tokenizer;
     }
 
     if (textgenerationwebui_settings.type === OPENROUTER) {

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -48,6 +48,28 @@ const TOKENIZER_SELECTORS = {
     [tokenizer_settings.ENCODING]: '#encoding_tokenizer',
 };
 
+const TOKENIZER_OPTIONS = [
+    { tokenizerId: tokenizers.BEST_MATCH, tokenizerName: 'Best match (recommended)' },
+    { tokenizerId: tokenizers.NONE, tokenizerName: 'None / Estimated' },
+    { tokenizerId: tokenizers.GPT2, tokenizerName: 'GPT-2' },
+    // Option #2 was a legacy GPT-2/3 tokenizer setting and is no longer selectable.
+    { tokenizerId: tokenizers.LLAMA, tokenizerName: 'Llama 1/2' },
+    { tokenizerId: tokenizers.LLAMA3, tokenizerName: 'Llama 3' },
+    { tokenizerId: tokenizers.GEMMA, tokenizerName: 'Gemma / Gemini' },
+    { tokenizerId: tokenizers.JAMBA, tokenizerName: 'Jamba' },
+    { tokenizerId: tokenizers.QWEN2, tokenizerName: 'Qwen2' },
+    { tokenizerId: tokenizers.COMMAND_R, tokenizerName: 'Command-R' },
+    { tokenizerId: tokenizers.COMMAND_A, tokenizerName: 'Command-A' },
+    { tokenizerId: tokenizers.NERD, tokenizerName: 'NerdStash (NovelAI Clio)' },
+    { tokenizerId: tokenizers.NERD2, tokenizerName: 'NerdStash v2 (NovelAI Kayra)' },
+    { tokenizerId: tokenizers.MISTRAL, tokenizerName: 'Mistral V1' },
+    { tokenizerId: tokenizers.NEMO, tokenizerName: 'Mistral Nemo' },
+    { tokenizerId: tokenizers.YI, tokenizerName: 'Yi' },
+    { tokenizerId: tokenizers.CLAUDE, tokenizerName: 'Claude 1/2' },
+    { tokenizerId: tokenizers.DEEPSEEK, tokenizerName: 'DeepSeek V3' },
+    { tokenizerId: tokenizers.API_CURRENT, tokenizerName: 'API (WebUI / koboldcpp)' },
+];
+
 // A list of local tokenizers that support encoding and decoding token ids.
 export const ENCODE_TOKENIZERS = [
     tokenizers.LLAMA,
@@ -221,12 +243,34 @@ async function resetTokenCache() {
  * @returns {Tokenizer[]} Tokenizer info.
  */
 export function getAvailableTokenizers() {
-    const tokenizerOptions = $(TOKENIZER_SELECTORS[tokenizer_settings.COUNTING]).find('option').toArray();
-    return tokenizerOptions.map(tokenizerOption => ({
-        tokenizerId: Number(tokenizerOption.value),
-        tokenizerKey: Object.entries(tokenizers).find(([_, value]) => value === Number(tokenizerOption.value))[0].toLocaleLowerCase(),
-        tokenizerName: tokenizerOption.text,
+    return TOKENIZER_OPTIONS.map(tokenizerOption => ({
+        ...tokenizerOption,
+        tokenizerKey: Object.entries(tokenizers).find(([_, value]) => value === tokenizerOption.tokenizerId)[0].toLocaleLowerCase(),
     }));
+}
+
+/**
+ * Checks if a tokenizer type is selectable in the tokenizer settings UI.
+ * @param {number} tokenizerType Tokenizer type.
+ * @returns {boolean} True if tokenizer is selectable.
+ */
+export function isSelectableTokenizer(tokenizerType) {
+    return TOKENIZER_OPTIONS.some(tokenizerOption => tokenizerOption.tokenizerId === tokenizerType);
+}
+
+export function initTokenizerSelects() {
+    const options = getAvailableTokenizers().map(tokenizer => new Option(tokenizer.tokenizerName, String(tokenizer.tokenizerId)));
+
+    for (const selector of Object.values(TOKENIZER_SELECTORS)) {
+        const select = $(selector);
+        const selected = select.val();
+
+        select.empty().append(options.map(option => option.cloneNode(true)));
+
+        if (selected !== null) {
+            select.val(selected);
+        }
+    }
 }
 
 /**
@@ -1360,6 +1404,8 @@ export function decodeTextTokens(tokenizerType, ids) {
 }
 
 export async function initTokenizers() {
+    initTokenizerSelects();
+
     TEXTGEN_TOKENIZERS.push(
         textgen_types.OOBA,
         textgen_types.TABBY,

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -37,6 +37,17 @@ export const tokenizers = {
     BEST_MATCH: 99,
 };
 
+export const tokenizerSettings = {
+    COUNTING: 'counting',
+    ENCODING: 'encoding',
+    BOTH: 'both',
+};
+
+const TOKENIZER_SELECTORS = {
+    [tokenizerSettings.COUNTING]: '#counting_tokenizer',
+    [tokenizerSettings.ENCODING]: '#encoding_tokenizer',
+};
+
 // A list of local tokenizers that support encoding and decoding token ids.
 export const ENCODE_TOKENIZERS = [
     tokenizers.LLAMA,
@@ -210,7 +221,7 @@ async function resetTokenCache() {
  * @returns {Tokenizer[]} Tokenizer info.
  */
 export function getAvailableTokenizers() {
-    const tokenizerOptions = $('#tokenizer').find('option').toArray();
+    const tokenizerOptions = $(TOKENIZER_SELECTORS[tokenizerSettings.COUNTING]).find('option').toArray();
     return tokenizerOptions.map(tokenizerOption => ({
         tokenizerId: Number(tokenizerOption.value),
         tokenizerKey: Object.entries(tokenizers).find(([_, value]) => value === Number(tokenizerOption.value))[0].toLocaleLowerCase(),
@@ -219,19 +230,65 @@ export function getAvailableTokenizers() {
 }
 
 /**
+ * Gets tokenizer info by tokenizer ID.
+ * @param {number} tokenizerId Tokenizer ID.
+ * @returns {Tokenizer|null} Tokenizer info.
+ */
+function getTokenizerInfo(tokenizerId) {
+    return getAvailableTokenizers().find(tokenizer => tokenizer.tokenizerId === tokenizerId) ?? null;
+}
+
+/**
+ * Gets the selected tokenizer setting value.
+ * @param {string} target Tokenizer setting target.
+ * @returns {number} Tokenizer type.
+ */
+function getTokenizerSetting(target) {
+    const tokenizerType = target === tokenizerSettings.ENCODING
+        ? power_user.encoding_tokenizer
+        : power_user.counting_tokenizer;
+    return typeof tokenizerType === 'number' ? tokenizerType : tokenizers.BEST_MATCH;
+}
+
+/**
+ * Gets the counting tokenizer setting value.
+ * @returns {number} Tokenizer type.
+ */
+export function getCountingTokenizerType() {
+    return getTokenizerSetting(tokenizerSettings.COUNTING);
+}
+
+/**
+ * Gets the encoding tokenizer setting value.
+ * @returns {number} Tokenizer type.
+ */
+export function getEncodingTokenizerType() {
+    return getTokenizerSetting(tokenizerSettings.ENCODING);
+}
+
+/**
  * Selects tokenizer if not already selected.
  * @param {number} tokenizerId Tokenizer ID.
  */
-export function selectTokenizer(tokenizerId) {
-    if (tokenizerId !== power_user.tokenizer) {
-        const tokenizer = getAvailableTokenizers().find(tokenizer => tokenizer.tokenizerId === tokenizerId);
-        if (!tokenizer) {
-            console.warn('Failed to find tokenizer with id', tokenizerId);
-            return;
-        }
-        $('#tokenizer').val(tokenizer.tokenizerId).trigger('change');
-        toastr.info(`Tokenizer: "${tokenizer.tokenizerName}" selected`);
+export function selectTokenizer(tokenizerId, target = tokenizerSettings.BOTH) {
+    const tokenizer = getTokenizerInfo(tokenizerId);
+    if (!tokenizer) {
+        console.warn('Failed to find tokenizer with id', tokenizerId);
+        return;
     }
+
+    const targets = target === tokenizerSettings.BOTH
+        ? [tokenizerSettings.COUNTING, tokenizerSettings.ENCODING]
+        : [target];
+
+    for (const tokenizerTarget of targets) {
+        if (tokenizerId !== getTokenizerSetting(tokenizerTarget)) {
+            $(TOKENIZER_SELECTORS[tokenizerTarget]).val(tokenizer.tokenizerId).trigger('change');
+        }
+    }
+
+    const targetName = target === tokenizerSettings.BOTH ? 'Tokenizer' : `${target} tokenizer`;
+    toastr.info(`${targetName}: "${tokenizer.tokenizerName}" selected`);
 }
 
 /**
@@ -239,16 +296,15 @@ export function selectTokenizer(tokenizerId) {
  * @param {string} forApi API to get the tokenizer for. Defaults to the main API.
  * @returns {Tokenizer} Tokenizer info
  */
-export function getFriendlyTokenizerName(forApi) {
+export function getFriendlyTokenizerName(forApi, target = tokenizerSettings.COUNTING) {
     if (!forApi) {
         forApi = main_api;
     }
 
-    const tokenizerOption = $('#tokenizer').find(':selected');
-    let tokenizerId = Number(tokenizerOption.val());
-    let tokenizerName = tokenizerOption.text();
+    let tokenizerId = getTokenizerSetting(target);
+    let tokenizerName = getTokenizerInfo(tokenizerId)?.tokenizerName ?? '';
 
-    if (forApi !== 'openai' && tokenizerId === tokenizers.BEST_MATCH) {
+    if (tokenizerId === tokenizers.BEST_MATCH) {
         tokenizerId = getTokenizerBestMatch(forApi);
 
         switch (tokenizerId) {
@@ -259,22 +315,76 @@ export function getFriendlyTokenizerName(forApi) {
                 tokenizerName = 'API (Text Completion)';
                 break;
             default:
-                tokenizerName = $(`#tokenizer option[value="${tokenizerId}"]`).text();
+                tokenizerName = getTokenizerInfo(tokenizerId)?.tokenizerName ?? '';
                 break;
         }
     }
 
-    tokenizerName = forApi == 'openai'
+    tokenizerName = forApi == 'openai' && getTokenizerSetting(target) === tokenizers.BEST_MATCH
         ? getTokenizerModel()
         : tokenizerName;
 
-    tokenizerId = forApi == 'openai'
+    tokenizerId = forApi == 'openai' && getTokenizerSetting(target) === tokenizers.BEST_MATCH
         ? tokenizers.OPENAI
         : tokenizerId;
 
     const tokenizerKey = Object.entries(tokenizers).find(([_, value]) => value === tokenizerId)[0].toLocaleLowerCase();
 
     return { tokenizerName, tokenizerKey, tokenizerId };
+}
+
+/**
+ * Resolves a tokenizer setting into an actual tokenizer type.
+ * @param {number} tokenizerType Tokenizer setting value.
+ * @param {string} forApi API to resolve best match for.
+ * @returns {number} Resolved tokenizer type.
+ */
+function resolveTokenizerType(tokenizerType, forApi = main_api) {
+    return tokenizerType === tokenizers.BEST_MATCH ? getTokenizerBestMatch(forApi) : tokenizerType;
+}
+
+/**
+ * Maps a tokenizer type to a model name accepted by the OpenAI-compatible tokenizer endpoints.
+ * @param {number} tokenizerType Tokenizer type.
+ * @returns {string|null} Tokenizer model name.
+ */
+export function getTokenizerModelForType(tokenizerType) {
+    switch (tokenizerType) {
+        case tokenizers.GPT2:
+            return 'gpt2';
+        case tokenizers.OPENAI:
+            return getTokenizerModel();
+        case tokenizers.LLAMA:
+            return 'llama';
+        case tokenizers.NERD:
+            return 'nerdstash';
+        case tokenizers.NERD2:
+            return 'nerdstash_v2';
+        case tokenizers.MISTRAL:
+            return 'mistral';
+        case tokenizers.YI:
+            return 'yi';
+        case tokenizers.CLAUDE:
+            return 'claude';
+        case tokenizers.LLAMA3:
+            return 'llama3';
+        case tokenizers.GEMMA:
+            return 'gemma';
+        case tokenizers.JAMBA:
+            return 'jamba';
+        case tokenizers.QWEN2:
+            return 'qwen2';
+        case tokenizers.COMMAND_R:
+            return 'command-r';
+        case tokenizers.COMMAND_A:
+            return 'command-a';
+        case tokenizers.NEMO:
+            return 'nemo';
+        case tokenizers.DEEPSEEK:
+            return 'deepseek';
+        default:
+            return null;
+    }
 }
 
 /**
@@ -377,6 +487,17 @@ function currentRemoteTokenizerAPI() {
 }
 
 /**
+ * Gets model-specific cache suffix for remote API tokenizers.
+ * @param {number} tokenizerType Tokenizer type.
+ * @returns {string} Cache suffix.
+ */
+function getTokenizerModelHash(tokenizerType) {
+    return tokenizerType === tokenizers.API_TEXTGENERATIONWEBUI
+        ? getStringHash(getTextGenModel() || online_status).toString()
+        : '';
+}
+
+/**
  * Calls the underlying tokenizer model to the token count for a string.
  * @param {number} type Tokenizer type.
  * @param {string} str String to tokenize.
@@ -445,26 +566,23 @@ export async function getTokenCountAsync(str, padding = undefined) {
         return 0;
     }
 
-    let tokenizerType = power_user.tokenizer;
+    const selectedTokenizerType = getCountingTokenizerType();
+    let tokenizerType = selectedTokenizerType;
     let modelHash = '';
 
     if (main_api === 'openai') {
-        if (padding === power_user.token_padding) {
+        if (selectedTokenizerType === tokenizers.BEST_MATCH && padding === power_user.token_padding) {
             // For main "shadow" prompt building
             tokenizerType = tokenizers.NONE;
-        } else {
+        } else if (selectedTokenizerType === tokenizers.BEST_MATCH) {
             // For extensions and WI
             return counterWrapperOpenAIAsync(str);
         }
     }
 
-    if (tokenizerType === tokenizers.BEST_MATCH) {
-        tokenizerType = getTokenizerBestMatch(main_api);
-    }
+    tokenizerType = resolveTokenizerType(tokenizerType, main_api);
 
-    if (tokenizerType === tokenizers.API_TEXTGENERATIONWEBUI) {
-        modelHash = getStringHash(getTextGenModel() || online_status).toString();
-    }
+    modelHash = getTokenizerModelHash(tokenizerType);
 
     if (padding === undefined) {
         padding = 0;
@@ -501,26 +619,23 @@ export function getTokenCount(str, padding = undefined) {
         return 0;
     }
 
-    let tokenizerType = power_user.tokenizer;
+    const selectedTokenizerType = getCountingTokenizerType();
+    let tokenizerType = selectedTokenizerType;
     let modelHash = '';
 
     if (main_api === 'openai') {
-        if (padding === power_user.token_padding) {
+        if (selectedTokenizerType === tokenizers.BEST_MATCH && padding === power_user.token_padding) {
             // For main "shadow" prompt building
             tokenizerType = tokenizers.NONE;
-        } else {
+        } else if (selectedTokenizerType === tokenizers.BEST_MATCH) {
             // For extensions and WI
             return counterWrapperOpenAI(str);
         }
     }
 
-    if (tokenizerType === tokenizers.BEST_MATCH) {
-        tokenizerType = getTokenizerBestMatch(main_api);
-    }
+    tokenizerType = resolveTokenizerType(tokenizerType, main_api);
 
-    if (tokenizerType === tokenizers.API_TEXTGENERATIONWEBUI) {
-        modelHash = getStringHash(getTextGenModel() || online_status).toString();
-    }
+    modelHash = getTokenizerModelHash(tokenizerType);
 
     if (padding === undefined) {
         padding = 0;
@@ -794,28 +909,46 @@ export function getTokenizerModel() {
  * @deprecated Use countTokensOpenAIAsync instead.
  */
 export function countTokensOpenAI(messages, full = false) {
-    const tokenizerEndpoint = `/api/tokenizers/openai/count?model=${getTokenizerModel()}`;
+    const selectedTokenizerType = getCountingTokenizerType();
+    const resolvedTokenizerType = resolveTokenizerType(selectedTokenizerType, 'openai');
+    const countingTokenizerType = resolvedTokenizerType === tokenizers.API_CURRENT
+        ? currentRemoteTokenizerAPI()
+        : resolvedTokenizerType;
+    const model = selectedTokenizerType === tokenizers.BEST_MATCH
+        ? getTokenizerModel()
+        : getTokenizerModelForType(countingTokenizerType);
+    const tokenizerEndpoint = model ? `/api/tokenizers/openai/count?model=${model}` : null;
     const cacheObject = getTokenCacheObject();
+    const modelHash = getTokenizerModelHash(countingTokenizerType);
 
     if (!Array.isArray(messages)) {
         messages = [messages];
     }
 
+    if (!tokenizerEndpoint) {
+        full = true;
+    }
+
     let token_count = 0;
 
     for (const message of messages) {
-        const model = getTokenizerModel();
+        const cacheModel = model ?? `${countingTokenizerType}${modelHash}`;
 
         if (model === 'claude') {
             full = true;
         }
 
         const hash = getStringHash(JSON.stringify(message));
-        const cacheKey = `${model}-${hash}`;
+        const cacheKey = `${cacheModel}-${hash}`;
         const cachedCount = cacheObject[cacheKey];
 
         if (typeof cachedCount === 'number') {
             token_count += cachedCount;
+        } else if (!tokenizerEndpoint) {
+            const jsonBody = Object.values(message).join('\n\n');
+            const count = callTokenizer(countingTokenizerType, jsonBody);
+            token_count += count;
+            cacheObject[cacheKey] = count;
         } else {
             jQuery.ajax({
                 async: false,
@@ -844,28 +977,46 @@ export function countTokensOpenAI(messages, full = false) {
  * @returns {Promise<number>} Token count.
  */
 export async function countTokensOpenAIAsync(messages, full = false) {
-    const tokenizerEndpoint = `/api/tokenizers/openai/count?model=${getTokenizerModel()}`;
+    const selectedTokenizerType = getCountingTokenizerType();
+    const resolvedTokenizerType = resolveTokenizerType(selectedTokenizerType, 'openai');
+    const countingTokenizerType = resolvedTokenizerType === tokenizers.API_CURRENT
+        ? currentRemoteTokenizerAPI()
+        : resolvedTokenizerType;
+    const model = selectedTokenizerType === tokenizers.BEST_MATCH
+        ? getTokenizerModel()
+        : getTokenizerModelForType(countingTokenizerType);
+    const tokenizerEndpoint = model ? `/api/tokenizers/openai/count?model=${model}` : null;
     const cacheObject = getTokenCacheObject();
+    const modelHash = getTokenizerModelHash(countingTokenizerType);
 
     if (!Array.isArray(messages)) {
         messages = [messages];
     }
 
+    if (!tokenizerEndpoint) {
+        full = true;
+    }
+
     let token_count = 0;
 
     for (const message of messages) {
-        const model = getTokenizerModel();
+        const cacheModel = model ?? `${countingTokenizerType}${modelHash}`;
 
         if (model === 'claude') {
             full = true;
         }
 
         const hash = getStringHash(JSON.stringify(message));
-        const cacheKey = `${model}-${hash}`;
+        const cacheKey = `${cacheModel}-${hash}`;
         const cachedCount = cacheObject[cacheKey];
 
         if (typeof cachedCount === 'number') {
             token_count += cachedCount;
+        } else if (!tokenizerEndpoint) {
+            const jsonBody = Object.values(message).join('\n\n');
+            const count = await callTokenizerAsync(countingTokenizerType, jsonBody);
+            token_count += count;
+            cacheObject[cacheKey] = count;
         } else {
             const data = await jQuery.ajax({
                 async: true,
@@ -1030,7 +1181,7 @@ function apiFailureTokenCount(str) {
     }
 
     // Only try again if we guarantee not to be looped by the same error
-    if (shouldTryAgain && power_user.tokenizer === tokenizers.BEST_MATCH) {
+    if (shouldTryAgain && getCountingTokenizerType() === tokenizers.BEST_MATCH) {
         return getTokenCount(str);
     }
 
@@ -1228,4 +1379,3 @@ export async function initTokenizers() {
     await loadTokenCache();
     registerDebugFunction('resetTokenCache', 'Reset token cache', 'Purges the calculated token counts. Use this if you want to force a full re-tokenization of all chats or suspect the token counts are wrong.', resetTokenCache);
 }
-

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -269,8 +269,10 @@ export function getEncodingTokenizerType() {
 /**
  * Selects tokenizer if not already selected.
  * @param {number} tokenizerId Tokenizer ID.
+ * @param {object} [options] Options.
+ * @param {string} [options.target] Tokenizer setting target.
  */
-export function selectTokenizer(tokenizerId, target = tokenizer_settings.BOTH) {
+export function selectTokenizer(tokenizerId, { target = tokenizer_settings.BOTH } = {}) {
     const tokenizer = getTokenizerInfo(tokenizerId);
     if (!tokenizer) {
         console.warn('Failed to find tokenizer with id', tokenizerId);
@@ -294,9 +296,11 @@ export function selectTokenizer(tokenizerId, target = tokenizer_settings.BOTH) {
 /**
  * Gets the friendly name of the current tokenizer.
  * @param {string} forApi API to get the tokenizer for. Defaults to the main API.
+ * @param {object} [options] Options.
+ * @param {string} [options.target] Tokenizer setting target.
  * @returns {Tokenizer} Tokenizer info
  */
-export function getFriendlyTokenizerName(forApi, target = tokenizer_settings.COUNTING) {
+export function getFriendlyTokenizerName(forApi, { target = tokenizer_settings.COUNTING } = {}) {
     if (!forApi) {
         forApi = main_api;
     }
@@ -637,7 +641,7 @@ function counterWrapperOpenAIAsync(text) {
     return countTokensOpenAIAsync(message, true);
 }
 
-export function getTokenizerModel(tokenizerType = tokenizers.BEST_MATCH) {
+export function getTokenizerModel({ tokenizerType = tokenizers.BEST_MATCH } = {}) {
     switch (tokenizerType) {
         case tokenizers.GPT2:
             return 'gpt2';
@@ -910,7 +914,7 @@ export function countTokensOpenAI(messages, full = false) {
         : resolvedTokenizerType;
     const model = selectedTokenizerType === tokenizers.BEST_MATCH
         ? getTokenizerModel()
-        : getTokenizerModel(countingTokenizerType);
+        : getTokenizerModel({ tokenizerType: countingTokenizerType });
     const tokenizerEndpoint = model ? `/api/tokenizers/openai/count?model=${model}` : null;
     const cacheObject = getTokenCacheObject();
     const modelHash = getTokenizerModelHash(countingTokenizerType);
@@ -978,7 +982,7 @@ export async function countTokensOpenAIAsync(messages, full = false) {
         : resolvedTokenizerType;
     const model = selectedTokenizerType === tokenizers.BEST_MATCH
         ? getTokenizerModel()
-        : getTokenizerModel(countingTokenizerType);
+        : getTokenizerModel({ tokenizerType: countingTokenizerType });
     const tokenizerEndpoint = model ? `/api/tokenizers/openai/count?model=${model}` : null;
     const cacheObject = getTokenCacheObject();
     const modelHash = getTokenizerModelHash(countingTokenizerType);

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -344,50 +344,6 @@ function resolveTokenizerType(tokenizerType, forApi = main_api) {
 }
 
 /**
- * Maps a tokenizer type to a model name accepted by the OpenAI-compatible tokenizer endpoints.
- * @param {number} tokenizerType Tokenizer type.
- * @returns {string|null} Tokenizer model name.
- */
-export function getTokenizerModelForType(tokenizerType) {
-    switch (tokenizerType) {
-        case tokenizers.GPT2:
-            return 'gpt2';
-        case tokenizers.OPENAI:
-            return getTokenizerModel();
-        case tokenizers.LLAMA:
-            return 'llama';
-        case tokenizers.NERD:
-            return 'nerdstash';
-        case tokenizers.NERD2:
-            return 'nerdstash_v2';
-        case tokenizers.MISTRAL:
-            return 'mistral';
-        case tokenizers.YI:
-            return 'yi';
-        case tokenizers.CLAUDE:
-            return 'claude';
-        case tokenizers.LLAMA3:
-            return 'llama3';
-        case tokenizers.GEMMA:
-            return 'gemma';
-        case tokenizers.JAMBA:
-            return 'jamba';
-        case tokenizers.QWEN2:
-            return 'qwen2';
-        case tokenizers.COMMAND_R:
-            return 'command-r';
-        case tokenizers.COMMAND_A:
-            return 'command-a';
-        case tokenizers.NEMO:
-            return 'nemo';
-        case tokenizers.DEEPSEEK:
-            return 'deepseek';
-        default:
-            return null;
-    }
-}
-
-/**
  * Gets the best tokenizer for the current API.
  * @param {string} forApi API to get the tokenizer for. Defaults to the main API.
  * @returns {number} Tokenizer type.
@@ -681,7 +637,45 @@ function counterWrapperOpenAIAsync(text) {
     return countTokensOpenAIAsync(message, true);
 }
 
-export function getTokenizerModel() {
+export function getTokenizerModel(tokenizerType = tokenizers.BEST_MATCH) {
+    switch (tokenizerType) {
+        case tokenizers.GPT2:
+            return 'gpt2';
+        case tokenizers.LLAMA:
+            return 'llama';
+        case tokenizers.NERD:
+            return 'nerdstash';
+        case tokenizers.NERD2:
+            return 'nerdstash_v2';
+        case tokenizers.MISTRAL:
+            return 'mistral';
+        case tokenizers.YI:
+            return 'yi';
+        case tokenizers.CLAUDE:
+            return 'claude';
+        case tokenizers.LLAMA3:
+            return 'llama3';
+        case tokenizers.GEMMA:
+            return 'gemma';
+        case tokenizers.JAMBA:
+            return 'jamba';
+        case tokenizers.QWEN2:
+            return 'qwen2';
+        case tokenizers.COMMAND_R:
+            return 'command-r';
+        case tokenizers.COMMAND_A:
+            return 'command-a';
+        case tokenizers.NEMO:
+            return 'nemo';
+        case tokenizers.DEEPSEEK:
+            return 'deepseek';
+        case tokenizers.BEST_MATCH:
+        case tokenizers.OPENAI:
+            break;
+        default:
+            return null;
+    }
+
     // OpenAI models always provide their own tokenizer
     if (oai_settings.chat_completion_source == chat_completion_sources.OPENAI) {
         return oai_settings.openai_model;
@@ -916,7 +910,7 @@ export function countTokensOpenAI(messages, full = false) {
         : resolvedTokenizerType;
     const model = selectedTokenizerType === tokenizers.BEST_MATCH
         ? getTokenizerModel()
-        : getTokenizerModelForType(countingTokenizerType);
+        : getTokenizerModel(countingTokenizerType);
     const tokenizerEndpoint = model ? `/api/tokenizers/openai/count?model=${model}` : null;
     const cacheObject = getTokenCacheObject();
     const modelHash = getTokenizerModelHash(countingTokenizerType);
@@ -984,7 +978,7 @@ export async function countTokensOpenAIAsync(messages, full = false) {
         : resolvedTokenizerType;
     const model = selectedTokenizerType === tokenizers.BEST_MATCH
         ? getTokenizerModel()
-        : getTokenizerModelForType(countingTokenizerType);
+        : getTokenizerModel(countingTokenizerType);
     const tokenizerEndpoint = model ? `/api/tokenizers/openai/count?model=${model}` : null;
     const cacheObject = getTokenCacheObject();
     const modelHash = getTokenizerModelHash(countingTokenizerType);

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -37,15 +37,15 @@ export const tokenizers = {
     BEST_MATCH: 99,
 };
 
-export const tokenizerSettings = {
+export const tokenizer_settings = {
     COUNTING: 'counting',
     ENCODING: 'encoding',
     BOTH: 'both',
 };
 
 const TOKENIZER_SELECTORS = {
-    [tokenizerSettings.COUNTING]: '#counting_tokenizer',
-    [tokenizerSettings.ENCODING]: '#encoding_tokenizer',
+    [tokenizer_settings.COUNTING]: '#counting_tokenizer',
+    [tokenizer_settings.ENCODING]: '#encoding_tokenizer',
 };
 
 // A list of local tokenizers that support encoding and decoding token ids.
@@ -221,7 +221,7 @@ async function resetTokenCache() {
  * @returns {Tokenizer[]} Tokenizer info.
  */
 export function getAvailableTokenizers() {
-    const tokenizerOptions = $(TOKENIZER_SELECTORS[tokenizerSettings.COUNTING]).find('option').toArray();
+    const tokenizerOptions = $(TOKENIZER_SELECTORS[tokenizer_settings.COUNTING]).find('option').toArray();
     return tokenizerOptions.map(tokenizerOption => ({
         tokenizerId: Number(tokenizerOption.value),
         tokenizerKey: Object.entries(tokenizers).find(([_, value]) => value === Number(tokenizerOption.value))[0].toLocaleLowerCase(),
@@ -244,7 +244,7 @@ function getTokenizerInfo(tokenizerId) {
  * @returns {number} Tokenizer type.
  */
 function getTokenizerSetting(target) {
-    const tokenizerType = target === tokenizerSettings.ENCODING
+    const tokenizerType = target === tokenizer_settings.ENCODING
         ? power_user.encoding_tokenizer
         : power_user.counting_tokenizer;
     return typeof tokenizerType === 'number' ? tokenizerType : tokenizers.BEST_MATCH;
@@ -255,7 +255,7 @@ function getTokenizerSetting(target) {
  * @returns {number} Tokenizer type.
  */
 export function getCountingTokenizerType() {
-    return getTokenizerSetting(tokenizerSettings.COUNTING);
+    return getTokenizerSetting(tokenizer_settings.COUNTING);
 }
 
 /**
@@ -263,22 +263,22 @@ export function getCountingTokenizerType() {
  * @returns {number} Tokenizer type.
  */
 export function getEncodingTokenizerType() {
-    return getTokenizerSetting(tokenizerSettings.ENCODING);
+    return getTokenizerSetting(tokenizer_settings.ENCODING);
 }
 
 /**
  * Selects tokenizer if not already selected.
  * @param {number} tokenizerId Tokenizer ID.
  */
-export function selectTokenizer(tokenizerId, target = tokenizerSettings.BOTH) {
+export function selectTokenizer(tokenizerId, target = tokenizer_settings.BOTH) {
     const tokenizer = getTokenizerInfo(tokenizerId);
     if (!tokenizer) {
         console.warn('Failed to find tokenizer with id', tokenizerId);
         return;
     }
 
-    const targets = target === tokenizerSettings.BOTH
-        ? [tokenizerSettings.COUNTING, tokenizerSettings.ENCODING]
+    const targets = target === tokenizer_settings.BOTH
+        ? [tokenizer_settings.COUNTING, tokenizer_settings.ENCODING]
         : [target];
 
     for (const tokenizerTarget of targets) {
@@ -287,7 +287,7 @@ export function selectTokenizer(tokenizerId, target = tokenizerSettings.BOTH) {
         }
     }
 
-    const targetName = target === tokenizerSettings.BOTH ? 'Tokenizer' : `${target} tokenizer`;
+    const targetName = target === tokenizer_settings.BOTH ? 'Tokenizer' : `${target} tokenizer`;
     toastr.info(`${targetName}: "${tokenizer.tokenizerName}" selected`);
 }
 
@@ -296,7 +296,7 @@ export function selectTokenizer(tokenizerId, target = tokenizerSettings.BOTH) {
  * @param {string} forApi API to get the tokenizer for. Defaults to the main API.
  * @returns {Tokenizer} Tokenizer info
  */
-export function getFriendlyTokenizerName(forApi, target = tokenizerSettings.COUNTING) {
+export function getFriendlyTokenizerName(forApi, target = tokenizer_settings.COUNTING) {
     if (!forApi) {
         forApi = main_api;
     }

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -293,16 +293,16 @@ export function getSentencepiceTokenizer(model) {
         return spp_llama;
     }
 
+    if (model.includes('nerdstash_v2')) {
+        return spp_nerd_v2;
+    }
+
     if (model.includes('nerdstash')) {
         return spp_nerd;
     }
 
     if (model.includes('mistral')) {
         return spp_mistral;
-    }
-
-    if (model.includes('nerdstash_v2')) {
-        return spp_nerd_v2;
     }
 
     if (model.includes('yi')) {
@@ -472,6 +472,18 @@ export function getTokenizerModel(requestModel) {
 
     if (TEXT_COMPLETION_MODELS.includes(requestModel)) {
         return requestModel;
+    }
+
+    if (requestModel.includes('gpt2')) {
+        return 'gpt2';
+    }
+
+    if (requestModel.includes('nerdstash_v2')) {
+        return 'nerdstash_v2';
+    }
+
+    if (requestModel.includes('nerdstash')) {
+        return 'nerdstash';
     }
 
     if (requestModel.includes('claude')) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Summary

This PR makes tokenizer settings apply to Chat Completion, and separates tokenizer configuration into:

- Counting Tokenizer
- Encoding Tokenizer

This includes breaking changes.

## Changes

The DOM element `#tokenizer` has been removed and replaced with:

- `#counting_tokenizer`
- `#encoding_tokenizer`

New power user settings have been added:

- `power_user.counting_tokenizer`
- `power_user.encoding_tokenizer`

During migration, the existing `power_user.tokenizer` value is copied to both new settings. After migration, `power_user.tokenizer` is removed.

The `/tokenizer` command has also been updated.

<img width="1494" height="600" alt="Screenshot for /tokenizer" src="https://github.com/user-attachments/assets/af969e37-5dde-4edc-b5ea-c784ef20c23e" />


## Notes

Yes, this introduces a breaking change.

The main reason is that I was not sure whether the old `power_user.tokenizer` setting should follow `power_user.counting_tokenizer` or `power_user.encoding_tokenizer`. To avoid preserving ambiguous behavior, I chose to split the setting explicitly.

I also considered splitting this into several stacked PRs, but these changes are fairly tightly coupled in practice, so I decided to keep them together in one PR.

My experience with this part of the codebase is still limited, so feedback and suggestions are very welcome.