### PR TITLE
perf(util): read each file's mtime once when getImages sorts by date

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -666,18 +666,7 @@ export function removeOldBackups(directory, prefix, limit = null) {
  * @returns {string[]} List of image file names
  */
 export function getImages(directoryPath, sortBy = 'name', type = MEDIA_REQUEST_TYPE.IMAGE) {
-    function getSortFunction() {
-        switch (sortBy) {
-            case 'name':
-                return Intl.Collator().compare;
-            case 'date':
-                return (a, b) => fs.statSync(path.join(directoryPath, a)).mtimeMs - fs.statSync(path.join(directoryPath, b)).mtimeMs;
-            default:
-                return (_a, _b) => 0;
-        }
-    }
-
-    return fs
+    const files = fs
         .readdirSync(directoryPath, { withFileTypes: true })
         .filter(dirent => dirent.isFile())
         .map(dirent => dirent.name)
@@ -696,8 +685,28 @@ export function getImages(directoryPath, sortBy = 'name', type = MEDIA_REQUEST_T
                 return true;
             }
             return false;
-        })
-        .sort(getSortFunction());
+        });
+
+    switch (sortBy) {
+        case 'name':
+            return files.sort(Intl.Collator().compare);
+        case 'date': {
+            const mtimes = new Map();
+            for (const file of files) {
+                try {
+                    mtimes.set(file, fs.statSync(path.join(directoryPath, file)).mtimeMs);
+                } catch (err) {
+                    if (err?.code !== 'ENOENT') {
+                        throw err;
+                    }
+                    mtimes.set(file, 0);
+                }
+            }
+            return files.sort((a, b) => mtimes.get(a) - mtimes.get(b));
+        }
+        default:
+            return files;
+    }
 }
 
 /**

--- a/tests/util-fs.test.js
+++ b/tests/util-fs.test.js
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, test, expect, jest } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getImages } from '../src/util';
+import { MEDIA_REQUEST_TYPE } from '../src/constants';
+
+describe('getImages', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'st-getimages-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeFile(name, mtimeMs = null) {
+        const filePath = path.join(tmpDir, name);
+        fs.writeFileSync(filePath, '');
+        if (mtimeMs !== null) {
+            const secs = mtimeMs / 1000;
+            fs.utimesSync(filePath, secs, secs);
+        }
+    }
+
+    test('sorts by name with natural collation', () => {
+        writeFile('b.png');
+        writeFile('a.png');
+        writeFile('c.png');
+        expect(getImages(tmpDir, 'name')).toEqual(['a.png', 'b.png', 'c.png']);
+    });
+
+    test('sorts by date oldest-first using file mtime', () => {
+        writeFile('newest.png', 3_000_000);
+        writeFile('oldest.png', 1_000_000);
+        writeFile('middle.png', 2_000_000);
+        expect(getImages(tmpDir, 'date')).toEqual(['oldest.png', 'middle.png', 'newest.png']);
+    });
+
+    test('reads each file mtime only once when sorting by date', () => {
+        for (let i = 0; i < 8; i++) {
+            writeFile(`img${i}.png`, (8 - i) * 1_000_000);
+        }
+        const spy = jest.spyOn(fs, 'statSync');
+        try {
+            const result = getImages(tmpDir, 'date');
+            expect(result).toEqual(['img7.png', 'img6.png', 'img5.png', 'img4.png', 'img3.png', 'img2.png', 'img1.png', 'img0.png']);
+            expect(spy).toHaveBeenCalledTimes(8);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    test('falls back to mtime 0 if a file disappears between readdir and stat', () => {
+        writeFile('survivor.png', 2_000_000);
+        writeFile('ghost.png', 1_000_000);
+        const realStat = fs.statSync;
+        const spy = jest.spyOn(fs, 'statSync').mockImplementation((p, ...rest) => {
+            if (typeof p === 'string' && p.endsWith('ghost.png')) {
+                const err = new Error('ENOENT');
+                err.code = 'ENOENT';
+                throw err;
+            }
+            return realStat(p, ...rest);
+        });
+        try {
+            expect(getImages(tmpDir, 'date')).toEqual(['ghost.png', 'survivor.png']);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    test('propagates non-ENOENT stat errors (e.g. EACCES) instead of masking them', () => {
+        writeFile('readable.png', 1_000_000);
+        writeFile('forbidden.png', 2_000_000);
+        const realStat = fs.statSync;
+        const spy = jest.spyOn(fs, 'statSync').mockImplementation((p, ...rest) => {
+            if (typeof p === 'string' && p.endsWith('forbidden.png')) {
+                const err = new Error('EACCES');
+                err.code = 'EACCES';
+                throw err;
+            }
+            return realStat(p, ...rest);
+        });
+        try {
+            expect(() => getImages(tmpDir, 'date')).toThrow(/EACCES/);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    test('filters to image types by default', () => {
+        writeFile('keep.png');
+        writeFile('keep.jpg');
+        writeFile('drop.mp4');
+        writeFile('drop.mp3');
+        writeFile('drop.txt');
+        writeFile('no-extension');
+        expect(getImages(tmpDir, 'name')).toEqual(['keep.jpg', 'keep.png']);
+    });
+
+    test('filters to video types when requested', () => {
+        writeFile('drop.png');
+        writeFile('keep.mp4');
+        writeFile('keep.webm');
+        expect(getImages(tmpDir, 'name', MEDIA_REQUEST_TYPE.VIDEO)).toEqual(['keep.mp4', 'keep.webm']);
+    });
+
+    test('filters to audio types when requested', () => {
+        writeFile('drop.png');
+        writeFile('keep.mp3');
+        writeFile('keep.wav');
+        expect(getImages(tmpDir, 'name', MEDIA_REQUEST_TYPE.AUDIO)).toEqual(['keep.mp3', 'keep.wav']);
+    });
+
+    test('accepts combined media-type bitmask', () => {
+        writeFile('img.png');
+        writeFile('clip.mp4');
+        writeFile('song.mp3');
+        const result = getImages(tmpDir, 'name', MEDIA_REQUEST_TYPE.IMAGE | MEDIA_REQUEST_TYPE.AUDIO);
+        expect(result).toEqual(['img.png', 'song.mp3']);
+    });
+
+    test('skips subdirectories', () => {
+        writeFile('real.png');
+        fs.mkdirSync(path.join(tmpDir, 'sub.png'));
+        expect(getImages(tmpDir, 'name')).toEqual(['real.png']);
+    });
+
+    test('returns empty array for an empty directory', () => {
+        expect(getImages(tmpDir, 'name')).toEqual([]);
+        expect(getImages(tmpDir, 'date')).toEqual([]);
+    });
+});


### PR DESCRIPTION
The previous date sort read file modification times while comparing items, which meant stat'ing the same files over and over for one listing. mtimes are now read once per file before sorting. Files that disappear during the call (e.g. concurrent deletion) sort to the start instead of crashing.

This also adds `tests/util-fs.test.js` to help prove it works correctly and prevent future accidental changes to file-related APIs.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
