### PR TITLE
Avoid unwanted mobile text input autofocus

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -11,7 +11,7 @@ import {
     lodash,
 } from './lib.js';
 
-import { humanizedDateTime, favsToHotswap, getMessageTimeStamp, dragElement, isMobile, initRossMods } from './scripts/RossAscends-mods.js';
+import { humanizedDateTime, favsToHotswap, getMessageTimeStamp, dragElement, isMobile, shouldAutoFocusSendTextarea, initRossMods } from './scripts/RossAscends-mods.js';
 import { userStatsHandler, statMesProcess, initStats } from './scripts/stats.js';
 import {
     generateKoboldWithStreaming,
@@ -7644,6 +7644,9 @@ export async function getChat() {
 
         // Focus on the textarea if not already focused on a visible text input
         delay(debounce_timeout.short).then(() => {
+            if (!shouldAutoFocusSendTextarea()) {
+                return;
+            }
             if ($(document.activeElement).is('input:visible, textarea:visible')) {
                 return;
             }
@@ -11085,7 +11088,7 @@ jQuery(async function () {
         S_TAPreviouslyFocused = true;
     });
     $('#send_but, #option_regenerate, #option_continue, #mes_continue, #mes_impersonate').on('click', () => {
-        if (S_TAPreviouslyFocused) {
+        if (S_TAPreviouslyFocused && shouldAutoFocusSendTextarea()) {
             $('#send_textarea').trigger('focus');
         }
     });
@@ -12301,13 +12304,17 @@ jQuery(async function () {
             const isEditVisible = $('#curEditTextarea').is(':visible') || $('.reasoning_edit_textarea').length > 0;
             if (isEditVisible && power_user.auto_save_msg_edits === false) {
                 closeMessageEditor('all');
-                $('#send_textarea').trigger('focus');
+                if (shouldAutoFocusSendTextarea()) {
+                    $('#send_textarea').trigger('focus');
+                }
                 return;
             }
             if (isEditVisible && power_user.auto_save_msg_edits === true) {
                 chatElement.find(`.mes[mesid="${this_edit_mes_id}"] .mes_edit_done`).trigger('click');
                 closeMessageEditor('reasoning');
-                $('#send_textarea').trigger('focus');
+                if (shouldAutoFocusSendTextarea()) {
+                    $('#send_textarea').trigger('focus');
+                }
                 return;
             }
             if (this_edit_mes_id === undefined && $('#mes_stop').is(':visible')) {

--- a/public/script.js
+++ b/public/script.js
@@ -8554,10 +8554,12 @@ export async function displayPastChats(hightlightNames = []) {
     });
 
     // UX convenience: Focus the search field when the Manage Chat Files view opens.
-    setTimeout(function () {
-        const textSearchElement = $('#select_chat_search');
-        textSearchElement.trigger('click').trigger('focus').trigger('select');
-    }, 200);
+    if (shouldAutoFocusTextInput()) {
+        setTimeout(function () {
+            const textSearchElement = $('#select_chat_search');
+            textSearchElement.trigger('click').trigger('focus').trigger('select');
+        }, 200);
+    }
 
     addChatBackupsBrowser();
 }

--- a/public/script.js
+++ b/public/script.js
@@ -11,7 +11,7 @@ import {
     lodash,
 } from './lib.js';
 
-import { humanizedDateTime, favsToHotswap, getMessageTimeStamp, dragElement, isMobile, shouldAutoFocusSendTextarea, initRossMods } from './scripts/RossAscends-mods.js';
+import { humanizedDateTime, favsToHotswap, getMessageTimeStamp, dragElement, isMobile, shouldAutoFocusTextInput, initRossMods } from './scripts/RossAscends-mods.js';
 import { userStatsHandler, statMesProcess, initStats } from './scripts/stats.js';
 import {
     generateKoboldWithStreaming,
@@ -7644,7 +7644,7 @@ export async function getChat() {
 
         // Focus on the textarea if not already focused on a visible text input
         delay(debounce_timeout.short).then(() => {
-            if (!shouldAutoFocusSendTextarea()) {
+            if (!shouldAutoFocusTextInput()) {
                 return;
             }
             if ($(document.activeElement).is('input:visible, textarea:visible')) {
@@ -8261,13 +8261,21 @@ export async function messageEdit(editMessageId) {
         $editTextArea.height(editTextArea.scrollHeight);
     }
 
-    $editTextArea.trigger('focus');
+    const shouldAutoFocus = shouldAutoFocusTextInput();
 
-    // Sets the cursor at the end of the text
-    editTextArea.setSelectionRange(text.length, text.length);
+    if (shouldAutoFocus) {
+        $editTextArea.trigger('focus');
+
+        // Sets the cursor at the end of the text
+        editTextArea.setSelectionRange(text.length, text.length);
+    }
 
     if (Number(this_edit_mes_id) === chat.length - 1) {
         chatElement.scrollTop(chatScrollPosition);
+    }
+
+    if (!shouldAutoFocus) {
+        scrollTextareaEndIntoChatView(editTextArea);
     }
 
     updateEditArrowClasses();
@@ -9481,6 +9489,35 @@ export function updateEditArrowClasses() {
     downButton.toggleClass('disabled', lastId === Number(this_edit_mes_id));
     // The first message cannot be moved up.
     upButton.toggleClass('disabled', firstId === Number(this_edit_mes_id));
+}
+
+/**
+ * Scrolls the chat view enough to show the bottom of an element.
+ * @param {HTMLElement} element Element inside the chat view.
+ */
+function scrollElementBottomIntoChatView(element) {
+    const chat = chatElement[0];
+    if (!chat) {
+        return;
+    }
+
+    const elementRect = element.getBoundingClientRect();
+    const chatRect = chat.getBoundingClientRect();
+
+    if (elementRect.bottom > chatRect.bottom) {
+        chat.scrollTop += elementRect.bottom - chatRect.bottom;
+    }
+}
+
+/**
+ * Scrolls a textarea to its content end without focusing it.
+ * @param {HTMLTextAreaElement} textarea Textarea inside the chat view.
+ */
+function scrollTextareaEndIntoChatView(textarea) {
+    requestAnimationFrame(() => {
+        textarea.scrollTop = textarea.scrollHeight;
+        scrollElementBottomIntoChatView(textarea);
+    });
 }
 
 /**
@@ -11088,7 +11125,7 @@ jQuery(async function () {
         S_TAPreviouslyFocused = true;
     });
     $('#send_but, #option_regenerate, #option_continue, #mes_continue, #mes_impersonate').on('click', () => {
-        if (S_TAPreviouslyFocused && shouldAutoFocusSendTextarea()) {
+        if (S_TAPreviouslyFocused && shouldAutoFocusTextInput()) {
             $('#send_textarea').trigger('focus');
         }
     });
@@ -12304,7 +12341,7 @@ jQuery(async function () {
             const isEditVisible = $('#curEditTextarea').is(':visible') || $('.reasoning_edit_textarea').length > 0;
             if (isEditVisible && power_user.auto_save_msg_edits === false) {
                 closeMessageEditor('all');
-                if (shouldAutoFocusSendTextarea()) {
+                if (shouldAutoFocusTextInput()) {
                     $('#send_textarea').trigger('focus');
                 }
                 return;
@@ -12312,7 +12349,7 @@ jQuery(async function () {
             if (isEditVisible && power_user.auto_save_msg_edits === true) {
                 chatElement.find(`.mes[mesid="${this_edit_mes_id}"] .mes_edit_done`).trigger('click');
                 closeMessageEditor('reasoning');
-                if (shouldAutoFocusSendTextarea()) {
+                if (shouldAutoFocusTextInput()) {
                     $('#send_textarea').trigger('focus');
                 }
                 return;

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -146,6 +146,14 @@ export function isMobile() {
     return mobileTypes.includes(getParsedUA()?.platform?.type);
 }
 
+/**
+ * Checks if SillyTavern should automatically return focus to the main chat input.
+ * @returns {boolean} True when automatic focus should run.
+ */
+export function shouldAutoFocusSendTextarea() {
+    return !isMobile();
+}
+
 export function shouldSendOnEnter() {
     if (!power_user) {
         return false;
@@ -1046,12 +1054,16 @@ export function initRossMods() {
             const reasoningMesDone = $('.mes_reasoning_edit_done:visible');
             if (editMesDone.length > 0) {
                 console.debug('Accepting edits with Ctrl+Enter');
-                $('#send_textarea').trigger('focus');
+                if (shouldAutoFocusSendTextarea()) {
+                    $('#send_textarea').trigger('focus');
+                }
                 editMesDone.trigger('click');
                 return;
             } else if (reasoningMesDone.length > 0) {
                 console.debug('Accepting edits with Ctrl+Enter');
-                $('#send_textarea').trigger('focus');
+                if (shouldAutoFocusSendTextarea()) {
+                    $('#send_textarea').trigger('focus');
+                }
                 reasoningMesDone.trigger('click');
                 return;
             } else if (is_send_press == false) {

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -147,10 +147,10 @@ export function isMobile() {
 }
 
 /**
- * Checks if SillyTavern should automatically return focus to the main chat input.
+ * Checks if SillyTavern should automatically focus text inputs.
  * @returns {boolean} True when automatic focus should run.
  */
-export function shouldAutoFocusSendTextarea() {
+export function shouldAutoFocusTextInput() {
     return !isMobile();
 }
 
@@ -1054,14 +1054,14 @@ export function initRossMods() {
             const reasoningMesDone = $('.mes_reasoning_edit_done:visible');
             if (editMesDone.length > 0) {
                 console.debug('Accepting edits with Ctrl+Enter');
-                if (shouldAutoFocusSendTextarea()) {
+                if (shouldAutoFocusTextInput()) {
                     $('#send_textarea').trigger('focus');
                 }
                 editMesDone.trigger('click');
                 return;
             } else if (reasoningMesDone.length > 0) {
                 console.debug('Accepting edits with Ctrl+Enter');
-                if (shouldAutoFocusSendTextarea()) {
+                if (shouldAutoFocusTextInput()) {
                     $('#send_textarea').trigger('focus');
                 }
                 reasoningMesDone.trigger('click');

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -54,7 +54,7 @@ import { ScraperManager } from './scrapers.js';
 import { DragAndDropHandler } from './dragdrop.js';
 import { renderTemplateAsync } from './templates.js';
 import { t } from './i18n.js';
-import { humanizedDateTime } from './RossAscends-mods.js';
+import { humanizedDateTime, shouldAutoFocusTextInput } from './RossAscends-mods.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { MEDIA_DISPLAY, MEDIA_SOURCE, MEDIA_TYPE, SCROLL_BEHAVIOR, SWIPE_DIRECTION } from './constants.js';
 
@@ -2106,6 +2106,26 @@ async function onImageSwiped(messageId, element, direction) {
     appendMediaToMessage(message, element);
 }
 
+function scrollElementBottomIntoChatView(element) {
+    requestAnimationFrame(() => {
+        const chat = chatElement[0];
+        if (!chat) {
+            return;
+        }
+
+        if (element instanceof HTMLTextAreaElement) {
+            element.scrollTop = element.scrollHeight;
+        }
+
+        const elementRect = element.getBoundingClientRect();
+        const chatRect = chat.getBoundingClientRect();
+
+        if (elementRect.bottom > chatRect.bottom) {
+            chat.scrollTop += elementRect.bottom - chatRect.bottom;
+        }
+    });
+}
+
 export function initChatUtilities() {
     $(document).on('click', '.mes_hide', async function () {
         const messageBlock = $(this).closest('.mes');
@@ -2294,7 +2314,12 @@ export function initChatUtilities() {
         if ($('.edit_textarea').length) return;
         $(this).closest('.mes').find('.mes_edit').trigger('click');
         if ($(event.target).closest('.mes_reasoning').length) {
-            $('.reasoning_edit_textarea').trigger('focus');
+            const reasoningEditTextarea = $('.reasoning_edit_textarea').last();
+            if (shouldAutoFocusTextInput()) {
+                reasoningEditTextarea.trigger('focus');
+            } else if (reasoningEditTextarea[0] instanceof HTMLElement) {
+                scrollElementBottomIntoChatView(reasoningEditTextarea[0]);
+            }
         }
     });
 

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -9,6 +9,7 @@ import { chat_completion_sources, getChatCompletionModel, oai_settings } from '.
 import { Popup } from './popup.js';
 import { performFuzzySearch, power_user } from './power-user.js';
 import { getPresetManager } from './preset-manager.js';
+import { shouldAutoFocusTextInput } from './RossAscends-mods.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { commonEnumProviders, enumIcons } from './slash-commands/SlashCommandCommonEnumsProvider.js';
@@ -1190,6 +1191,26 @@ function setReasoningEventHandlers() {
         message.extra.reasoning_type = message.extra.reasoning_type ? ReasoningType.Edited : ReasoningType.Manual;
     }
 
+    /**
+     * Scrolls a textarea to its content end without focusing it.
+     * @param {HTMLTextAreaElement} textarea Textarea inside the chat view.
+     * @param {HTMLElement} chatElement Chat container.
+     */
+    function scrollTextareaEndIntoChatView(textarea, chatElement) {
+        requestAnimationFrame(() => {
+            textarea.scrollTop = textarea.scrollHeight;
+
+            const textareaRect = textarea.getBoundingClientRect();
+            const chatRect = chatElement.getBoundingClientRect();
+
+            // Scroll if textarea bottom is below visible area
+            if (textareaRect.bottom > chatRect.bottom) {
+                const scrollOffset = textareaRect.bottom - chatRect.bottom;
+                chatElement.scrollTop += scrollOffset;
+            }
+        });
+    }
+
     $(document).on('click', '.mes_reasoning_details', function (e) {
         if (!e.target.closest('.mes_reasoning_actions') && !e.target.closest('.mes_reasoning_header')) {
             e.preventDefault();
@@ -1248,17 +1269,12 @@ function setReasoningEventHandlers() {
             resetHeight();
         }
 
-        textarea.focus();
-        textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-
-        const textareaRect = textarea.getBoundingClientRect();
-        const chatRect = chatElement.getBoundingClientRect();
-
-        // Scroll if textarea bottom is below visible area
-        if (textareaRect.bottom > chatRect.bottom) {
-            const scrollOffset = textareaRect.bottom - chatRect.bottom;
-            chatElement.scrollTop += scrollOffset;
+        if (shouldAutoFocusTextInput()) {
+            textarea.focus();
+            textarea.setSelectionRange(textarea.value.length, textarea.value.length);
         }
+
+        scrollTextareaEndIntoChatView(textarea, chatElement);
     });
 
     $(document).on('click', '.mes_reasoning_close_all', function (e) {

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -32,7 +32,7 @@ import { getRegexedString, regex_placement } from './extensions/regex/engine.js'
 import { deleteGroupChatByName, getGroupAvatar, groups, is_group_generating, openGroupById, openGroupChat } from './group-chats.js';
 import { t } from './i18n.js';
 import { callGenericPopup, POPUP_TYPE } from './popup.js';
-import { getMessageTimeStamp } from './RossAscends-mods.js';
+import { getMessageTimeStamp, shouldAutoFocusSendTextarea } from './RossAscends-mods.js';
 import { renderTemplateAsync } from './templates.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { clamp, flashHighlight, isElementInViewport, sortMoments, timestampToMoment } from './utils.js';
@@ -384,7 +384,7 @@ async function sendWelcomePanel(chats, expand = false) {
         fragment.querySelectorAll('button.openTemporaryChat').forEach((button) => {
             button.addEventListener('click', async () => {
                 await newAssistantChat({ temporary: true });
-                if (sendTextArea instanceof HTMLTextAreaElement) {
+                if (sendTextArea instanceof HTMLTextAreaElement && shouldAutoFocusSendTextarea()) {
                     sendTextArea.focus();
                 }
             });

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -32,7 +32,7 @@ import { getRegexedString, regex_placement } from './extensions/regex/engine.js'
 import { deleteGroupChatByName, getGroupAvatar, groups, is_group_generating, openGroupById, openGroupChat } from './group-chats.js';
 import { t } from './i18n.js';
 import { callGenericPopup, POPUP_TYPE } from './popup.js';
-import { getMessageTimeStamp, shouldAutoFocusSendTextarea } from './RossAscends-mods.js';
+import { getMessageTimeStamp, shouldAutoFocusTextInput } from './RossAscends-mods.js';
 import { renderTemplateAsync } from './templates.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { clamp, flashHighlight, isElementInViewport, sortMoments, timestampToMoment } from './utils.js';
@@ -384,7 +384,7 @@ async function sendWelcomePanel(chats, expand = false) {
         fragment.querySelectorAll('button.openTemporaryChat').forEach((button) => {
             button.addEventListener('click', async () => {
                 await newAssistantChat({ temporary: true });
-                if (sendTextArea instanceof HTMLTextAreaElement && shouldAutoFocusSendTextarea()) {
+                if (sendTextArea instanceof HTMLTextAreaElement && shouldAutoFocusTextInput()) {
                     sendTextArea.focus();
                 }
             });


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## What is the reason for this change?

On mobile, SillyTavern currently programmatically focuses text inputs after several actions, including loading a chat, sending, continuing, regenerating, accepting edits, opening a temporary chat, opening message or reasoning editors, and opening the Manage Chat Files search field.

On mobile browsers, focusing a text input opens the virtual keyboard. This can pull the user into input mode even when they did not tap the input themselves. Repeated unwanted keyboard openings make the mobile experience worse.

These focus calls also made the previous inactive autocomplete performance issue more noticeable: that issue made keyboard open/close interactions sluggish, and unwanted focus calls caused the keyboard to open more often than necessary.

Related to #5703.

## What did you do to achieve this?

Added a shared `shouldAutoFocusTextInput()` check that keeps automatic text input focus enabled on desktop, while skipping these automatic focus calls on mobile/tablet devices.

For mobile message and reasoning editors, the editor still opens and scrolls to the end of the edited textarea content, but it does not focus the textarea or open the virtual keyboard. Users can still tap the exact position they want to edit, and the keyboard opens normally.

For Manage Chat Files, desktop still focuses the search field when the view opens. Mobile opens in browsing mode instead; users can tap the search field when they want to search.

The existing desktop convenience behavior is preserved.

## How would a reviewer test the change?

Desktop:
- Load or switch chats and confirm existing desktop input behavior is unchanged.
- Send, continue, regenerate, or accept edits after the chat input was previously focused, and confirm focus can return to the chat input.
- Open ordinary message editing and reasoning editing, and confirm the editor still focuses as before.
- Open Manage Chat Files and confirm the search field still focuses on desktop.

Mobile:
- Load or switch chats and confirm the virtual keyboard does not open automatically.
- Send, continue, regenerate, or accept edits and confirm the virtual keyboard does not open automatically.
- Open a temporary chat from the welcome screen and confirm the virtual keyboard does not open automatically.
- Open ordinary message editing and confirm the keyboard does not open automatically.
- Open reasoning editing and confirm the keyboard does not open automatically.
- Open Manage Chat Files and confirm the search field does not focus automatically or open the keyboard.
- Tap the Manage Chat Files search field manually and confirm the keyboard opens and search still works.
- Confirm message and reasoning editors still scroll to the end of the edited textarea content.
- Tap the chat input or editor textarea manually and confirm the virtual keyboard still opens normally.

## Local checks

- `npx eslint public/script.js public/scripts/RossAscends-mods.js public/scripts/welcome-screen.js public/scripts/reasoning.js public/scripts/chats.js` passes.
- `npx eslint public/script.js` passes after the Manage Chat Files search update.
- `git diff --check` passes.

Note: full `npm run lint` was previously blocked by an unrelated pre-existing trailing whitespace issue in `public/scripts/macros/definitions/variable-macros.js`.