### PR TITLE
fix: extension name display fallback when manifest uses 'name' instead of 'display_name'

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -46,8 +46,8 @@ const activeExtensions = new Set();
 const extensionLoadErrors = new Set();
 
 const getApiUrl = () => extension_settings.apiUrl;
-const sortManifestsByOrder = (a, b) => parseInt(a.loading_order) - parseInt(b.loading_order) || String(a.display_name).localeCompare(String(b.display_name));
-const sortManifestsByName = (a, b) => String(a.display_name).localeCompare(String(b.display_name)) || parseInt(a.loading_order) - parseInt(b.loading_order);
+const sortManifestsByOrder = (a, b) => parseInt(a.loading_order) - parseInt(b.loading_order) || String(a.display_name || a.name || '').localeCompare(String(b.display_name || b.name || ''));
+const sortManifestsByName = (a, b) => String(a.display_name || a.name || '').localeCompare(String(b.display_name || b.name || '')) || parseInt(a.loading_order) - parseInt(b.loading_order);
 let connectedToApi = false;
 
 /**
@@ -578,7 +578,7 @@ async function activateExtensions() {
         const extrasRequirements = manifest.requires;
         const extensionDependencies = manifest.dependencies;
         const minClientVersion = manifest.minimum_client_version;
-        const displayName = manifest.display_name || name;
+        const displayName = manifest.display_name || manifest.name || name;
 
         if (activeExtensions.has(name)) {
             continue;
@@ -914,7 +914,7 @@ function generateExtensionElement(name, manifest, isActive, isDisabled, isExtern
     }
 
     const isUserAdmin = isAdmin();
-    const displayName = manifest.display_name;
+    const displayName = manifest.display_name || manifest.name || name;
     const displayVersion = manifest.version || '';
     const externalId = name.replace('third-party', '');
 

--- a/public/scripts/macros/definitions/variable-macros.js
+++ b/public/scripts/macros/definitions/variable-macros.js
@@ -388,7 +388,7 @@ export function registerVariableMacros() {
             return '';
         },
     });
-    
+
     // {{getglobalvarkey::name::key}} -> returns value at key
     MacroRegistry.registerMacro('getglobalvarkey', {
         aliases: [{ alias: 'getglobalvarindex' }],


### PR DESCRIPTION
Fixes #5725

## Problem
Custom extensions with a manifest.json that uses the `name` field (common in many package formats) instead of SillyTavern's expected `display_name` field show broken display names in the extension list. The UI falls back to showing only the version and author, making the extension appear as e.g. '1.0.0 (-)'.

## Root Cause
The `generateExtensionElement()` function only reads `manifest.display_name` without any fallback. Many developers naturally use `name` instead of `display_name` when creating custom extensions, which results in `undefined` being displayed.

## Fix
Add a robust fallback chain for extension display names:
- `display_name` → `name` → folder name (as last resort)

This is applied to:
- `generateExtensionElement()` (UI rendering)
- `activateExtensions()` (consistency with logging)
- `sortManifestsByOrder()` and `sortManifestsByName()` (correct sorting)

Also fixed a pre-existing trailing spaces lint error in `variable-macros.js` to ensure `npm run lint` passes cleanly.

## Verification
- `npm run lint` passes ✅
- Backward compatible: existing extensions with `display_name` are unaffected
