### PR TITLE
feat(nanogpt): Display per-message billing info

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3666,6 +3666,10 @@
                                     <input id="nanogpt_payg_override" type="checkbox" />
                                     <span data-i18n="Use pay-as-you-go billing">Use pay-as-you-go billing</span>
                                 </label>
+                                <label class="checkbox_label marginTopBot5" for="nanogpt_show_billing">
+                                    <input id="nanogpt_show_billing" type="checkbox" />
+                                    <span data-i18n="Show billing details on each message">Show billing details on each message</span>
+                                </label>
                             </div>
                         </div>
                         <div id="workers_ai_form" data-source="workers_ai">
@@ -7390,6 +7394,12 @@
                     <div class="mesIDDisplay"></div>
                     <div class="mes_timer"></div>
                     <div class="tokenCounterDisplay"></div>
+                    <div class="nanogptBillingDisplay" hidden>
+                        <div class="nanogptBillingLine nanogptBillingLinePrimary">
+                            <span>cost: </span><span class="nanogptBillingCostValue"></span>
+                            <span class="nanogptBillingCacheCost" hidden> cache: <span class="nanogptBillingCostValue nanogptBillingCacheCostValue"></span></span>
+                        </div>
+                    </div>
                 </div>
                 <div class="swipe_left fa-solid fa-chevron-left"></div>
                 <div class="mes_block">

--- a/public/script.js
+++ b/public/script.js
@@ -112,6 +112,11 @@ import {
     selected_proxy,
     initOpenAI,
 } from './scripts/openai.js';
+import {
+    createNanoGptBillingEntryFromResponse,
+    formatNanoGptBillingDisplay,
+    mergeNanoGptBillingMetadata,
+} from './scripts/nanogpt-billing.js';
 
 import {
     generateNovelWithStreaming,
@@ -2547,6 +2552,61 @@ export function addOneMessage(mes, { type = undefined, insertAfter = null, scrol
     return messageElement;
 }
 
+const NANO_GPT_BILLING_APPEND_TYPES = new Set(['append', 'continue', 'appendFinal']);
+
+/**
+ * Applies a NanoGPT billing request to a message.
+ * @param {ChatMessage} message Message object
+ * @param {object|null} billingRequest NanoGPT billing request
+ * @param {string} type Generation type
+ */
+function applyNanoGptBillingToMessage(message, billingRequest, type) {
+    if (!message) {
+        return;
+    }
+
+    message.extra ??= {};
+    const append = NANO_GPT_BILLING_APPEND_TYPES.has(type);
+    const nanogpt = mergeNanoGptBillingMetadata(message.extra.nanogpt, billingRequest, { append });
+
+    if (nanogpt) {
+        message.extra.nanogpt = nanogpt;
+    } else if (append && message.extra.nanogpt) {
+        message.extra.nanogpt.incomplete = true;
+    } else if (!append) {
+        delete message.extra.nanogpt;
+    }
+}
+
+/**
+ * Updates the NanoGPT billing display for a message element.
+ * @param {JQuery<HTMLElement>} messageElement Message element
+ * @param {ChatMessage} mes Message object
+ */
+function updateNanoGptBillingDisplay(messageElement, mes) {
+    const display = messageElement.find('.nanogptBillingDisplay');
+    if (!display.length) {
+        return;
+    }
+
+    const formatted = formatNanoGptBillingDisplay(mes?.extra?.nanogpt);
+    display.prop('hidden', !formatted);
+
+    if (!formatted) {
+        display.find('.nanogptBillingLinePrimary').attr('title', '');
+        display.find('.nanogptBillingCostValue').text('');
+        display.find('.nanogptBillingCacheCost').prop('hidden', true);
+        return;
+    }
+
+    display.find('.nanogptBillingLinePrimary').attr('title', formatted.title);
+    display.find('.nanogptBillingLinePrimary > .nanogptBillingCostValue').text(formatted.totalCost);
+    display.find('.nanogptBillingCacheCost')
+        .prop('hidden', !formatted.cacheCost)
+        .find('.nanogptBillingCacheCostValue')
+        .text(formatted.cacheCost ?? '');
+}
+
 /**
  * Creates the element of a single message as if it were the last message or at forceMesId
  * @param {ChatMessage} mes Message object
@@ -2605,6 +2665,7 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
     tokenCount && messageElement.find('.tokenCounterDisplay').text(`${tokenCount}t`);
     mes.title && messageElement.attr('title', mes.title);
     timerValue && messageElement.find('.mes_timer').attr('title', timerTitle).text(timerValue);
+    updateNanoGptBillingDisplay(messageElement, mes);
     bookmarkLink && updateBookmarkDisplay(messageElement);
 
     if (mes.extra?.bias !== '') {
@@ -3524,6 +3585,8 @@ class StreamingProcessor {
         this.images = [];
         /** @type {string?} */
         this.reasoningSignature = null;
+        /** @type {object|null} */
+        this.nanogptBilling = null;
     }
 
     /**
@@ -3718,6 +3781,8 @@ class StreamingProcessor {
             message.swipe_info.push(...swipeInfoArray);
         }
 
+        applyNanoGptBillingToMessage(message, this.nanogptBilling, this.type);
+        updateNanoGptBillingDisplay(messageElement, message);
         syncMesToSwipe(messageId);
         saveLogprobsForActiveMessage(this.messageLogprobs.filter(Boolean), this.continueMessage);
 
@@ -3833,6 +3898,7 @@ class StreamingProcessor {
                 this.reasoningHandler.updateReasoning(this.messageId, state?.reasoning);
                 this.images = state?.images ?? [];
                 this.reasoningSignature = state?.signature ?? null;
+                this.nanogptBilling = state?.nanogptBilling ?? this.nanogptBilling;
                 await eventSource.emit(event_types.STREAM_TOKEN_RECEIVED, text);
                 await sw.tick(async () => await this.onProgressStreaming(this.messageId, this.continueMessage + text));
             }
@@ -5432,6 +5498,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         kobold_horde_model = title;
 
         const swipes = extractMultiSwipes(data, type);
+        const nanogptBilling = main_api === 'openai' && oai_settings.chat_completion_source === chat_completion_sources.NANOGPT
+            ? createNanoGptBillingEntryFromResponse(data, originalType)
+            : null;
 
         messageChunk = cleanUpMessage({
             getMessage: getMessage,
@@ -5470,9 +5539,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         } else {
             // Without streaming we'll be having a full message on continuation. Treat it as a last chunk.
             if (originalType !== 'continue') {
-                ({ type, getMessage } = await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature }));
+                ({ type, getMessage } = await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, nanogptBilling }));
             } else {
-                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, title, swipes, reasoning, imageUrls, reasoningSignature }));
+                ({ type, getMessage } = await saveReply({ type: 'appendFinal', getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, nanogptBilling }));
             }
 
             // This relies on `saveReply` having been called to add the message to the chat, so it must be last.
@@ -6575,16 +6644,17 @@ async function processImageAttachment(message, { imageUrls }) {
  * @property {string} [reasoning] Message reasoning
  * @property {string[]} [imageUrls] Links to images
  * @property {string?} [reasoningSignature] Encrypted signature of the reasoning text
+ * @property {object?} [nanogptBilling] NanoGPT billing request metadata
  *
  * @typedef {object} SaveReplyResult
  * @property {string} type Type of generation
  * @property {string} getMessage Generated message
  */
-export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrls = [], reasoningSignature = null }) {
+export async function saveReply({ type, getMessage, fromStreaming = false, title = '', swipes = [], reasoning = '', imageUrls = [], reasoningSignature = null, nanogptBilling = null }) {
     // Backward compatibility
     if (arguments.length > 1 && typeof arguments[0] !== 'object') {
         console.trace('saveReply called with positional arguments. Please use an object instead.');
-        [type, getMessage, fromStreaming, title, swipes, reasoning, imageUrls, reasoningSignature] = arguments;
+        [type, getMessage, fromStreaming, title, swipes, reasoning, imageUrls, reasoningSignature, nanogptBilling] = arguments;
     }
 
     const lastMessage = chat[chat.length - 1];
@@ -6623,6 +6693,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
             lastMessage.extra.reasoning = reasoning;
             lastMessage.extra.reasoning_duration = null;
             lastMessage.extra.reasoning_signature = reasoningSignature;
+            applyNanoGptBillingToMessage(lastMessage, nanogptBilling, type);
             await processImageAttachment(lastMessage, { imageUrls });
             if (power_user.message_token_count_enabled) {
                 const tokenCountText = (reasoning || '') + lastMessage.mes;
@@ -6648,6 +6719,9 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.extra.reasoning = reasoning;
         lastMessage.extra.reasoning_duration = null;
         lastMessage.extra.reasoning_signature = reasoningSignature;
+        if (nanogptBilling || !fromStreaming) {
+            applyNanoGptBillingToMessage(lastMessage, nanogptBilling, type);
+        }
         await processImageAttachment(lastMessage, { imageUrls });
         if (power_user.message_token_count_enabled) {
             const tokenCountText = (reasoning || '') + lastMessage.mes;
@@ -6669,6 +6743,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         lastMessage.extra.model = getGeneratingModel();
         lastMessage.extra.reasoning += reasoning;
         lastMessage.extra.reasoning_signature = reasoningSignature;
+        applyNanoGptBillingToMessage(lastMessage, nanogptBilling, type);
         await processImageAttachment(lastMessage, { imageUrls });
         // We don't know if the reasoning duration extended, so we don't update it here on purpose.
         if (power_user.message_token_count_enabled) {
@@ -6692,6 +6767,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         newMessage.extra.reasoning = reasoning;
         newMessage.extra.reasoning_duration = null;
         newMessage.extra.reasoning_signature = reasoningSignature;
+        applyNanoGptBillingToMessage(newMessage, nanogptBilling, type);
         if (power_user.trim_spaces) {
             getMessage = getMessage.trim();
         }

--- a/public/scripts/nanogpt-billing.js
+++ b/public/scripts/nanogpt-billing.js
@@ -1,0 +1,462 @@
+const MAX_STRING_LENGTH = 256;
+const MAX_ARRAY_LENGTH = 32;
+const MAX_OBJECT_DEPTH = 4;
+const SENSITIVE_KEY_PATTERN = /(?:account|team|payment|invoice|customer|email|api[_-]?key|secret|credential|wallet|balance|credit|subscription|organization|org_id)/i;
+
+const TOTAL_COST_PATHS = [
+    'amount',
+    'cost',
+    'total_cost',
+    'totalCost',
+    'cost_usd',
+    'total_cost_usd',
+];
+
+const CACHE_COST_PATHS = [
+    'cache_cost',
+    'cacheCost',
+    'cache_cost_usd',
+    'cache_total_cost',
+    'cacheTotalCost',
+    'total_cache_cost',
+    'totalCacheCost',
+];
+
+const INPUT_TOKEN_PATHS = [
+    'prompt_tokens',
+    'input_tokens',
+];
+
+const OUTPUT_TOKEN_PATHS = [
+    'completion_tokens',
+    'output_tokens',
+];
+
+const CACHE_READ_TOKEN_PATHS = [
+    'readTokens',
+    'cache_read_tokens',
+    'cache_read_input_tokens',
+    'cached_tokens',
+    'prompt_tokens_details.cached_tokens',
+    'input_tokens_details.cached_tokens',
+];
+
+const CACHE_WRITE_TOKEN_PATHS = [
+    'writeTokens',
+    'cache_write_tokens',
+    'cache_write_input_tokens',
+    'cache_creation_tokens',
+    'cache_creation_input_tokens',
+    'prompt_tokens_details.cache_creation_tokens',
+    'input_tokens_details.cache_creation_tokens',
+];
+
+const PROVIDER_PATHS = [
+    'provider',
+    'provider_name',
+    'providerName',
+];
+
+const MODEL_PATHS = [
+    'model',
+    'model_name',
+    'modelName',
+];
+
+/**
+ * Checks if a value is a plain object.
+ * @param {unknown} value Value to test
+ * @returns {value is Record<string, any>}
+ */
+function isPlainObject(value) {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Reads a dotted path from an object.
+ * @param {Record<string, any>} source Source object
+ * @param {string} path Dotted path
+ * @returns {unknown}
+ */
+function readPath(source, path) {
+    const parts = path.split('.');
+    let value = source;
+
+    for (const part of parts) {
+        if (!isPlainObject(value) || !Object.hasOwn(value, part)) {
+            return undefined;
+        }
+
+        value = value[part];
+    }
+
+    return value;
+}
+
+/**
+ * Reads the first present value from a list of dotted paths.
+ * @param {Record<string, any>} source Source object
+ * @param {string[]} paths Dotted paths
+ * @returns {unknown}
+ */
+function pickValue(source, paths) {
+    if (!isPlainObject(source)) {
+        return undefined;
+    }
+
+    for (const path of paths) {
+        const value = readPath(source, path);
+        if (value !== undefined && value !== null && value !== '') {
+            return value;
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Converts a value to a non-negative integer when exact enough to display.
+ * @param {unknown} value Value to convert
+ * @returns {number|null}
+ */
+function toTokenCount(value) {
+    if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0) {
+        return value;
+    }
+
+    if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
+        const parsed = Number(value.trim());
+        return Number.isSafeInteger(parsed) ? parsed : null;
+    }
+
+    return null;
+}
+
+/**
+ * Converts a value to a non-negative dollar cost.
+ * @param {unknown} value Value to convert
+ * @returns {number|null}
+ */
+function toCost(value) {
+    if (typeof value !== 'number' && typeof value !== 'string') {
+        return null;
+    }
+
+    const parsed = Number(String(value).trim());
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+/**
+ * Checks if a pricing object is denominated in USD when it declares a currency.
+ * @param {Record<string, any>} pricing Pricing metadata
+ * @returns {boolean}
+ */
+function isUsdPricing(pricing) {
+    const currency = toDisplayString(pricing.currency);
+    return !currency || currency.toUpperCase() === 'USD';
+}
+
+/**
+ * Converts a value to a bounded string.
+ * @param {unknown} value Value to convert
+ * @returns {string|null}
+ */
+function toDisplayString(value) {
+    if (typeof value !== 'string' && typeof value !== 'number') {
+        return null;
+    }
+
+    const stringValue = String(value).trim();
+    return stringValue ? stringValue.slice(0, MAX_STRING_LENGTH) : null;
+}
+
+/**
+ * Sanitizes a NanoGPT-returned metadata object for chat storage.
+ * @param {unknown} value Value to sanitize
+ * @param {number} [depth=0] Recursion depth
+ * @returns {unknown}
+ */
+export function sanitizeNanoGptMetadata(value, depth = 0) {
+    if (value === null || typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : undefined;
+    }
+
+    if (typeof value === 'string') {
+        return value.slice(0, MAX_STRING_LENGTH);
+    }
+
+    if (depth >= MAX_OBJECT_DEPTH) {
+        return undefined;
+    }
+
+    if (Array.isArray(value)) {
+        const sanitized = value
+            .slice(0, MAX_ARRAY_LENGTH)
+            .map(item => sanitizeNanoGptMetadata(item, depth + 1))
+            .filter(item => item !== undefined);
+
+        return sanitized;
+    }
+
+    if (isPlainObject(value)) {
+        const sanitized = {};
+
+        for (const [key, item] of Object.entries(value)) {
+            if (SENSITIVE_KEY_PATTERN.test(key)) {
+                continue;
+            }
+
+            const sanitizedItem = sanitizeNanoGptMetadata(item, depth + 1);
+            if (sanitizedItem !== undefined) {
+                sanitized[key] = sanitizedItem;
+            }
+        }
+
+        return sanitized;
+    }
+
+    return undefined;
+}
+
+/**
+ * Extracts provider/model metadata from NanoGPT response data.
+ * @param {Record<string, any>} data Response data
+ * @param {Record<string, any>} pricing NanoGPT pricing metadata
+ * @returns {{provider: string|null, model: string|null}}
+ */
+function extractProviderModel(data, pricing) {
+    const provider = toDisplayString(pickValue(pricing, PROVIDER_PATHS) ?? pickValue(data, PROVIDER_PATHS));
+    const model = toDisplayString(pickValue(pricing, MODEL_PATHS) ?? pickValue(data, MODEL_PATHS));
+
+    return { provider, model };
+}
+
+/**
+ * Builds a sanitized NanoGPT billing request entry from response data.
+ * @param {unknown} data Response data
+ * @param {string} [type='normal'] Generation type
+ * @param {number} [createdAt=Date.now()] Creation timestamp
+ * @returns {object|null}
+ */
+export function createNanoGptBillingEntryFromResponse(data, type = 'normal', createdAt = Date.now()) {
+    if (!isPlainObject(data) || !isPlainObject(data.x_nanogpt_pricing) || !isPlainObject(data.usage)) {
+        return null;
+    }
+
+    const totalCost = toCost(pickValue(data.x_nanogpt_pricing, TOTAL_COST_PATHS));
+    const inputTokens = toTokenCount(pickValue(data.usage, INPUT_TOKEN_PATHS));
+    const outputTokens = toTokenCount(pickValue(data.usage, OUTPUT_TOKEN_PATHS));
+
+    if (totalCost === null || inputTokens === null || outputTokens === null || !isUsdPricing(data.x_nanogpt_pricing)) {
+        return null;
+    }
+
+    const { provider, model } = extractProviderModel(data, data.x_nanogpt_pricing);
+    const pricing = sanitizeNanoGptMetadata(data.x_nanogpt_pricing);
+    const usage = sanitizeNanoGptMetadata(data.usage);
+    const cache = isPlainObject(data.x_nanogpt_cache) ? sanitizeNanoGptMetadata(data.x_nanogpt_cache) : undefined;
+
+    if (!isPlainObject(pricing) || !isPlainObject(usage)) {
+        return null;
+    }
+
+    return sanitizeNanoGptBillingRequest({
+        provider,
+        model,
+        pricing,
+        usage,
+        ...(isPlainObject(cache) ? { cache } : {}),
+        created_at: Number.isFinite(createdAt) ? createdAt : Date.now(),
+        type: typeof type === 'string' && type ? type : 'normal',
+    });
+}
+
+/**
+ * Sanitizes a stored NanoGPT billing request entry.
+ * @param {unknown} request Request entry
+ * @returns {object|null}
+ */
+export function sanitizeNanoGptBillingRequest(request) {
+    if (!isPlainObject(request) || !isPlainObject(request.pricing) || !isPlainObject(request.usage)) {
+        return null;
+    }
+
+    const totalCost = toCost(pickValue(request.pricing, TOTAL_COST_PATHS));
+    const inputTokens = toTokenCount(pickValue(request.usage, INPUT_TOKEN_PATHS));
+    const outputTokens = toTokenCount(pickValue(request.usage, OUTPUT_TOKEN_PATHS));
+
+    if (totalCost === null || inputTokens === null || outputTokens === null || !isUsdPricing(request.pricing)) {
+        return null;
+    }
+
+    const pricing = sanitizeNanoGptMetadata(request.pricing);
+    const usage = sanitizeNanoGptMetadata(request.usage);
+    const cache = isPlainObject(request.cache) ? sanitizeNanoGptMetadata(request.cache) : undefined;
+
+    if (!isPlainObject(pricing) || !isPlainObject(usage)) {
+        return null;
+    }
+
+    const createdAt = toTokenCount(request.created_at) ?? Date.now();
+
+    return {
+        provider: toDisplayString(request.provider),
+        model: toDisplayString(request.model),
+        pricing,
+        usage,
+        ...(isPlainObject(cache) ? { cache } : {}),
+        created_at: createdAt,
+        type: typeof request.type === 'string' && request.type ? request.type.slice(0, 64) : 'normal',
+    };
+}
+
+/**
+ * Appends or replaces NanoGPT billing metadata.
+ * @param {unknown} existing Existing message.extra.nanogpt object
+ * @param {unknown} request New request entry
+ * @param {object} [options] Options
+ * @param {boolean} [options.append=false] Whether to append to existing requests
+ * @returns {{requests: object[]}|undefined}
+ */
+export function mergeNanoGptBillingMetadata(existing, request, { append = false } = {}) {
+    const sanitizedRequest = sanitizeNanoGptBillingRequest(request);
+    if (!sanitizedRequest) {
+        return undefined;
+    }
+
+    const existingRequests = append && isPlainObject(existing) && Array.isArray(existing.requests)
+        ? existing.requests.map(sanitizeNanoGptBillingRequest).filter(Boolean)
+        : [];
+    const incomplete = append && isPlainObject(existing) && existing.incomplete === true;
+
+    return {
+        requests: [...existingRequests, sanitizedRequest],
+        ...(incomplete ? { incomplete } : {}),
+    };
+}
+
+/**
+ * Formats a USD value with the required fixed precision.
+ * @param {number} value Dollar value
+ * @returns {string}
+ */
+export function formatNanoGptUsd(value) {
+    return `$${Number(value).toFixed(6)}`;
+}
+
+/**
+ * Gets request metrics from a sanitized billing request.
+ * @param {object} request Billing request
+ * @returns {object|null}
+ */
+function getRequestMetrics(request) {
+    const totalCost = toCost(pickValue(request.pricing, TOTAL_COST_PATHS));
+    const inputTokens = toTokenCount(pickValue(request.usage, INPUT_TOKEN_PATHS));
+    const outputTokens = toTokenCount(pickValue(request.usage, OUTPUT_TOKEN_PATHS));
+
+    if (totalCost === null || inputTokens === null || outputTokens === null) {
+        return null;
+    }
+
+    return {
+        totalCost,
+        inputTokens,
+        outputTokens,
+        cacheReadTokens: toTokenCount(pickValue(request.usage, CACHE_READ_TOKEN_PATHS) ?? pickValue(request.cache, CACHE_READ_TOKEN_PATHS)),
+        cacheWriteTokens: toTokenCount(pickValue(request.usage, CACHE_WRITE_TOKEN_PATHS) ?? pickValue(request.cache, CACHE_WRITE_TOKEN_PATHS)),
+        cacheCost: toCost(pickValue(request.pricing, CACHE_COST_PATHS)),
+    };
+}
+
+/**
+ * Accumulates NanoGPT billing metadata from message extra data.
+ * @param {unknown} nanogptMetadata message.extra.nanogpt
+ * @returns {object|null}
+ */
+export function accumulateNanoGptBilling(nanogptMetadata) {
+    if (!isPlainObject(nanogptMetadata) || !Array.isArray(nanogptMetadata.requests)) {
+        return null;
+    }
+
+    if (nanogptMetadata.incomplete === true) {
+        return null;
+    }
+
+    const requests = nanogptMetadata.requests.map(sanitizeNanoGptBillingRequest).filter(Boolean);
+    if (!requests.length) {
+        return null;
+    }
+
+    const summary = {
+        totalCost: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        cacheCost: 0,
+        hasCacheCost: false,
+        canShowCacheCost: true,
+    };
+
+    for (const request of requests) {
+        const metrics = getRequestMetrics(request);
+
+        if (!metrics) {
+            continue;
+        }
+
+        summary.totalCost += metrics.totalCost;
+        summary.inputTokens += metrics.inputTokens;
+        summary.outputTokens += metrics.outputTokens;
+
+        const cacheReadTokens = metrics.cacheReadTokens ?? 0;
+        const cacheWriteTokens = metrics.cacheWriteTokens ?? 0;
+        summary.cacheReadTokens += cacheReadTokens;
+        summary.cacheWriteTokens += cacheWriteTokens;
+
+        if (metrics.cacheCost !== null) {
+            summary.cacheCost += metrics.cacheCost;
+            summary.hasCacheCost = true;
+        } else if (cacheReadTokens > 0 || cacheWriteTokens > 0) {
+            summary.canShowCacheCost = false;
+        }
+    }
+
+    if (!summary.canShowCacheCost || !summary.hasCacheCost) {
+        summary.cacheCost = null;
+    }
+
+    return summary;
+}
+
+/**
+ * Formats NanoGPT billing metadata for display.
+ * @param {unknown} nanogptMetadata message.extra.nanogpt
+ * @returns {object|null}
+ */
+export function formatNanoGptBillingDisplay(nanogptMetadata) {
+    const summary = accumulateNanoGptBilling(nanogptMetadata);
+    if (!summary) {
+        return null;
+    }
+
+    const hasCacheTokens = summary.cacheReadTokens > 0 || summary.cacheWriteTokens > 0;
+    const hasCacheCost = summary.cacheCost !== null && (summary.cacheCost > 0 || hasCacheTokens);
+    const totalCost = formatNanoGptUsd(summary.totalCost);
+    const cacheCost = hasCacheCost ? formatNanoGptUsd(summary.cacheCost) : null;
+    const title = [`in/out: ${summary.inputTokens}t/${summary.outputTokens}t`];
+
+    if (hasCacheTokens) {
+        title.push(`cache: ${summary.cacheReadTokens}t/${summary.cacheWriteTokens}t`);
+    }
+
+    return {
+        totalCost,
+        cacheCost,
+        title: title.join(' '),
+    };
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -81,6 +81,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
 import { syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
+import { createNanoGptBillingEntryFromResponse } from './nanogpt-billing.js';
 
 export {
     openai_messages_count,
@@ -331,6 +332,7 @@ export const settingsToUpdate = {
     nanogpt_model: ['#model_nanogpt_select', 'nanogpt_model', false, true],
     nanogpt_provider: ['#nanogpt_provider', 'nanogpt_provider', false, true],
     nanogpt_payg_override: ['#nanogpt_payg_override', 'nanogpt_payg_override', true, true],
+    nanogpt_show_billing: ['#nanogpt_show_billing', 'nanogpt_show_billing', true, true],
     deepseek_model: ['#model_deepseek_select', 'deepseek_model', false, true],
     aimlapi_model: ['#model_aimlapi_select', 'aimlapi_model', false, true],
     xai_model: ['#model_xai_select', 'xai_model', false, true],
@@ -447,6 +449,7 @@ const default_settings = {
     nanogpt_model: 'gpt-4o-mini',
     nanogpt_provider: '',
     nanogpt_payg_override: false,
+    nanogpt_show_billing: false,
     deepseek_model: 'deepseek-v4-flash',
     aimlapi_model: 'chatgpt-4o-latest',
     xai_model: 'grok-3-beta',
@@ -3071,7 +3074,7 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
             let text = '';
             const swipes = [];
             const toolCalls = [];
-            const state = { reasoning: '', images: [], signature: '', toolSignatures: {} };
+            const state = { reasoning: '', images: [], signature: '', toolSignatures: {}, nanogptBilling: null };
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) return;
@@ -3079,6 +3082,9 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
                 if (rawData === '[DONE]') return;
                 tryParseStreamingError(response, rawData);
                 const parsed = JSON.parse(rawData);
+                if (oai_settings.chat_completion_source === chat_completion_sources.NANOGPT) {
+                    state.nanogptBilling = createNanoGptBillingEntryFromResponse(parsed, type) ?? state.nanogptBilling;
+                }
 
                 if (canMultiSwipe && Array.isArray(parsed?.choices) && parsed?.choices?.[0]?.index > 0) {
                     const swipeIndex = parsed.choices[0].index - 1;
@@ -4211,6 +4217,10 @@ function migrateChatCompletionSettings(settings) {
     }
 }
 
+function setNanoGptBillingDisplayEnabled(enabled) {
+    document.body?.classList.toggle('nanogptShowBilling', Boolean(enabled));
+}
+
 /**
  * Load OpenAI settings from backend data
  * @param {any} data Settings data from backend
@@ -4300,6 +4310,7 @@ function loadOpenAISettings(data, settings) {
     $('#openrouter_providers_chat').trigger('change');
     $('#openrouter_quantizations_chat').trigger('change');
     $('#nanogpt_provider').trigger('change');
+    setNanoGptBillingDisplayEnabled(oai_settings.nanogpt_show_billing);
     $('#chat_completion_source').trigger('change');
 }
 
@@ -7154,6 +7165,12 @@ export function initOpenAI() {
 
     $('#nanogpt_payg_override').on('input', function () {
         oai_settings.nanogpt_payg_override = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#nanogpt_show_billing').on('input', function () {
+        oai_settings.nanogpt_show_billing = !!$(this).prop('checked');
+        setNanoGptBillingDisplayEnabled(oai_settings.nanogpt_show_billing);
         saveSettingsDebounced();
     });
 

--- a/public/style.css
+++ b/public/style.css
@@ -625,6 +625,40 @@ input[type='checkbox']:focus-visible {
     text-align: center;
 }
 
+.nanogptBillingDisplay {
+    cursor: default;
+    display: none;
+    flex-direction: column;
+    gap: 1px;
+    max-width: 100%;
+    margin-top: 2px;
+    color: var(--SmartThemeBodyColor);
+    opacity: 0.7;
+    font-size: calc(var(--mainFontSize) * 0.8);
+    font-weight: 600;
+    line-height: 1.25;
+}
+
+body.nanogptShowBilling .nanogptBillingDisplay:not([hidden]) {
+    display: flex;
+}
+
+.nanogptBillingDisplay[hidden] {
+    display: none !important;
+}
+
+.nanogptBillingLine {
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nanogptBillingCostValue {
+    font-weight: 700;
+}
+
 .mes_translate,
 .sd_message_gen,
 .mes_ghost,

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2389,6 +2389,9 @@ router.post('/generate', async function (request, response) {
                 headers['X-Billing-Mode'] = 'paygo';
                 bodyParams['billing_mode'] = 'paygo';
             }
+            if (request.body.stream) {
+                bodyParams['stream_options'] = { include_usage: true };
+            }
             if (request.body.enable_web_search && !/:online$/.test(request.body.model)) {
                 request.body.model = `${request.body.model}:online`;
             }

--- a/tests/nanogpt-billing.test.js
+++ b/tests/nanogpt-billing.test.js
@@ -1,0 +1,222 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+    createNanoGptBillingEntryFromResponse,
+    formatNanoGptBillingDisplay,
+    mergeNanoGptBillingMetadata,
+} from '../public/scripts/nanogpt-billing.js';
+
+function makeResponse({
+    provider = 'Auto',
+    model = 'moonshotai/kimi-k2.6',
+    cost = 0.000001,
+    promptTokens = 1234,
+    completionTokens = 567,
+    pricing = {},
+    usage = {},
+    cache = null,
+} = {}) {
+    const response = {
+        model,
+        x_nanogpt_pricing: {
+            provider,
+            model,
+            cost,
+            account_id: 'acct-secret',
+            payment_id: 'pay-secret',
+            ...pricing,
+        },
+        usage: {
+            prompt_tokens: promptTokens,
+            completion_tokens: completionTokens,
+            team_id: 'team-secret',
+            ...usage,
+        },
+    };
+
+    if (cache) {
+        response.x_nanogpt_cache = cache;
+    }
+
+    return response;
+}
+
+describe('NanoGPT billing metadata', () => {
+    test('captures exact non-stream metadata and sanitizes identifiers', () => {
+        const entry = createNanoGptBillingEntryFromResponse(makeResponse(), 'normal', 1760000000000);
+
+        expect(entry).toMatchObject({
+            provider: 'Auto',
+            model: 'moonshotai/kimi-k2.6',
+            created_at: 1760000000000,
+            type: 'normal',
+        });
+        expect(entry.pricing.account_id).toBeUndefined();
+        expect(entry.pricing.payment_id).toBeUndefined();
+        expect(entry.usage.team_id).toBeUndefined();
+
+        const display = formatNanoGptBillingDisplay({ requests: [entry] });
+        expect(display).toEqual({
+            totalCost: '$0.000001',
+            cacheCost: null,
+            title: 'in/out: 1234t/567t',
+        });
+    });
+
+    test('captures final stream chunk metadata and ignores partial chunks', () => {
+        expect(createNanoGptBillingEntryFromResponse({ choices: [{ delta: { content: 'hi' } }] }, 'normal')).toBeNull();
+
+        const finalChunk = {
+            choices: [],
+            ...makeResponse({ cost: 0.000002, promptTokens: 10, completionTokens: 5 }),
+        };
+        const entry = createNanoGptBillingEntryFromResponse(finalChunk, 'normal', 1760000000001);
+
+        expect(formatNanoGptBillingDisplay({ requests: [entry] }).totalCost).toBe('$0.000002');
+    });
+
+    test('formats cache cost and moves token details to title', () => {
+        const entry = createNanoGptBillingEntryFromResponse(makeResponse({
+            cost: 0.000003,
+            pricing: {
+                cache_cost: 0.000002,
+                cache_ttl_seconds: 300,
+            },
+            usage: {
+                cache_read_tokens: 1000,
+                cache_write_tokens: 500,
+            },
+        }));
+
+        const display = formatNanoGptBillingDisplay({ requests: [entry] });
+        expect(display).toEqual({
+            totalCost: '$0.000003',
+            cacheCost: '$0.000002',
+            title: 'in/out: 1234t/567t cache: 1000t/500t',
+        });
+    });
+
+    test('captures NanoGPT amount pricing and cache metadata response shape', () => {
+        const entry = createNanoGptBillingEntryFromResponse({
+            id: 'msg_014QWSN7eHqs56h7QmP9ukjE',
+            object: 'chat.completion',
+            model: 'anthropic/claude-opus-4.6:thinking:medium',
+            choices: [],
+            usage: {
+                prompt_tokens: 113,
+                completion_tokens: 51,
+                total_tokens: 164,
+                cache_creation_input_tokens: 100,
+                cache_read_input_tokens: 20,
+                input_tokens: 113,
+            },
+            x_nanogpt_pricing: {
+                amount: 0.001840131,
+                currency: 'USD',
+            },
+            x_nanogpt_cache: {
+                requested: true,
+                enabledForDispatch: true,
+                supported: true,
+                status: 'requested_unknown',
+                ttl: '5m',
+                readTokens: 20,
+                writeTokens: 100,
+            },
+        });
+
+        expect(entry.pricing.amount).toBe(0.001840131);
+        expect(entry.cache.ttl).toBe('5m');
+
+        const display = formatNanoGptBillingDisplay({ requests: [entry] });
+        expect(display.title).toBe('in/out: 113t/51t cache: 20t/100t');
+    });
+
+    test('omits missing and all-zero cache fields', () => {
+        const noCache = createNanoGptBillingEntryFromResponse(makeResponse({
+            pricing: { cache_cost: 0 },
+            usage: { cache_read_tokens: 0, cache_write_tokens: 0 },
+            cache: { ttl: '5m' },
+        }));
+        expect(formatNanoGptBillingDisplay({ requests: [noCache] }).cacheCost).toBeNull();
+
+        const zeroCacheCost = createNanoGptBillingEntryFromResponse(makeResponse({
+            pricing: { cache_cost: 0 },
+            usage: { cache_read_tokens: 1000, cache_write_tokens: 500 },
+        }));
+        expect(formatNanoGptBillingDisplay({ requests: [zeroCacheCost] }).cacheCost).toBe('$0.000000');
+
+        const missingCacheCost = createNanoGptBillingEntryFromResponse(makeResponse({
+            usage: { cache_read_tokens: 1000, cache_write_tokens: 500 },
+        }));
+        const display = formatNanoGptBillingDisplay({ requests: [missingCacheCost] });
+
+        expect(display.cacheCost).toBeNull();
+        expect(display.title).toContain('cache: 1000t/500t');
+    });
+
+    test('returns no display for missing billing metadata', () => {
+        expect(createNanoGptBillingEntryFromResponse({ usage: { prompt_tokens: 1, completion_tokens: 1 } })).toBeNull();
+        expect(createNanoGptBillingEntryFromResponse({ x_nanogpt_pricing: { cost: 1 } })).toBeNull();
+        expect(createNanoGptBillingEntryFromResponse(makeResponse({ pricing: { currency: 'EUR' } }))).toBeNull();
+        expect(formatNanoGptBillingDisplay({ requests: [] })).toBeNull();
+    });
+
+    test('incomplete accumulated metadata preserves requests but shows nothing', () => {
+        const first = createNanoGptBillingEntryFromResponse(makeResponse());
+        const metadata = mergeNanoGptBillingMetadata(undefined, first);
+        metadata.incomplete = true;
+
+        expect(metadata.requests).toHaveLength(1);
+        expect(formatNanoGptBillingDisplay(metadata)).toBeNull();
+    });
+
+    test('append/continue accumulates totals and token details', () => {
+        const first = createNanoGptBillingEntryFromResponse(makeResponse({
+            cost: 0.000001,
+            promptTokens: 100,
+            completionTokens: 20,
+            pricing: { cache_ttl_seconds: 300 },
+            usage: { cache_read_tokens: 1, cache_write_tokens: 2 },
+        }), 'normal');
+        const second = createNanoGptBillingEntryFromResponse(makeResponse({
+            provider: 'Other',
+            model: 'other/model',
+            cost: 0.000002,
+            promptTokens: 50,
+            completionTokens: 30,
+            pricing: { cache_ttl_seconds: 600 },
+            usage: { cache_read_tokens: 3, cache_write_tokens: 4 },
+        }), 'continue');
+
+        let metadata = mergeNanoGptBillingMetadata(undefined, first);
+        metadata = mergeNanoGptBillingMetadata(metadata, second, { append: true });
+
+        const display = formatNanoGptBillingDisplay(metadata);
+        expect(display.totalCost).toBe('$0.000003');
+        expect(display.title).toBe('in/out: 150t/50t cache: 4t/6t');
+    });
+
+    test('selected swipe extra controls the displayed billing metadata', () => {
+        const first = mergeNanoGptBillingMetadata(undefined, createNanoGptBillingEntryFromResponse(makeResponse({
+            model: 'first/model',
+            cost: 0.000001,
+        })));
+        const second = mergeNanoGptBillingMetadata(undefined, createNanoGptBillingEntryFromResponse(makeResponse({
+            model: 'second/model',
+            cost: 0.000002,
+        })));
+        const message = {
+            swipe_id: 1,
+            swipe_info: [
+                { extra: { nanogpt: first } },
+                { extra: { nanogpt: second } },
+            ],
+            extra: structuredClone(second),
+        };
+
+        message.extra = structuredClone(message.swipe_info[message.swipe_id].extra);
+
+        const display = formatNanoGptBillingDisplay(message.extra.nanogpt);
+        expect(display.totalCost).toBe('$0.000002');
+    });
+});


### PR DESCRIPTION
Add an option to display NanoGPT pricing data on messages. Shows $ by default (with caching broken out) and tokens on hover.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Hi

First, let me give a shoutout to GPT 5.5 who wrote this for me.

Second, this is a feature I personally wanted but I have no idea if anybody else wants it. **I will have absolutely zero hard feelings if you close this PR as something you're not interested in.**

## Summary

Adds optional per-message NanoGPT billing display.
- Requests exact usage metadata for NanoGPT streaming responses
- Captures NanoGPT pricing/usage metadata for streamed and non-streamed replies
- Stores sanitized billing data per message/swipe in `extra.nanogpt`
- Adds a NanoGPT setting to show/hide billing details in chat
- Adds unit coverage for billing parsing, sanitization, accumulation, and swipe behavior

## PR size note

This exceeds the ~200 line soft guideline. I kept it as one vertical PR because the parser, storage path, UI display, and tests are tightly coupled. Most added lines are isolated helper logic and focused tests; the integration surface is small.

I can split this if maintainers prefer.

## Notes

The display is disabled by default and only appears when NanoGPT returns usable USD pricing and usage metadata.

## Screenshots

A picture's worth a thousand words, right?

<img width="1886" height="422" alt="nanogpt_billing_toggle" src="https://github.com/user-attachments/assets/6dbff820-5523-4625-8d78-fbc8ae278dca" />
<img width="817" height="511" alt="nanogpt_billing_example" src="https://github.com/user-attachments/assets/ca52c662-ffbc-49ef-afc2-5592a126f275" />
