### PR TITLE
fix: Preserve content type in CORS proxy responses

### DIFF
--- a/src/middleware/corsProxy.js
+++ b/src/middleware/corsProxy.js
@@ -34,6 +34,11 @@ export default async function corsProxyMiddleware(req, res) {
             body: bodyMethods.includes(req.method) ? JSON.stringify(req.body) : undefined,
         });
 
+        const contentType = response.headers.get('content-type');
+        if (contentType) {
+            res.setHeader('Content-Type', contentType);
+        }
+
         // Copy over relevant response params to the proxy response
         await forwardFetchResponse(response, res);
     } catch (error) {


### PR DESCRIPTION
## Summary

Preserves the upstream `Content-Type` header when returning responses through the built-in CORS proxy.

## Why

I discovered this while using Chatterbox TTS through SillyTavern's CORS proxy. The proxied TTS response contained valid audio data, but the browser received it without an `audio/*` MIME type because the proxy was not forwarding the upstream `Content-Type`.

That caused SillyTavern's TTS playback validation to reject the response as invalid:

```text
TTS received HTTP response with invalid data format. Expecting audio/*, got
```

## Changes

- Read the upstream response `content-type` header.
- Set the same `Content-Type` on the proxied response before streaming the body.

## Validation

- Ran `node --check src/middleware/corsProxy.js`.
- Tested on my own setup

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
