### PR TITLE
feat: add /api/files/patch-json for partial JSON file updates

### DIFF
--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -75,6 +75,45 @@ router.post('/delete', async (request, response) => {
     }
 });
 
+router.post('/patch-json', async (request, response) => {
+    try {
+        if (!request.body.name) {
+            return response.status(400).send('No file name specified');
+        }
+
+        if (!request.body.data || typeof request.body.data !== 'object' || Array.isArray(request.body.data)) {
+            return response.status(400).send('Patch data must be a plain object');
+        }
+
+        const validation = validateAssetFileName(request.body.name);
+        if (validation.error)
+            return response.status(400).send(validation.message);
+
+        const pathToFile = path.join(request.user.directories.files, request.body.name);
+
+        let existing = {};
+        if (fs.existsSync(pathToFile)) {
+            try {
+                const parsed = JSON.parse(fs.readFileSync(pathToFile, 'utf8'));
+                if (typeof parsed !== 'object' || Array.isArray(parsed) || parsed === null) {
+                    return response.status(400).send('Existing file is not a JSON object');
+                }
+                existing = parsed;
+            } catch {
+                return response.status(400).send('Existing file is not valid JSON');
+            }
+        }
+
+        writeFileSyncAtomic(pathToFile, JSON.stringify(Object.assign(existing, request.body.data)));
+        const url = clientRelativePath(request.user.directories.root, pathToFile);
+        console.info(`Patched file: ${url} from ${request.user.profile.handle}`);
+        return response.send({ path: url });
+    } catch (error) {
+        console.error(error);
+        return response.sendStatus(500);
+    }
+});
+
 router.post('/verify', async (request, response) => {
     try {
         if (!Array.isArray(request.body.urls)) {


### PR DESCRIPTION
Extensions that use large keyed JSON files (e.g. a store indexed by UUID) currently have no way to update a single key without reading the entire file, modifying it client-side, and re-uploading the whole blob via `/api/files/upload`. For files that grow with use, this round-trip scales poorly.

This adds `POST /api/files/patch-json` as a companion to `/upload`. The server reads the existing file, shallow-merges the supplied object into it, and writes it back atomically — sending only the changed key over the network.

**Design decisions:**

- **Shallow merge only.** The files directory enforces a flat namespace (no subdirectories, via `validateAssetFileName`). The merge depth matches that philosophy: top-level keys only, no deep path traversal. Extensions that need nested structure manage it within their own values.
- **Same security boundary as `/upload`.** The filename goes through `validateAssetFileName` identically, and the write target is `request.user.directories.files` — no new attack surface.
- **Missing file bootstraps from `{}`.** Consistent with how extensions naturally initialise their stores.
- **Corrupt or non-object file returns 400** rather than silently overwriting.
- **Atomic write** via `write-file-atomic`, same as every other endpoint in this file.

**Verification:**

```javascript
const token = await fetch('/csrf-token').then(r => r.json()).then(d => d.token);
// create
await fetch('/api/files/patch-json', { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': token }, body: JSON.stringify({ name: 'test.json', data: { a: 1 } }) }).then(r => r.json());
// merge
await fetch('/api/files/patch-json', { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': token }, body: JSON.stringify({ name: 'test.json', data: { b: 2 } }) }).then(r => r.json());
// verify both keys present, neither overwritten
await fetch('/user/files/test.json').then(r => r.json()); // → { a: 1, b: 2 }


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
