### PR TITLE
chore: Sync NanoGPT providers: UOMI and Wafer

### DIFF
--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -315,12 +315,12 @@ const NANOGPT_PROVIDERS = [
         'label': 'Venice',
     },
     {
-        'id': 'wandb',
-        'label': 'Weights & Biases',
-    },
-    {
         'id': 'wafer',
         'label': 'Wafer',
+    },
+    {
+        'id': 'wandb',
+        'label': 'Weights & Biases',
     },
     {
         'id': 'xiaomi',

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -212,7 +212,7 @@ const NANOGPT_PROVIDERS = [
     },
     {
         'id': 'ionet',
-        'label': 'Io Net',
+        'label': 'io.net',
     },
     {
         'id': 'inceptron',
@@ -256,7 +256,7 @@ const NANOGPT_PROVIDERS = [
     },
     {
         'id': 'neuralwatt',
-        'label': 'Neuralwatt',
+        'label': 'NeuralWatt',
     },
     {
         'id': 'tensorix',
@@ -307,12 +307,20 @@ const NANOGPT_PROVIDERS = [
         'label': 'Together',
     },
     {
+        'id': 'uomi',
+        'label': 'UOMI',
+    },
+    {
         'id': 'venice',
         'label': 'Venice',
     },
     {
         'id': 'wandb',
         'label': 'Weights & Biases',
+    },
+    {
+        'id': 'wafer',
+        'label': 'Wafer',
     },
     {
         'id': 'xiaomi',


### PR DESCRIPTION
## Summary
Synced the NanoGPT provider list adding missing providers to `public\scripts\textgen-models.js.`

## Note
Updated labels to match upstream. 

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
