### PR TITLE
Improve TTS provider capability handling

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -154,6 +154,13 @@ const ttsProviders = {
 let ttsProvider;
 let ttsProviderName;
 
+function getTtsProviderCapabilities() {
+    return {
+        preferredChunking: 'paragraph',
+        supportsStreaming: false,
+        ...(ttsProvider?.capabilities || {}),
+    };
+}
 
 async function onNarrateOneMessage() {
     audioElement.src = '/sounds/silence.mp3';
@@ -270,6 +277,12 @@ function processAndQueueTtsMessage(message, messageId = null, { manual = false }
     const clone = structuredClone(message);
     clone.id = messageId ?? null;
     clone.manual = manual ?? false;
+
+    const capabilities = getTtsProviderCapabilities();
+    if (capabilities.preferredChunking === 'provider') {
+        ttsJobQueue.push(clone);
+        return;
+    }
 
     if (!extension_settings.tts.narrate_by_paragraphs) {
         ttsJobQueue.push(clone);
@@ -1506,8 +1519,10 @@ async function initVoiceMapInternal(unrestricted) {
     let voiceIdsFromProvider;
     try {
         voiceIdsFromProvider = await ttsProvider.fetchTtsVoiceObjects();
-    } catch {
-        toastr.error('TTS Provider failed to return voice ids.');
+    } catch (error) {
+        const message = `TTS Provider failed to return voice ids. ${error}`;
+        setTtsStatus(message, false);
+        voiceIdsFromProvider = [];
     }
 
     // Build UI using VoiceMapEntry objects


### PR DESCRIPTION
## Summary

This PR makes two small provider-neutral improvements to the native TTS extension.

### Provider capability defaults

Adds a small `getTtsProviderCapabilities()` helper for the active TTS provider. Providers now have default capabilities:

```js
{
    preferredChunking: 'paragraph',
    supportsStreaming: false,
    ...(ttsProvider?.capabilities || {}),
}
```

Existing providers do not need changes because the default keeps the current paragraph behavior.

### Provider-controlled chunking opt-out

`processAndQueueTtsMessage()` now checks `capabilities.preferredChunking`. If a provider sets:

```js
capabilities = { preferredChunking: 'provider' }
```

SillyTavern queues the full cloned message and skips native paragraph splitting. This lets providers that handle chunking or streaming server-side receive the original selected text as one request.

### Quieter voice discovery failures

`initVoiceMapInternal()` now reports `fetchTtsVoiceObjects()` failures through the TTS status area and falls back to an empty voice list instead of always raising a toast during automatic refresh paths.

This keeps provider readiness failures visible without repeatedly interrupting users during chat changes or voice-map refreshes.

## Files touched

- `public/scripts/extensions/tts/index.js`

## Compatibility

- Existing providers without `capabilities` behave as before.
- Existing paragraph splitting remains the default.
- Providers can opt into whole-message handling with `preferredChunking: 'provider'`.
- Voice discovery failures remain visible in the TTS status area.

## Test Plan

- [x] `npm run lint -- --quiet`
- [ ] `npm test` from `tests/`

`npm test` was run outside the sandbox and failed on an existing/local environment port bind issue unrelated to this diff:

```text
FAIL ./mock-server.test.js
MockServer tests > should provide OpenAI-compatible endpoint
listen EACCES: permission denied 127.0.0.1:3000
```

The run reported 314 passing tests and 1 failing test. Port 3000 was already occupied locally by `svchost`.
