### PR TITLE
Optimize empty chat search metadata reads

### DIFF
--- a/src/chat-search.js
+++ b/src/chat-search.js
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { formatBytes, tryParse } from './util.js';
+
+export const CHAT_SEARCH_FILE_CONCURRENCY = 4;
+
+const READ_BUFFER_SIZE = 1024 * 1024;
+const PREVIEW_LENGTH = 400;
+
+export function getPreviewMessage(lastMessage) {
+    if (!lastMessage) {
+        return '';
+    }
+
+    return lastMessage.length > PREVIEW_LENGTH
+        ? '...' + lastMessage.substring(lastMessage.length - PREVIEW_LENGTH)
+        : lastMessage;
+}
+
+export function getChatSearchFragments(query) {
+    return String(query ?? '').trim().toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+export async function mapAsyncLimited(items, limit, mapper) {
+    if (items.length === 0) {
+        return [];
+    }
+
+    const results = new Array(items.length);
+    const workerCount = Math.max(1, Math.min(Math.floor(limit), items.length));
+    let nextIndex = 0;
+
+    async function worker() {
+        while (nextIndex < items.length) {
+            const index = nextIndex++;
+            try {
+                results[index] = { status: 'fulfilled', value: await mapper(items[index], index) };
+            } catch (reason) {
+                results[index] = { status: 'rejected', reason };
+            }
+        }
+    }
+
+    await Promise.all(Array.from({ length: workerCount }, worker));
+    return results;
+}
+
+function isChatEntry(jsonData) {
+    return Boolean(jsonData && (jsonData.name || jsonData.character_name || jsonData.chat_metadata));
+}
+
+function updateFromLastLine(result, stats, line, chatFilePath) {
+    const jsonData = tryParse(line.replace(/\r$/, ''));
+
+    if (isChatEntry(jsonData)) {
+        result.preview_message = getPreviewMessage(jsonData.mes || '[The message is empty]');
+        result.last_mes = jsonData.send_date || new Date(Math.round(stats.mtimeMs)).toISOString();
+    } else {
+        console.warn('Found an invalid or corrupted chat file:', chatFilePath);
+        result.valid = false;
+    }
+}
+
+export async function getChatSearchResult(chatFilePath) {
+    const parsedPath = path.parse(chatFilePath);
+    const stats = await fs.promises.stat(chatFilePath);
+    const result = {
+        file_name: parsedPath.name,
+        file_size: formatBytes(stats.size),
+        message_count: 0,
+        last_mes: stats.mtimeMs,
+        preview_message: '[The chat is empty]',
+        valid: true,
+    };
+
+    if (stats.size === 0) {
+        return result;
+    }
+
+    const fileHandle = await fs.promises.open(chatFilePath, 'r');
+
+    try {
+        const buffer = Buffer.allocUnsafe(READ_BUFFER_SIZE);
+        let lineCounter = 0;
+        let position = 0;
+        let previousLineStart = 0;
+        let lastLineStart = 0;
+        let lastByte = null;
+
+        while (position < stats.size) {
+            const { bytesRead } = await fileHandle.read(buffer, 0, buffer.length, position);
+            if (bytesRead === 0) {
+                break;
+            }
+
+            const chunk = buffer.subarray(0, bytesRead);
+            let searchOffset = 0;
+            let newlineOffset;
+
+            while ((newlineOffset = chunk.indexOf(10, searchOffset)) !== -1) {
+                lineCounter++;
+                previousLineStart = lastLineStart;
+                lastLineStart = position + newlineOffset + 1;
+                searchOffset = newlineOffset + 1;
+            }
+
+            lastByte = chunk[bytesRead - 1];
+            position += bytesRead;
+        }
+
+        if (position === 0) {
+            return result;
+        }
+
+        if (lastByte !== 10) {
+            lineCounter++;
+        }
+
+        result.message_count = Math.max(0, lineCounter - 1);
+
+        const lastLineStartOffset = lastByte === 10 ? previousLineStart : lastLineStart;
+        const lastLineEndOffset = lastByte === 10 ? Math.max(0, position - 1) : position;
+        const lastLineLength = lastLineEndOffset - lastLineStartOffset;
+
+        if (lastLineLength <= 0) {
+            return result;
+        }
+
+        const lastLineBuffer = Buffer.allocUnsafe(lastLineLength);
+        const { bytesRead } = await fileHandle.read(lastLineBuffer, 0, lastLineLength, lastLineStartOffset);
+        const lastLine = lastLineBuffer.subarray(0, bytesRead).toString('utf8');
+        updateFromLastLine(result, stats, lastLine, chatFilePath);
+    } finally {
+        await fileHandle.close();
+    }
+
+    return result;
+}

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -10,6 +10,13 @@ import _ from 'lodash';
 
 import validateAvatarUrlMiddleware from '../middleware/validateFileName.js';
 import {
+    CHAT_SEARCH_FILE_CONCURRENCY,
+    getChatSearchFragments,
+    getPreviewMessage,
+    getChatSearchResult,
+    mapAsyncLimited,
+} from '../chat-search.js';
+import {
     getConfigValue,
     humanizedDateTime,
     tryParse,
@@ -75,23 +82,6 @@ function getBackupFunction(handle) {
         backupFunctions.set(handle, _.throttle(backupChat, throttleInterval, { leading: true, trailing: true }));
     }
     return backupFunctions.get(handle) || (() => { });
-}
-
-/**
- * Gets a preview message from a chat message string.
- * @param {string} [lastMessage] - The message to truncate
- * @returns {string} A truncated preview of the last message or empty string if no messages
- */
-function getPreviewMessage(lastMessage) {
-    const strlen = 400;
-
-    if (!lastMessage) {
-        return '';
-    }
-
-    return lastMessage.length > strlen
-        ? '...' + lastMessage.substring(lastMessage.length - strlen)
-        : lastMessage;
 }
 
 process.on('exit', () => {
@@ -930,21 +920,46 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
          * @property {string} [preview_message] - A preview of the last message
          */
         const results = [];
+        const fragments = getChatSearchFragments(query);
 
-        /** @type {string[]} */
-        const fragments = query ? query.trim().toLowerCase().split(/\s+/).filter(x => x) : [];
+        if (fragments.length === 0) {
+            const chatInfoResults = await mapAsyncLimited(
+                chatFiles,
+                CHAT_SEARCH_FILE_CONCURRENCY,
+                chatFile => getChatSearchResult(chatFile),
+            );
+
+            for (const chatInfoResult of chatInfoResults) {
+                if (chatInfoResult.status === 'rejected') {
+                    console.warn('Failed to read chat search metadata:', chatInfoResult.reason);
+                    continue;
+                }
+
+                const chatInfo = chatInfoResult.value;
+
+                if (!chatInfo.valid) {
+                    continue;
+                }
+
+                results.push({
+                    file_name: chatInfo.file_name,
+                    file_size: chatInfo.file_size,
+                    message_count: chatInfo.message_count,
+                    last_mes: chatInfo.last_mes,
+                    preview_message: chatInfo.preview_message,
+                });
+            }
+
+            return response.send(results);
+        }
 
         /** @type {ChatMatchFunction} */
         const hasTextMatch = (textArray) => {
-            if (fragments.length === 0) {
-                return true;
-            }
             return fragments.every(fragment => textArray.some(text => String(text ?? '').toLowerCase().includes(fragment)));
         };
 
         for (const chatFile of chatFiles) {
-            const matcher = query ? hasTextMatch : null;
-            const chatInfo = await getChatInfo(chatFile, {}, false, matcher);
+            const chatInfo = await getChatInfo(chatFile, {}, false, hasTextMatch);
             const hasMatch = chatInfo.match || hasTextMatch([chatInfo.file_id ?? '']);
 
             // Skip corrupted or invalid chat files
@@ -953,12 +968,12 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
             }
 
             // Empty chats without a file name match are skipped when searching with a query
-            if (query && chatInfo.chat_items === 0 && !hasMatch) {
+            if (chatInfo.chat_items === 0 && !hasMatch) {
                 continue;
             }
 
-            // If no search query or a match was found, include the chat in results
-            if (!query || hasMatch) {
+            // If a match was found, include the chat in results
+            if (hasMatch) {
                 results.push({
                     file_name: chatInfo.file_id,
                     file_size: chatInfo.file_size,

--- a/tests/chat-search.test.js
+++ b/tests/chat-search.test.js
@@ -1,0 +1,147 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const mockTryParse = jest.fn((str) => {
+    try {
+        return JSON.parse(str);
+    } catch {
+        return undefined;
+    }
+});
+
+jest.unstable_mockModule('../src/util.js', () => ({
+    formatBytes: bytes => `${bytes} B`,
+    tryParse: mockTryParse,
+}));
+
+/** @type {typeof import('../src/chat-search.js')} */
+let chatSearch;
+/** @type {string[]} */
+const tempDirs = [];
+let warnSpy;
+
+beforeAll(async () => {
+    chatSearch = await import('../src/chat-search.js');
+});
+
+beforeEach(() => {
+    mockTryParse.mockClear();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(async () => {
+    warnSpy?.mockRestore();
+
+    const dirs = tempDirs.splice(0);
+    await Promise.all(dirs.map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function createTempDir() {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'st-chat-search-'));
+    tempDirs.push(tempDir);
+    return tempDir;
+}
+
+/**
+ * @param {string} filePath File path
+ * @param {(object|string)[]} entries JSONL entries
+ * @returns {Promise<number>} Written byte length
+ */
+async function writeJsonl(filePath, entries) {
+    const contents = entries
+        .map(entry => typeof entry === 'string' ? entry : JSON.stringify(entry))
+        .join('\n');
+    await fs.writeFile(filePath, contents);
+    return Buffer.byteLength(contents);
+}
+
+describe('chat search metadata', () => {
+    test('empty query returns summary fields and only parses the last line', async () => {
+        const tempDir = await createTempDir();
+        const lastMessage = {
+            name: 'Seraphina',
+            mes: 'second hello',
+            send_date: '2026-01-02T03:04:05.000Z',
+        };
+        const filePath = path.join(tempDir, 'Morning Chat.jsonl');
+        const size = await writeJsonl(filePath, [
+            { user_name: 'User', character_name: 'Seraphina', chat_metadata: {} },
+            { name: 'User', mes: 'first hello', send_date: '2026-01-01T03:04:05.000Z' },
+            lastMessage,
+        ]);
+
+        const result = await chatSearch.getChatSearchResult(filePath);
+
+        expect(result).toMatchObject({
+            file_name: 'Morning Chat',
+            file_size: `${size} B`,
+            message_count: 2,
+            last_mes: lastMessage.send_date,
+            preview_message: lastMessage.mes,
+            valid: true,
+        });
+        expect(mockTryParse).toHaveBeenCalledTimes(1);
+        expect(mockTryParse).toHaveBeenCalledWith(JSON.stringify(lastMessage));
+    });
+
+    test('group chat ids are returned without the .jsonl extension', async () => {
+        const tempDir = await createTempDir();
+        const filePath = path.join(tempDir, 'group-session-123.jsonl');
+        await writeJsonl(filePath, [
+            { user_name: 'User', character_name: 'Group', chat_metadata: {} },
+            { name: 'Group', mes: 'hello group', send_date: '2026-02-03T04:05:06.000Z' },
+        ]);
+
+        const result = await chatSearch.getChatSearchResult(filePath);
+
+        expect(result.file_name).toBe('group-session-123');
+        expect(result.message_count).toBe(1);
+        expect(result.preview_message).toBe('hello group');
+    });
+
+    test('corrupted middle JSON lines do not fail empty search metadata', async () => {
+        const tempDir = await createTempDir();
+        const filePath = path.join(tempDir, 'Corrupted Lines.jsonl');
+        await writeJsonl(filePath, [
+            { user_name: 'User', character_name: 'Character', chat_metadata: {} },
+            '{not valid json',
+            { name: 'Character', mes: 'survivor line', send_date: '2026-05-06T07:08:09.000Z' },
+        ]);
+
+        const result = await chatSearch.getChatSearchResult(filePath);
+
+        expect(result).toMatchObject({
+            file_name: 'Corrupted Lines',
+            message_count: 2,
+            last_mes: '2026-05-06T07:08:09.000Z',
+            preview_message: 'survivor line',
+            valid: true,
+        });
+        expect(mockTryParse).toHaveBeenCalledTimes(1);
+    });
+
+    test('empty and invalid chats do not throw', async () => {
+        const tempDir = await createTempDir();
+        const emptyPath = path.join(tempDir, 'Empty.jsonl');
+        const invalidPath = path.join(tempDir, 'Invalid.jsonl');
+        await fs.writeFile(emptyPath, '');
+        await fs.writeFile(invalidPath, '{not valid json');
+
+        await expect(chatSearch.getChatSearchResult(emptyPath)).resolves.toMatchObject({
+            file_name: 'Empty',
+            message_count: 0,
+            preview_message: '[The chat is empty]',
+            valid: true,
+        });
+        await expect(chatSearch.getChatSearchResult(invalidPath)).resolves.toMatchObject({
+            file_name: 'Invalid',
+            valid: false,
+        });
+    });
+
+    test('normalizes search query fragments', () => {
+        expect(chatSearch.getChatSearchFragments('  Alpha   Beta  ')).toEqual(['alpha', 'beta']);
+    });
+});


### PR DESCRIPTION
## Summary

Optimizes the empty `/api/chats/search` path used by the Manage Chat Files view.

When the search query is empty, the endpoint only needs:

- `file_name`
- `file_size`
- `message_count`
- `last_mes`
- `preview_message`

Previously this path used the general chat info reader, which scans JSONL files line by line through `readline` to count messages, then parses the final line for preview metadata. This PR adds a lightweight empty-search reader that counts JSONL lines with buffer scans and parses only the final line.

Keyword searches keep using the existing matching path.

## Motivation

Opening Manage Chat Files can be slow for users with many or large chat files. This can happen in real-world use, even if my local test data is not especially extreme.

In my local test setup, opening the chat manager for one character improved from about `3.1s` to about `109ms`.

## Testing

- `node --check src/chat-search.js`
- `node --check src/endpoints/chats.js`
- `node_modules\.bin\eslint.cmd src/chat-search.js src/endpoints/chats.js`
- `npm.cmd --prefix tests run test:unit -- chat-search.test.js`
- `& ..\node_modules\.bin\eslint.cmd chat-search.test.js`

## Checklist

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).