### PR TITLE
Redirect `/index.html` to `/` to avoid causing confusion

### DIFF
--- a/src/server-main.js
+++ b/src/server-main.js
@@ -210,6 +210,14 @@ if (!cliArgs.disableCsrf) {
 }
 
 // Static files
+// Redirect /index.html to / so that location.href agrees with <base href="/">.
+// Otherwise jQuery UI tabs' _isLocal() sees a mismatch and AJAX-loads in-page
+// tab anchors as if they were remote URLs, duplicating every id in the document.
+app.get('/index.html', (request, response) => {
+    const query = request.url.split('?')[1];
+    return response.redirect(301, query ? `/?${query}` : '/');
+});
+
 // Host index page
 app.get('/', cacheBuster.middleware, (request, response) => {
     if (shouldRedirectToLogin(request)) {


### PR DESCRIPTION
Hi,

This PR ensures that accessing `/index.html` will be redirected to `/`. The reason is that I accidentally accessed `/index.html` and there are lots of weird behaviors:

- Though API is configured correctly, I have several CSRF errors, and the textarea says "API not connected" because there are actually two textareas.
- Even disabling CSRF protection, I can not send any messages, but the completion works (the message history only has `system` roles, though).

After several hours, I noticed this discrepancy, and thus I think the fix is necessary.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
