### PR TITLE
Lorebook "Apply Current Sorting" — Order control, ascending mode, step size, and live validation feedback

### DIFF
--- a/public/scripts/popup.js
+++ b/public/scripts/popup.js
@@ -85,6 +85,7 @@ export const POPUP_RESULT = {
  * @property {number?} [max] - The maximum value for number inputs
  * @property {number?} [step] - The step value for number inputs
  * @property {boolean?} [disabled=false] - Whether the input should be disabled
+ * @property {boolean?} [autoFocus=false] - Whether this input should be auto-focused when the popup opens
  */
 
 /**
@@ -336,6 +337,7 @@ export class Popup {
                 inputElement.id = input.id;
                 inputElement.checked = Boolean(input.defaultState ?? false);
                 inputElement.disabled = Boolean(input.disabled ?? false);
+                if (input.autoFocus) { inputElement.setAttribute('autofocus', ''); inputElement.tabIndex = 0; }
                 label.appendChild(inputElement);
                 const labelText = document.createElement('span');
                 labelText.innerText = input.label;
@@ -362,6 +364,7 @@ export class Popup {
                 inputElement.value = String(input.defaultState ?? '');
                 inputElement.placeholder = input.tooltip ?? '';
                 inputElement.disabled = Boolean(input.disabled ?? false);
+                if (input.autoFocus) { inputElement.setAttribute('autofocus', ''); inputElement.tabIndex = 0; }
                 setTitleFromTooltip(inputElement, input.tooltip);
 
                 const labelText = document.createElement('span');
@@ -384,6 +387,7 @@ export class Popup {
                 inputElement.rows = input.rows ?? 1;
                 inputElement.placeholder = input.tooltip ?? '';
                 inputElement.disabled = Boolean(input.disabled ?? false);
+                if (input.autoFocus) { inputElement.setAttribute('autofocus', ''); inputElement.tabIndex = 0; }
                 setTitleFromTooltip(inputElement, input.tooltip);
 
                 const labelText = document.createElement('span');
@@ -409,6 +413,7 @@ export class Popup {
                 inputElement.max = String(input.max ?? '');
                 inputElement.step = String(input.step ?? '');
                 inputElement.disabled = Boolean(input.disabled ?? false);
+                if (input.autoFocus) { inputElement.setAttribute('autofocus', ''); inputElement.tabIndex = 0; }
                 setTitleFromTooltip(inputElement, input.tooltip);
 
                 inputElement.addEventListener('change', () => {

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -7,7 +7,7 @@ import {
 } from '../lib.js';
 
 import { getContext } from './extensions.js';
-import { characters, getRequestHeaders, processDroppedFiles, this_chid, user_avatar } from '../script.js';
+import { animation_duration, characters, getRequestHeaders, processDroppedFiles, this_chid, user_avatar } from '../script.js';
 import { isMobile } from './RossAscends-mods.js';
 import { collapseNewlines, power_user } from './power-user.js';
 import { debounce_timeout } from './constants.js';
@@ -2786,32 +2786,54 @@ export function arraysEqual(a, b) {
  * @param {string | HTMLElement} target - The CSS selector or the HTML element of the information block
  * @param {string | HTMLElement?} content - The message to display inside the information block (supports HTML) or an HTML element
  * @param {'hint' | 'info' | 'warning' | 'error'} [type='info'] - The type of message, which determines the styling of the information block
+ * @param {object} [options={}] - Optional settings
+ * @param {boolean} [options.animate=true] - Whether to animate the block sliding in when first shown
  */
-export function setInfoBlock(target, content, type = 'info') {
+export function setInfoBlock(target, content, type = 'info', { animate = true } = {}) {
     if (!content) {
         clearInfoBlock(target);
         return;
     }
 
     const infoBlock = typeof target === 'string' ? document.querySelector(target) : target;
-    if (infoBlock) {
-        infoBlock.className = `info-block ${type}`;
-        if (typeof content === 'string') {
-            infoBlock.innerHTML = content;
-        } else {
-            infoBlock.innerHTML = '';
-            infoBlock.appendChild(content);
-        }
+    if (!infoBlock) return;
+
+    const wasVisible = infoBlock.classList.contains('info-block');
+
+    if (!wasVisible && animate) {
+        $(infoBlock).hide();
+    }
+
+    infoBlock.className = `info-block ${type}`;
+    if (typeof content === 'string') {
+        infoBlock.innerHTML = content;
+    } else {
+        infoBlock.innerHTML = '';
+        infoBlock.appendChild(content);
+    }
+
+    if (!wasVisible && animate) {
+        $(infoBlock).slideDown(animation_duration * 1.5);
     }
 }
 
 /**
  * Clears the content and style of an information block.
  * @param {string | HTMLElement} target - The CSS selector or the HTML element of the information block
+ * @param {object} [options={}] - Optional settings
+ * @param {boolean} [options.animate=true] - Whether to animate the block fading out before clearing
  */
-export function clearInfoBlock(target) {
+export function clearInfoBlock(target, { animate = true } = {}) {
     const infoBlock = typeof target === 'string' ? document.querySelector(target) : target;
-    if (infoBlock && infoBlock.classList.contains('info-block')) {
+    if (!infoBlock || !infoBlock.classList.contains('info-block')) return;
+
+    if (animate) {
+        $(infoBlock).slideUp(animation_duration * 1.5, () => {
+            infoBlock.className = '';
+            infoBlock.innerHTML = '';
+            $(infoBlock).css('display', '');
+        });
+    } else {
         infoBlock.className = '';
         infoBlock.innerHTML = '';
     }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1,7 +1,7 @@
 import { Fuse } from '../lib.js';
 
 import { saveSettings, substituteParams, getRequestHeaders, chat_metadata, this_chid, characters, saveCharacterDebounced, menu_type, eventSource, event_types, getExtensionPromptByName, saveMetadata, getCurrentChatId, extension_prompt_roles, create_save, createOrEditCharacter, name1, getOneCharacter, select_selected_character } from '../script.js';
-import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents, uuidv4, normalizeArray, getUniqueName, logSlashCommandWarn, addLongPressEvent, escapeHtml } from './utils.js';
+import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents, uuidv4, normalizeArray, getUniqueName, logSlashCommandWarn, addLongPressEvent, escapeHtml, setInfoBlock, clearInfoBlock } from './utils.js';
 import { extension_settings, getContext } from './extensions.js';
 import { NOTE_MODULE_NAME, metadata_keys, shouldWIAddPrompt } from './authors-note.js';
 import { isMobile } from './RossAscends-mods.js';
@@ -2495,45 +2495,122 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
 
     $('#world_apply_current_sorting').off('click').on('click', async () => {
         const entryCount = Object.keys(data.entries).length;
-        const moreThan100 = entryCount > 100;
 
-        let content = '<span>' + t`Apply your current sorting to the "Order" field. The Order values will go down from the chosen number.` + '</span>';
-        if (moreThan100) {
-            content += '<div class="m-t-1"><i class="fa-solid fa-triangle-exclamation" style="color: #FFD43B;"></i> ' + t`More than 100 entries in this world. If you don't choose a number higher than that, the lower entries will default to 0.<br />(Usual default: 100)<br />Minimum: ${entryCount}` + '</div>';
-        }
+        const contentEl = document.createElement('div');
 
-        const result = await Popup.show.input(t`Apply Current Sorting`, content, '100', { okButton: t`Apply`, cancelButton: 'Cancel' });
-        if (!result) return;
+        const heading = document.createElement('h3');
+        heading.textContent = t`Apply Current Sorting`;
+        contentEl.appendChild(heading);
 
-        const start = Number(result);
+        const description = document.createElement('span');
+        const descriptionText = document.createElement('p');
+        descriptionText.innerHTML = t`Assigns Order values to all entries based on their current sort position.`;
+        contentEl.appendChild(descriptionText);
+        const descriptionDetail = document.createElement('p');
+        descriptionDetail.innerHTML = t`Entries are ordered <b>descending</b> by default — the first entry in the list gets the highest value and will be inserted first into the prompt.`;
+        contentEl.appendChild(descriptionDetail);
+        const entryCountText = document.createElement('small');
+        entryCountText.textContent = t`(${entryCount} entries total)`;
+        contentEl.appendChild(entryCountText);
+        contentEl.appendChild(description);
+
+        const warningEl = document.createElement('div');
+        contentEl.appendChild(warningEl);
+
+        /** @type {(startInput: HTMLInputElement, ascendingInput: HTMLInputElement) => void} */
+        const updateWarning = (startInput, ascendingInput) => {
+            const startVal = Number(startInput.value);
+            const isAscending = ascendingInput.checked;
+            if (!isAscending && !isNaN(startVal) && startVal < entryCount) {
+                setInfoBlock(warningEl, t`Starting value is lower than the entry count (${entryCount}). Entries that fall below 0 will be clamped to 0, causing collisions at the bottom of the order.`, 'warning');
+            } else {
+                clearInfoBlock(warningEl);
+            }
+        };
+
+        /** @type {import('./popup.js').CustomPopupInput[]} */
+        const customInputs = [
+            {
+                id: 'wi_sort_start',
+                label: t`Starting value`,
+                tooltip: t`The Order value assigned to the first entry. In descending mode, values count down from here; in ascending mode, values count up from here.` + ' ' + t`(${entryCount} entries total)`,
+                type: 'number',
+                defaultState: '100',
+                min: 0,
+                step: 1,
+                autoFocus: true,
+            },
+            {
+                id: 'wi_sort_step',
+                label: t`Step`,
+                tooltip: t`The gap between each Order value. For example, a step of 5 produces values like 100, 95, 90... (descending) or 0, 5, 10... (ascending).`,
+                type: 'number',
+                defaultState: '1',
+                min: 1,
+                step: 1,
+            },
+            {
+                id: 'wi_sort_ascending',
+                label: t`Ascending order`,
+                tooltip: t`When checked, Order values count upward from the starting value (first sorted entry gets the lowest Order). When unchecked, values count downward (first sorted entry gets the highest Order).`,
+                type: 'checkbox',
+                defaultState: false,
+            },
+        ];
+
+        const popup = new Popup(contentEl, POPUP_TYPE.TEXT, null, {
+            okButton: t`Apply`,
+            cancelButton: t`Cancel`,
+            customInputs,
+        });
+
+        const startInput = /** @type {HTMLInputElement} */ (popup.dlg.querySelector('#wi_sort_start'));
+        const ascendingInput = /** @type {HTMLInputElement} */ (popup.dlg.querySelector('#wi_sort_ascending'));
+        startInput.addEventListener('input', () => updateWarning(startInput, ascendingInput));
+        ascendingInput.addEventListener('change', () => updateWarning(startInput, ascendingInput));
+        updateWarning(startInput, ascendingInput);
+
+        const result = await popup.show();
+        if (result !== POPUP_RESULT.AFFIRMATIVE) return;
+
+        const start = Number(popup.inputResults.get('wi_sort_start') ?? '100');
+        const step = Number(popup.inputResults.get('wi_sort_step') ?? '1');
+        const ascending = Boolean(popup.inputResults.get('wi_sort_ascending'));
+
         if (isNaN(start) || start < 0) {
-            toastr.error(t`Invalid number: ${result}`, t`Apply Current Sorting`);
+            toastr.error(t`Invalid starting value: ${start}`, t`Apply Current Sorting`);
             return;
         }
-        if (start < entryCount) {
-            toastr.warning(t`A number lower than the entry count has been chosen. All entries below that will default to 0.`, t`Apply Current Sorting`);
+        if (isNaN(step) || step < 1) {
+            toastr.error(t`Invalid step value: ${step}`, t`Apply Current Sorting`);
+            return;
+        }
+        if (!ascending && start < entryCount) {
+            toastr.warning(t`A starting value lower than the entry count has been chosen. All entries below that will default to 0.`, t`Apply Current Sorting`);
         }
 
         // We need to sort the entries here, as the data source isn't sorted
         const entries = Object.values(data.entries);
         sortWorldInfoEntries(entries);
 
-        let updated = 0, current = start;
-        for (const entry of entries) {
-            const newOrder = Math.max(current--, 0);
-            if (entry.order === newOrder) continue;
+        let updated = 0;
+        entries.forEach((entry, index) => {
+            const newOrder = ascending
+                ? start + index * step
+                : Math.max(start - index * step, 0);
+            if (entry.order === newOrder) return;
 
             entry.order = newOrder;
-            setWIOriginalDataValue(data, entry.order, 'order', entry.order);
+            setWIOriginalDataValue(data, entry.uid, 'order', entry.order);
             updated++;
-        }
+        });
 
         if (updated > 0) {
-            toastr.info(`Updated ${updated} Order values`, 'Apply Custom Sorting');
+            toastr.info(t`Updated ${updated} Order values`, t`Apply Current Sorting`);
             await saveWorldInfo(name, data, true);
             updateEditor(navigation_option.previous);
         } else {
-            toastr.info('All values up to date', 'Apply Custom Sorting');
+            toastr.info(t`All values up to date`, t`Apply Current Sorting`);
         }
     });
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2517,12 +2517,13 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
         const warningEl = document.createElement('div');
         contentEl.appendChild(warningEl);
 
-        /** @type {(startInput: HTMLInputElement, ascendingInput: HTMLInputElement) => void} */
-        const updateWarning = (startInput, ascendingInput) => {
+        /** @type {(startInput: HTMLInputElement, stepInput: HTMLInputElement, ascendingInput: HTMLInputElement) => void} */
+        const updateWarning = (startInput, stepInput, ascendingInput) => {
             const startVal = Number(startInput.value);
+            const stepVal = Number(stepInput.value);
             const isAscending = ascendingInput.checked;
-            if (!isAscending && !isNaN(startVal) && startVal < entryCount) {
-                setInfoBlock(warningEl, t`Starting value is lower than the entry count (${entryCount}). Entries that fall below 0 will be clamped to 0, causing collisions at the bottom of the order.`, 'warning');
+            if (!isAscending && !isNaN(startVal) && !isNaN(stepVal) && startVal - (entryCount - 1) * stepVal < 0) {
+                setInfoBlock(warningEl, t`Some entries will be clamped to Order 0, causing collisions at the bottom. The last entry would reach ${startVal - (entryCount - 1) * stepVal} (${entryCount} entries, step ${stepVal}).`, 'warning');
             } else {
                 clearInfoBlock(warningEl);
             }
@@ -2565,10 +2566,12 @@ async function displayWorldEntries(name, data, navigation = navigation_option.no
         });
 
         const startInput = /** @type {HTMLInputElement} */ (popup.dlg.querySelector('#wi_sort_start'));
+        const stepInput = /** @type {HTMLInputElement} */ (popup.dlg.querySelector('#wi_sort_step'));
         const ascendingInput = /** @type {HTMLInputElement} */ (popup.dlg.querySelector('#wi_sort_ascending'));
-        startInput.addEventListener('input', () => updateWarning(startInput, ascendingInput));
-        ascendingInput.addEventListener('change', () => updateWarning(startInput, ascendingInput));
-        updateWarning(startInput, ascendingInput);
+        startInput.addEventListener('input', () => updateWarning(startInput, stepInput, ascendingInput));
+        stepInput.addEventListener('input', () => updateWarning(startInput, stepInput, ascendingInput));
+        ascendingInput.addEventListener('change', () => updateWarning(startInput, stepInput, ascendingInput));
+        updateWarning(startInput, stepInput, ascendingInput);
 
         const result = await popup.show();
         if (result !== POPUP_RESULT.AFFIRMATIVE) return;


### PR DESCRIPTION
The "Apply Current Sorting" button in the World Info editor previously only accepted a single starting value through a plain text input. This PR replaces it with a proper multi-input popup offering full control over how Order values are assigned, adds a live warning when the configuration would cause collisions, and fixes a bug in how the underlying data was being updated. Two reusable framework pieces were also improved along the way: custom popup inputs now support auto-focus, and the info block utility gained animated show/hide behaviour.

---

### New Feature: Enhanced "Apply Current Sorting"

The popup now has three inputs:

- **Starting value** — the Order value assigned to the first entry in the sorted list (auto-focused on open, tooltip shows total entry count)
- **Step** — the gap between consecutive Order values (e.g. a step of 5 gives 100, 95, 90… or 0, 5, 10…)
- **Ascending order** — when checked, values count *up* from the starting value instead of down; the first entry in the list gets the *lowest* Order

A **live warning** appears (with a slide-in animation) if the starting value is too low in descending mode — i.e. when some entries would be clamped to 0 and collide. It disappears automatically when the inputs are adjusted to a valid configuration or ascending mode is enabled.

The popup content itself is built with DOM methods rather than HTML string concatenation, keeping it clean and safe for future translation.

**Bug fix included:** the previous implementation passed `entry.order` as the UID to `setWIOriginalDataValue`, meaning the underlying data was never actually updated correctly. The call now correctly passes `entry.uid`.

Also fixed: toastr strings were previously not wrapped in `t\`...\`` translation tags — they now are.

---

### Framework: `autoFocus` support for custom popup inputs

`CustomPopupInput` now accepts an `autoFocus` boolean property. When set, the input element gets the native `autofocus` attribute and a `tabIndex`, which plugs into the popup's existing `setAutoFocus` mechanism. This works for all input types: checkbox, text, textarea, and number. No `onOpen` callback workaround needed.

---

### Framework: Animated `setInfoBlock` / `clearInfoBlock`

`setInfoBlock` and `clearInfoBlock` in `utils.js` now animate using jQuery `slideDown` / `slideUp`, driven by the existing `animation_duration` value — which is already set to `0` when reduced motion is enabled, and is also governed by `jQuery.fx.off`, so both code paths for reduced motion are respected automatically.

Both functions accept an optional `{ animate: true }` argument (default on) to opt out of animation when immediate placement is preferred. `setInfoBlock` hides the element *before* populating its content to avoid a single-frame flash, then slides it in.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://www.youtube.com/watch?v=e-GwojpaoQI).