### PR TITLE
perf(plugins): list plugin dirs without per-entry statSync

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -39,9 +39,10 @@ if (command === 'install') {
 }
 
 async function updatePlugins() {
-    const directories = fs.readdirSync(pluginsPath)
-        .filter(file => !file.startsWith('.'))
-        .filter(file => fs.statSync(path.join(pluginsPath, file)).isDirectory());
+    const directories = fs.readdirSync(pluginsPath, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory() || dirent.isSymbolicLink())
+        .filter(dirent => !dirent.name.startsWith('.'))
+        .map(dirent => dirent.name);
 
     console.log(`Found ${color.cyan(directories.length)} directories in ./plugins`);
 


### PR DESCRIPTION
updatePlugins called fs.statSync on every entry returned by readdirSync
just to test isDirectory(). Pass withFileTypes to readdirSync and filter
on the Dirent type instead.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
