### PR TITLE
Enforce stricter npm source restrictions in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,6 @@
 ignore-scripts=true
 min-release-age=7
+allow-directory=none
+allow-file=none
+allow-git=none
+allow-remote=none


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

Further hardening against npm supply chain attacks.

Disallow "exotic" package sources from installing via `.npmrc`, including local files/directories, non-registry tarball URLs, git repositories, etc.

Matches pnpm's default "blockexoticsubdeps" setting: https://pnpm.io/settings#blockexoticsubdeps

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
