### PR TITLE
perf(extensions): list discover folders without per-entry statSync

### DIFF
--- a/src/endpoints/extensions.js
+++ b/src/endpoints/extensions.js
@@ -488,23 +488,23 @@ router.get('/discover', function (request, response) {
 
     // Get all folders in system extensions folder, excluding third-party
     const builtInExtensions = fs
-        .readdirSync(PUBLIC_DIRECTORIES.extensions)
-        .filter(f => fs.statSync(path.join(PUBLIC_DIRECTORIES.extensions, f)).isDirectory())
-        .filter(f => f !== 'third-party')
-        .map(f => ({ type: 'system', name: f }));
+        .readdirSync(PUBLIC_DIRECTORIES.extensions, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory() || dirent.isSymbolicLink())
+        .filter(dirent => dirent.name !== 'third-party')
+        .map(dirent => ({ type: 'system', name: dirent.name }));
 
     // Get all folders in local extensions folder
     const userExtensions = fs
-        .readdirSync(path.join(request.user.directories.extensions))
-        .filter(f => fs.statSync(path.join(request.user.directories.extensions, f)).isDirectory())
-        .map(f => ({ type: 'local', name: `third-party/${f}` }));
+        .readdirSync(path.join(request.user.directories.extensions), { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory() || dirent.isSymbolicLink())
+        .map(dirent => ({ type: 'local', name: `third-party/${dirent.name}` }));
 
     // Get all folders in global extensions folder
     // In case of a conflict, the extension will be loaded from the user folder
     const globalExtensions = fs
-        .readdirSync(PUBLIC_DIRECTORIES.globalExtensions)
-        .filter(f => fs.statSync(path.join(PUBLIC_DIRECTORIES.globalExtensions, f)).isDirectory())
-        .map(f => ({ type: 'global', name: `third-party/${f}` }))
+        .readdirSync(PUBLIC_DIRECTORIES.globalExtensions, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory() || dirent.isSymbolicLink())
+        .map(dirent => ({ type: 'global', name: `third-party/${dirent.name}` }))
         .filter(f => !userExtensions.some(e => e.name === f.name));
 
     // Combine all extensions


### PR DESCRIPTION
The /extensions/discover handler now lists built-in, user, and global extension folders via the Dirent type returned by readdirSync({ withFileTypes: true }) instead of calling fs.statSync on every entry; symlinks are still treated as directories.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).