### PR TITLE
feat(tts): Fetch MiniMax voice list from API

### DIFF
--- a/public/scripts/extensions/tts/minimax.js
+++ b/public/scripts/extensions/tts/minimax.js
@@ -709,19 +709,47 @@ class MiniMaxTtsProvider {
 
     async fetchTtsVoiceObjects() {
         try {
-            if (!secret_state[SECRET_KEYS.MINIMAX] || !secret_state[SECRET_KEYS.MINIMAX_GROUP_ID]) {
-                console.warn('MiniMax TTS: API Key and Group ID required for fetching voices');
-                console.warn('Using all available voices (default + custom). Please check your API credentials');
+            if (!secret_state[SECRET_KEYS.MINIMAX]) {
+                console.warn('MiniMax TTS: API Key required for fetching voices');
                 return this.getAllVoices();
             }
 
-            // MiniMax API doesn't provide a voices listing endpoint
-            // Using all available voices (default + custom)
-            console.info('MiniMax TTS: Using all available voices (default + custom)');
+            const response = await fetch('/api/minimax/get-voices', {
+                method: 'POST',
+                headers: getRequestHeaders(),
+                body: JSON.stringify({
+                    apiHost: this.settings.apiHost || 'https://api.minimax.io',
+                    voiceType: 'all',
+                }),
+            });
+
+            if (!response.ok) {
+                console.warn('MiniMax TTS: Failed to fetch voices from API, using defaults');
+                return this.getAllVoices();
+            }
+
+            const data = await response.json();
+            const apiVoices = [];
+
+            if (data.system_voice) {
+                for (const v of data.system_voice) {
+                    apiVoices.push({
+                        name: v.voice_name || v.voice_id,
+                        voice_id: v.voice_id,
+                        lang: 'zh-CN',
+                        preview_url: null,
+                    });
+                }
+            }
+
+            if (apiVoices.length > 0) {
+                console.info(`MiniMax TTS: Fetched ${apiVoices.length} voices from API`);
+                return [...apiVoices, ...this.settings.customVoices];
+            }
+
             return this.getAllVoices();
         } catch (error) {
             console.error('Error fetching MiniMax voices:', error);
-            console.warn('Using all available voices (default + custom). Please check your API credentials');
             return this.getAllVoices();
         }
     }

--- a/src/endpoints/minimax.js
+++ b/src/endpoints/minimax.js
@@ -16,6 +16,37 @@ const getAudioMimeType = (format) => {
     return mimeTypes[format] || 'audio/mpeg';
 };
 
+router.post('/get-voices', async (request, response) => {
+    try {
+        const { apiHost = 'https://api.minimax.io', voiceType = 'all' } = request.body;
+        const apiKey = readSecret(request.user.directories, SECRET_KEYS.MINIMAX);
+
+        if (!apiKey) {
+            return response.status(400).json({ error: 'Missing MiniMax API key' });
+        }
+
+        const apiUrl = `${apiHost}/v1/get_voice`;
+        const apiResponse = await fetch(apiUrl, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiKey}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ voice_type: voiceType }),
+        });
+
+        if (!apiResponse.ok) {
+            return response.status(apiResponse.status).json({ error: `HTTP ${apiResponse.status}` });
+        }
+
+        const data = await apiResponse.json();
+        return response.json(data);
+    } catch (error) {
+        console.error('MiniMax get voices failed:', error);
+        return response.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 router.post('/generate-voice', async (request, response) => {
     try {
         const {


### PR DESCRIPTION
## Summary

- Add backend endpoint `POST /api/minimax/get-voices` that proxies MiniMax's `/v1/get_voice` API
- Update frontend `fetchTtsVoiceObjects()` to fetch voices from API instead of using hardcoded defaults
- MiniMax provides 300+ system voices via API, but the current implementation only has 1 hardcoded default voice (`Unrestrained_Young_Man`), requiring users to manually add each voice one by one

## Before
Only 1 default voice available. Users must manually input voice IDs via "Custom Voice Management".

## After
Click "Connect" or "Refresh" to automatically load all 300+ MiniMax system voices into the dropdown.

## Test plan
- [ ] Set MiniMax API Key and Group ID in ST
- [ ] Set API Host to appropriate endpoint (api.minimax.io or api.minimaxi.com)
- [ ] Click "Connect" or "Refresh" in TTS settings
- [ ] Verify voice dropdown populates with system voices
- [ ] Verify TTS generation works with selected voice
- [ ] Verify custom voices still work alongside API voices
- [ ] Verify fallback to defaults when API is unavailable