### PR TITLE
Add MLX-LM Text Completion Backend

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1283,7 +1283,7 @@
                                         <input class="neo-range-slider" type="range" id="top_p_textgenerationwebui" name="volume" min="0" max="1" step="0.01">
                                         <input class="neo-range-input" type="number" min="0" max="1" step="0.01" data-for="top_p_textgenerationwebui" id="top_p_counter_textgenerationwebui">
                                     </div>
-                                    <div data-tg-type-mode="except" data-tg-type="generic" data-tg-samplers="typical_p" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-tg-type-mode="except" data-tg-type="generic,mlx_lm" data-tg-samplers="typical_p" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Typical P">Typical P</span>
                                             <div class="fa-solid fa-circle-info opacity50p" title="Typical P Sampling prioritizes tokens based on their deviation from the average entropy of the set.&#13;It maintains tokens whose cumulative probability is close to a predefined threshold (e.g., 0.5), emphasizing those with average information content.&#13;Set to 1.0 to disable." data-i18n="[title]Typical_P_desc"></div>
@@ -1299,7 +1299,15 @@
                                         <input class="neo-range-slider" type="range" id="min_p_textgenerationwebui" name="volume" min="0" max="1" step="0.001">
                                         <input class="neo-range-input" type="number" min="0" max="1" step="0.001" data-for="min_p_textgenerationwebui" id="min_p_counter_textgenerationwebui">
                                     </div>
-                                    <div data-tg-type-mode="except" data-tg-type="generic,llamacpp" data-tg-samplers="top_a" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-tg-type="mlx_lm" data-tg-samplers="num_draft_tokens" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                        <small>
+                                            <span data-i18n="Num Draft Tokens">Num Draft Tokens</span>
+                                            <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Num_Draft_Tokens_desc" title="Number of draft tokens to predict per generation step.&#13;Only used when Draft Model is set.&#13;E.g 3 lets the draft model predict 3 tokens at a time before the main model verifies them."></div>
+                                        </small>
+                                        <input class="neo-range-slider" type="range" id="num_draft_tokens_textgenerationwebui" name="volume" min="0" max="30" step="1">
+                                        <input class="neo-range-input" type="number" min="0" max="30" step="1" data-for="num_draft_tokens_textgenerationwebui" id="num_draft_tokens_counter_textgenerationwebui">
+                                    </div>
+                                    <div data-tg-type-mode="except" data-tg-type="generic,llamacpp,mlx_lm" data-tg-samplers="top_a" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="Top A">Top A</span>
                                             <div class="fa-solid fa-circle-info opacity50p" title="Top A sets a threshold for token selection based on the square of the highest token probability.&#13;E.g if the Top-A value is 0.2 and the top token's probability is 50%, tokens with probabilities below 5% (0.2 * 0.5^2) are excluded.&#13;Set to 0 to disable." data-i18n="[title]Top_A_desc"></div>
@@ -1307,7 +1315,7 @@
                                         <input class="neo-range-slider" type="range" id="top_a_textgenerationwebui" name="volume" min="0" max="1" step="0.01">
                                         <input class="neo-range-input" type="number" min="0" max="1" step="0.01" data-for="top_a_textgenerationwebui" id="top_a_counter_textgenerationwebui">
                                     </div>
-                                    <div data-tg-type-mode="except" data-tg-type="generic,llamacpp" data-tg-samplers="tfs" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                    <div data-tg-type-mode="except" data-tg-type="generic,llamacpp,mlx_lm" data-tg-samplers="tfs" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small>
                                             <span data-i18n="TFS">TFS</span>
                                             <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Tail_Free_Sampling_desc" title="Tail-Free Sampling (TFS) searches for a tail of low-probability tokens in the distribution,&#13;by analyzing the rate of change in token probabilities using derivatives. It retains tokens up to a threshold (e.g., 0.3) based on the normalized second derivative.&#13;The closer to 0, the more discarded tokens. Set to 1.0 to disable."></div>
@@ -1357,6 +1365,11 @@
                                         <input class="neo-range-slider" type="range" id="rep_pen_range_textgenerationwebui" name="volume" min="-1" max="8192" step="1">
                                         <input class="neo-range-input" type="number" min="-1" max="8192" step="1" data-for="rep_pen_range_textgenerationwebui" id="rep_pen_range_counter_textgenerationwebui">
                                     </div>
+                                    <div data-tg-type="mlx_lm" data-tg-samplers="repetition_context_size" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                        <small data-i18n="Repetition Context Size">Repetition Context Size</small>
+                                        <input class="neo-range-slider" type="range" id="repetition_context_size_textgenerationwebui" name="volume" min="0" max="8192" step="1">
+                                        <input class="neo-range-input" type="number" min="0" max="8192" step="1" data-for="repetition_context_size_textgenerationwebui" id="repetition_context_size_counter_textgenerationwebui">
+                                    </div>
                                     <div data-tg-type="koboldcpp" data-tg-samplers="rep_pen_slope" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small data-i18n="Rep. Pen. Slope">Rep Pen Slope</small>
                                         <input class="neo-range-slider" type="range" id="rep_pen_slope_textgenerationwebui" name="volume" min="0" max="10" step="0.01">
@@ -1377,10 +1390,20 @@
                                         <input class="neo-range-slider" type="range" id="freq_pen_textgenerationwebui" name="volume" min="-2" max="2" step="0.01" />
                                         <input class="neo-range-input" type="number" data-for="freq_pen_textgenerationwebui" min="-2" max="2" step="0.01" id="freq_pen_counter_textgenerationwebui">
                                     </div>
+                                    <div data-tg-type="mlx_lm" data-tg-samplers="frequency_context_size" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                        <small data-i18n="Frequency Context Size">Frequency Context Size</small>
+                                        <input class="neo-range-slider" type="range" id="frequency_context_size_textgenerationwebui" name="volume" min="0" max="8192" step="1">
+                                        <input class="neo-range-input" type="number" min="0" max="8192" step="1" data-for="frequency_context_size_textgenerationwebui" id="frequency_context_size_counter_textgenerationwebui">
+                                    </div>
                                     <div data-tg-samplers="presence_pen" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small data-i18n="Presence Penalty">Presence Penalty</small>
                                         <input class="neo-range-slider" type="range" id="presence_pen_textgenerationwebui" name="volume" min="-2" max="2" step="0.01" />
                                         <input class="neo-range-input" type="number" min="-2" max="2" step="0.01" data-for="presence_pen_textgenerationwebui" id="presence_pen_counter_textgenerationwebui">
+                                    </div>
+                                    <div data-tg-type="mlx_lm" data-tg-samplers="presence_context_size" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
+                                        <small data-i18n="Presence Context Size">Presence Context Size</small>
+                                        <input class="neo-range-slider" type="range" id="presence_context_size_textgenerationwebui" name="volume" min="0" max="8192" step="1">
+                                        <input class="neo-range-input" type="number" min="0" max="8192" step="1" data-for="presence_context_size_textgenerationwebui" id="presence_context_size_counter_textgenerationwebui">
                                     </div>
                                     <div data-tg-type="aphrodite, ooba" data-tg-samplers="no_repeat_ngram_size" class="alignitemscenter flex-container flexFlowColumn flexBasis30p flexGrow flexShrink gap0">
                                         <small data-i18n="No Repeat Ngram Size">No Repeat Ngram Size</small>
@@ -1443,7 +1466,7 @@
                                         </div>
                                     </div>
 
-                                    <div data-tg-type="koboldcpp, aphrodite, mancer, tabby, ooba, llamacpp" data-tg-samplers="xtc_probability" id="xtc_block" class="wide100p">
+                                    <div data-tg-type="koboldcpp, aphrodite, mancer, tabby, ooba, llamacpp, mlx_lm" data-tg-samplers="xtc_probability" id="xtc_block" class="wide100p">
                                         <h4 class="wide100p textAlignCenter">
                                             <label data-i18n="Exclude Top Choices (XTC)">Exclude Top Choices (XTC)</label>
                                             <a href="https://github.com/oobabooga/text-generation-webui/pull/6335" target="_blank">
@@ -1598,7 +1621,7 @@
                                             <input class="neo-range-input" type="number" min="0" max="5" step="0.05" data-for="penalty_alpha_textgenerationwebui" id="penalty_alpha_counter_textgenerationwebui">
                                         </div>
                                     </div>
-                                    <div name="checkboxes" class="flex-container flexBasis48p justifyCenter flexGrow flexShrink ">
+                                    <div name="checkboxes" data-tg-type-mode="except" data-tg-type="mlx_lm" class="flex-container flexBasis48p justifyCenter flexGrow flexShrink ">
                                         <div class="flex-container flexFlowColumn marginTop5">
                                             <label data-tg-type="ooba" data-tg-samplers="do_sample" class="checkbox_label  flexGrow flexShrink" for="do_sample_textgenerationwebui">
                                                 <input type="checkbox" id="do_sample_textgenerationwebui" />
@@ -1643,14 +1666,14 @@
                                             </label>
                                         </div>
                                     </div>
-                                    <div data-tg-type="mancer, ooba, koboldcpp, vllm, aphrodite, llamacpp, ollama, infermaticai, huggingface, generic" data-tg-samplers="seed" class="flex-container flexFlowColumn alignitemscenter flexBasis48p flexGrow flexShrink gap0">
+                                    <div data-tg-type="mancer, ooba, koboldcpp, vllm, aphrodite, llamacpp, ollama, infermaticai, huggingface, generic, mlx_lm" data-tg-samplers="seed" class="flex-container flexFlowColumn alignitemscenter flexBasis48p flexGrow flexShrink gap0">
                                         <label>
                                             <small data-i18n="Seed">Seed</small>
                                             <div class="fa-solid fa-circle-info opacity50p " data-i18n="[title]Seed_desc" title="A random seed to use for deterministic and reproducable outputs. Set to -1 to use a random seed."></div>
                                         </label>
                                         <input type="number" id="seed_textgenerationwebui" class="text_pole textAlignCenter" min="-1" value="-1" />
                                     </div>
-                                    <div data-tg-type-mode="except" data-tg-type="generic" data-tg-samplers="banned_tokens" id="banned_tokens_block_ooba" class="wide100p">
+                                    <div data-tg-type-mode="except" data-tg-type="generic,mlx_lm" data-tg-samplers="banned_tokens" id="banned_tokens_block_ooba" class="wide100p">
                                         <hr class="width100p">
                                         <div class="range-block-title title_restorable">
                                             <div>
@@ -1872,6 +1895,29 @@
                                         <div id="aphrodite_default_order" class="menu_button menu_button_icon">
                                             <span data-i18n="Load default order">Load default order</span>
                                         </div>
+                                    </div>
+                                    <div id="stream_options_block_mlx_lm" data-tg-type="mlx_lm" data-tg-samplers="mlx_lm_stream_options" class="wide100p">
+                                        <hr class="wide100p">
+                                        <h4 class="wide100p textAlignCenter">
+                                            <div class="flex-container justifyCenter alignitemscenter">
+                                                <span data-i18n="Stream Options">Stream Options</span>
+                                                <div class="margin5 fa-solid fa-circle-info opacity50p " data-i18n="[title]MLX_LM_Stream_Options_desc" title="MLX-LM stream_options object in JSON format.&#13;Only used when Streaming is enabled.&#13;Set &quot;include_usage&quot; to true to request a final usage chunk.&#13;Leave empty for default behavior."></div>
+                                            </div>
+                                        </h4>
+                                        <textarea id="mlx_lm_stream_options_textgenerationwebui" rows="3" class="text_pole textarea_compact monospace" data-i18n="[placeholder]{&quot;include_usage&quot;: true}" placeholder="{&quot;include_usage&quot;: true}"></textarea>
+                                    </div>
+                                    <div id="custom_parameters_block_mlx_lm" data-tg-type="mlx_lm" data-tg-samplers="mlx_lm_custom_parameters" class="wide100p">
+                                        <hr class="wide100p">
+                                        <h4 class="wide100p textAlignCenter">
+                                            <div class="flex-container justifyCenter alignitemscenter">
+                                                <span data-i18n="Custom Parameters (advanced)">Custom Parameters (advanced)</span>
+                                                <div class="margin5 fa-solid fa-circle-info opacity50p " data-i18n="[title]MLX_LM_Custom_Parameters_desc" title="Custom MLX-LM request body fields in YAML format. Matching keys override existing fields, new keys are added, and keys listed in DELETE are removed.&#13;Use only if you know what you're doing.&#13;For example, you can use this to override values beyond UI control ranges, set fields without dedicated controls, add future MLX-LM request fields, or remove unwanted fields via DELETE.&#13;Leave empty for default behavior."></div>
+                                            </div>
+                                        </h4>
+                                        <div class="toggle-description justifyCenter" data-i18n="Override, add, or delete fields.">
+                                            Override, add, or delete fields.
+                                        </div>
+                                        <textarea id="mlx_lm_custom_parameters_textgenerationwebui" rows="6" class="text_pole textarea_compact monospace" data-i18n="[placeholder]temperature: 10&#10;prompt: &quot;hello&quot;&#10;future_field: value&#10;DELETE: [top_p, min_p]" placeholder="temperature: 10&#10;prompt: &quot;hello&quot;&#10;future_field: value&#10;DELETE: [top_p, min_p]"></textarea>
                                     </div>
                                 </div>
                             </div><!-- end of textgen settings-->
@@ -2434,6 +2480,7 @@
                                     <option value="koboldcpp">KoboldCpp</option>
                                     <option value="llamacpp">llama.cpp</option>
                                     <option value="mancer">Mancer</option>
+                                    <option value="mlx_lm">MLX-LM</option>
                                     <option value="ollama">Ollama</option>
                                     <option value="openrouter">OpenRouter</option>
                                     <option value="tabby">TabbyAPI</option>
@@ -2675,6 +2722,40 @@
                                     </option>
                                 </select>
                             </div>
+                            <div data-tg-type="mlx_lm">
+                                <div class="flex-container flexFlowColumn">
+                                    <a href="https://github.com/ml-explore/mlx-lm" target="_blank" data-i18n="ml-explore/mlx-lm">
+                                        ml-explore/mlx-lm
+                                    </a>
+                                </div>
+                                <h4 data-i18n="MLX-LM API key">MLX-LM API key</h4>
+                                <div class="flex-container">
+                                    <input id="api_key_mlx_lm" name="api_key_mlx_lm" class="text_pole flex1 wide100p" type="text" autocomplete="off">
+                                    <div title="Manage API keys" data-i18n="[title]Manage API keys" class="menu_button fa-solid fa-key fa-fw manage-api-keys" data-key="api_key_mlx_lm">
+                                    </div>
+                                </div>
+                                <div data-for="api_key_mlx_lm" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'.">
+                                    For privacy reasons, your API key will be hidden after you click 'Connect'.
+                                </div>
+                                <div class="flex1">
+                                    <h4 data-i18n="API url">API URL</h4>
+                                    <small data-i18n="Example: http://127.0.0.1:8080">Example: http://127.0.0.1:8080</small>
+                                    <input id="mlx_lm_api_url_text" class="text_pole wide100p" value="" autocomplete="off" data-server-history="mlx_lm">
+                                </div>
+                                <div>
+                                    <h4 data-i18n="MLX-LM Model">MLX-LM Model</h4>
+                                    <select id="mlx_lm_model">
+                                        <option value="" data-i18n="-- Connect to the API --">
+                                            -- Connect to the API --
+                                        </option>
+                                    </select>
+                                </div>
+                                <hr>
+                                <h4 data-i18n="Adapter">Adapter</h4>
+                                <input id="mlx_lm_adapters_textgenerationwebui" class="text_pole wide100p" placeholder="/path/to/adapter (optional)" data-i18n="[placeholder]/path/to/adapter (optional)" type="text">
+                                <h4 data-i18n="Draft Model">Draft Model</h4>
+                                <input id="mlx_lm_draft_model_textgenerationwebui" class="text_pole wide100p" placeholder="/path/to/draft_model (optional)" data-i18n="[placeholder]/path/to/draft_model (optional)" type="text">
+                            </div>
                             <div data-tg-type="vllm">
                                 <div class="flex-container flexFlowColumn">
                                     <a href="https://github.com/vllm-project/vllm" target="_blank" data-i18n="vllm-project/vllm">
@@ -2891,7 +2972,7 @@
                                 </label>
                             </div>
                             <div class="flex-container">
-                                <div id="api_button_textgenerationwebui" class="api_button menu_button menu_button_icon" type="submit" data-i18n="Connect" data-server-connect="ooba_blocking,vllm,aphrodite,tabby,koboldcpp,ollama,llamacpp,huggingface">Connect</div>
+                                <div id="api_button_textgenerationwebui" class="api_button menu_button menu_button_icon" type="submit" data-i18n="Connect" data-server-connect="ooba_blocking,vllm,aphrodite,tabby,koboldcpp,ollama,llamacpp,huggingface,mlx_lm">Connect</div>
                                 <div data-tg-type="openrouter" class="menu_button menu_button_icon openrouter_authorize" title="Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai" data-i18n="Authorize;[title]Get your OpenRouter API token using OAuth flow. You will be redirected to openrouter.ai">Authorize</div>
                                 <div class="api_loading menu_button menu_button_icon" data-i18n="Cancel">Cancel</div>
                             </div>

--- a/public/script.js
+++ b/public/script.js
@@ -6233,6 +6233,10 @@ function parseAndSaveLogprobs(data, continueFrom) {
                 case textgen_types.TABBY: {
                     logprobs = parseTabbyLogprobs(data) || null;
                 } break;
+                case textgen_types.MLXLM: {
+                    // TODO: Token Probabilities panel disabled due to upstream issues. Consider making changes when upstream changes
+                    logprobs = null;
+                } break;
             } break;
         default:
             return;

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -724,6 +724,9 @@ class PresetManager {
             'auto_expand',
             'show_hidden',
             'max_additions',
+            'mlx_lm_model',
+            'mlx_lm_adapters',
+            'mlx_lm_draft_model',
         ];
         /** @type {Record<string, any>} */
         const settings = Object.assign({}, getSettingsByApiId(this.apiId));

--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -157,6 +157,18 @@ function getRelatedDOMElement(samplerName) {
         displayname = 'Smoothing Block';
     }
 
+    if (samplerName === 'mlx_lm_stream_options') {
+        relatedDOMElement = $('#stream_options_block_mlx_lm');
+        targetDisplayType = 'block';
+        displayname = 'Stream Options Block';
+    }
+
+    if (samplerName === 'mlx_lm_custom_parameters') {
+        relatedDOMElement = $('#custom_parameters_block_mlx_lm');
+        targetDisplayType = 'block';
+        displayname = 'Custom Parameters Block';
+    }
+
     return { relatedDOMElement, targetDisplayType, displayname };
 }
 
@@ -220,7 +232,7 @@ async function listSamplers(main_api, arrayOnly = false) {
     let availableSamplers;
     if (main_api === 'textgenerationwebui') {
         availableSamplers = TGsamplerNames;
-        const valuesToRemove = new Set(['streaming', 'bypass_status_check', 'custom_model', 'generic_model', 'openrouter_allow_fallbacks', 'legacy_api', 'extensions']);
+        const valuesToRemove = new Set(['streaming', 'bypass_status_check', 'custom_model', 'generic_model', 'openrouter_allow_fallbacks', 'legacy_api', 'extensions', 'mlx_lm_adapters', 'mlx_lm_draft_model']);
         availableSamplers = availableSamplers.filter(sampler => !valuesToRemove.has(sampler));
         availableSamplers.sort();
     }

--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -79,6 +79,7 @@ export const SECRET_KEYS = {
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
     WORKERS_AI: 'api_key_workers_ai',
+    MLXLM: 'api_key_mlx_lm',
 };
 
 const FRIENDLY_NAMES = {
@@ -144,6 +145,7 @@ const FRIENDLY_NAMES = {
     [SECRET_KEYS.VOLCENGINE_APP_ID]: 'Volcengine App ID',
     [SECRET_KEYS.VOLCENGINE_ACCESS_KEY]: 'Volcengine Access Key',
     [SECRET_KEYS.WORKERS_AI]: 'Cloudflare Workers AI',
+    [SECRET_KEYS.MLXLM]: 'MLX-LM',
 };
 
 const INPUT_MAP = {
@@ -189,6 +191,7 @@ const INPUT_MAP = {
     [SECRET_KEYS.MINIMAX]: '#api_key_minimax',
     [SECRET_KEYS.POLLINATIONS]: '#api_key_pollinations',
     [SECRET_KEYS.WORKERS_AI]: '#api_key_workers_ai',
+    [SECRET_KEYS.MLXLM]: '#api_key_mlx_lm',
 };
 
 const getLabel = () => moment().format('L LT');

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -6250,6 +6250,7 @@ function getModelOptions(quiet) {
         { id: 'tabby_model', api: 'textgenerationwebui', type: textgen_types.TABBY },
         { id: 'llamacpp_model', api: 'textgenerationwebui', type: textgen_types.LLAMACPP },
         { id: 'featherless_model', api: 'textgenerationwebui', type: textgen_types.FEATHERLESS },
+        { id: 'mlx_lm_model', api: 'textgenerationwebui', type: textgen_types.MLXLM },
         { id: 'model_openai_select', api: 'openai', type: chat_completion_sources.OPENAI },
         { id: 'model_claude_select', api: 'openai', type: chat_completion_sources.CLAUDE },
         { id: 'model_openrouter_select', api: 'openai', type: chat_completion_sources.OPENROUTER },

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -730,6 +730,28 @@ export async function loadAphroditeModels(data) {
     }
 }
 
+export async function loadMlxLmModels(data) {
+    if (!Array.isArray(data)) {
+        console.error('Invalid MLX-LM models data', data);
+        return;
+    }
+
+    data.sort((a, b) => a.id.localeCompare(b.id));
+
+    if (!data.find(x => x.id === textgen_settings.mlx_lm_model)) {
+        textgen_settings.mlx_lm_model = data[0]?.id || '';
+    }
+
+    $('#mlx_lm_model').empty();
+    for (const model of data) {
+        const option = document.createElement('option');
+        option.value = model.id;
+        option.text = model.id;
+        option.selected = model.id === textgen_settings.mlx_lm_model;
+        $('#mlx_lm_model').append(option);
+    }
+}
+
 let featherlessCurrentPage = 1;
 export async function loadFeatherlessModels(data) {
     const searchBar = document.getElementById('featherless_model_search_bar');
@@ -1060,6 +1082,12 @@ function onAphroditeModelSelect() {
     $('#api_button_textgenerationwebui').trigger('click');
 }
 
+function onMlxLmModelSelect() {
+    const modelId = String($('#mlx_lm_model').val());
+    textgen_settings.mlx_lm_model = modelId;
+    $('#api_button_textgenerationwebui').trigger('click');
+}
+
 function getMancerModelTemplate(option) {
     const model = mancerModels.find(x => x.id === option?.element?.value);
 
@@ -1357,6 +1385,7 @@ export function initTextGenModels() {
     $('#tabby_model').on('change', onTabbyModelSelect);
     $('#llamacpp_model').on('change', onLlamaCppModelSelect);
     $('#featherless_model').on('change', () => onFeatherlessModelSelect(String($('#featherless_model').val())));
+    $('#mlx_lm_model').on('change', onMlxLmModelSelect);
 
     const providersSelect = $('.openrouter_providers');
     for (const provider of OPENROUTER_PROVIDERS) {
@@ -1444,6 +1473,13 @@ export function initTextGenModels() {
             searchInputCssClass: 'text_pole',
             width: '100%',
             templateResult: getAphroditeModelTemplate,
+        });
+        $('#mlx_lm_model').select2({
+            placeholder: t`[Server default]`,
+            searchInputPlaceholder: t`Search models...`,
+            searchInputCssClass: 'text_pole',
+            width: '100%',
+            allowClear: true,
         });
         $('.openrouter_quantizations').select2({
             closeOnSelect: false,

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -17,13 +17,14 @@ import {
 import { deriveTemplatesFromChatTemplate } from './chat-templates.js';
 import { t } from './i18n.js';
 import { autoSelectInstructPreset, selectContextPreset, selectInstructPreset } from './instruct-mode.js';
+import { yaml } from '../lib.js';
 import { BIAS_CACHE, createNewLogitBiasEntry, displayLogitBias, getLogitBiasListResult } from './logit-bias.js';
 
 import { power_user, registerDebugFunction } from './power-user.js';
 import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
-import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, updateOpenRouterProvidersWarning } from './textgen-models.js';
+import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadMlxLmModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { ENCODE_TOKENIZERS, TEXTGEN_TOKENIZERS, TOKENIZER_SUPPORTED_KEY, getTextTokens, getTokenizerBestMatch, tokenizers } from './tokenizers.js';
 import { AbortReason } from './util/AbortReason.js';
 import { getSortableDelay, onlyUnique, arraysEqual, isObject } from './utils.js';
@@ -44,6 +45,7 @@ export const textgen_types = {
     FEATHERLESS: 'featherless',
     HUGGINGFACE: 'huggingface',
     GENERIC: 'generic',
+    MLXLM: 'mlx_lm',
 };
 
 const {
@@ -62,6 +64,7 @@ const {
     KOBOLDCPP,
     HUGGINGFACE,
     FEATHERLESS,
+    MLXLM,
 } = textgen_types;
 
 const LLAMACPP_DEFAULT_ORDER = [
@@ -138,6 +141,7 @@ export const SERVER_INPUTS = {
     [textgen_types.OLLAMA]: '#ollama_api_url_text',
     [textgen_types.HUGGINGFACE]: '#huggingface_api_url_text',
     [textgen_types.GENERIC]: '#generic_api_url_text',
+    [textgen_types.MLXLM]: '#mlx_lm_api_url_text',
 };
 
 const KOBOLDCPP_ORDER = [6, 0, 1, 3, 4, 2, 5];
@@ -234,6 +238,15 @@ export const textgenerationwebui_settings = {
     extensions: {},
     adaptive_target: -0.01,
     adaptive_decay: 0.9,
+    mlx_lm_model: '',
+    mlx_lm_adapters: '',
+    mlx_lm_draft_model: '',
+    num_draft_tokens: 0,
+    mlx_lm_stream_options: '',
+    mlx_lm_custom_parameters: '',
+    repetition_context_size: 0,
+    presence_context_size: 0,
+    frequency_context_size: 0,
 };
 
 export {
@@ -320,6 +333,14 @@ export const setting_names = [
     'json_schema_allow_empty',
     'adaptive_target',
     'adaptive_decay',
+    'mlx_lm_adapters',
+    'mlx_lm_draft_model',
+    'num_draft_tokens',
+    'mlx_lm_stream_options',
+    'mlx_lm_custom_parameters',
+    'repetition_context_size',
+    'presence_context_size',
+    'frequency_context_size',
 ];
 
 const DYNATEMP_BLOCK = document.getElementById('dynatemp_block_ooba');
@@ -724,6 +745,9 @@ async function getStatusTextgen() {
         } else if (textgenerationwebui_settings.type === textgen_types.GENERIC) {
             loadGenericModels(data?.data);
             setOnlineStatus(textgenerationwebui_settings.generic_model || data?.result || t`Connected`);
+        } else if (textgenerationwebui_settings.type === textgen_types.MLXLM) {
+            loadMlxLmModels(data?.data);
+            setOnlineStatus(textgenerationwebui_settings.mlx_lm_model || t`Connected`);
         } else {
             setOnlineStatus(data?.result);
         }
@@ -1006,6 +1030,10 @@ export function initTextGenSettings() {
             'min_keep_textgenerationwebui': 0,
             'adaptive_target_textgenerationwebui': -0.01,
             'adaptive_decay_textgenerationwebui': 0.9,
+            'num_draft_tokens_textgenerationwebui': 0,
+            'repetition_context_size_textgenerationwebui': 0,
+            'presence_context_size_textgenerationwebui': 0,
+            'frequency_context_size_textgenerationwebui': 0,
         };
 
         for (const [id, value] of Object.entries(inputs)) {
@@ -1107,6 +1135,7 @@ export function initTextGenSettings() {
             { id: 'api_key_featherless', secret: SECRET_KEYS.FEATHERLESS },
             { id: 'api_key_huggingface', secret: SECRET_KEYS.HUGGINGFACE },
             { id: 'api_key_generic', secret: SECRET_KEYS.GENERIC },
+            { id: 'api_key_mlx_lm', secret: SECRET_KEYS.MLXLM },
         ];
 
         for (const key of keys) {
@@ -1397,6 +1426,10 @@ export function parseTextgenLogprobs(token, logprobs) {
             }
             return null;
         }
+        case MLXLM: {
+            // TODO: Token Probabilities panel disabled due to upstream issues. Consider making changes when upstream changes
+            return null;
+        }
         default:
             return null;
     }
@@ -1507,6 +1540,11 @@ export function getTextGenModel(settings = null) {
         case LLAMACPP:
             if (settings.llamacpp_model) {
                 return settings.llamacpp_model;
+            }
+            break;
+        case MLXLM:
+            if (settings.mlx_lm_model) {
+                return settings.mlx_lm_model;
             }
             break;
         default:
@@ -1748,6 +1786,18 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
             ? settings.samplers_priorities
             : undefined,
     };
+    const mlxLmParams = {
+        'max_completion_tokens': maxTokens,
+        'repetition_context_size': settings.repetition_context_size,
+        'presence_context_size': settings.presence_context_size,
+        'frequency_context_size': settings.frequency_context_size,
+        'num_draft_tokens': settings.num_draft_tokens,
+        'adapters': settings.mlx_lm_adapters || undefined,
+        'draft_model': settings.mlx_lm_draft_model || undefined,
+        'seed': settings.seed >= 0 ? settings.seed : undefined,
+        'logprobs': power_user.request_token_probabilities,
+        'top_logprobs': power_user.request_token_probabilities ? getLogprobsNumber(MLXLM) : undefined,
+    };
 
     if (settings.type === OPENROUTER) {
         params.provider = settings.openrouter_providers;
@@ -1795,6 +1845,10 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
             params = Object.assign(params, aphroditeParams);
             break;
 
+        case MLXLM:
+            params = Object.assign(params, mlxLmParams);
+            break;
+
         default:
             params = Object.assign(params, nonAphroditeParams);
             break;
@@ -1836,6 +1890,44 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
         } else {
             delete params.json_schema;
             delete params.guided_json;
+        }
+    }
+
+    if (settings.type === MLXLM) {
+        // TODO: Drop xtc_* due to upstream issues. Consider making changes when upstream changes
+        delete params.xtc_probability;
+        delete params.xtc_threshold;
+
+        // Parse user-provided stream_options JSON
+        if (settings.mlx_lm_stream_options) {
+            try {
+                params.stream_options = JSON.parse(settings.mlx_lm_stream_options);
+            } catch {
+                // Ignore parse errors
+            }
+        }
+
+        // Parse user-provided custom parameters YAML
+        if (settings.mlx_lm_custom_parameters) {
+            try {
+                const parsed = yaml.parse(settings.mlx_lm_custom_parameters);
+                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                    const deleteList = Array.isArray(parsed.DELETE) ? parsed.DELETE : null;
+                    delete parsed.DELETE;
+
+                    // Merge user fields into params
+                    Object.assign(params, parsed);
+
+                    // Delete params fields listed in DELETE
+                    if (deleteList) {
+                        for (const key of deleteList) {
+                            delete params[key];
+                        }
+                    }
+                }
+            } catch {
+                // Ignore parse errors
+            }
         }
     }
     return params;

--- a/src/additional-headers.js
+++ b/src/additional-headers.js
@@ -199,6 +199,20 @@ function getGenericHeaders(directories, secretId = null) {
     }) : {};
 }
 
+/**
+ * Gets the headers for the MLX-LM API.
+ * @param {import('./users.js').UserDirectoryList} directories
+ * @param {string|null} secretId Secret ID for the request (optional, used to determine which secret to use)
+ * @returns {object} Headers for the request
+ */
+function getMlxLmHeaders(directories, secretId = null) {
+    const apiKey = readSecret(directories, SECRET_KEYS.MLXLM, secretId);
+
+    return apiKey ? ({
+        'Authorization': `Bearer ${apiKey}`,
+    }) : {};
+}
+
 export function getOverrideHeaders(urlHost) {
     const requestOverrides = getConfigValue('requestOverrides', []);
     const overrideHeaders = requestOverrides?.find((e) => e.hosts?.includes(urlHost))?.headers;
@@ -243,6 +257,7 @@ export function setAdditionalHeadersByType(requestHeaders, type, server, directo
         [TEXTGEN_TYPES.FEATHERLESS]: getFeatherlessHeaders,
         [TEXTGEN_TYPES.HUGGINGFACE]: getHuggingFaceHeaders,
         [TEXTGEN_TYPES.GENERIC]: getGenericHeaders,
+        [TEXTGEN_TYPES.MLXLM]: getMlxLmHeaders,
     };
 
     const getHeaders = headerGetters[type];

--- a/src/constants.js
+++ b/src/constants.js
@@ -235,6 +235,7 @@ export const TEXTGEN_TYPES = {
     FEATHERLESS: 'featherless',
     HUGGINGFACE: 'huggingface',
     GENERIC: 'generic',
+    MLXLM: 'mlx_lm',
 };
 
 export const INFERMATICAI_KEYS = [

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -128,6 +128,7 @@ router.post('/status', async function (request, response) {
             case TEXTGEN_TYPES.INFERMATICAI:
             case TEXTGEN_TYPES.OPENROUTER:
             case TEXTGEN_TYPES.FEATHERLESS:
+            case TEXTGEN_TYPES.MLXLM:
                 url += '/v1/models';
                 break;
             case TEXTGEN_TYPES.DREAMGEN:
@@ -304,6 +305,7 @@ router.post('/generate', async function (request, response) {
             case TEXTGEN_TYPES.TOGETHERAI:
             case TEXTGEN_TYPES.INFERMATICAI:
             case TEXTGEN_TYPES.HUGGINGFACE:
+            case TEXTGEN_TYPES.MLXLM:
                 url += '/v1/completions';
                 break;
             case TEXTGEN_TYPES.DREAMGEN:

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -70,6 +70,7 @@ export const SECRET_KEYS = {
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
     WORKERS_AI: 'api_key_workers_ai',
+    MLXLM: 'api_key_mlx_lm',
 };
 
 /**


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Background

[MLX](https://opensource.apple.com/projects/mlx/) is Apple's official machine learning framework, purpose-built for Apple Silicon's unified memory architecture. [mlx-lm](https://github.com/ml-explore/mlx-lm) is the companion Python package providing LLM inference, quantization, fine-tuning, and an OpenAI-compatible HTTP server.

Today, Mac users running `mlx_lm.server` connect through **Generic (OpenAI-compatible)**, whose whitelist doesn't cover most of mlx-lm's protocol fields. This PR adds mlx-lm as a first-class text completion source, matching the pattern of other local backends, and supports all mlx-lm protocol fields.

## Implementation

All mlx-lm protocol fields are supported: `model`, `max_completion_tokens`, `max_tokens`, `temperature`, `top_p`, `top_k`, `min_p`, `repetition_penalty`, `presence_penalty`, `frequency_penalty`, `repetition_context_size`, `presence_context_size`, `frequency_context_size`, `num_draft_tokens`, `adapters`, `draft_model`, `seed`, `logit_bias`, `stop`, `stream`, `stream_options`, `logprobs`, `top_logprobs`, `xtc_probability`, `xtc_threshold`.

The integration reuses existing ST controls wherever possible, adds new UI only for mlx-specific fields, and follows the same patterns as other text-completion backends in ST.

A few upstream mlx-lm limitations are gated in code with inline comments and will resolve once the upstream fixes land. Everything else currently works as expected.

### UI screenshots

**API Connections**

<img width="716" height="656" alt="Screenshot_apiconnections" src="https://github.com/user-attachments/assets/80664ccb-f5f5-466e-939a-4715a2d22641" />

**AI Response Configuration**

<img width="518" height="1000" alt="Screenshot_airesponseconfiguration" src="https://github.com/user-attachments/assets/9f89962c-daa0-4e20-a7b3-de4429a71f54" />

## Testing

ESLint reports no new errors. End-to-end testing on M3 Pro covered the full integration surface.

To reproduce locally:

```bash
uv pip install mlx-lm
mlx_lm.server --model <model-id>
```

Then in ST: **Text Completion → MLX-LM**, set API URL to `http://127.0.0.1:8080`, click **Connect**, and send a message.