### PR TITLE
fix: reject localhost and .localhost domains in /api/search/visit to prevent SSRF bypass

### DIFF
--- a/src/endpoints/search.js
+++ b/src/endpoints/search.js
@@ -420,6 +420,11 @@ router.post('/visit', async (request, response) => {
             if (ipRegex.v4({ exact: true }).test(urlObj.hostname) || ipRegex.v6({ exact: true }).test(urlObj.hostname)) {
                 throw new Error('Invalid hostname');
             }
+
+            // Reject localhost and .localhost domains to prevent SSRF bypass
+            if (urlObj.hostname === 'localhost' || urlObj.hostname.endsWith('.localhost')) {
+                throw new Error('Invalid hostname');
+            }
         } catch (error) {
             console.error('Invalid url provided for /visit', url);
             return response.sendStatus(400);

--- a/src/endpoints/search.js
+++ b/src/endpoints/search.js
@@ -6,6 +6,7 @@ import { decode } from 'html-entities';
 import { readSecret, SECRET_KEYS } from './secrets.js';
 import { trimV1 } from '../util.js';
 import { setAdditionalHeaders } from '../additional-headers.js';
+import { getUntrustedRequestAgent } from '../private-request-filter.js';
 
 export const router = express.Router();
 
@@ -416,8 +417,9 @@ router.post('/visit', async (request, response) => {
                 throw new Error('Invalid port');
             }
 
-            // Reject IP addresses
-            if (ipRegex.v4({ exact: true }).test(urlObj.hostname) || ipRegex.v6({ exact: true }).test(urlObj.hostname)) {
+            // Reject IP addresses. A bracketed IPv6 literal keeps its brackets in URL.hostname.
+            const bareHostname = urlObj.hostname.replace(/^\[|\]$/g, '');
+            if (ipRegex.v4({ exact: true }).test(bareHostname) || ipRegex.v6({ exact: true }).test(bareHostname)) {
                 throw new Error('Invalid hostname');
             }
 
@@ -432,7 +434,10 @@ router.post('/visit', async (request, response) => {
 
         console.info('Visiting web URL', url);
 
-        const result = await fetch(url, { headers: visitHeaders });
+        // The URL checks above only guard the literal input. The agent enforces the actual network
+        // boundary: it blocks connections to private addresses after DNS resolution, on every redirect
+        // hop, and pins the connection to the validated IP to prevent DNS rebinding.
+        const result = await fetch(url, { headers: visitHeaders, agent: getUntrustedRequestAgent() });
 
         if (!result.ok) {
             console.error(`Visit failed ${result.status} ${result.statusText}`);

--- a/src/private-request-filter.js
+++ b/src/private-request-filter.js
@@ -197,6 +197,35 @@ class PrivateRequestAgent extends Agent {
 }
 
 /**
+ * Whether requests to untrusted URLs should follow the global agent chain instead of the strict agent:
+ * either the private request filter is enabled (the global agents filter with the user's configured
+ * whitelist), or a request proxy owns outbound routing and a direct connection would bypass it.
+ * @type {boolean}
+ */
+let untrustedFilteringDelegated = false;
+
+/** @type {PrivateRequestAgent|null} */
+let strictAgent = null;
+
+/**
+ * Get the agent to use for outbound requests to untrusted, user-supplied URLs (e.g. /api/search/visit).
+ * Returns a strict agent that blocks all private addresses at connection time, including on redirect hops,
+ * regardless of whether the private request filter is enabled. Returns undefined when the global agent
+ * chain already handles these requests (private request filter enabled, or request proxy owns routing),
+ * so the default agent selection applies.
+ * @returns {PrivateRequestAgent|undefined} The agent to pass to the outbound request, or undefined.
+ */
+export function getUntrustedRequestAgent() {
+    if (untrustedFilteringDelegated) {
+        return undefined;
+    }
+    if (!strictAgent) {
+        strictAgent = new PrivateRequestAgent({ privateAddressWhitelist: [], logBlocked: true, logAllowed: false, allowUnresolvedHosts: false, enableKeepAlive: false });
+    }
+    return strictAgent;
+}
+
+/**
  * Initialize the private request filter by replacing the global HTTP and HTTPS agents with an instance of PrivateRequestAgent.
  * @param {object} options Options for initializing the private request filter.
  * @param {boolean} options.listen Whether the server is listening for incoming requests. This is used to determine whether to log a warning if the private request filter is not enabled.
@@ -206,8 +235,11 @@ class PrivateRequestAgent extends Agent {
  * @param {boolean} options.logAllowed Whether to log allowed requests to the console.
  * @param {boolean} options.allowUnresolvedHosts Whether to allow requests to hosts that cannot be resolved.
  * @param {boolean} options.enableKeepAlive Whether to enable HTTP/HTTPS keep-alive.
+ * @param {boolean} [options.requestProxyEnabled] Whether a request proxy is enabled and owns outbound routing.
  */
-export default function initPrivateRequestFilter({ listen, enabled, privateAddressWhitelist, logBlocked, logAllowed, allowUnresolvedHosts, enableKeepAlive }) {
+export default function initPrivateRequestFilter({ listen, enabled, privateAddressWhitelist, logBlocked, logAllowed, allowUnresolvedHosts, enableKeepAlive, requestProxyEnabled }) {
+    untrustedFilteringDelegated = !!enabled || !!requestProxyEnabled;
+
     if (!enabled) {
         if (listen) {
             console.warn();

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -343,6 +343,7 @@ async function preSetupTasks() {
         logAllowed: !!getConfigValue('privateAddressWhitelist.log.allowedRequests', false, 'boolean'),
         allowUnresolvedHosts: !!getConfigValue('privateAddressWhitelist.allowUnresolvedHosts', false, 'boolean'),
         enableKeepAlive: cliArgs.enableKeepAlive,
+        requestProxyEnabled: !!cliArgs.requestProxyEnabled,
     };
     initPrivateRequestFilter(requestFilterOptions);
 

--- a/tests/private-request-filter.test.js
+++ b/tests/private-request-filter.test.js
@@ -31,6 +31,8 @@ jest.unstable_mockModule('../src/express-common.js', () => ({
 
 /** @type {import('../src/private-request-filter.js').default} */
 let initPrivateRequestFilter;
+/** @type {import('../src/private-request-filter.js').getUntrustedRequestAgent} */
+let getUntrustedRequestAgent;
 /** @type {import('node:http').default} */
 let http;
 /** @type {import('node:https').default} */
@@ -39,7 +41,7 @@ let originalHttpGlobalAgent;
 let originalHttpsGlobalAgent;
 
 beforeAll(async () => {
-    ({ default: initPrivateRequestFilter } = await import('../src/private-request-filter.js'));
+    ({ default: initPrivateRequestFilter, getUntrustedRequestAgent } = await import('../src/private-request-filter.js'));
     ({ default: http } = await import('node:http'));
     ({ default: https } = await import('node:https'));
     originalHttpGlobalAgent = http.globalAgent;
@@ -59,14 +61,15 @@ afterAll(() => {
     https.globalAgent = originalHttpsGlobalAgent;
 });
 
-function initAgent({ privateAddressWhitelist = [], allowUnresolvedHosts = false } = {}) {
+function initAgent({ privateAddressWhitelist = [], allowUnresolvedHosts = false, enabled = true, requestProxyEnabled = false } = {}) {
     initPrivateRequestFilter({
         listen: false,
-        enabled: true,
+        enabled,
         privateAddressWhitelist,
         logBlocked: false,
         logAllowed: false,
         allowUnresolvedHosts,
+        requestProxyEnabled,
     });
 
     return http.globalAgent;
@@ -126,5 +129,71 @@ describe('private request filter', () => {
         expect(mockLookup).toHaveBeenCalledWith('example.com');
         expect(mockTlsConnect).toHaveBeenCalledWith(expect.objectContaining({ host: '93.184.216.34' }));
         expect(mockNetConnect).not.toHaveBeenCalled();
+    });
+});
+
+describe('untrusted request agent', () => {
+    test('returns undefined when the private request filter is enabled', () => {
+        initAgent({ enabled: true });
+        expect(getUntrustedRequestAgent()).toBeUndefined();
+    });
+
+    test('returns undefined when a request proxy owns outbound routing', () => {
+        initAgent({ enabled: false, requestProxyEnabled: true });
+        expect(getUntrustedRequestAgent()).toBeUndefined();
+    });
+
+    test('returns the same strict agent instance when the filter is disabled', () => {
+        initAgent({ enabled: false });
+        const agent = getUntrustedRequestAgent();
+        expect(agent).toBeDefined();
+        expect(getUntrustedRequestAgent()).toBe(agent);
+    });
+
+    test('blocks private addresses even when the configured whitelist allows them', async () => {
+        initAgent({ enabled: false, privateAddressWhitelist: ['127.0.0.0/8', '::1/128'] });
+        const agent = getUntrustedRequestAgent();
+
+        await expect(agent.connect({}, { host: '127.0.0.1', secureEndpoint: false }))
+            .rejects
+            .toThrow('Blocked request to private IP address: 127.0.0.1');
+        await expect(agent.connect({}, { host: '::1', secureEndpoint: false }))
+            .rejects
+            .toThrow('Blocked request to private IP address: ::1');
+        expect(mockNetConnect).not.toHaveBeenCalled();
+    });
+
+    test('blocks hostnames that resolve to private addresses', async () => {
+        initAgent({ enabled: false });
+        mockLookup.mockResolvedValue({ address: '192.168.1.8' });
+        const agent = getUntrustedRequestAgent();
+
+        await expect(agent.connect({}, { host: 'internal.example.com', secureEndpoint: false }))
+            .rejects
+            .toThrow('Blocked request to private IP address: 192.168.1.8');
+        expect(mockNetConnect).not.toHaveBeenCalled();
+    });
+
+    test('blocks unresolvable hostnames', async () => {
+        initAgent({ enabled: false });
+        mockLookup.mockRejectedValue(new Error('lookup failed'));
+        const agent = getUntrustedRequestAgent();
+
+        await expect(agent.connect({}, { host: 'missing-host.local', secureEndpoint: false }))
+            .rejects
+            .toThrow('Unable to resolve host: missing-host.local');
+        expect(mockNetConnect).not.toHaveBeenCalled();
+    });
+
+    test('connects public hostnames to their resolved IP for both http and https', async () => {
+        initAgent({ enabled: false });
+        mockLookup.mockResolvedValue({ address: '93.184.216.34' });
+        const agent = getUntrustedRequestAgent();
+
+        await agent.connect({}, { host: 'example.com', secureEndpoint: false });
+        expect(mockNetConnect).toHaveBeenCalledWith(expect.objectContaining({ host: '93.184.216.34' }));
+
+        await agent.connect({}, { host: 'example.com', secureEndpoint: true });
+        expect(mockTlsConnect).toHaveBeenCalledWith(expect.objectContaining({ host: '93.184.216.34' }));
     });
 });

--- a/tests/search-visit.test.js
+++ b/tests/search-visit.test.js
@@ -1,0 +1,97 @@
+import { describe, test, expect, jest, beforeAll, afterAll, beforeEach } from '@jest/globals';
+
+// secrets.js reads this config value at module load. The env var override takes
+// precedence over config.yaml, so the search router imports without a config file.
+process.env.SILLYTAVERN_ALLOWKEYSEXPOSURE = 'false';
+
+const fetchMock = jest.fn();
+jest.unstable_mockModule('node-fetch', () => ({
+    default: fetchMock,
+}));
+
+/** @type {import('express').Router} */
+let router;
+/** @type {import('../src/private-request-filter.js').getUntrustedRequestAgent} */
+let getUntrustedRequestAgent;
+/** @type {import('node:http').Server} */
+let server;
+let baseUrl;
+
+beforeAll(async () => {
+    ({ router } = await import('../src/endpoints/search.js'));
+    ({ getUntrustedRequestAgent } = await import('../src/private-request-filter.js'));
+    const express = (await import('express')).default;
+    const app = express();
+    app.use(express.json());
+    app.use('/api/search', router);
+    server = app.listen(0, '127.0.0.1');
+    await new Promise(resolve => server.once('listening', resolve));
+    baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(() => new Promise(resolve => server.close(resolve)));
+
+beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+        ok: true,
+        headers: { get: () => 'text/html' },
+        text: async () => '<html>ok</html>',
+    });
+});
+
+function visit(url) {
+    return fetch(`${baseUrl}/api/search/visit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+    });
+}
+
+describe('POST /api/search/visit URL validation', () => {
+    const rejectedUrls = [
+        ['missing url', undefined],
+        ['empty url', ''],
+        ['relative url', '/etc/passwd'],
+        ['ftp protocol', 'ftp://example.com/'],
+        ['file protocol', 'file:///etc/passwd'],
+        ['non-standard port', 'http://example.com:8080/'],
+        ['literal IPv4 loopback', 'http://127.0.0.1/'],
+        ['literal IPv4 private', 'http://10.0.0.1/'],
+        ['literal IPv4 metadata service', 'http://169.254.169.254/'],
+        ['hex IPv4 form', 'http://0x7f000001/'],
+        ['octal IPv4 form', 'http://0177.0.0.1/'],
+        ['decimal IPv4 form', 'http://2130706433/'],
+        ['bracketed IPv6 loopback', 'http://[::1]/'],
+        ['bracketed IPv6 link-local', 'http://[fe80::1]/'],
+        ['localhost', 'http://localhost/'],
+        ['localhost subdomain', 'http://sub.localhost/'],
+        ['https localhost', 'https://localhost/'],
+    ];
+
+    for (const [label, url] of rejectedUrls) {
+        test(`rejects ${label} with 400 before any request is made`, async () => {
+            const response = await visit(url);
+            expect(response.status).toBe(400);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+    }
+
+    const allowedUrls = [
+        ['public http url', 'http://example.com/'],
+        ['public https url', 'https://example.com/some/page?query=1'],
+    ];
+
+    for (const [label, url] of allowedUrls) {
+        test(`passes ${label} to fetch through the untrusted request agent`, async () => {
+            const response = await visit(url);
+            expect(response.status).toBe(200);
+            expect(await response.text()).toBe('<html>ok</html>');
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(fetchMock).toHaveBeenCalledWith(url, expect.objectContaining({
+                agent: getUntrustedRequestAgent(),
+            }));
+            expect(getUntrustedRequestAgent()).toBeDefined();
+        });
+    }
+});


### PR DESCRIPTION
## Description

Fixes GHSA-wm7j-m6jm-8797

The hostname check in `/api/search/visit` only validated IP addresses using `ipRegex`, but did not block `'localhost'` or subdomains ending in `'.localhost'`. This allowed SSRF bypasses to internal services via localhost URLs.

## Changes

- Add explicit rejection of `'localhost'` hostname
- Add rejection of any hostname ending in `'.localhost'` (RFC 6761 reserved)

## Testing

- `npx eslint src/endpoints/search.js` passes with no errors
- Verified that `http://localhost/` and `http://sub.localhost/` are now rejected with 400

## Security Impact

This closes a remaining SSRF bypass vector distinct from the previously fixed CVE-2025-59159, CVE-2026-26286, and GHSA-vjv2-8gh6-4hc2.