### PR TITLE
fix: preserve disabled OpenRouter providers when editing provider list

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -7136,7 +7136,7 @@ export function initOpenAI() {
     }
 
     $('#openrouter_providers_chat').on('change', function () {
-        const selectedProviders = $(this).val();
+        const selectedProviders = Array.from(this.selectedOptions).map(option => option.value);
 
         // Not a multiple select?
         if (!Array.isArray(selectedProviders)) {


### PR DESCRIPTION
Closes #5721

## Problem

When editing the OpenRouter provider list after switching to a model that doesn't support some previously selected providers, those unsupported providers are silently removed from the saved list. This happens because jQuery 3.x's `val()` on a multiple `<select>` filters out **disabled** options, even if they were selected.

## Root Cause

In `public/scripts/openai.js`, the `change` event handler for `#openrouter_providers_chat` uses `$(this).val()` to read selected providers. When `syncOpenRouterProvidersForModel()` disables unsupported providers, jQuery's `val()` no longer includes them in the returned array, causing the user's selection to be overwritten without the disabled providers.

## Fix

Replace `$(this).val()` with `Array.from(this.selectedOptions).map(option => option.value)` to read all selected options using the native DOM API, which correctly includes disabled options that are still selected.

## Verification

- ESLint passes (`npm run lint`) — no new lint errors introduced by this change
- The existing trailing space error in `variable-macros.js` is pre-existing and unrelated
- Minimal change: single line, low risk, fully backward compatible
