### PR TITLE
Add `MessageFormatter`: a structured hook system for extensions to transform message content pre-DOM

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -282,6 +282,7 @@ import { initDomHandlers } from './scripts/dom-handlers.js';
 import { SimpleMutex } from './scripts/util/SimpleMutex.js';
 import { AudioPlayer } from './scripts/audio-player.js';
 import { MacroEnvBuilder } from './scripts/macros/engine/MacroEnvBuilder.js';
+import { MessageFormatter } from './scripts/message-formatter.js';
 import { MacroEngine } from './scripts/macros/engine/MacroEngine.js';
 import { addChatBackupsBrowser } from './scripts/chat-backups.js';
 import { onboardingExperimentalMacroEngine } from './scripts/macros/engine/MacroDiagnostics.js';
@@ -1740,15 +1741,35 @@ export async function sendTextareaMessage() {
 }
 
 /**
- * Formats the message text into an HTML string using Markdown and other formatting.
- * @param {string} mes Message text
- * @param {string} ch_name Character name
- * @param {boolean} isSystem If the message was sent by the system
- * @param {boolean} isUser If the message was sent by the user
- * @param {number} messageId Message index in chat array
- * @param {Partial<DOMPurify.Config>} [sanitizerOverrides] DOMPurify sanitizer option overrides
- * @param {boolean} [isReasoning] If the message is reasoning output
- * @returns {string} HTML string
+ * Formats raw message text into an HTML string ready for DOM insertion.
+ *
+ * The pipeline is, in order:
+ *   1. Prompt-bias stripping (message 0 only)
+ *   2. Comment / hidden-message normalisation
+ *   3. `beforeRegex` extension hooks (see {@link MessageFormatter})
+ *   4. Custom regex rules (`getRegexedString`)
+ *   5. `afterRegex` extension hooks
+ *   6. Markdown auto-fix (`fixMarkdown`)
+ *   7. HTML tag encoding (`encode_tags`)
+ *   8. Showdown Markdown → HTML conversion
+ *   9. `afterMarkdown` extension hooks
+ *  10. Name-prefix stripping (`allow_name2_display`)
+ *  11. DOMPurify sanitization
+ *
+ * All extension hooks run **before** DOMPurify (steps 3, 5, 9) so their
+ * output is always sanitised.
+ *
+ * @param {string} mes - Raw message text.
+ * @param {string} ch_name - Character name associated with the message.
+ * @param {boolean} isSystem - Whether the message is a system message.
+ * @param {boolean} isUser - Whether the message was sent by the user.
+ * @param {number} messageId - Index of the message in the chat array, or -1
+ *   for transient messages (e.g. streaming previews).
+ * @param {Partial<DOMPurify.Config>} [sanitizerOverrides] - DOMPurify option
+ *   overrides. Merged on top of the default config.
+ * @param {boolean} [isReasoning=false] - Whether the message is reasoning/thinking
+ *   output (affects regex placement and some display rules).
+ * @returns {string} Sanitized HTML string ready to assign to `innerHTML`.
  */
 export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, sanitizerOverrides = {}, isReasoning = false) {
     if (!mes) {
@@ -1805,12 +1826,20 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         const indexOf = usableMessages.findIndex(x => x.index === Number(messageId));
         const depth = messageId >= 0 && indexOf !== -1 ? (usableMessages.length - indexOf - 1) : undefined;
 
+        mes = MessageFormatter.runStage(MessageFormatter.stage.BEFORE_REGEX, mes,
+            { ch_name, isSystem, isUser, messageId, isReasoning },
+        );
+
         // Always override the character name
         mes = getRegexedString(mes, regexPlacement, {
             characterOverride: ch_name,
             isMarkdown: true,
             depth: depth,
         });
+
+        mes = MessageFormatter.runStage(MessageFormatter.stage.AFTER_REGEX, mes,
+            { ch_name, isSystem, isUser, messageId, isReasoning },
+        );
     }
 
     if (power_user.auto_fix_generated_markdown) {
@@ -1889,6 +1918,10 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         mes = mes.replace(/<code(.*)>[\s\S]*?<\/code>/g, function (match) {
             return match.replace(/&amp;/g, '&');
         });
+
+        mes = MessageFormatter.runStage(MessageFormatter.stage.AFTER_MARKDOWN, mes,
+            { ch_name, isSystem, isUser, messageId, isReasoning },
+        );
     }
 
     if (!power_user.allow_name2_display && ch_name && !isUser && !isSystem) {

--- a/public/scripts/message-formatter.js
+++ b/public/scripts/message-formatter.js
@@ -215,6 +215,22 @@ class MessageFormatter {
      * Extensions that already import `getContext()` can use this instead of
      * importing `messageFormatting` directly from `script.js`.
      *
+     * The pipeline is, in order:
+     *   1. Prompt-bias stripping (message 0 only)
+     *   2. Comment / hidden-message normalisation
+     *   3. `beforeRegex` extension hooks (see {@link MessageFormatter})
+     *   4. Custom regex rules (`getRegexedString`)
+     *   5. `afterRegex` extension hooks
+     *   6. Markdown auto-fix (`fixMarkdown`)
+     *   7. HTML tag encoding (`encode_tags`)
+     *   8. Showdown Markdown → HTML conversion
+     *   9. `afterMarkdown` extension hooks
+     *  10. Name-prefix stripping (`allow_name2_display`)
+     *  11. DOMPurify sanitization
+     *
+     * All extension hooks run **before** DOMPurify (steps 3, 5, 9) so their
+     * output is always sanitised.
+     *
      * @param {string} mes - Raw message text.
      * @param {string} ch_name - Character name.
      * @param {boolean} isSystem - Whether this is a system message.

--- a/public/scripts/message-formatter.js
+++ b/public/scripts/message-formatter.js
@@ -58,7 +58,11 @@ export const formatting_stage = {
  * A formatting hook function.
  * Receives the current message text (plain Markdown or HTML, depending on
  * the stage) and an immutable context object.  Must return the (possibly
- * modified) message text synchronously.
+ * modified) message text **synchronously** as a `string`.  Passing an async
+ * function to {@link MessageFormatter#addHook} will throw a `TypeError` at
+ * registration time.  If a hook returns a non-string at runtime, a console
+ * warning is emitted and the return value is ignored (the pipeline continues
+ * with the previous text unchanged).
  *
  * @callback MessageFormattingHook
  * @param {string}                    mes - Current message text at this pipeline stage.
@@ -174,10 +178,12 @@ class MessageFormatter {
      *   Options object. `stage` defaults to `'afterMarkdown'`; `order` defaults to `50`.
      * @returns {void}
      *
-     * @throws {TypeError} If `fn` is not a function.
+     * @throws {TypeError} If `fn` is not a function or is an async function.
+     * @throws {RangeError} If `stage` is not a known {@link formatting_stage} value.
      */
     addHook(fn, { stage = formatting_stage.AFTER_MARKDOWN, order = hook_order.NORMAL } = {}) {
         if (typeof fn !== 'function') throw new TypeError('MessageFormatter: hook must be a function');
+        if (fn.constructor?.name === 'AsyncFunction') throw new TypeError(`MessageFormatter: hook registered for stage '${stage}' must be synchronous — async functions are not supported`);
         if (!this.#hooks.has(stage)) throw new RangeError(`MessageFormatter: unknown stage '${stage}'`);
         this.#hooks.get(stage).push({ fn, order });
     }
@@ -199,7 +205,12 @@ class MessageFormatter {
         const sorted = bucket.slice().sort((a, b) => a.order - b.order);
         for (const { fn } of sorted) {
             try {
-                mes = fn(mes, ctx);
+                const result = fn(mes, ctx);
+                if (typeof result !== 'string') {
+                    console.warn(`[MessageFormatter] Hook at stage '${stage}' returned ${/** @type {unknown} */ (result) instanceof Promise ? 'a Promise (hook may be async)' : typeof result} instead of a string. The hook's return value has been ignored.`);
+                } else {
+                    mes = result;
+                }
             } catch (e) {
                 console.error(`[MessageFormatter] Hook error at stage '${stage}':`, e);
             }

--- a/public/scripts/message-formatter.js
+++ b/public/scripts/message-formatter.js
@@ -1,0 +1,232 @@
+import { messageFormatting } from '../script.js';
+
+/**
+ * Pipeline stages at which extension hooks may run.
+ * All stages occur **before** DOMPurify sanitization so output is always safe.
+ *
+ * - `BEFORE_REGEX`   – Raw message text, after prompt-bias stripping but before
+ *                      custom regex rules are applied. Suitable for transforms
+ *                      that should be invisible to regex rules.
+ * - `AFTER_REGEX`    – After custom regex rules, before Markdown conversion.
+ *                      The text is still plain Markdown at this point.
+ * - `AFTER_MARKDOWN` – After Markdown-to-HTML conversion (showdown), before
+ *                      DOMPurify. The value is an HTML string. This is the
+ *                      **default** stage and the most common insertion point
+ *                      for extensions that want to annotate rendered HTML (e.g.
+ *                      adding ruby tags, tooltips, highlights).
+ *
+ * > There is intentionally no post-sanitize stage.
+ * > All hooks run before DOMPurify so their output is always sanitized along
+ * > with the rest of the message. If your hook inserts HTML, make sure it is
+ * > safe to pass through DOMPurify (i.e. avoid `<script>` tags and inline
+ * > event handlers — they will be stripped anyway, but it is still bad
+ * > practice to produce them).
+ *
+ * @enum {string}
+ */
+export const formatting_stage = {
+    BEFORE_REGEX: 'beforeRegex',
+    AFTER_REGEX: 'afterRegex',
+    AFTER_MARKDOWN: 'afterMarkdown',
+};
+
+/**
+ * @typedef {formatting_stage[keyof formatting_stage]} MessageFormattingStage
+ */
+
+/**
+ * Message metadata supplied by {@link messageFormatting} to {@link MessageFormatter#runStage}.
+ * Does not include `stage` — that is injected by `runStage` itself.
+ *
+ * @typedef {Object} MessageFormattingBase
+ * @property {string} ch_name - Character name associated with the message.
+ * @property {boolean} isSystem - Whether the message is a system message.
+ * @property {boolean} isUser - Whether the message was sent by the user.
+ * @property {number} messageId - Index of the message in the chat array, or -1 for transient messages (e.g. streaming previews).
+ * @property {boolean} isReasoning - Whether the message is reasoning/thinking output.
+ */
+
+/**
+ * Immutable context object passed to every formatting hook.
+ * Built from {@link MessageFormattingBase} with `stage` added and the whole
+ * object frozen by {@link MessageFormatter#runStage}.
+ *
+ * @typedef {Readonly<MessageFormattingBase & { stage: MessageFormattingStage }>} MessageFormattingContext
+ */
+
+/**
+ * A formatting hook function.
+ * Receives the current message text (plain Markdown or HTML, depending on
+ * the stage) and an immutable context object.  Must return the (possibly
+ * modified) message text synchronously.
+ *
+ * @callback MessageFormattingHook
+ * @param {string}                    mes - Current message text at this pipeline stage.
+ * @param {MessageFormattingContext}  ctx - Immutable metadata about the message.
+ * @returns {string} The (possibly transformed) message text.
+ */
+
+/**
+ * Options accepted by {@link MessageFormatter#addHook}.
+ *
+ * @typedef {Object} AddHookOptions
+ * @property {hook_order|number} [order=hook_order.NORMAL] - Numeric priority within the stage.
+ *   Lower numbers run first. Use the exported {@link hook_order} constants for readable values.
+ */
+
+/**
+ * Ordering buckets for formatting hooks.
+ * Use these when calling {@link MessageFormatter#addHook} to express
+ * intent rather than bare numbers.
+ *
+ * @enum {number}
+ */
+export const hook_order = {
+    EARLIEST: 0,
+    EARLY: 10,
+    NORMAL: 50,
+    LATE: 90,
+    LATEST: 100,
+};
+
+/** @type {MessageFormatter} */
+let instance;
+
+/**
+ * Singleton instance of {@link MessageFormatter}.
+ * Exported under the class name so callers can write
+ * `import { MessageFormatter } from './message-formatter.js'`
+ * and use it directly.
+ *
+ * @type {MessageFormatter}
+ */
+export { instance as MessageFormatter };
+
+/**
+ * Manages the message-formatting pipeline and exposes registration points
+ * for extensions that need to transform message text before it reaches the
+ * DOM.
+ *
+ * Extensions should obtain the singleton via `getContext().messageFormatter`
+ * and call {@link MessageFormatter#addHook} once during their init phase.
+ *
+ * @example
+ * // In your extension's init function:
+ * const { messageFormatter } = getContext();
+ * messageFormatter.addHook((mes, ctx) => {
+ *     if (ctx.isUser) return mes;
+ *     return addFurigana(mes);
+ * });
+ *
+ * // With an explicit stage and order (using the enum accessors on the singleton):
+ * const { messageFormatter } = getContext();
+ * messageFormatter.addHook((mes, ctx) => transform(mes), {
+ *     stage: messageFormatter.stage.AFTER_REGEX,
+ *     order: messageFormatter.order.EARLY,
+ * });
+ */
+class MessageFormatter {
+    /** @type {MessageFormatter} */
+    static #instance;
+
+    /** @returns {MessageFormatter} */
+    static get instance() {
+        return MessageFormatter.#instance ?? (MessageFormatter.#instance = new MessageFormatter());
+    }
+
+    /**
+     * Internal storage: one sorted bucket per stage.
+     *
+     * @type {Map<MessageFormattingStage, { fn: MessageFormattingHook, order: number }[]>}
+     */
+    #hooks = new Map();
+
+    /**
+     * Exposes {@link formatting_stage} on the instance so extensions can
+     * access stage constants without a separate import.
+     * @type {typeof formatting_stage}
+     * @readonly
+     */
+    stage = formatting_stage;
+
+    /**
+     * Exposes {@link hook_order} on the instance so extensions can
+     * access order constants without a separate import.
+     * @type {typeof hook_order}
+     * @readonly
+     */
+    order = hook_order;
+
+    constructor() {
+        this.#hooks.set(formatting_stage.BEFORE_REGEX, []);
+        this.#hooks.set(formatting_stage.AFTER_REGEX, []);
+        this.#hooks.set(formatting_stage.AFTER_MARKDOWN, []);
+    }
+
+    /**
+     * Registers a hook function to run at a specific pipeline stage.
+     *
+     * Should be called once during the extension's init/setup phase.
+     * Hooks are applied in ascending `order` within each stage.
+     *
+     * @param {MessageFormattingHook} fn - The hook function.
+     * @param {AddHookOptions & { stage?: MessageFormattingStage }} [options={}]
+     *   Options object. `stage` defaults to `'afterMarkdown'`; `order` defaults to `50`.
+     * @returns {void}
+     *
+     * @throws {TypeError} If `fn` is not a function.
+     */
+    addHook(fn, { stage = formatting_stage.AFTER_MARKDOWN, order = hook_order.NORMAL } = {}) {
+        if (typeof fn !== 'function') throw new TypeError('MessageFormatter: hook must be a function');
+        if (!this.#hooks.has(stage)) throw new RangeError(`MessageFormatter: unknown stage '${stage}'`);
+        this.#hooks.get(stage).push({ fn, order });
+    }
+
+    /**
+     * Runs all hooks registered for the given stage in order.
+     * Called internally by {@link messageFormatting} at each pipeline point.
+     * Extensions do not need to call this directly.
+     *
+     * @param {MessageFormattingStage} stage - The pipeline stage to execute.
+     * @param {string} mes - Current message text.
+     * @param {MessageFormattingBase} base - Message metadata. `stage` is injected automatically.
+     * @returns {string} The message text after all hooks have been applied.
+     */
+    runStage(stage, mes, base) {
+        const bucket = this.#hooks.get(stage);
+        if (!bucket?.length) return mes;
+        const ctx = Object.freeze({ ...base, stage });
+        const sorted = bucket.slice().sort((a, b) => a.order - b.order);
+        for (const { fn } of sorted) {
+            try {
+                mes = fn(mes, ctx);
+            } catch (e) {
+                console.error(`[MessageFormatter] Hook error at stage '${stage}':`, e);
+            }
+        }
+        return mes;
+    }
+
+    /**
+     * Formats a message using the full pipeline (including all registered
+     * hooks). This is a convenience shim over the top-level
+     * {@link messageFormatting} function and accepts the same arguments.
+     *
+     * Extensions that already import `getContext()` can use this instead of
+     * importing `messageFormatting` directly from `script.js`.
+     *
+     * @param {string} mes - Raw message text.
+     * @param {string} ch_name - Character name.
+     * @param {boolean} isSystem - Whether this is a system message.
+     * @param {boolean} isUser - Whether this was sent by the user.
+     * @param {number} messageId - Message index in the chat array.
+     * @param {Partial<import('dompurify').Config>} [sanitizerOverrides={}] - DOMPurify option overrides.
+     * @param {boolean} [isReasoning=false] - Whether this is reasoning output.
+     * @returns {string} Formatted HTML string ready for DOM insertion.
+     */
+    format(mes, ch_name, isSystem, isUser, messageId, sanitizerOverrides = {}, isReasoning = false) {
+        return messageFormatting(mes, ch_name, isSystem, isUser, messageId, sanitizerOverrides, isReasoning);
+    }
+}
+
+instance = MessageFormatter.instance;

--- a/public/scripts/message-formatter.js
+++ b/public/scripts/message-formatter.js
@@ -39,7 +39,7 @@ export const formatting_stage = {
  * Does not include `stage` — that is injected by `runStage` itself.
  *
  * @typedef {Object} MessageFormattingBase
- * @property {string} ch_name - Character name associated with the message.
+ * @property {string} characterName - Character name associated with the message.
  * @property {boolean} isSystem - Whether the message is a system message.
  * @property {boolean} isUser - Whether the message was sent by the user.
  * @property {number} messageId - Index of the message in the chat array, or -1 for transient messages (e.g. streaming previews).
@@ -243,7 +243,7 @@ class MessageFormatter {
      * output is always sanitised.
      *
      * @param {string} mes - Raw message text.
-     * @param {string} ch_name - Character name.
+     * @param {string} characterName - Character name.
      * @param {boolean} isSystem - Whether this is a system message.
      * @param {boolean} isUser - Whether this was sent by the user.
      * @param {number} messageId - Message index in the chat array.
@@ -251,8 +251,8 @@ class MessageFormatter {
      * @param {boolean} [isReasoning=false] - Whether this is reasoning output.
      * @returns {string} Formatted HTML string ready for DOM insertion.
      */
-    format(mes, ch_name, isSystem, isUser, messageId, sanitizerOverrides = {}, isReasoning = false) {
-        return messageFormatting(mes, ch_name, isSystem, isUser, messageId, sanitizerOverrides, isReasoning);
+    format(mes, characterName, isSystem, isUser, messageId, sanitizerOverrides = {}, isReasoning = false) {
+        return messageFormatting(mes, characterName, isSystem, isUser, messageId, sanitizerOverrides, isReasoning);
     }
 }
 

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -110,6 +110,7 @@ import { ConnectionManagerRequestService } from './extensions/shared.js';
 import { updateReasoningUI, parseReasoningFromString, getReasoningTemplateByName } from './reasoning.js';
 import { IGNORE_SYMBOL } from './constants.js';
 import { macros } from './macros/macro-system.js';
+import { MessageFormatter } from './message-formatter.js';
 
 export function getContext() {
     return {
@@ -242,6 +243,7 @@ export function getContext() {
         scrollChatToBottom,
         scrollOnMediaLoad,
         macros,
+        messageFormatter: MessageFormatter,
         loader,
         swipe: {
             left: swipe_left,

--- a/tests/frontend/MessageFormatter.e2e.js
+++ b/tests/frontend/MessageFormatter.e2e.js
@@ -1,0 +1,323 @@
+import { test, expect } from '@playwright/test';
+import { testSetup } from './frontent-test-utils.js';
+
+/**
+ * @typedef {import('../../public/scripts/message-formatter.js').MessageFormattingContext} MessageFormattingContext
+ */
+
+test.describe('MessageFormatter', () => {
+    // message-formatter.js imports script.js, which requires the full ST module
+    // graph to be settled before dynamic import works (otherwise hits SlashCommandParser TDZ).
+    test.beforeEach(testSetup.awaitST);
+
+    // -------------------------------------------------------------------------
+    // Module exports & singleton
+    // -------------------------------------------------------------------------
+
+    test.describe('Module exports & singleton', () => {
+        test('should export formatting_stage with expected keys', async ({ page }) => {
+            const stage = await page.evaluate(async () => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { formatting_stage } = await import('./scripts/message-formatter.js');
+                return formatting_stage;
+            });
+
+            expect(stage).toEqual({
+                BEFORE_REGEX: 'beforeRegex',
+                AFTER_REGEX: 'afterRegex',
+                AFTER_MARKDOWN: 'afterMarkdown',
+            });
+        });
+
+        test('should export hook_order with expected keys', async ({ page }) => {
+            const order = await page.evaluate(async () => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { hook_order } = await import('./scripts/message-formatter.js');
+                return hook_order;
+            });
+
+            expect(order).toMatchObject({
+                EARLIEST: 0,
+                EARLY: 10,
+                NORMAL: 50,
+                LATE: 90,
+                LATEST: 100,
+            });
+        });
+
+        test('should expose stage and order constants on the instance', async ({ page }) => {
+            const result = await page.evaluate(async () => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter, formatting_stage, hook_order } = await import('./scripts/message-formatter.js');
+                return {
+                    stageMatches: JSON.stringify(MessageFormatter.stage) === JSON.stringify(formatting_stage),
+                    orderMatches: JSON.stringify(MessageFormatter.order) === JSON.stringify(hook_order),
+                };
+            });
+
+            expect(result.stageMatches).toBe(true);
+            expect(result.orderMatches).toBe(true);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // addHook — registration validation
+    // -------------------------------------------------------------------------
+
+    test.describe('addHook — registration validation', () => {
+        test('should throw TypeError when registering a non-function hook', async ({ page }) => {
+            const errorMessage = await page.evaluate(async () => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { formatting_stage } = await import('./scripts/message-formatter.js');
+
+                // Use a fresh MessageFormatter instance so we don't pollute the singleton
+                const { MessageFormatter: MF } = await import('./scripts/message-formatter.js');
+                try {
+                    // @ts-ignore intentional misuse
+                    MF.addHook('not a function', { stage: formatting_stage.AFTER_MARKDOWN });
+                    return null;
+                } catch (e) {
+                    return { name: e.name, message: e.message };
+                }
+            });
+
+            expect(errorMessage).not.toBeNull();
+            expect(errorMessage.name).toBe('TypeError');
+        });
+
+        test('should throw TypeError when registering an async hook', async ({ page }) => {
+            const errorMessage = await page.evaluate(async () => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter } = await import('./scripts/message-formatter.js');
+                try {
+                    MessageFormatter.addHook(async (mes) => mes);
+                    return null;
+                } catch (e) {
+                    return { name: e.name, message: e.message };
+                }
+            });
+
+            expect(errorMessage).not.toBeNull();
+            expect(errorMessage.name).toBe('TypeError');
+            expect(errorMessage.message).toContain('synchronous');
+        });
+
+        test('should throw RangeError when registering a hook with an unknown stage', async ({ page }) => {
+            const errorMessage = await page.evaluate(async () => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter } = await import('./scripts/message-formatter.js');
+                try {
+                    // @ts-ignore intentional misuse
+                    MessageFormatter.addHook((mes) => mes, { stage: 'nonExistentStage' });
+                    return null;
+                } catch (e) {
+                    return { name: e.name, message: e.message };
+                }
+            });
+
+            expect(errorMessage).not.toBeNull();
+            expect(errorMessage.name).toBe('RangeError');
+            expect(errorMessage.message).toContain('nonExistentStage');
+        });
+
+        test('should successfully register a valid synchronous hook', async ({ page }) => {
+            const threw = await page.evaluate(async () => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter } = await import('./scripts/message-formatter.js');
+                try {
+                    MessageFormatter.addHook((mes) => mes);
+                    return false;
+                } catch {
+                    return true;
+                }
+            });
+
+            expect(threw).toBe(false);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // runStage — hook execution
+    // -------------------------------------------------------------------------
+
+    test.describe('runStage — hook execution', () => {
+        /** @type {import('../../public/scripts/message-formatter.js').MessageFormattingBase} */
+        const BASE_CTX = { ch_name: 'Test', isSystem: false, isUser: false, messageId: 1, isReasoning: false };
+
+        test('should return the message unchanged when no hooks are registered for a stage', async ({ page }) => {
+            // Use a unique tag that no registered hook could produce so the result
+            // is deterministic regardless of hooks other tests added to the singleton.
+            const TAG = `__mf_test_nohooks_${Date.now()}`;
+            const output = await page.evaluate(async ({ base, tag }) => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter, formatting_stage } = await import('./scripts/message-formatter.js');
+                // No hook is registered that would append/modify `tag`, so it must come back unchanged.
+                return MessageFormatter.runStage(formatting_stage.AFTER_MARKDOWN, tag, base);
+            }, { base: BASE_CTX, tag: TAG });
+
+            expect(output).toBe(TAG);
+        });
+
+        test('should apply a registered hook and return the transformed text', async ({ page }) => {
+            const TAG = `__mf_test_transform_${Date.now()}`;
+            const output = await page.evaluate(async ({ base, tag }) => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter, formatting_stage } = await import('./scripts/message-formatter.js');
+                MessageFormatter.addHook((mes) => mes + tag, { stage: formatting_stage.BEFORE_REGEX });
+                return MessageFormatter.runStage(formatting_stage.BEFORE_REGEX, 'hello', base);
+            }, { base: BASE_CTX, tag: TAG });
+
+            expect(output).toBe(`hello${TAG}`);
+        });
+
+        test('should pass an immutable frozen context to hooks', async ({ page }) => {
+            const result = await page.evaluate(async (base) => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter, formatting_stage } = await import('./scripts/message-formatter.js');
+
+                let receivedCtx = null;
+                let isFrozen = false;
+
+                MessageFormatter.addHook((mes, ctx) => {
+                    receivedCtx = { ...ctx };
+                    isFrozen = Object.isFrozen(ctx);
+                    return mes;
+                }, { stage: formatting_stage.AFTER_REGEX });
+
+                MessageFormatter.runStage(formatting_stage.AFTER_REGEX, 'text', base);
+
+                return { receivedCtx, isFrozen };
+            }, BASE_CTX);
+
+            expect(result.receivedCtx.stage).toBe('afterRegex');
+            expect(result.receivedCtx.ch_name).toBe(BASE_CTX.ch_name);
+            expect(result.isFrozen).toBe(true);
+        });
+
+        test('should inject the correct stage into the context', async ({ page }) => {
+            const stages = await page.evaluate(async (base) => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter, formatting_stage } = await import('./scripts/message-formatter.js');
+
+                const seen = [];
+                const hook = (mes, ctx) => { seen.push(ctx.stage); return mes; };
+
+                MessageFormatter.addHook(hook, { stage: formatting_stage.BEFORE_REGEX });
+                MessageFormatter.addHook(hook, { stage: formatting_stage.AFTER_REGEX });
+                MessageFormatter.addHook(hook, { stage: formatting_stage.AFTER_MARKDOWN });
+
+                MessageFormatter.runStage(formatting_stage.BEFORE_REGEX, 'a', base);
+                MessageFormatter.runStage(formatting_stage.AFTER_REGEX, 'b', base);
+                MessageFormatter.runStage(formatting_stage.AFTER_MARKDOWN, 'c', base);
+
+                return seen;
+            }, BASE_CTX);
+
+            expect(stages).toContain('beforeRegex');
+            expect(stages).toContain('afterRegex');
+            expect(stages).toContain('afterMarkdown');
+        });
+
+        test('should run hooks in ascending order within a stage', async ({ page }) => {
+            const TAG = `__mf_test_order_${Date.now()}`;
+            const output = await page.evaluate(async ({ base, tag }) => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter, formatting_stage, hook_order } = await import('./scripts/message-formatter.js');
+
+                MessageFormatter.addHook((mes) => mes + `[late${tag}]`, { stage: formatting_stage.AFTER_MARKDOWN, order: hook_order.LATE });
+                MessageFormatter.addHook((mes) => mes + `[early${tag}]`, { stage: formatting_stage.AFTER_MARKDOWN, order: hook_order.EARLY });
+                MessageFormatter.addHook((mes) => mes + `[normal${tag}]`, { stage: formatting_stage.AFTER_MARKDOWN, order: hook_order.NORMAL });
+
+                return MessageFormatter.runStage(formatting_stage.AFTER_MARKDOWN, '', base);
+            }, { base: BASE_CTX, tag: TAG });
+
+            // early → normal → late
+            const earlyIdx = output.indexOf(`[early${TAG}]`);
+            const normalIdx = output.indexOf(`[normal${TAG}]`);
+            const lateIdx = output.indexOf(`[late${TAG}]`);
+            expect(earlyIdx).toBeLessThan(normalIdx);
+            expect(normalIdx).toBeLessThan(lateIdx);
+        });
+
+        test('should continue pipeline and skip a hook that throws', async ({ page }) => {
+            const TAG = `__mf_test_throw_${Date.now()}`;
+            const output = await page.evaluate(async ({ base, tag }) => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter, formatting_stage, hook_order } = await import('./scripts/message-formatter.js');
+
+                // Hook 1: throws
+                MessageFormatter.addHook(() => { throw new Error('intentional test error'); }, {
+                    stage: formatting_stage.BEFORE_REGEX,
+                    order: hook_order.EARLY,
+                });
+                // Hook 2: appends tag to prove it still ran
+                MessageFormatter.addHook((mes) => mes + tag, {
+                    stage: formatting_stage.BEFORE_REGEX,
+                    order: hook_order.LATE,
+                });
+
+                return MessageFormatter.runStage(formatting_stage.BEFORE_REGEX, 'base', base);
+            }, { base: BASE_CTX, tag: TAG });
+
+            expect(output).toBe(`base${TAG}`);
+        });
+
+        test('should ignore a hook that returns a non-string and keep the previous text', async ({ page }) => {
+            const TAG = `__mf_test_nonstring_${Date.now()}`;
+            const result = await page.evaluate(async ({ base, tag }) => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter, formatting_stage, hook_order } = await import('./scripts/message-formatter.js');
+
+                const warnings = [];
+                const origWarn = console.warn.bind(console);
+                console.warn = (...args) => { warnings.push(args.join(' ')); origWarn(...args); };
+
+                // Hook 1: returns undefined (bad hook)
+                MessageFormatter.addHook(() => undefined, {
+                    stage: formatting_stage.AFTER_REGEX,
+                    order: hook_order.EARLY,
+                });
+                // Hook 2: valid, appends tag
+                MessageFormatter.addHook((mes) => mes + tag, {
+                    stage: formatting_stage.AFTER_REGEX,
+                    order: hook_order.LATE,
+                });
+
+                const output = MessageFormatter.runStage(formatting_stage.AFTER_REGEX, 'original', base);
+
+                console.warn = origWarn;
+                return { output, hasWarning: warnings.some(w => w.includes('undefined')) };
+            }, { base: BASE_CTX, tag: TAG });
+
+            expect(result.output).toBe(`original${TAG}`);
+            expect(result.hasWarning).toBe(true);
+        });
+
+        test('should warn and keep text when a hook returns a Promise (simulated async escape)', async ({ page }) => {
+            const result = await page.evaluate(async (base) => {
+                /** @type {import('../../public/scripts/message-formatter.js')} */
+                const { MessageFormatter, formatting_stage } = await import('./scripts/message-formatter.js');
+
+                const warnings = [];
+                const origWarn = console.warn.bind(console);
+                console.warn = (...args) => { warnings.push(args.join(' ')); origWarn(...args); };
+
+                // Bypasses registration check by wrapping async call inside a sync function
+                MessageFormatter.addHook(() => Promise.resolve('sneaky async'), {
+                    stage: formatting_stage.BEFORE_REGEX,
+                });
+
+                const output = MessageFormatter.runStage(formatting_stage.BEFORE_REGEX, 'safe', base);
+
+                console.warn = origWarn;
+                return {
+                    output,
+                    hasPromiseWarning: warnings.some(w => w.toLowerCase().includes('promise')),
+                };
+            }, BASE_CTX);
+
+            expect(result.output).toBe('safe');
+            expect(result.hasPromiseWarning).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Introduces a new `MessageFormatter` singleton that lets extensions register pure-transform hooks at specific points in the message formatting pipeline — **before the content ever hits the DOM**.

### What Changed

- **New file `public/scripts/message-formatter.js`** — the `MessageFormatter` class with `addHook`, `runStage`, and a `format` convenience shim, exported as a singleton
- **Two new enums** — `formatting_stage` (`BEFORE_REGEX`, `AFTER_REGEX`, `AFTER_MARKDOWN`) and `hook_order` (`EARLIEST` through `LATEST`) for readable, type-safe hook registration
- **`messageFormatting()` in `script.js`** — now calls `MessageFormatter.runStage()` at three points in the pipeline
- **`getContext()`** — exposes the singleton as `messageFormatter` so extensions don't need any direct imports beyond `getContext()`
- Both enums are also accessible directly on the singleton instance (`messageFormatter.stage.*`, `messageFormatter.order.*`) — no extra imports required in extension code

### Why These Changes

Extensions that work with message content (highlighting, annotation, content transformation, trackers, etc.) previously had no clean way to modify text before it was assigned to `innerHTML`. The only option was to post-process the DOM after render, which causes visible flicker and races with streaming. A pre-render hook solves this correctly and is a commonly requested extension capability.

### How It Works

The message formatting pipeline already had a clear sequence (regex → markdown → sanitize). `MessageFormatter` inserts three named hook points into that sequence:

- **`BEFORE_REGEX`** — raw Markdown text, before custom regex rules run
- **`AFTER_REGEX`** — still Markdown, after regex rules, before Showdown conversion
- **`AFTER_MARKDOWN`** — rendered HTML, after Showdown, **before DOMPurify** *(default)*

Each hook is a simple synchronous function `(mes, ctx) => string`. The `ctx` is an immutable frozen object (injected by `runStage`) containing message metadata: character name, flags for system/user/reasoning messages, and the current stage. Multiple hooks at the same stage are executed in ascending `order`.

There is intentionally **no post-sanitize stage** — all hooks run through DOMPurify automatically.

### Impact

Extensions can now cleanly transform message content pre-render with a single call during init:

```js
const { messageFormatter } = getContext();
messageFormatter.addHook((mes, ctx) => {
    if (ctx.isSystem) return mes;
    return addFurigana(mes); // or any other transform
});
```

No imports from `script.js`, no DOM polling, no flicker.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).