### PR TITLE
feat: add Voyage AI as an embedding provider

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -74,6 +74,7 @@ const settings = {
     chutes_model: 'chutes-qwen-qwen3-embedding-8b',
     nanogpt_model: 'text-embedding-3-small',
     siliconflow_model: 'Qwen/Qwen3-Embedding-0.6B',
+    voyageai_model: 'voyage-4-large',
     summarize: false,
     summarize_sent: false,
     summary_source: 'main',
@@ -990,6 +991,9 @@ function getVectorsRequestBody(args = {}) {
             body.model = extension_settings.vectors.workers_ai_model || '@cf/baai/bge-m3';
             body.workers_ai_account_id = oai_settings.workers_ai_account_id;
             break;
+        case 'voyageai':
+            body.model = extension_settings.vectors.voyageai_model || 'voyage-4-large';
+            break;
         default:
             break;
     }
@@ -1084,7 +1088,8 @@ function throwIfSourceInvalid() {
         settings.source === 'nomicai' && !secret_state[SECRET_KEYS.NOMICAI] ||
         settings.source === 'cohere' && !secret_state[SECRET_KEYS.COHERE] ||
         settings.source === 'workers_ai' && !secret_state[SECRET_KEYS.WORKERS_AI] ||
-        settings.source === 'siliconflow' && !secret_state[SECRET_KEYS.SILICONFLOW]) {
+        settings.source === 'siliconflow' && !secret_state[SECRET_KEYS.SILICONFLOW] ||
+        settings.source === 'voyageai' && !secret_state[SECRET_KEYS.VOYAGEAI]) {
         throw new Error('Vectors: API key missing', { cause: 'api_key_missing' });
     }
 
@@ -1304,6 +1309,8 @@ function toggleSettings() {
     $('#llamacpp_vectorsModel').toggle(settings.source === 'llamacpp');
     $('#vllm_vectorsModel').toggle(settings.source === 'vllm');
     $('#nomicai_apiKey').toggle(settings.source === 'nomicai');
+    $('#voyageai_vectorsModel').toggle(settings.source === 'voyageai');
+    $('#voyageai_apiKey').toggle(settings.source === 'voyageai');
     $('#webllm_vectorsModel').toggle(settings.source === 'webllm');
     $('#koboldcpp_vectorsModel').toggle(settings.source === 'koboldcpp');
     $('#google_vectorsModel').toggle(settings.source === 'palm' || settings.source === 'vertexai');
@@ -1809,6 +1816,11 @@ export async function init() {
         Object.assign(extension_settings.vectors, settings);
         saveSettingsDebounced();
     });
+    $('#vectors_voyageai_model').val(settings.voyageai_model).on('change', () => {
+        settings.voyageai_model = String($('#vectors_voyageai_model').val());
+        Object.assign(extension_settings.vectors, settings);
+        saveSettingsDebounced();
+    });
     $('#vectors_openrouter_model').val(settings.openrouter_model).on('change', () => {
         settings.openrouter_model = String($('#vectors_openrouter_model').val());
         Object.assign(extension_settings.vectors, settings);
@@ -2079,6 +2091,14 @@ export async function init() {
         eventSource.on(event, (/** @type {string} */ key) => {
             if (key !== SECRET_KEYS.NOMICAI) return;
             $('#api_key_nomicai').toggleClass('success', !!secret_state[SECRET_KEYS.NOMICAI]);
+        });
+    });
+
+    $('#api_key_voyageai').toggleClass('success', !!secret_state[SECRET_KEYS.VOYAGEAI]);
+    [event_types.SECRET_WRITTEN, event_types.SECRET_DELETED, event_types.SECRET_ROTATED].forEach(event => {
+        eventSource.on(event, (/** @type {string} */ key) => {
+            if (key !== SECRET_KEYS.VOYAGEAI) return;
+            $('#api_key_voyageai').toggleClass('success', !!secret_state[SECRET_KEYS.VOYAGEAI]);
         });
     });
 

--- a/public/scripts/extensions/vectors/settings.html
+++ b/public/scripts/extensions/vectors/settings.html
@@ -29,6 +29,7 @@
                     <option value="siliconflow">SiliconFlow</option>
                     <option value="togetherai">TogetherAI</option>
                     <option value="vllm">vLLM</option>
+                    <option value="voyageai">Voyage AI</option>
                     <option value="webllm" data-i18n="WebLLM Extension">WebLLM Extension</option>
                 </select>
             </div>
@@ -183,6 +184,35 @@
                     <span data-i18n="NomicAI API Key">NomicAI API Key</span>
                 </label>
                 <div id="api_key_nomicai" class="menu_button menu_button_icon manage-api-keys" data-key="api_key_nomicai">
+                    <i class="fa-solid fa-key"></i>
+                    <span data-i18n="Click to set">Click to set</span>
+                </div>
+            </div>
+            <div class="flex-container flexFlowColumn" id="voyageai_vectorsModel">
+                <label for="vectors_voyageai_model" data-i18n="Vectorization Model">
+                    Vectorization Model
+                </label>
+                <select id="vectors_voyageai_model" class="text_pole">
+                    <option value="voyage-4-large">voyage-4-large</option>
+                    <option value="voyage-4">voyage-4</option>
+                    <option value="voyage-4-lite">voyage-4-lite</option>
+                    <option value="voyage-4-nano">voyage-4-nano</option>
+                    <option value="voyage-3.5">voyage-3.5</option>
+                    <option value="voyage-3.5-lite">voyage-3.5-lite</option>
+                    <option value="voyage-3-large">voyage-3-large</option>
+                    <option value="voyage-3">voyage-3</option>
+                    <option value="voyage-3-lite">voyage-3-lite</option>
+                    <option value="voyage-code-3">voyage-code-3</option>
+                    <option value="voyage-finance-2">voyage-finance-2</option>
+                    <option value="voyage-law-2">voyage-law-2</option>
+                    <option value="voyage-multilingual-2">voyage-multilingual-2</option>
+                </select>
+            </div>
+            <div class="flex-container alignItemsCenter" id="voyageai_apiKey">
+                <label for="api_key_voyageai" class="flex1">
+                    <span data-i18n="Voyage AI API Key">Voyage AI API Key</span>
+                </label>
+                <div id="api_key_voyageai" class="menu_button menu_button_icon manage-api-keys" data-key="api_key_voyageai">
                     <i class="fa-solid fa-key"></i>
                     <span data-i18n="Click to set">Click to set</span>
                 </div>

--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -79,6 +79,7 @@ export const SECRET_KEYS = {
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
     WORKERS_AI: 'api_key_workers_ai',
+    VOYAGEAI: 'api_key_voyageai',
 };
 
 const FRIENDLY_NAMES = {
@@ -144,6 +145,7 @@ const FRIENDLY_NAMES = {
     [SECRET_KEYS.VOLCENGINE_APP_ID]: 'Volcengine App ID',
     [SECRET_KEYS.VOLCENGINE_ACCESS_KEY]: 'Volcengine Access Key',
     [SECRET_KEYS.WORKERS_AI]: 'Cloudflare Workers AI',
+    [SECRET_KEYS.VOYAGEAI]: 'Voyage AI',
 };
 
 const INPUT_MAP = {

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -70,6 +70,7 @@ export const SECRET_KEYS = {
     VOLCENGINE_APP_ID: 'volcengine_app_id',
     VOLCENGINE_ACCESS_KEY: 'volcengine_access_key',
     WORKERS_AI: 'api_key_workers_ai',
+    VOYAGEAI: 'api_key_voyageai',
 };
 
 /**

--- a/src/endpoints/vectors.js
+++ b/src/endpoints/vectors.js
@@ -40,6 +40,7 @@ const SOURCES = [
     'nanogpt',
     'siliconflow',
     'workers_ai',
+    'voyageai',
 ];
 
 /**
@@ -91,6 +92,8 @@ async function getVector(source, sourceSettings, text, isQuery, directories) {
             return getOpenAIVector(text, source, directories, sourceSettings.model, sourceSettings.urlOverride);
         case 'workers_ai':
             return getOpenAIVector(text, source, directories, sourceSettings.model, sourceSettings.urlOverride);
+        case 'voyageai':
+            return getOpenAIVector(text, source, directories, sourceSettings.model);
     }
 
     throw new Error(`Unknown vector source ${source}`);
@@ -167,6 +170,9 @@ async function getBatchVector(source, sourceSettings, texts, isQuery, directorie
                 break;
             case 'workers_ai':
                 results.push(...await getOpenAIBatchVector(batch, source, directories, sourceSettings.model, sourceSettings.urlOverride));
+                break;
+            case 'voyageai':
+                results.push(...await getOpenAIBatchVector(batch, source, directories, sourceSettings.model));
                 break;
             default:
                 throw new Error(`Unknown vector source ${source}`);
@@ -275,6 +281,10 @@ function getSourceSettings(source, request) {
                     : null,
             };
         }
+        case 'voyageai':
+            return {
+                model: String(request.body.model || 'voyage-4-large'),
+            };
         default:
             return {};
     }

--- a/src/vectors/openai-vectors.js
+++ b/src/vectors/openai-vectors.js
@@ -68,6 +68,13 @@ const SOURCES = {
         headers: {},
         processBody: () => {},
     },
+    'voyageai': {
+        secretKey: SECRET_KEYS.VOYAGEAI,
+        url: 'https://api.voyageai.com/v1',
+        model: 'voyage-4-large',
+        headers: {},
+        processBody: () => {},
+    },
 };
 
 /**


### PR DESCRIPTION
Registers Voyage AI's /v1/embeddings endpoint (OpenAI-compatible) as a vectorization source. Adds a model dropdown covering the current Voyage AI model lineup, with voyage-4-large as the default. API key is managed via the existing secrets store.

Files changed:
- src/endpoints/secrets.js — SECRET_KEYS.VOYAGEAI
- src/vectors/openai-vectors.js — SOURCES entry (url, key, default model)
- src/endpoints/vectors.js — SOURCES array + dispatch in getVector, getBatchVector, getSourceSettings
- public/scripts/secrets.js — SECRET_KEYS.VOYAGEAI + friendly name
- public/scripts/extensions/vectors/settings.html — dropdown option, model select, API key button
- public/scripts/extensions/vectors/index.js — settings default, body builder, API key validation, visibility toggles, key state

<!-- Put X in the box below to confirm -->

## Checklist:

- [X ] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
