### PR TITLE
Fix fused token probabilities for llama.cpp

### DIFF
--- a/public/scripts/logprobs.js
+++ b/public/scripts/logprobs.js
@@ -484,7 +484,7 @@ function withVirtualWhitespace(text, span) {
     if (text.match(/^\n(?:.|\n)+\n$/)) {
         result.unshift($('<br>'));
         result.push($('<br>'));
-    } else if (text.match(/^\n/)) {
+    } else if (text.match(/^\n[^\n]/)) { // a fused token that starts with a newline needs a break before it, not after
         result.unshift($('<br>'));
     } else if (text.match(/\n$/)) {
         result.push($('<br>'));

--- a/public/scripts/logprobs.js
+++ b/public/scripts/logprobs.js
@@ -484,7 +484,7 @@ function withVirtualWhitespace(text, span) {
     if (text.match(/^\n(?:.|\n)+\n$/)) {
         result.unshift($('<br>'));
         result.push($('<br>'));
-    } else if (text.match(/^\n[^\n]/)) { // a fused token that starts with a newline needs a break before it, not after
+    } else if (text.match(/^\n+[^\n]/)) { // a fused token that starts with a newline needs a break before it, not after
         result.unshift($('<br>'));
     } else if (text.match(/\n$/)) {
         result.push($('<br>'));

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1352,13 +1352,13 @@ export async function generateTextGenWithStreaming(generate_data, signal) {
  * @returns {import('./logprobs.js').TokenLogprobs|null} - Resolved logprobs, or null if no lookahead occurred
  */
 function handleLlamaCppLookahead(token, logprobs) {
-    // in practice there should be no danger of infinite recursion unless llama.cpp produces
-    // really weird outputs, but let's err on the side of caution
-    if (logprobs.is_lookahead) {
+    if (!logprobs || !logprobs.length) {
         return null;
     }
 
-    if (!logprobs || !logprobs.length) {
+    // in practice there should be no danger of infinite recursion unless llama.cpp produces
+    // really weird outputs, but let's err on the side of caution
+    if (logprobs.is_lookahead) {
         return null;
     }
 
@@ -1384,13 +1384,13 @@ function handleLlamaCppLookahead(token, logprobs) {
     if (!isLookaheadBuffer && !isLookaheadFlush) {
         return null;
     }
-	
-	logprobs.is_lookahead = true;
-	const resolvedLogprobs = parseTextgenLogprobs(expectedPiece, logprobs);
-	if (resolvedLogprobs) {
+    
+    logprobs.is_lookahead = true;
+    const resolvedLogprobs = parseTextgenLogprobs(expectedPiece, logprobs);
+    if (resolvedLogprobs) {
         resolvedLogprobs.is_lookahead = true;
     }
-	
+
     return resolvedLogprobs;
 }
 

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1343,6 +1343,58 @@ export async function generateTextGenWithStreaming(generate_data, signal) {
 }
 
 /**
+ * Detects and resolves llama.cpp stopping-string lookahead flushing.
+ * (see https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md, search for "stop:")
+ * Aligns the emitted token with the actual selected vocab piece, recovering 
+ * real candidate lists from empty lookahead steps and stripping flushed prefixes.
+ * @param {string} token - The text of the token
+ * @param {Object[]} logprobs - Logprobs array from the API
+ * @returns {import('./logprobs.js').TokenLogprobs|null} - Resolved logprobs, or null if no lookahead occurred
+ */
+function handleLlamaCppLookahead(token, logprobs) {
+    // in practice there should be no danger of infinite recursion unless llama.cpp produces
+    // really weird outputs, but let's err on the side of caution
+    if (logprobs.is_lookahead) {
+        return null;
+    }
+
+    if (!logprobs || !logprobs.length) {
+        return null;
+    }
+
+    const chosenId = logprobs[0].id;
+    if (chosenId === undefined) {
+        return null;
+    }
+
+    let expectedPiece = null;
+    if (Array.isArray(logprobs[0].top_logprobs)) {
+        const chosenCandidate = logprobs[0].top_logprobs.find(x => x.id === chosenId);
+        if (chosenCandidate) {
+            expectedPiece = chosenCandidate.token;
+        }
+    }
+
+    if (!expectedPiece) {
+        return null;
+    }
+
+    const isLookaheadBuffer = token === "";
+    const isLookaheadFlush = token.length > expectedPiece.length && token.endsWith(expectedPiece);
+    if (!isLookaheadBuffer && !isLookaheadFlush) {
+        return null;
+    }
+	
+	logprobs.is_lookahead = true;
+	const resolvedLogprobs = parseTextgenLogprobs(expectedPiece, logprobs);
+	if (resolvedLogprobs) {
+        resolvedLogprobs.is_lookahead = true;
+    }
+	
+    return resolvedLogprobs;
+}
+
+/**
  * parseTextgenLogprobs converts a logprobs object returned from a textgen API
  * for a single token into a TokenLogprobs object used by the Token
  * Probabilities feature.
@@ -1374,6 +1426,29 @@ export function parseTextgenLogprobs(token, logprobs) {
         case LLAMACPP: {
             if (!logprobs?.length) {
                 return null;
+            }
+
+            // Handle llama.cpp lookahead buffering related to stopping strings.
+            //
+            // When the server generates text that could be part of any of the stopping strings,
+            // it buffers this text, and only flushes it after it generates more, merged into a single token.
+            //
+            // For example, if the server generates "AB\nCD", the following tokens are expected:
+            //
+            // "AB", "\n", "CD"
+            //
+            // However, if a stopping string is specified (for example, by the "stop": ["\nUser:"] array
+            // in the text completions request), you get this:
+            //
+            // "AB", "", "\nCD"
+            //
+            // This is completely fine for just outputting the text, but, for example, in the token
+            // probability window, the probabilities are displayed incorrectly.
+            //
+            // Here, we fix this, splitting the merged token back into its original distinct tokens.
+            const lookahead = handleLlamaCppLookahead(token, logprobs);
+            if (lookahead) {
+                return lookahead;
             }
 
             // 3 cases:


### PR DESCRIPTION
Repairs incorrect probabilities in Token Probabilities window.

Here is how it is currently (text generation llama.cpp endpoint, gemma 4):

<img width="1298" height="437" alt="firefox_LPOXX7UtvL" src="https://github.com/user-attachments/assets/dd6c16c3-742b-4da0-ba98-db450ba3bc61" />

The newline is fused into CD, the correct prediction is not displayed (the correct one is `CD`, but the red rectangle highlights `<others>`), the `↵` character is after the line break even though you'd expect it be before the break, and it's impossible to see what probability the newline had when model was generating the response.

With the fix from this PR applied, you get this:

<img width="1320" height="378" alt="firefox_ZyPKAY4rNo" src="https://github.com/user-attachments/assets/d97f83cc-c863-4871-9347-e11494c73478" />

Inspecting the probability of newline also works:

<img width="1028" height="391" alt="firefox_TunMHwGYZx" src="https://github.com/user-attachments/assets/7de65470-891d-4571-8341-8d84598b7d60" />

Most importantly, since newline and CD are now separated, it is possible to reroll just the CD, keeping the newline.

I tested this on a few edge cases and on a proper ERP chat. Seems to work.

If anyone wants to know, this is caused by llama.cpp holding off some tokens from output when it thinks a stopping string could be produced soon. You can observe the effect locally with those requests (gemma 4):

```
curl -N http://localhost:8080/completion -H "Content-Type: application/json" -d '{ "prompt": "<|turn>user\nWrite AB, followed by a newline, followed by CD<turn|>\n<|turn>model\n<|channel>thought\n<channel|>", "n_predict": 128, "temperature": 0.7, "top_k": 40, "top_p": 0.9, "n_probs": 3, "stream": true}'
```
(produces "AB", "\n", "CD")

```
curl -N http://localhost:8080/completion -H "Content-Type: application/json" -d '{ "prompt": "<|turn>user\nWrite AB, followed by a newline, followed by CD<turn|>\n<|turn>model\n<|channel>thought\n<channel|>", "n_predict": 128, "temperature": 0.7, "top_k": 40, "top_p": 0.9, "n_probs": 3, "stream": true, "stop": ["\nUser:"] }'
```
(produces "AB", "", "\nCD")

Stopping stings also work and produce correct output:

<img width="1481" height="359" alt="firefox_gyCF2sFGXM" src="https://github.com/user-attachments/assets/3d25f918-ebec-4d21-b58f-07ea671f1837" />

(here, the generation is stopped by "\nUser:" stopping string, and it's correctly omitted in chat window, but you can still see its tokens in probabilities window)

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
