### PR TITLE
Prevent mobile keyboard from reopening during generation

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -12,6 +12,7 @@ import {
 } from './lib.js';
 
 import { humanizedDateTime, favsToHotswap, getMessageTimeStamp, dragElement, isMobile, initRossMods } from './scripts/RossAscends-mods.js';
+import { blurSendTextareaOnMobileGenerationStart } from './scripts/mobile-keyboard.js';
 import { userStatsHandler, statMesProcess, initStats } from './scripts/stats.js';
 import {
     generateKoboldWithStreaming,
@@ -731,6 +732,11 @@ async function firstLoadInit() {
     addDOMPurifyHooks();
     reloadMarkdownProcessor();
     applyBrowserFixes();
+    eventSource.on(event_types.GENERATION_STARTED, (generationType, generationOptions, isDryRun) => {
+        blurSendTextareaOnMobileGenerationStart(generationType, generationOptions, isDryRun, {
+            isMobileDevice: isMobile(),
+        });
+    });
     await getClientVersion();
     await initSecrets();
     await readSecretState();

--- a/public/scripts/mobile-keyboard.js
+++ b/public/scripts/mobile-keyboard.js
@@ -1,0 +1,64 @@
+const READ_MODE_GENERATION_TYPES = new Set(['normal', 'continue', 'regenerate', 'swipe']);
+
+/**
+ * Checks whether mobile generation should move the chat input out of edit mode.
+ * @param {object} options Check options
+ * @param {Element|null} options.activeElement Currently focused element
+ * @param {object} [options.generationOptions] Generate options
+ * @param {string} options.generationType Generation type
+ * @param {boolean} options.isDryRun Whether this is a dry run
+ * @param {boolean} options.isMobileDevice Whether the current device is mobile/tablet
+ * @param {Element|null} options.sendTextarea Send textarea element
+ * @returns {boolean} True if the send textarea should be blurred
+ */
+export function shouldBlurSendTextareaOnMobileGenerationStart({
+    activeElement,
+    generationOptions = {},
+    generationType,
+    isDryRun,
+    isMobileDevice,
+    sendTextarea,
+}) {
+    if (isDryRun || !isMobileDevice || generationOptions?.automatic_trigger) {
+        return false;
+    }
+
+    if (!READ_MODE_GENERATION_TYPES.has(generationType)) {
+        return false;
+    }
+
+    return Boolean(sendTextarea) && activeElement === sendTextarea;
+}
+
+/**
+ * Blurs the focused send textarea when mobile foreground generation starts.
+ * @param {string} generationType Generation type
+ * @param {object} generationOptions Generate options
+ * @param {boolean} isDryRun Whether this is a dry run
+ * @param {object} options Runtime dependencies
+ * @param {Document} [options.documentObject=document] Document object
+ * @param {boolean} options.isMobileDevice Whether the current device is mobile/tablet
+ * @returns {boolean} True if the send textarea was blurred
+ */
+export function blurSendTextareaOnMobileGenerationStart(
+    generationType,
+    generationOptions,
+    isDryRun,
+    { documentObject = document, isMobileDevice } = {},
+) {
+    const sendTextarea = documentObject.getElementById('send_textarea');
+    const shouldBlur = shouldBlurSendTextareaOnMobileGenerationStart({
+        activeElement: documentObject.activeElement,
+        generationOptions,
+        generationType,
+        isDryRun,
+        isMobileDevice,
+        sendTextarea,
+    });
+
+    if (shouldBlur) {
+        sendTextarea.blur();
+    }
+
+    return shouldBlur;
+}

--- a/tests/mobile-keyboard.test.js
+++ b/tests/mobile-keyboard.test.js
@@ -1,0 +1,113 @@
+import { jest } from '@jest/globals';
+import {
+    blurSendTextareaOnMobileGenerationStart,
+    shouldBlurSendTextareaOnMobileGenerationStart,
+} from '../public/scripts/mobile-keyboard.js';
+
+function createDocumentWithSendTextarea({ active = true } = {}) {
+    const sendTextarea = {
+        blur: jest.fn(),
+    };
+    const otherElement = {};
+
+    return {
+        documentObject: {
+            activeElement: active ? sendTextarea : otherElement,
+            getElementById: jest.fn(id => id === 'send_textarea' ? sendTextarea : null),
+        },
+        sendTextarea,
+        otherElement,
+    };
+}
+
+describe('mobile generation keyboard handling', () => {
+    test('blurs the focused send textarea for mobile foreground reply generation', () => {
+        const { documentObject, sendTextarea } = createDocumentWithSendTextarea();
+
+        blurSendTextareaOnMobileGenerationStart('normal', {}, false, {
+            documentObject,
+            isMobileDevice: true,
+        });
+
+        expect(sendTextarea.blur).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not blur during dry run', () => {
+        const { documentObject, sendTextarea } = createDocumentWithSendTextarea();
+
+        blurSendTextareaOnMobileGenerationStart('normal', {}, true, {
+            documentObject,
+            isMobileDevice: true,
+        });
+
+        expect(sendTextarea.blur).not.toHaveBeenCalled();
+    });
+
+    test('does not blur on desktop', () => {
+        const { documentObject, sendTextarea } = createDocumentWithSendTextarea();
+
+        blurSendTextareaOnMobileGenerationStart('normal', {}, false, {
+            documentObject,
+            isMobileDevice: false,
+        });
+
+        expect(sendTextarea.blur).not.toHaveBeenCalled();
+    });
+
+    test('does not blur during quiet generation', () => {
+        const { documentObject, sendTextarea } = createDocumentWithSendTextarea();
+
+        blurSendTextareaOnMobileGenerationStart('quiet', {}, false, {
+            documentObject,
+            isMobileDevice: true,
+        });
+
+        expect(sendTextarea.blur).not.toHaveBeenCalled();
+    });
+
+    test('does not blur during impersonation', () => {
+        const { documentObject, sendTextarea } = createDocumentWithSendTextarea();
+
+        blurSendTextareaOnMobileGenerationStart('impersonate', {}, false, {
+            documentObject,
+            isMobileDevice: true,
+        });
+
+        expect(sendTextarea.blur).not.toHaveBeenCalled();
+    });
+
+    test('does not blur during automatic generation', () => {
+        const { documentObject, sendTextarea } = createDocumentWithSendTextarea();
+
+        blurSendTextareaOnMobileGenerationStart('normal', { automatic_trigger: true }, false, {
+            documentObject,
+            isMobileDevice: true,
+        });
+
+        expect(sendTextarea.blur).not.toHaveBeenCalled();
+    });
+
+    test('does not blur when send textarea is not focused', () => {
+        const { documentObject, sendTextarea } = createDocumentWithSendTextarea({ active: false });
+
+        blurSendTextareaOnMobileGenerationStart('normal', {}, false, {
+            documentObject,
+            isMobileDevice: true,
+        });
+
+        expect(sendTextarea.blur).not.toHaveBeenCalled();
+    });
+
+    test('reports whether focused mobile send textarea should blur', () => {
+        const sendTextarea = {};
+
+        expect(shouldBlurSendTextareaOnMobileGenerationStart({
+            activeElement: sendTextarea,
+            generationOptions: {},
+            generationType: 'continue',
+            isDryRun: false,
+            isMobileDevice: true,
+            sendTextarea,
+        })).toBe(true);
+    });
+});


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## What is the reason for this change?

On mobile browsers, hiding the virtual keyboard does not always clear DOM focus. After sending a message, `#send_textarea` can remain `document.activeElement` even though the user is now reading the generated response.

During streaming generation, the chat DOM updates, the page scrolls, and the visual viewport/layout can change. Some mobile browsers may restore or reopen the virtual keyboard when the focused element is still an editable textarea during those changes.

This can happen repeatedly during a streaming response. In some cases, manually hiding the keyboard with the keyboard dismiss button is not enough because the keyboard may reopen again almost immediately while generation continues.

I have been running into this repeatedly during regular mobile use, especially while reading streaming replies, and it makes the mobile chat flow harder to use.

This was especially noticeable when combined with the previous inactive autocomplete repositioning performance issue, because repeated keyboard open/close interactions could become very sluggish. That performance issue has been addressed separately, but the unwanted keyboard reopen is still a separate behavior problem: after pressing send, the mobile UI should be in reading mode until the user taps the input again.

Related to #5703.

## What did you do to achieve this?

Added a small mobile keyboard helper that blurs `#send_textarea` when generation starts on mobile/tablet devices.

The blur only runs when `#send_textarea` is currently focused. It skips dry runs, quiet generations, impersonation, and automatic triggers, so background generation and AI-assisted user message generation are not interrupted.

This intentionally hooks into `GENERATION_STARTED`: on mobile, pressing send means leaving input mode, even if the sent text is a slash command. Quick Replies that directly execute slash commands do not enter this path; Quick Replies that fill the chat input and press send are treated the same as user sends.

Desktop behavior is unchanged.

## How would a reviewer test the change?

Desktop:
- Focus the chat input, send a message, continue, regenerate, and swipe. Confirm desktop behavior remains usable.
- Run impersonation and confirm the generated text can still be edited in the chat input.

Mobile:
- Focus the chat input, send a normal message, and confirm the virtual keyboard closes when generation starts.
- While the reply streams or the chat scrolls, confirm the keyboard does not reopen by itself.
- Tap the chat input again and confirm the keyboard opens normally.
- Send a slash command from the chat input and confirm the keyboard closes after pressing send.
- Run a Quick Reply that directly executes a slash command and confirm it is not blurred by this change.
- Run a Quick Reply that fills the chat input and sends it, and confirm it behaves like pressing send.
- Trigger impersonation / AI-assisted user message generation while the chat input is not focused, and confirm it does not open the keyboard.
- Trigger impersonation / AI-assisted user message generation while the chat input is already focused, and confirm the generated text remains editable in the chat input.

## Local checks

- `npm --prefix tests run test:unit -- mobile-keyboard.test.js` passes.
- `npx eslint public/script.js public/scripts/mobile-keyboard.js tests/mobile-keyboard.test.js` passes.
- `git diff --check` passes.