### PR TITLE
feat(net): implement Happy Eyeballs (RFC 8305) for outgoing connections

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -16,6 +16,15 @@ protocol:
     ipv6: false
 # Prefers IPv6 for DNS. Enable this on ISPs that don't have issues with IPv6
 dnsPreferIPv6: false
+# Enable Happy Eyeballs algorithm (RFC 8305) for dual-stack IPv4/IPv6 connections.
+# When enabled, outgoing connections will race IPv6 and IPv4 simultaneously,
+# using whichever connects first. This ensures fast connections on dual-stack networks.
+# Disable only if you experience connection issues on single-stack networks.
+enableHappyEyeballs: true
+# Happy Eyeballs connection attempt timeout in milliseconds.
+# This is the delay before starting a fallback connection attempt on the other address family.
+# Lower values make fallback faster but may cause unnecessary dual connections.
+happyEyeballsTimeout: 250
 # -- BROWSER LAUNCH CONFIGURATION --
 browserLaunch:
   # Open the browser automatically on server startup.

--- a/src/command-line.js
+++ b/src/command-line.js
@@ -18,6 +18,8 @@ import { initConfig } from './config-init.js';
  * @property {boolean|string} enableIPv4 If enable IPv4 protocol ("auto" is also allowed)
  * @property {boolean|string} enableIPv6 If enable IPv6 protocol ("auto" is also allowed)
  * @property {boolean} dnsPreferIPv6 If prefer IPv6 for DNS
+ * @property {boolean} enableHappyEyeballs If enable Happy Eyeballs algorithm (RFC 8305) for dual-stack connections
+ * @property {number} happyEyeballsTimeout Happy Eyeballs connection attempt timeout in milliseconds
  * @property {number} heartbeatInterval Interval in seconds to write a heartbeat file. 0 to disable.
  * @property {boolean} browserLaunchEnabled If automatically launch SillyTavern in the browser
  * @property {string} browserLaunchHostname Browser launch hostname
@@ -64,6 +66,8 @@ export class CommandLineParser {
             enableIPv4: true,
             enableIPv6: false,
             dnsPreferIPv6: false,
+            enableHappyEyeballs: true,
+            happyEyeballsTimeout: 250,
             heartbeatInterval: 0,
             browserLaunchEnabled: false,
             browserLaunchHostname: 'auto',
@@ -138,6 +142,16 @@ export class CommandLineParser {
                 type: 'boolean',
                 default: null,
                 describe: 'Prefers IPv6 for DNS\nYou should probably have the enabled if you\'re on an IPv6 only network',
+            })
+            .option('enableHappyEyeballs', {
+                type: 'boolean',
+                default: null,
+                describe: 'Enable Happy Eyeballs (RFC 8305) for dual-stack IPv4/IPv6 connections',
+            })
+            .option('happyEyeballsTimeout', {
+                type: 'number',
+                default: null,
+                describe: 'Happy Eyeballs connection attempt timeout in milliseconds (default: 250)',
             })
             .option('browserLaunchEnabled', {
                 type: 'boolean',
@@ -307,6 +321,8 @@ export class CommandLineParser {
             enableIPv4: stringToBool(cliArguments.enableIPv4) ?? stringToBool(getConfigValue('protocol.ipv4', defaultConfig.enableIPv4)) ?? defaultConfig.enableIPv4,
             enableIPv6: stringToBool(cliArguments.enableIPv6) ?? stringToBool(getConfigValue('protocol.ipv6', defaultConfig.enableIPv6)) ?? defaultConfig.enableIPv6,
             dnsPreferIPv6: cliArguments.dnsPreferIPv6 ?? getConfigValue('dnsPreferIPv6', defaultConfig.dnsPreferIPv6, 'boolean'),
+            enableHappyEyeballs: cliArguments.enableHappyEyeballs ?? getConfigValue('enableHappyEyeballs', defaultConfig.enableHappyEyeballs, 'boolean'),
+            happyEyeballsTimeout: cliArguments.happyEyeballsTimeout ?? getConfigValue('happyEyeballsTimeout', defaultConfig.happyEyeballsTimeout, 'number'),
             heartbeatInterval: cliArguments.heartbeatInterval ?? getConfigValue('heartbeatInterval', defaultConfig.heartbeatInterval, 'number'),
             browserLaunchEnabled: cliArguments.browserLaunchEnabled ?? cliArguments.autorun ?? getConfigValue('browserLaunch.enabled', defaultConfig.browserLaunchEnabled, 'boolean'),
             browserLaunchHostname: cliArguments.browserLaunchHostname ?? cliArguments.autorunHostname ?? getConfigValue('browserLaunch.hostname', defaultConfig.browserLaunchHostname),

--- a/src/private-request-filter.js
+++ b/src/private-request-filter.js
@@ -63,6 +63,18 @@ class PrivateRequestAgent extends Agent {
     allowUnresolvedHosts = false;
 
     /**
+     * Whether to enable Happy Eyeballs (autoSelectFamily) for connections
+     * @type {boolean}
+     */
+    enableHappyEyeballs = true;
+
+    /**
+     * Happy Eyeballs connection attempt timeout in milliseconds
+     * @type {number}
+     */
+    happyEyeballsTimeout = 250;
+
+    /**
      * Create a new PrivateRequestAgent instance.
      * @param {object} options
      * @param {string[]} options.privateAddressWhitelist List of private IP addresses or CIDR ranges to allow.
@@ -70,8 +82,10 @@ class PrivateRequestAgent extends Agent {
      * @param {boolean} options.logAllowed Whether to log allowed requests to the console.
      * @param {boolean} options.allowUnresolvedHosts Whether to allow requests to hosts that cannot be resolved.
      * @param {boolean} options.enableKeepAlive Whether to enable HTTP/HTTPS keep-alive.
+     * @param {boolean} [options.enableHappyEyeballs] Whether to enable Happy Eyeballs (RFC 8305) for connections.
+     * @param {number} [options.happyEyeballsTimeout] Happy Eyeballs connection attempt timeout in milliseconds.
      */
-    constructor(options = { privateAddressWhitelist: [], logBlocked: true, logAllowed: false, allowUnresolvedHosts: false, enableKeepAlive: false }) {
+    constructor(options = { privateAddressWhitelist: [], logBlocked: true, logAllowed: false, allowUnresolvedHosts: false, enableKeepAlive: false, enableHappyEyeballs: true, happyEyeballsTimeout: 250 }) {
         super({ keepAlive: options.enableKeepAlive });
 
         const logEntryWarning = (entry, message) => `${color.red('Warning')}: Ignoring invalid private whitelist entry ${color.yellow(entry)} - ${message}`;
@@ -80,6 +94,8 @@ class PrivateRequestAgent extends Agent {
         this.allowUnresolvedHosts = options.allowUnresolvedHosts;
         this.logBlocked = options.logBlocked;
         this.logAllowed = options.logAllowed;
+        this.enableHappyEyeballs = options.enableHappyEyeballs ?? true;
+        this.happyEyeballsTimeout = options.happyEyeballsTimeout ?? 250;
     }
 
     /**
@@ -103,6 +119,9 @@ class PrivateRequestAgent extends Agent {
 
     /**
      * Connect method that checks if the target host resolves to a private IP address and blocks the request if it does.
+     * When the host is a name, all DNS-resolved addresses are validated and then handed to net/tls.connect
+     * via a custom `lookup` so Happy Eyeballs (RFC 8305) can race them without re-querying DNS.
+     * Re-using the validated address set is what closes the DNS-rebinding window.
      * @param {http.ClientRequest} _req HTTP request object.
      * @param {import('agent-base').AgentConnectOpts} options Agent connection options.
      */
@@ -121,53 +140,62 @@ class PrivateRequestAgent extends Agent {
 
         /**
          * Establish a connection to the target host using either TLS or a regular socket based on the options provided.
-         * @param {string|null} [hostOverride] Pass a host to override the one in options when connecting.
+         * Uses Happy Eyeballs (autoSelectFamily) when enabled to race IPv4/IPv6 connections.
+         * @param {dns.LookupAddress[]|null} [validatedAddresses] Pre-validated addresses. When provided, a custom
+         *   `lookup` is installed so the socket does not re-resolve DNS (preventing TOCTOU/DNS-rebinding).
          * @returns {net.Socket|tls.TLSSocket} A socket connected to the target host.
          */
-        const connect = (hostOverride = null) => {
-            if (hostOverride) {
-                options.host = hostOverride;
+        const connect = (validatedAddresses = null) => {
+            const connectOptions = { ...options };
+
+            if (this.enableHappyEyeballs) {
+                connectOptions.autoSelectFamily = true;
+                connectOptions.autoSelectFamilyAttemptTimeout = this.happyEyeballsTimeout;
             }
-            if (options.secureEndpoint) {
-                return tls.connect(options);
+
+            if (validatedAddresses && validatedAddresses.length > 0) {
+                connectOptions.lookup = (_hostname, lookupOptions, callback) => {
+                    if (lookupOptions && lookupOptions.all) {
+                        callback(null, validatedAddresses);
+                    } else {
+                        const first = validatedAddresses[0];
+                        callback(null, first.address, first.family);
+                    }
+                };
+            }
+
+            if (connectOptions.secureEndpoint) {
+                return tls.connect(connectOptions);
             } else {
-                return net.connect(options);
+                return net.connect(connectOptions);
             }
         };
 
         /**
-         * Validate the given IP address against the private address whitelist and connect if it's allowed.
+         * Validate the given IP address against the private address whitelist.
          * @param {string} ip The IP address to validate.
-         * @returns {net.Socket|tls.TLSSocket} A socket connected to the target IP address if it's allowed, otherwise an error is raised.
+         * @returns {boolean} Whether the IP address is allowed (not private or whitelisted).
          */
-        const validateIpAddress = (ip) => {
+        const isIpAllowed = (ip) => {
             // Not a private IP address, allow the request
             if (!this.#isPrivateIp(ip)) {
-                return connect(ip);
+                return true;
             }
-
             // Private IP address, check if it's allowed in the whitelist
-            if (this.#isAllowedPrivateAddress(ip)) {
-                if (this.logAllowed) {
-                    console.info(color.green(LOG_HEADER), 'Allowed request to private IP address:', color.blue(ip));
-                }
-
-                return connect(ip);
-            }
-
-            return raiseError(`Blocked request to private IP address: ${ip}`, this.logBlocked);
+            return this.#isAllowedPrivateAddress(ip);
         };
 
         /**
-         * Resolve the given host to an IP address using DNS lookup.
-         * @param {string} host The host to resolve to an IP address.
-         * @returns {Promise<string>} The resolved IP address for the given host, or an empty string if the host cannot be resolved.
+         * Resolve the given host to all IP addresses using DNS lookup.
+         * Returns all addresses for Happy Eyeballs support.
+         * @param {string} host The host to resolve to IP addresses.
+         * @returns {Promise<dns.LookupAddress[]>} All resolved addresses for the given host.
          */
-        const lookupHost = async (host) => {
+        const lookupHostAll = async (host) => {
             try {
-                return (await dns.promises.lookup(host)).address;
+                return await dns.promises.lookup(host, { all: true });
             } catch {
-                return '';
+                return [];
             }
         };
 
@@ -180,19 +208,43 @@ class PrivateRequestAgent extends Agent {
         const isIp = ipRegex.v4({ exact: true }).test(host) || ipRegex.v6({ exact: true }).test(host);
 
         if (isIp) {
-            return validateIpAddress(host);
-        } else {
-            const address = await lookupHost(host);
-            if (!address) {
-                if (this.allowUnresolvedHosts) {
-                    return connect();
-                } else {
-                    return raiseError(`Unable to resolve host: ${host}. Set privateAddressWhitelist.allowUnresolvedHosts to true to bypass this check.`, true);
-                }
+            // Direct IP address - validate and connect
+            if (!isIpAllowed(host)) {
+                return raiseError(`Blocked request to private IP address: ${host}`, this.logBlocked);
             }
-
-            return validateIpAddress(address);
+            if (this.logAllowed && this.#isPrivateIp(host)) {
+                console.info(color.green(LOG_HEADER), 'Allowed request to private IP address:', color.blue(host));
+            }
+            return connect();
         }
+
+        // Hostname - resolve all addresses, validate them, then connect using the validated set.
+        const addresses = await lookupHostAll(host);
+
+        if (addresses.length === 0) {
+            if (this.allowUnresolvedHosts) {
+                return connect();
+            } else {
+                return raiseError(`Unable to resolve host: ${host}. Set privateAddressWhitelist.allowUnresolvedHosts to true to bypass this check.`, true);
+            }
+        }
+
+        // Validate ALL resolved addresses to prevent SSRF via DNS rebinding.
+        // Block if any address is private and not whitelisted.
+        const blockedAddresses = addresses.filter(addr => !isIpAllowed(addr.address));
+        if (blockedAddresses.length > 0) {
+            const blockedIps = blockedAddresses.map(a => a.address).join(', ');
+            return raiseError(`Blocked request to ${host} - resolves to private IP address(es): ${blockedIps}`, this.logBlocked);
+        }
+
+        if (this.logAllowed) {
+            const privateAddrs = addresses.filter(addr => this.#isPrivateIp(addr.address));
+            if (privateAddrs.length > 0) {
+                console.info(color.green(LOG_HEADER), 'Allowed request to host with private address(es):', color.blue(host), '->', color.blue(privateAddrs.map(a => a.address).join(', ')));
+            }
+        }
+
+        return connect(addresses);
     }
 }
 
@@ -206,8 +258,10 @@ class PrivateRequestAgent extends Agent {
  * @param {boolean} options.logAllowed Whether to log allowed requests to the console.
  * @param {boolean} options.allowUnresolvedHosts Whether to allow requests to hosts that cannot be resolved.
  * @param {boolean} options.enableKeepAlive Whether to enable HTTP/HTTPS keep-alive.
+ * @param {boolean} [options.enableHappyEyeballs] Whether to enable Happy Eyeballs (RFC 8305) for connections.
+ * @param {number} [options.happyEyeballsTimeout] Happy Eyeballs connection attempt timeout in milliseconds.
  */
-export default function initPrivateRequestFilter({ listen, enabled, privateAddressWhitelist, logBlocked, logAllowed, allowUnresolvedHosts, enableKeepAlive }) {
+export default function initPrivateRequestFilter({ listen, enabled, privateAddressWhitelist, logBlocked, logAllowed, allowUnresolvedHosts, enableKeepAlive, enableHappyEyeballs, happyEyeballsTimeout }) {
     if (!enabled) {
         if (listen) {
             console.warn();
@@ -217,7 +271,7 @@ export default function initPrivateRequestFilter({ listen, enabled, privateAddre
         return;
     }
 
-    const agent = new PrivateRequestAgent({ privateAddressWhitelist, logBlocked, logAllowed, allowUnresolvedHosts, enableKeepAlive });
+    const agent = new PrivateRequestAgent({ privateAddressWhitelist, logBlocked, logAllowed, allowUnresolvedHosts, enableKeepAlive, enableHappyEyeballs, happyEyeballsTimeout });
 
     http.globalAgent = agent;
     https.globalAgent = agent;

--- a/src/request-proxy.js
+++ b/src/request-proxy.js
@@ -14,9 +14,11 @@ const LOG_HEADER = '[Request Proxy]';
  * @property {string} url Proxy URL.
  * @property {string[]} bypass List of URLs to bypass proxy.
  * @property {boolean} enableKeepAlive Enable HTTP/HTTPS keep-alive.
+ * @property {boolean} [enableHappyEyeballs] Enable Happy Eyeballs (RFC 8305) for dual-stack connections.
+ * @property {number} [happyEyeballsTimeout] Happy Eyeballs connection attempt timeout in milliseconds.
  * @property {boolean} privateRequestFilterEnabled Whether the private request filter is enabled.
  */
-export default function initRequestProxy({ enabled, url, bypass, enableKeepAlive, privateRequestFilterEnabled }) {
+export default function initRequestProxy({ enabled, url, bypass, enableKeepAlive, enableHappyEyeballs, happyEyeballsTimeout, privateRequestFilterEnabled }) {
     try {
         // No proxy is enabled, so return
         if (!enabled) {
@@ -46,8 +48,15 @@ export default function initRequestProxy({ enabled, url, bypass, enableKeepAlive
             process.env.no_proxy = bypass.join(',');
         }
 
-        const httpAgent = http.globalAgent;
-        const httpsAgent = https.globalAgent;
+        const happyEyeballs = enableHappyEyeballs ?? true;
+        const agentOptions = {
+            keepAlive: enableKeepAlive,
+            autoSelectFamily: happyEyeballs,
+            ...(happyEyeballs ? { autoSelectFamilyAttemptTimeout: happyEyeballsTimeout ?? 250 } : {}),
+        };
+
+        const httpAgent = new http.Agent(agentOptions);
+        const httpsAgent = new https.Agent(agentOptions);
 
         const proxyAgent = new ProxyAgent({ httpAgent, httpsAgent, keepAlive: enableKeepAlive });
 

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -75,14 +75,6 @@ import { diskCache } from './endpoints/characters.js';
 import { migrateFlatSecrets } from './endpoints/secrets.js';
 import { migrateGroupChatsMetadataFormat } from './endpoints/groups.js';
 
-// Work around a node v20.0.0, v20.1.0, and v20.2.0 bug. The issue was fixed in v20.3.0.
-// https://github.com/nodejs/node/issues/47822#issuecomment-1564708870
-// Safe to remove once support for Node v20 is dropped.
-if (process.versions && process.versions.node && process.versions.node.match(/20\.[0-2]\.0/)) {
-    // @ts-ignore
-    if (net.setDefaultAutoSelectFamily) net.setDefaultAutoSelectFamily(false);
-}
-
 // Unrestrict console logs display limit
 util.inspect.defaultOptions.maxArrayLength = null;
 util.inspect.defaultOptions.maxStringLength = null;
@@ -96,9 +88,30 @@ if (!cliArgs.enableIPv6 && !cliArgs.enableIPv4) {
     process.exit(1);
 }
 
-// Set keep-alive preference for all HTTP/HTTPS requests.
-http.globalAgent = new http.Agent({ keepAlive: cliArgs.enableKeepAlive });
-https.globalAgent = new https.Agent({ keepAlive: cliArgs.enableKeepAlive });
+// Set the default auto-select family (Happy Eyeballs RFC 8305) preference.
+// This ensures dual-stack IPv4/IPv6 works for all outgoing connections.
+// Node v20.0.0–v20.2.0 had a broken implementation (https://github.com/nodejs/node/issues/47822),
+// so we force-disable Happy Eyeballs on those versions regardless of the user's preference.
+const nodeHasBrokenAutoSelectFamily = !!(process.versions?.node?.match(/^20\.[0-2]\.0$/));
+const happyEyeballsEnabled = cliArgs.enableHappyEyeballs && !nodeHasBrokenAutoSelectFamily;
+if (nodeHasBrokenAutoSelectFamily && cliArgs.enableHappyEyeballs) {
+    console.warn('Happy Eyeballs is disabled on Node v20.0.0–v20.2.0 due to a known bug. Upgrade Node to v20.3.0 or later to enable it.');
+}
+if (net.setDefaultAutoSelectFamily) {
+    net.setDefaultAutoSelectFamily(happyEyeballsEnabled);
+}
+if (happyEyeballsEnabled && net.setDefaultAutoSelectFamilyAttemptTimeout && cliArgs.happyEyeballsTimeout > 0) {
+    net.setDefaultAutoSelectFamilyAttemptTimeout(cliArgs.happyEyeballsTimeout);
+}
+
+// Set keep-alive and Happy Eyeballs preferences for all HTTP/HTTPS requests.
+const globalAgentOptions = {
+    keepAlive: cliArgs.enableKeepAlive,
+    autoSelectFamily: happyEyeballsEnabled,
+    ...(happyEyeballsEnabled ? { autoSelectFamilyAttemptTimeout: cliArgs.happyEyeballsTimeout } : {}),
+};
+http.globalAgent = new http.Agent(globalAgentOptions);
+https.globalAgent = new https.Agent(globalAgentOptions);
 
 const app = express();
 app.use(helmet({
@@ -343,11 +356,13 @@ async function preSetupTasks() {
         logAllowed: !!getConfigValue('privateAddressWhitelist.log.allowedRequests', false, 'boolean'),
         allowUnresolvedHosts: !!getConfigValue('privateAddressWhitelist.allowUnresolvedHosts', false, 'boolean'),
         enableKeepAlive: cliArgs.enableKeepAlive,
+        enableHappyEyeballs: cliArgs.enableHappyEyeballs,
+        happyEyeballsTimeout: cliArgs.happyEyeballsTimeout,
     };
     initPrivateRequestFilter(requestFilterOptions);
 
     // Add request proxy.
-    initRequestProxy({ enabled: cliArgs.requestProxyEnabled, url: cliArgs.requestProxyUrl, bypass: cliArgs.requestProxyBypass, enableKeepAlive: cliArgs.enableKeepAlive, privateRequestFilterEnabled: requestFilterOptions.enabled });
+    initRequestProxy({ enabled: cliArgs.requestProxyEnabled, url: cliArgs.requestProxyUrl, bypass: cliArgs.requestProxyBypass, enableKeepAlive: cliArgs.enableKeepAlive, enableHappyEyeballs: cliArgs.enableHappyEyeballs, happyEyeballsTimeout: cliArgs.happyEyeballsTimeout, privateRequestFilterEnabled: requestFilterOptions.enabled });
 
     // Wait for frontend libs to compile
     await webpackMiddleware.runWebpackCompiler({ pruneCache: true });
@@ -469,6 +484,10 @@ function setDnsResolutionOrder() {
         } else {
             dns.setDefaultResultOrder('ipv4first');
             console.log('Preferring IPv4 for DNS resolution');
+        }
+
+        if (happyEyeballsEnabled) {
+            console.log(`Happy Eyeballs (RFC 8305) enabled - racing IPv4/IPv6 connections (fallback delay: ${cliArgs.happyEyeballsTimeout}ms)`);
         }
     } catch (error) {
         console.warn('Failed to set DNS resolution order. Possibly unsupported in this Node version.');

--- a/tests/private-request-filter.test.js
+++ b/tests/private-request-filter.test.js
@@ -59,7 +59,7 @@ afterAll(() => {
     https.globalAgent = originalHttpsGlobalAgent;
 });
 
-function initAgent({ privateAddressWhitelist = [], allowUnresolvedHosts = false } = {}) {
+function initAgent({ privateAddressWhitelist = [], allowUnresolvedHosts = false, enableHappyEyeballs = true } = {}) {
     initPrivateRequestFilter({
         listen: false,
         enabled: true,
@@ -67,6 +67,8 @@ function initAgent({ privateAddressWhitelist = [], allowUnresolvedHosts = false 
         logBlocked: false,
         logAllowed: false,
         allowUnresolvedHosts,
+        enableHappyEyeballs,
+        happyEyeballsTimeout: 250,
     });
 
     return http.globalAgent;
@@ -86,23 +88,44 @@ describe('private request filter', () => {
     });
 
     test('resolves hostnames and blocks when DNS returns private IP', async () => {
-        mockLookup.mockResolvedValue({ address: '192.168.1.8' });
+        mockLookup.mockResolvedValue([{ address: '192.168.1.8', family: 4 }]);
         const agent = initAgent();
 
         await expect(agent.connect({}, { host: 'example.com', secureEndpoint: false }))
             .rejects
-            .toThrow('Blocked request to private IP address: 192.168.1.8');
+            .toThrow(/Blocked request to example\.com - resolves to private IP address\(es\): 192\.168\.1\.8/);
         expect(mockNetConnect).not.toHaveBeenCalled();
     });
 
-    test('connects to resolved public IP to avoid hostname re-resolution', async () => {
-        mockLookup.mockResolvedValue({ address: '93.184.216.34' });
-        const agent = initAgent();
+    test('connects using hostname for Happy Eyeballs when all resolved IPs are public', async () => {
+        mockLookup.mockResolvedValue([
+            { address: '93.184.216.34', family: 4 },
+            { address: '2606:2800:220:1:248:1893:25c8:1946', family: 6 },
+        ]);
+        const agent = initAgent({ enableHappyEyeballs: true });
 
         await agent.connect({}, { host: 'example.com', secureEndpoint: false });
 
-        expect(mockLookup).toHaveBeenCalledWith('example.com');
-        expect(mockNetConnect).toHaveBeenCalledWith(expect.objectContaining({ host: '93.184.216.34' }));
+        expect(mockLookup).toHaveBeenCalledWith('example.com', { all: true });
+        // With Happy Eyeballs, connects using hostname to allow address family racing
+        expect(mockNetConnect).toHaveBeenCalledWith(expect.objectContaining({
+            host: 'example.com',
+            autoSelectFamily: true,
+            autoSelectFamilyAttemptTimeout: 250,
+        }));
+    });
+
+    test('blocks when any resolved address is private (prevents DNS rebinding)', async () => {
+        mockLookup.mockResolvedValue([
+            { address: '93.184.216.34', family: 4 },
+            { address: '192.168.1.1', family: 4 },
+        ]);
+        const agent = initAgent();
+
+        await expect(agent.connect({}, { host: 'example.com', secureEndpoint: false }))
+            .rejects
+            .toThrow(/Blocked request to example\.com - resolves to private IP address\(es\): 192\.168\.1\.1/);
+        expect(mockNetConnect).not.toHaveBeenCalled();
     });
 
     test('handles unresolved hosts according to allowUnresolvedHosts setting', async () => {
@@ -120,11 +143,58 @@ describe('private request filter', () => {
     });
 
     test('uses tls.connect for secure endpoints', async () => {
-        mockLookup.mockResolvedValue({ address: '93.184.216.34' });
+        mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
         const agent = initAgent();
         await agent.connect({}, { host: 'example.com', secureEndpoint: true });
-        expect(mockLookup).toHaveBeenCalledWith('example.com');
-        expect(mockTlsConnect).toHaveBeenCalledWith(expect.objectContaining({ host: '93.184.216.34' }));
+        expect(mockLookup).toHaveBeenCalledWith('example.com', { all: true });
+        expect(mockTlsConnect).toHaveBeenCalledWith(expect.objectContaining({ host: 'example.com' }));
         expect(mockNetConnect).not.toHaveBeenCalled();
+    });
+
+    test('passes Happy Eyeballs options to connection', async () => {
+        mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+        const agent = initAgent({ enableHappyEyeballs: true });
+        await agent.connect({}, { host: 'example.com', secureEndpoint: false });
+
+        expect(mockNetConnect).toHaveBeenCalledWith(expect.objectContaining({
+            autoSelectFamily: true,
+            autoSelectFamilyAttemptTimeout: 250,
+        }));
+    });
+
+    test('omits Happy Eyeballs options when disabled', async () => {
+        mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+        const agent = initAgent({ enableHappyEyeballs: false });
+        await agent.connect({}, { host: 'example.com', secureEndpoint: false });
+
+        const callOptions = mockNetConnect.mock.calls[0][0];
+        expect(callOptions.autoSelectFamily).toBeUndefined();
+        expect(callOptions.autoSelectFamilyAttemptTimeout).toBeUndefined();
+    });
+
+    test('installs a custom lookup that returns the pre-validated addresses (anti-rebinding)', async () => {
+        const resolved = [
+            { address: '93.184.216.34', family: 4 },
+            { address: '2606:2800:220:1:248:1893:25c8:1946', family: 6 },
+        ];
+        mockLookup.mockResolvedValue(resolved);
+        const agent = initAgent({ enableHappyEyeballs: true });
+
+        await agent.connect({}, { host: 'example.com', secureEndpoint: false });
+
+        const callOptions = mockNetConnect.mock.calls[0][0];
+        expect(typeof callOptions.lookup).toBe('function');
+
+        // The socket should receive the validated set, never re-query DNS.
+        const allCb = jest.fn();
+        callOptions.lookup('example.com', { all: true }, allCb);
+        expect(allCb).toHaveBeenCalledWith(null, resolved);
+
+        const singleCb = jest.fn();
+        callOptions.lookup('example.com', {}, singleCb);
+        expect(singleCb).toHaveBeenCalledWith(null, resolved[0].address, resolved[0].family);
+
+        // Critically: the lookup we installed does NOT call the real DNS resolver again.
+        expect(mockLookup).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
SillyTavern's outbound connections (to OpenAI, Anthropic, etc.) didn't reliably do Happy Eyeballs — the algorithm that races IPv4/IPv6 connections in parallel so dual-stack networks just work. On hosts where one address family black-holes, this meant waiting for the OS-level TCP timeout (~75–130s) before falling back, while `curl` would have finished in well under a second.

The two root causes:

1. The global HTTP/HTTPS agents inherited whatever Node's default for `autoSelectFamily` happened to be on that release, which has flipped multiple times across Node 20.x / 22.x.
2. The `PrivateRequestAgent` SSRF filter resolved a single IP via `dns.lookup` and connected directly to that literal address, completely bypassing Node's `autoSelectFamily` machinery.

## Changes

- **Global agents** (server-main.js): Explicitly set `autoSelectFamily` + `autoSelectFamilyAttemptTimeout` on `http.globalAgent` / `https.globalAgent` and call `net.setDefaultAutoSelectFamily()` process-wide based on the new config. The existing Node v20.0.0–v20.2.0 [`autoSelectFamily` bug](https://github.com/nodejs/node/issues/47822) workaround is now folded into the toggle (it used to be silently overridden) and emits a warning if the user requested Happy Eyeballs on an affected runtime.
- **SSRF filter** (private-request-filter.js): Resolve all addresses via `dns.lookup(host, { all: true })`, validate every one of them against the private-IP whitelist, and then pass the validated set to `net.connect` / `tls.connect` through a custom `lookup` function. This lets Happy Eyeballs race IPv4 and IPv6 while guaranteeing the socket can only ever connect to an address we already approved — closing a DNS-rebinding / TOCTOU window that would otherwise open if we resolved twice. As a side benefit it also blocks the case where *any* address in a multi-A record is private (previously only the first was checked).
- **Proxy agent** (request-proxy.js): Backing HTTP/HTTPS agents wrapped by `ProxyAgent` now carry the same Happy Eyeballs options.
- **Config** (config.yaml, command-line.js): New `enableHappyEyeballs: true` and `happyEyeballsTimeout: 250` (the per-family fallback delay, in ms) with matching CLI flags `--enableHappyEyeballs` / `--happyEyeballsTimeout`. `autoSelectFamilyAttemptTimeout` is only set when the feature is enabled.
- **Tests**: Updated private-request-filter.test.js for the new all-address lookup contract. Added cases for: blocking when *any* resolved address is private (DNS-rebinding defence), Happy Eyeballs options being omitted when disabled, and the installed `lookup` returning the pre-validated address set in both `all` and single-address modes.

```yaml
# config.yaml — enabled by default, no action needed for most users
enableHappyEyeballs: true
happyEyeballsTimeout: 250
```

## Checklist

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

Co-Authored by @copilot