### PR TITLE
Macros: Access array and object elements (#4383)

### DIFF
--- a/public/scripts/macros/definitions/variable-macros.js
+++ b/public/scripts/macros/definitions/variable-macros.js
@@ -155,6 +155,61 @@ export function registerVariableMacros() {
         },
     });
 
+
+    // {{setarray::name::index::value}} -> ''
+    MacroRegistry.registerMacro('setarray', {
+        category: MacroCategory.VARIABLE,
+        unnamedArgs: [
+            {
+                name: 'name',
+                type: MacroValueType.STRING,
+                description: 'The name of the local array variable.',
+            },
+            {
+                name: 'index',
+                type: MacroValueType.NUMBER,
+                description: 'The index of the array element to set.',
+            },
+            {
+                name: 'value',
+                type: [MacroValueType.STRING, MacroValueType.NUMBER],
+                description: 'The value to set at the specified index.',
+            },
+        ],
+        description: 'Sets a value at a specific index in a local array variable. If the variable does not exist, it will be created as an array.',
+        returns: '',
+        exampleUsage: ['{{setarrayvar::myarray::0::foo}}', '{{setarrayvar::myarray::1::3}}'],
+        handler: ({ unnamedArgs: [name, index, value] }) => {
+            ctx.variables.local.set(name, value, { index });
+            return '';
+        },
+    });
+
+    // {{getarray::name::index}} -> returns value at index
+    MacroRegistry.registerMacro('getarray', {
+        category: MacroCategory.VARIABLE,
+        unnamedArgs: [
+            {
+                name: 'name',
+                type: MacroValueType.STRING,
+                description: 'The name of the local array variable to get from.',
+            },
+            {
+                name: 'index',
+                type: MacroValueType.NUMBER,
+                description: 'The index of the array element to get.',
+            },
+        ],
+        description: 'Gets a value at a specific index in a local array variable.',
+        returns: 'The value at the specified index in the local array variable.',
+        returnType: [MacroValueType.STRING, MacroValueType.NUMBER],
+        exampleUsage: ['{{getarrayvar::myarray::0}}', '{{getarrayvar::myarray::1}}'],
+        handler: ({ unnamedArgs: [name, index], normalize }) => {
+            const result = ctx.variables.local.get(name, { index });
+            return normalize(result);
+        },
+    });
+
     // {{setglobalvar::name::value}} -> ''
     MacroRegistry.registerMacro('setglobalvar', {
         category: MacroCategory.VARIABLE,
@@ -300,6 +355,60 @@ export function registerVariableMacros() {
         handler: ({ unnamedArgs: [name] }) => {
             ctx.variables.global.del(name);
             return '';
+        },
+    });
+
+    // {{setglobalarray::name::index::value}} -> ''
+    MacroRegistry.registerMacro('setglobalarray', {
+        category: MacroCategory.VARIABLE,
+        unnamedArgs: [
+            {
+                name: 'name',
+                type: MacroValueType.STRING,
+                description: 'The name of the global array variable.',
+            },
+            {
+                name: 'index',
+                type: MacroValueType.NUMBER,
+                description: 'The index of the array element to set.',
+            },
+            {
+                name: 'value',
+                type: [MacroValueType.STRING, MacroValueType.NUMBER],
+                description: 'The value to set at the specified index.',
+            },
+        ],
+        description: 'Sets a value at a specific index in a global array variable. If the variable does not exist, it will be created as an array.',
+        returns: '',
+        exampleUsage: ['{{setglobalarrayvar::myarray::0::foo}}', '{{setglobalarrayvar::myarray::1::3}}'],
+        handler: ({ unnamedArgs: [name, index, value] }) => {
+            ctx.variables.global.set(name, value, { index });
+            return '';
+        },
+    });
+    
+    // {{getglobalarray::name::index}} -> returns value at index
+    MacroRegistry.registerMacro('getglobalarray', {
+        category: MacroCategory.VARIABLE,
+        unnamedArgs: [
+            {
+                name: 'name',
+                type: MacroValueType.STRING,
+                description: 'The name of the global array variable to get from.',
+            },
+            {
+                name: 'index',
+                type: MacroValueType.NUMBER,
+                description: 'The index of the array element to get.',
+            },
+        ],
+        description: 'Gets a value at a specific index in a global array variable.',
+        returns: 'The value at the specified index in the global array variable.',
+        returnType: [MacroValueType.STRING, MacroValueType.NUMBER],
+        exampleUsage: ['{{getglobalarrayvar::myarray::0}}', '{{getglobalarrayvar::myarray::1}}'],
+        handler: ({ unnamedArgs: [name, index], normalize }) => {
+            const result = ctx.variables.global.get(name, { index });
+            return normalize(result);
         },
     });
 }

--- a/public/scripts/macros/definitions/variable-macros.js
+++ b/public/scripts/macros/definitions/variable-macros.js
@@ -156,56 +156,56 @@ export function registerVariableMacros() {
     });
 
 
-    // {{setarray::name::index::value}} -> ''
-    MacroRegistry.registerMacro('setarray', {
+    // {{setelement::name::key::value}} -> ''
+    MacroRegistry.registerMacro('setelement', {
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {
                 name: 'name',
                 type: MacroValueType.STRING,
-                description: 'The name of the local array variable.',
+                description: 'The name of the local object or array.',
             },
             {
-                name: 'index',
-                type: MacroValueType.NUMBER,
-                description: 'The index of the array element to set.',
+                name: 'key',
+                type: [MacroValueType.STRING, MacroValueType.NUMBER],
+                description: 'The key of an object or the index of an array.',
             },
             {
                 name: 'value',
                 type: [MacroValueType.STRING, MacroValueType.NUMBER],
-                description: 'The value to set at the specified index.',
+                description: 'The value to set at the specified key or index.',
             },
         ],
-        description: 'Sets a value at a specific index in a local array variable. If the variable does not exist, it will be created as an array.',
+        description: 'Sets a value at a specific key or index in a local object or array. If the variable does not exist, it will be created based on the type of the key.',
         returns: '',
-        exampleUsage: ['{{setarrayvar::myarray::0::foo}}', '{{setarrayvar::myarray::1::3}}'],
-        handler: ({ unnamedArgs: [name, index, value] }) => {
-            ctx.variables.local.set(name, value, { index });
+        exampleUsage: ['{{setelement::myarray::0::foo}}', '{{setelement::myobj::uniquekey::somevalue}}'],
+        handler: ({ unnamedArgs: [name, key, value] }) => {
+            ctx.variables.local.set(name, value, { index: key });
             return '';
         },
     });
 
-    // {{getarray::name::index}} -> returns value at index
-    MacroRegistry.registerMacro('getarray', {
+    // {{getelement::name::key}} -> returns value at key
+    MacroRegistry.registerMacro('getelement', {
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {
                 name: 'name',
                 type: MacroValueType.STRING,
-                description: 'The name of the local array variable to get from.',
+                description: 'The name of the local object or array variable to get from.',
             },
             {
-                name: 'index',
-                type: MacroValueType.NUMBER,
-                description: 'The index of the array element to get.',
+                name: 'key',
+                type: [MacroValueType.STRING, MacroValueType.NUMBER],
+                description: 'The key of an object or the index of an array.',
             },
         ],
-        description: 'Gets a value at a specific index in a local array variable.',
-        returns: 'The value at the specified index in the local array variable.',
+        description: 'Gets a value at a specific key or index in a local object or array variable.',
+        returns: 'The value at the specified key or index in the local object or array variable.',
         returnType: [MacroValueType.STRING, MacroValueType.NUMBER],
-        exampleUsage: ['{{getarrayvar::myarray::0}}', '{{getarrayvar::myarray::1}}'],
-        handler: ({ unnamedArgs: [name, index], normalize }) => {
-            const result = ctx.variables.local.get(name, { index });
+        exampleUsage: ['{{getelement::myarray::0}}', '{{getelement::myobj::uniquekey}}'],
+        handler: ({ unnamedArgs: [name, key], normalize }) => {
+            const result = ctx.variables.local.get(name, { index: key });
             return normalize(result);
         },
     });
@@ -358,56 +358,56 @@ export function registerVariableMacros() {
         },
     });
 
-    // {{setglobalarray::name::index::value}} -> ''
-    MacroRegistry.registerMacro('setglobalarray', {
+    // {{setglobalelement::name::key::value}} -> ''
+    MacroRegistry.registerMacro('setglobalelement', {
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {
                 name: 'name',
                 type: MacroValueType.STRING,
-                description: 'The name of the global array variable.',
+                description: 'The name of the global object or array variable.',
             },
             {
-                name: 'index',
-                type: MacroValueType.NUMBER,
-                description: 'The index of the array element to set.',
+                name: 'key',
+                type: [MacroValueType.STRING, MacroValueType.NUMBER],
+                description: 'The key of an object or the index of an array element to set.',
             },
             {
                 name: 'value',
                 type: [MacroValueType.STRING, MacroValueType.NUMBER],
-                description: 'The value to set at the specified index.',
+                description: 'The value to set at the specified key or index.',
             },
         ],
-        description: 'Sets a value at a specific index in a global array variable. If the variable does not exist, it will be created as an array.',
+        description: 'Sets a value at a specific key or index in a global object or array variable. If the variable does not exist, it will be created based on the type of the key.',
         returns: '',
-        exampleUsage: ['{{setglobalarrayvar::myarray::0::foo}}', '{{setglobalarrayvar::myarray::1::3}}'],
-        handler: ({ unnamedArgs: [name, index, value] }) => {
-            ctx.variables.global.set(name, value, { index });
+        exampleUsage: ['{{setglobalelement::myarray::0::foo}}', '{{setglobalelement::myobj::uniquekey::bar}}'],
+        handler: ({ unnamedArgs: [name, key, value] }) => {
+            ctx.variables.global.set(name, value, { index: key });
             return '';
         },
     });
     
-    // {{getglobalarray::name::index}} -> returns value at index
-    MacroRegistry.registerMacro('getglobalarray', {
+    // {{getglobalelement::name::key}} -> returns value at key
+    MacroRegistry.registerMacro('getglobalelement', {
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {
                 name: 'name',
                 type: MacroValueType.STRING,
-                description: 'The name of the global array variable to get from.',
+                description: 'The name of the global object or array variable to get from.',
             },
             {
-                name: 'index',
-                type: MacroValueType.NUMBER,
-                description: 'The index of the array element to get.',
+                name: 'key',
+                type: [MacroValueType.STRING, MacroValueType.NUMBER],
+                description: 'The key of an object or the index of an array element to get.',
             },
         ],
-        description: 'Gets a value at a specific index in a global array variable.',
-        returns: 'The value at the specified index in the global array variable.',
+        description: 'Gets a value at a specific key or index in a global object or array variable.',
+        returns: 'The value at the specified key or index in the global object or array variable.',
         returnType: [MacroValueType.STRING, MacroValueType.NUMBER],
-        exampleUsage: ['{{getglobalarrayvar::myarray::0}}', '{{getglobalarrayvar::myarray::1}}'],
-        handler: ({ unnamedArgs: [name, index], normalize }) => {
-            const result = ctx.variables.global.get(name, { index });
+        exampleUsage: ['{{getglobalelement::myarray::0}}', '{{getglobalelement::myobj::uniquekey}}'],
+        handler: ({ unnamedArgs: [name, key], normalize }) => {
+            const result = ctx.variables.global.get(name, { index: key });
             return normalize(result);
         },
     });

--- a/public/scripts/macros/definitions/variable-macros.js
+++ b/public/scripts/macros/definitions/variable-macros.js
@@ -155,8 +155,9 @@ export function registerVariableMacros() {
         },
     });
 
-    // {{setelement::name::key::value}} -> ''
-    MacroRegistry.registerMacro('setelement', {
+    // {{setvarkey::name::key::value}} -> ''
+    MacroRegistry.registerMacro('setvarkey', {
+        aliases: [{ alias: 'setvarindex' }],
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {
@@ -177,15 +178,16 @@ export function registerVariableMacros() {
         ],
         description: 'Sets a value at a specific key or index in a local object or array. If the variable does not exist, it will be created based on the type of the key.',
         returns: '',
-        exampleUsage: ['{{setelement::myarray::0::foo}}', '{{setelement::myobj::uniquekey::somevalue}}'],
+        exampleUsage: ['{{setvarkey::myarray::0::foo}}', '{{setvarkey::myobj::uniquekey::somevalue}}'],
         handler: ({ unnamedArgs: [name, key, value] }) => {
             ctx.variables.local.set(name, value, { index: key });
             return '';
         },
     });
 
-    // {{getelement::name::key}} -> returns value at key
-    MacroRegistry.registerMacro('getelement', {
+    // {{getvarkey::name::key}} -> returns value at key
+    MacroRegistry.registerMacro('getvarkey', {
+        aliases: [{ alias: 'getvarindex' }],
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {
@@ -202,7 +204,7 @@ export function registerVariableMacros() {
         description: 'Gets a value at a specific key or index in a local object or array variable.',
         returns: 'The value at the specified key or index in the local object or array variable.',
         returnType: [MacroValueType.STRING, MacroValueType.NUMBER],
-        exampleUsage: ['{{getelement::myarray::0}}', '{{getelement::myobj::uniquekey}}'],
+        exampleUsage: ['{{getvarkey::myarray::0}}', '{{getvarkey::myobj::uniquekey}}'],
         handler: ({ unnamedArgs: [name, key], normalize }) => {
             const result = ctx.variables.local.get(name, { index: key });
             return normalize(result);
@@ -357,8 +359,8 @@ export function registerVariableMacros() {
         },
     });
 
-    // {{setglobalelement::name::key::value}} -> ''
-    MacroRegistry.registerMacro('setglobalelement', {
+    // {{setglobalvarkey::name::key::value}} -> ''
+    MacroRegistry.registerMacro('setglobalvarkey', {
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {
@@ -379,15 +381,15 @@ export function registerVariableMacros() {
         ],
         description: 'Sets a value at a specific key or index in a global object or array variable. If the variable does not exist, it will be created based on the type of the key.',
         returns: '',
-        exampleUsage: ['{{setglobalelement::myarray::0::foo}}', '{{setglobalelement::myobj::uniquekey::bar}}'],
+        exampleUsage: ['{{setglobalvarkey::myarray::0::foo}}', '{{setglobalvarkey::myobj::uniquekey::bar}}'],
         handler: ({ unnamedArgs: [name, key, value] }) => {
             ctx.variables.global.set(name, value, { index: key });
             return '';
         },
     });
     
-    // {{getglobalelement::name::key}} -> returns value at key
-    MacroRegistry.registerMacro('getglobalelement', {
+    // {{getglobalvarkey::name::key}} -> returns value at key
+    MacroRegistry.registerMacro('getglobalvarkey', {
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {
@@ -404,7 +406,7 @@ export function registerVariableMacros() {
         description: 'Gets a value at a specific key or index in a global object or array variable.',
         returns: 'The value at the specified key or index in the global object or array variable.',
         returnType: [MacroValueType.STRING, MacroValueType.NUMBER],
-        exampleUsage: ['{{getglobalelement::myarray::0}}', '{{getglobalelement::myobj::uniquekey}}'],
+        exampleUsage: ['{{getglobalvarkey::myarray::0}}', '{{getglobalvarkey::myobj::uniquekey}}'],
         handler: ({ unnamedArgs: [name, key], normalize }) => {
             const result = ctx.variables.global.get(name, { index: key });
             return normalize(result);

--- a/public/scripts/macros/definitions/variable-macros.js
+++ b/public/scripts/macros/definitions/variable-macros.js
@@ -155,7 +155,6 @@ export function registerVariableMacros() {
         },
     });
 
-
     // {{setelement::name::key::value}} -> ''
     MacroRegistry.registerMacro('setelement', {
         category: MacroCategory.VARIABLE,

--- a/public/scripts/macros/definitions/variable-macros.js
+++ b/public/scripts/macros/definitions/variable-macros.js
@@ -361,6 +361,7 @@ export function registerVariableMacros() {
 
     // {{setglobalvarkey::name::key::value}} -> ''
     MacroRegistry.registerMacro('setglobalvarkey', {
+        aliases: [{ alias: 'setglobalvarindex' }],
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {
@@ -390,6 +391,7 @@ export function registerVariableMacros() {
     
     // {{getglobalvarkey::name::key}} -> returns value at key
     MacroRegistry.registerMacro('getglobalvarkey', {
+        aliases: [{ alias: 'getglobalvarindex' }],
         category: MacroCategory.VARIABLE,
         unnamedArgs: [
             {


### PR DESCRIPTION
## Notes

Not sure what I feel about the syntax
```
{{setvar::arrayname::value::index}}
```
I feel like it should be
```
{{setvar::arrayname::index::value}}
```
but that would make the code much more complex and unpredictable since these are unnamed args.

Open to suggestions.

Closes: https://github.com/SillyTavern/SillyTavern/issues/4383

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
