### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/default/content/presets/openai/Default.json
+++ b/default/content/presets/openai/Default.json
@@ -10,7 +10,7 @@
     "mistralai_model": "mistral-large-latest",
     "chutes_model": "deepseek-ai/DeepSeek-V3-0324",
     "chutes_sort_models": "alphabetically",
-    "minimax_model": "MiniMax-M2.7",
+    "minimax_model": "MiniMax-M3",
     "minimax_endpoint": "global",
     "electronhub_model": "gpt-4o-mini",
     "electronhub_sort_models": "alphabetically",

--- a/public/index.html
+++ b/public/index.html
@@ -3595,13 +3595,9 @@
                             </select>
                             <h4 data-i18n="MiniMax Model">MiniMax Model</h4>
                             <select id="model_minimax_select">
+                                <option value="MiniMax-M3">MiniMax-M3</option>
                                 <option value="MiniMax-M2.7">MiniMax-M2.7</option>
                                 <option value="MiniMax-M2.7-highspeed">MiniMax-M2.7-highspeed</option>
-                                <option value="MiniMax-M2.5">MiniMax-M2.5</option>
-                                <option value="MiniMax-M2.5-highspeed">MiniMax-M2.5-highspeed</option>
-                                <option value="MiniMax-M2.1">MiniMax-M2.1</option>
-                                <option value="MiniMax-M2.1-highspeed">MiniMax-M2.1-highspeed</option>
-                                <option value="MiniMax-M2">MiniMax-M2</option>
                                 <option value="M2-her">M2-her</option>
                             </select>
                         </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -447,7 +447,7 @@ const default_settings = {
     chutes_model: 'deepseek-ai/DeepSeek-V3-0324',
     siliconflow_model: 'deepseek-ai/DeepSeek-V3',
     siliconflow_endpoint: SILICONFLOW_ENDPOINT.GLOBAL,
-    minimax_model: 'MiniMax-M2.7',
+    minimax_model: 'MiniMax-M3',
     minimax_endpoint: MINIMAX_ENDPOINT.GLOBAL,
     electronhub_model: 'gpt-4o-mini',
     nanogpt_model: 'gpt-4o-mini',
@@ -5882,7 +5882,11 @@ async function onModelChange() {
     }
 
     if (oai_settings.chat_completion_source === chat_completion_sources.MINIMAX) {
-        const maxContext = oai_settings.minimax_model === 'M2-her' ? 65536 : 204800;
+        const maxContext = oai_settings.minimax_model === 'MiniMax-M3'
+            ? 524288
+            : oai_settings.minimax_model === 'M2-her'
+                ? 65536
+                : 204800;
         $('#openai_max_context').attr('max', maxContext);
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');


### PR DESCRIPTION
## Summary

Upgrade the MiniMax model selection list to include the new M3 model as the default, and remove deprecated older versions.

## Changes

- Add `MiniMax-M3` to the model selection dropdown (top of list)
- Set `MiniMax-M3` as the new default in both `openai.js` and `default/content/presets/openai/Default.json`
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove deprecated `MiniMax-M2.5` / `M2.5-highspeed` / `M2.1` / `M2.1-highspeed` / `M2` from the list
- Bump max context for `MiniMax-M3` to 524288 (512K window)
- Leave `M2-her` untouched (separate variant with its own 64K context size)

## Why

MiniMax-M3 is the new flagship model with a 512K context window, 128K max output, and image input support. Older M2.5 / M2.1 / M2 variants are deprecated upstream.

## Testing

- `npm run lint` passes on changed files
- JSON syntax of `Default.json` validated
- Dropdown options manually verified in the markup