### PR TITLE
Add option to insert existing gallery images into chat

### DIFF
--- a/public/scripts/extensions/gallery/index.js
+++ b/public/scripts/extensions/gallery/index.js
@@ -6,11 +6,18 @@ import {
     event_types,
     animation_duration,
     animation_easing,
+    chat,
+    addOneMessage,
+    saveChatConditional,
+    name1,
+    user_avatar,
+    getThumbnailUrl,
+    scrollOnMediaLoad,
 } from '../../../script.js';
 import { groups, selected_group } from '../../group-chats.js';
 import { loadFileToDocument, delay, getBase64Async, getSanitizedFilename, saveBase64AsFile, getFileExtension, getVideoThumbnail, clamp } from '../../utils.js';
-import { loadMovingUIState } from '../../power-user.js';
-import { dragElement } from '../../RossAscends-mods.js';
+import { loadMovingUIState, power_user } from '../../power-user.js';
+import { dragElement, getMessageTimeStamp } from '../../RossAscends-mods.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandNamedArgument } from '../../slash-commands/SlashCommandArgument.js';
@@ -19,7 +26,7 @@ import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnum
 import { t, translate } from '../../i18n.js';
 import { Popup } from '../../popup.js';
 import { deleteMediaFromServer } from '../../chats.js';
-import { MEDIA_REQUEST_TYPE, VIDEO_EXTENSIONS } from '../../constants.js';
+import { MEDIA_REQUEST_TYPE, MEDIA_SOURCE, MEDIA_TYPE, VIDEO_EXTENSIONS } from '../../constants.js';
 
 const isVideo = (/** @type {string} */ url) => VIDEO_EXTENSIONS.some(ext => new RegExp(`.${ext}$`, 'i').test(url));
 const extensionName = 'gallery';
@@ -675,6 +682,15 @@ function makeDragImg(id, url) {
         if (closeButton) {
             closeButton.id = `${uniqueId}close`;
             closeButton.dataset.relatedId = uniqueId;
+
+            // Add an "Insert into chat" button next to the close button so the
+            // image can be dropped back into the chat without re-uploading it.
+            const insertButton = document.createElement('div');
+            insertButton.classList.add('fa-fw', 'fa-solid', 'fa-comment-medical', 'dragInsertToChat', 'interactable');
+            insertButton.tabIndex = 0;
+            insertButton.title = t`Insert into chat`;
+            insertButton.addEventListener('click', () => insertImageToChat(url));
+            closeButton.parentElement?.insertBefore(insertButton, closeButton);
         }
 
         // Find the .drag-grabber and set its matching unique ID
@@ -719,6 +735,58 @@ function sanitizeHTMLId(id) {
         .replace(/\W/g, '');
 
     return id;
+}
+
+/**
+ * Inserts an existing gallery image (or video) into the current chat as a new user
+ * message, reusing the already-uploaded file instead of uploading a fresh copy.
+ *
+ * This lets users drop previously uploaded images from the gallery straight back into
+ * the chat without creating duplicate files in the gallery folder.
+ *
+ * @param {string} url - The URL of the gallery media to insert (e.g. user/images/Folder/file.png).
+ * @returns {Promise<void>} - Promise representing the completion of the message insertion.
+ */
+async function insertImageToChat(url) {
+    if (this_chid === undefined && !selected_group) {
+        toastr.warning(t`Select a character or group chat first.`);
+        return;
+    }
+
+    const mediaType = isVideo(url) ? MEDIA_TYPE.VIDEO : MEDIA_TYPE.IMAGE;
+    const title = url.substring(url.lastIndexOf('/') + 1);
+
+    const message = {
+        name: name1,
+        is_user: true,
+        is_system: false,
+        send_date: getMessageTimeStamp(),
+        mes: '',
+        extra: {
+            media: [{
+                url: url,
+                type: mediaType,
+                title: title,
+                source: MEDIA_SOURCE.UPLOAD,
+            }],
+            media_index: 0,
+            inline_image: true,
+        },
+    };
+
+    // Lock user avatar to a persona, mirroring sendMessageAsUser.
+    if (user_avatar in power_user.personas) {
+        message.force_avatar = getThumbnailUrl('persona', user_avatar);
+    }
+
+    chat.push(message);
+    const chatId = chat.length - 1;
+    await eventSource.emit(event_types.MESSAGE_SENT, chatId);
+    addOneMessage(message);
+    await eventSource.emit(event_types.USER_MESSAGE_RENDERED, chatId);
+    await saveChatConditional();
+    scrollOnMediaLoad();
+    toastr.success(t`Image added to chat.`);
 }
 
 /**

--- a/public/scripts/extensions/gallery/style.css
+++ b/public/scripts/extensions/gallery/style.css
@@ -53,3 +53,19 @@
 .galleryImageDraggable video {
     width: 100%;
 }
+
+.dragInsertToChat {
+    height: 15px;
+    aspect-ratio: 1 / 1;
+    font-size: calc(var(--mainFontSize)*1.3);
+    opacity: 0.5;
+    transition: all var(--animation-duration-2x);
+    filter: drop-shadow(0px 0px 2px black);
+    text-shadow: none;
+    margin-right: 5px;
+}
+
+.dragInsertToChat:hover {
+    cursor: pointer;
+    opacity: 1;
+}


### PR DESCRIPTION
## Motivation

Currently, the only way to put an image into a chat is to upload it, which also
saves a copy into the character's gallery. If the same image is added again, a
duplicate file is created in the gallery. There was no way to reuse an image that
is already in the gallery, leading to clutter and redundant files.

## Implementation

Adds an "Insert into chat" button (comment-medical icon) to the gallery's
draggable image viewer, next to the close button. Clicking it inserts the
selected media into the current chat as a new user message.

- Reuses the existing gallery file URL instead of re-uploading, so no duplicate
  is created in the gallery folder.
- Handles both images and videos via `MEDIA_TYPE` detection.
- Mirrors the normal user-message path: respects the active persona avatar and
  emits `MESSAGE_SENT` / `USER_MESSAGE_RENDERED` so the message integrates with
  the chat like any other.
- Adds matching CSS for the button (sizing + hover) consistent with the existing
  close button.

Scope is limited to the Gallery extension (`public/scripts/extensions/gallery/`),
~90 lines across two files.

## How to test

1. Select a character and open the Gallery (wand menu → Show Gallery, or `/sg`).
2. Click a previously uploaded image to open it in the viewer.
3. Click the new "Insert into chat" button.
4. The image appears in the chat as a new user message, and no new/duplicate file
   is added to the gallery folder.

## Checklist

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).