### PR TITLE
fix: resolve secret-id from profile's own API in connection manager

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -1,6 +1,6 @@
 import { DOMPurify, Fuse } from '../../../lib.js';
 
-import { activateSendButtons, deactivateSendButtons, event_types, eventSource, main_api, online_status, saveSettingsDebounced } from '../../../script.js';
+import { activateSendButtons, deactivateSendButtons, event_types, eventSource, main_api, online_status, saveSettingsDebounced, CONNECT_API_MAP } from '../../../script.js';
 import { extension_settings, getContext, renderExtensionTemplateAsync } from '../../extensions.js';
 import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from '../../popup.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
@@ -14,7 +14,7 @@ import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
 import { SlashCommandScope } from '../../slash-commands/SlashCommandScope.js';
 import { collapseSpaces, getUniqueName, isFalseBoolean, isTrueBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
 import { t } from '../../i18n.js';
-import { getSecretLabelById } from '../../secrets.js';
+import { getSecretLabelById, resolveSecretKeyForApi } from '../../secrets.js';
 import { performFuzzySearch } from '/scripts/power-user.js';
 import { StreamingDisplay } from '/scripts/streaming-display.js';
 import { ConnectionManagerRequestService } from '../shared.js';
@@ -224,6 +224,16 @@ async function readProfileFromCommands(mode, profile, cleanUp = false) {
 
             const allowEmpty = ALLOW_EMPTY.includes(command);
             const args = getNamedArguments();
+
+            // Resolve secret-id from the profile's own api field, not global provider state
+            if (command === 'secret-id' && profile.api) {
+                const apiMap = CONNECT_API_MAP[profile.api];
+                if (apiMap) {
+                    const secretKey = resolveSecretKeyForApi(apiMap.selected, apiMap.source, apiMap.type);
+                    if (secretKey) args.key = secretKey;
+                }
+            }
+
             const result = await SlashCommandParser.commands[command].callback(args, '');
             if (result || (allowEmpty && result === '')) {
                 profile[command] = result;

--- a/public/scripts/secrets.js
+++ b/public/scripts/secrets.js
@@ -237,6 +237,30 @@ export function resolveSecretKey() {
 }
 
 /**
+ * Resolves the secret key for a specific API configuration without relying on global state.
+ * @param {string} mainApi The main API type ('openai', 'textgenerationwebui', etc.)
+ * @param {string} [source] The chat completion source (for openai)
+ * @param {string} [type] The text generation type (for textgenerationwebui)
+ * @returns {string|null} The secret key, or null if not found.
+ */
+export function resolveSecretKeyForApi(mainApi, source, type) {
+    if (mainApi === 'koboldhorde') return SECRET_KEYS.HORDE;
+    if (mainApi === 'novel') return SECRET_KEYS.NOVEL;
+
+    if (mainApi === 'textgenerationwebui' && type) {
+        const [key] = Object.entries(textgen_types).find(([, value]) => value === type) ?? [null];
+        if (key && SECRET_KEYS[key]) return SECRET_KEYS[key];
+    }
+
+    if (mainApi === 'openai' && source) {
+        const [key] = Object.entries(chat_completion_sources).find(([, value]) => value === source) ?? [null];
+        if (key && SECRET_KEYS[key]) return SECRET_KEYS[key];
+    }
+
+    return null;
+}
+
+/**
  * Gets the label of a secret by its ID.
  * @param {string} id The ID of the secret to find.
  * @returns {string} The label of the secret with the given ID, or an empty string if not found.


### PR DESCRIPTION
readProfileFromCommands resolves the secret-id slash command using resolveSecretKey(), which reads the global main_api rather than the profile being updated. If you update an OpenRouter profile while DeepSeek is active as the main provider, the DeepSeek secret UUID gets written into the OpenRouter profile, causing 401s on the next request.

Fix: adds resolveSecretKeyForApi(mainApi, source, type) to secrets.js and calls it when processing the secret-id command, deriving the correct secret key from the profile's own CONNECT_API_MAP entry instead of global provider state.

Resolves #5634

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
