### PR TITLE
fix logprobs window rewrite/continue feature failing on user's messages

### DIFF
--- a/public/scripts/logprobs.js
+++ b/public/scripts/logprobs.js
@@ -426,6 +426,12 @@ function createSwipe(messageId, prompt) {
 
     console.debug('cleanedPrompt: ', cleanedPrompt);
 
+    // User messages cannot be swiped, so we have to just edit the message.
+    if (msg.is_user) {
+        msg.mes = cleanedPrompt;
+        return;
+    }
+
     /** @type {SwipeInfo} */
     const newSwipeInfo = {
         send_date: msg.send_date,
@@ -433,17 +439,6 @@ function createSwipe(messageId, prompt) {
         gen_finished: msg.gen_finished,
         extra: { ...structuredClone(msg.extra), from_logprobs: new Date().getTime() },
     };
-
-    // User messages cannot be swiped, so we have to just edit the message.
-    if (msg.is_user) {
-        if (shouldRerollReasoning) {
-            newSwipeInfo.extra.reasoning = cleanedPrompt;
-            msg.mes = '';
-        } else {
-            msg.mes = cleanedPrompt;
-        }
-        return;
-    }
 
     msg.swipes = msg.swipes || [];
     msg.swipe_info = msg.swipe_info || [];

--- a/public/scripts/logprobs.js
+++ b/public/scripts/logprobs.js
@@ -9,6 +9,7 @@ import {
     is_send_press,
     isStreamingEnabled,
     substituteParamsExtended,
+    updateMessageBlock,
 } from '../script.js';
 import { debounce, delay, getStringHash } from './utils.js';
 import { decodeTextTokens, getTokenizerBestMatch } from './tokenizers.js';
@@ -315,9 +316,17 @@ function checkGenerateReady() {
  */
 function addGeneration(prompt) {
     const messageId = chat.length - 1;
+    const msg = chat[messageId];
+    
     if (prompt && prompt.length > 0) {
         createSwipe(messageId, prompt);
-        $('.swipe_right:last').trigger('click');
+        
+        if (msg.is_user) {
+            updateMessageBlock(messageId, msg);
+        } else{
+            $('.swipe_right:last').trigger('click');
+        }
+        
         void Generate('continue');
     } else {
         $('.swipe_right:last').trigger('click');
@@ -424,6 +433,17 @@ function createSwipe(messageId, prompt) {
         gen_finished: msg.gen_finished,
         extra: { ...structuredClone(msg.extra), from_logprobs: new Date().getTime() },
     };
+
+    // User messages cannot be swiped, so we have to just edit the message.
+    if (msg.is_user) {
+        if (shouldRerollReasoning) {
+            newSwipeInfo.extra.reasoning = cleanedPrompt;
+            msg.mes = '';
+        } else {
+            msg.mes = cleanedPrompt;
+        }
+        return;
+    }
 
     msg.swipes = msg.swipes || [];
     msg.swipe_info = msg.swipe_info || [];


### PR DESCRIPTION
Fixes the bug that prevents user's messages from being edited via token logprobs window.

The cause is that at some point in development Silly decided that you are not allowed to swipe user's messages; the logprobs window uses exactly that to edit the message.

Currently, it works like this:

---

User's message (generated by impersonation) states:
> You pick up an apple and

User clicks the word [apple] expecting it to write something else instead, like
> You pick up an anvil with your bare hands.

What happens instead is Silly continues user's message from the end:
> You pick up an apple and throw it.

---

This PR fixes this behavior by editing user's message directly instead of creating a new swipe. Characters' messages work as before, by adding swipes.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
