### PR TITLE
feat(sd): add MiniMax image generation source

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -3576,7 +3576,7 @@ async function generateExtrasImage(prompt, negativePrompt, signal) {
  * Gets an aspect ratio for Stability that is the closest to the given width and height.
  * @param {number} width Target width
  * @param {number} height Target height
- * @param {'google'|'stability'|'zai'|'xai'} source Source of the request, used to determine aspect ratio
+ * @param {'google'|'stability'|'zai'|'xai'|'minimax'} source Source of the request, used to determine aspect ratio
  * @returns {string} Closest aspect ratio as a string
  */
 function getClosestAspectRatio(width, height, source) {
@@ -3623,6 +3623,17 @@ function getClosestAspectRatio(width, height, source) {
                     '20:9': 20 / 9,
                     '1:2': 1 / 2,
                     '2:1': 2 / 1,
+                };
+            case 'minimax':
+                return {
+                    '1:1': 1,
+                    '16:9': 16 / 9,
+                    '4:3': 4 / 3,
+                    '3:2': 3 / 2,
+                    '2:3': 2 / 3,
+                    '3:4': 3 / 4,
+                    '9:16': 9 / 16,
+                    '21:9': 21 / 9,
                 };
             default:
                 console.warn(`Unknown source "${source}" for aspect ratio calculation.`);

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -5204,6 +5204,8 @@ function isValidState() {
             return secret_state[SECRET_KEYS.NANOGPT];
         case sources.bfl:
             return secret_state[SECRET_KEYS.BFL];
+        case sources.minimax:
+            return secret_state[SECRET_KEYS.MINIMAX];
         case sources.falai:
             return secret_state[SECRET_KEYS.FALAI];
         case sources.xai:

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -464,6 +464,17 @@ function toggleSourceControls() {
     });
 }
 
+function toggleMinimaxModelControls() {
+    const currentModel = extension_settings.sd.model || '';
+    $('[data-minimax-model]').each(function () {
+        const match = $(this).data('minimax-model').split(',');
+        $(this).toggle(match.includes(currentModel));
+    });
+    const isMinimax = extension_settings.sd.source === sources.minimax;
+    $('#sd_negative_prompt').closest('label, .flex-container, .marginTopBot5, div').first().toggle(!isMinimax);
+    $('#sd_character_negative_prompt').closest('label, .flex-container, .marginTopBot5, div').first().toggle(!isMinimax);
+}
+
 async function loadSettings() {
     // Initialize settings
     if (Object.keys(extension_settings.sd).length === 0) {
@@ -562,6 +573,8 @@ async function loadSettings() {
     $('#sd_huggingface_model_id').val(extension_settings.sd.huggingface_model_id);
     $('#sd_function_tool').prop('checked', extension_settings.sd.function_tool);
     $('#sd_bfl_upsampling').prop('checked', extension_settings.sd.bfl_upsampling);
+    $('#sd_minimax_optimizer').prop('checked', !!extension_settings.sd.minimax_optimizer);
+    $('#sd_minimax_style_type').val(extension_settings.sd.minimax_style_type);
     $('#sd_google_api').val(extension_settings.sd.google_api);
     $('#sd_google_enhance').prop('checked', extension_settings.sd.google_enhance);
     $('#sd_google_duration').val(extension_settings.sd.google_duration);
@@ -1144,6 +1157,7 @@ async function onSourceChange() {
     extension_settings.sd.scheduler = null;
     extension_settings.sd.vae = null;
     toggleSourceControls();
+    toggleMinimaxModelControls();
     saveSettingsDebounced();
     await loadSettingOptions();
 }
@@ -5950,6 +5964,16 @@ export async function init() {
     $('#sd_huggingface_model_id').on('input', onHFModelInput);
     $('#sd_function_tool').on('input', onFunctionToolInput);
     $('#sd_bfl_upsampling').on('input', onBflUpsamplingInput);
+
+    $('#sd_minimax_optimizer').on('input', function () {
+        extension_settings.sd.minimax_optimizer = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#sd_minimax_style_type').on('change', function () {
+        extension_settings.sd.minimax_style_type = String($(this).val() || '漫画');
+        saveSettingsDebounced();
+    });
 
     $('#sd_google_api').on('input', function () {
         extension_settings.sd.google_api = String($(this).val());

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -1507,6 +1507,7 @@ async function onModelChange() {
     const selectedModel = $('#sd_model').find(':selected');
     extension_settings.sd.model = selectedModel.val();
     saveSettingsDebounced();
+    toggleMinimaxModelControls();
 
     if (extension_settings.sd.model && extension_settings.sd.source === sources.electronhub) {
         const cachedModel = selectedModel.data('model');

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -357,6 +357,10 @@ const defaultSettings = {
     // BFL API settings
     bfl_upsampling: false,
 
+    // MiniMax API settings
+    minimax_optimizer: false,
+    minimax_style_type: '漫画',
+
     // Google settings
     google_api: 'makersuite',
     google_enhance: true,
@@ -3414,6 +3418,9 @@ async function sendGenerationRequest(generationType, prompt, additionalNegativeP
             case sources.bfl:
                 result = await generateBflImage(prefixedPrompt, signal);
                 break;
+            case sources.minimax:
+                result = await generateMinimaxImage(prefixedPrompt, signal);
+                break;
             case sources.falai:
                 result = await generateFalaiImage(prefixedPrompt, negativePrompt, signal);
                 break;
@@ -4507,6 +4514,44 @@ async function generateBflImage(prompt, signal) {
     if (result.ok) {
         const data = await result.json();
         return { format: 'jpg', data: data.image };
+    } else {
+        const text = await result.text();
+        throw new Error(text);
+    }
+}
+
+/**
+ * Generates an image using the MiniMax API.
+ * @param {string} prompt - The main instruction used to guide the image generation.
+ * @param {AbortSignal} signal - An AbortSignal object that can be used to cancel the request.
+ * @returns {Promise<{format: string, data: string}>} - A promise that resolves with the generated image.
+ */
+async function generateMinimaxImage(prompt, signal) {
+    const body = {
+        prompt: prompt,
+        model: extension_settings.sd.model,
+        aspect_ratio: getClosestAspectRatio(extension_settings.sd.width, extension_settings.sd.height, 'minimax'),
+        prompt_optimizer: !!extension_settings.sd.minimax_optimizer,
+    };
+
+    if (Number.isInteger(extension_settings.sd.seed) && extension_settings.sd.seed >= 0) {
+        body.seed = extension_settings.sd.seed;
+    }
+
+    if (extension_settings.sd.model === 'image-01-live') {
+        body.style_type = extension_settings.sd.minimax_style_type;
+    }
+
+    const result = await fetch('/api/sd/minimax/generate', {
+        method: 'POST',
+        headers: getRequestHeaders(),
+        signal: signal,
+        body: JSON.stringify(body),
+    });
+
+    if (result.ok) {
+        const data = await result.json();
+        return { format: data.format || 'jpeg', data: data.image };
     } else {
         const text = await result.text();
         throw new Error(text);

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -88,6 +88,7 @@ const sources = {
     chutes: 'chutes',
     electronhub: 'electronhub',
     nanogpt: 'nanogpt',
+    minimax: 'minimax',
     bfl: 'bfl',
     falai: 'falai',
     xai: 'xai',
@@ -1746,6 +1747,9 @@ async function loadSamplers() {
         case sources.workersai:
             samplers = ['N/A'];
             break;
+        case sources.minimax:
+            samplers = ['N/A'];
+            break;
     }
 
     for (const sampler of samplers) {
@@ -1999,6 +2003,9 @@ async function loadModels() {
         case sources.workersai:
             models = await loadWorkersAIImageModels();
             break;
+        case sources.minimax:
+            models = await loadMinimaxModels();
+            break;
     }
 
     if (extension_settings.sd.source === sources.electronhub) {
@@ -2101,6 +2108,13 @@ async function loadBflModels() {
         { value: 'flux-pro-1.1', text: 'flux-pro-1.1' },
         { value: 'flux-pro', text: 'flux-pro' },
         { value: 'flux-dev', text: 'flux-dev' },
+    ];
+}
+
+async function loadMinimaxModels() {
+    return [
+        { value: 'image-01', text: 'image-01' },
+        { value: 'image-01-live', text: 'image-01-live' },
     ];
 }
 

--- a/public/scripts/extensions/stable-diffusion/settings.html
+++ b/public/scripts/extensions/stable-diffusion/settings.html
@@ -53,6 +53,7 @@
                 <option value="google">Google AI</option>
                 <option value="huggingface">HuggingFace Inference API (serverless)</option>
                 <option value="nanogpt">NanoGPT</option>
+                <option value="minimax">MiniMax</option>
                 <option value="novel">NovelAI Diffusion</option>
                 <option value="openai">OpenAI</option>
                 <option value="openrouter">OpenRouter</option>
@@ -584,6 +585,28 @@
                     <small data-i18n="(-1 for random)">(-1 for random)</small>
                 </label>
                 <input id="sd_seed" type="number" class="text_pole" min="-1" max="9999999999" step="1" />
+            </div>
+
+            <div data-sd-source="minimax" class="marginTop5">
+                <div class="flex-container">
+                    <div id="sd_minimax_key" class="menu_button menu_button_icon manage-api-keys" data-key="api_key_minimax">
+                        <i class="fa-solid fa-key"></i>
+                        <span data-i18n="Manage API Keys">Manage API Keys</span>
+                    </div>
+                </div>
+                <div class="flex-container marginTopBot5" data-minimax-model="image-01-live">
+                    <label for="sd_minimax_style_type" data-i18n="Style type">Style type</label>
+                    <select id="sd_minimax_style_type" class="text_pole flex1">
+                        <option value="漫画">漫画</option>
+                        <option value="元气">元气</option>
+                        <option value="中世纪">中世纪</option>
+                        <option value="水彩">水彩</option>
+                    </select>
+                </div>
+                <label class="flex1 checkbox_label" for="sd_minimax_optimizer" data-i18n="[title]Let MiniMax optimize the prompt before sending it." title="Let MiniMax optimize the prompt before sending it.">
+                    <input id="sd_minimax_optimizer" type="checkbox" />
+                    <span data-i18n="Enable prompt optimizer">Enable prompt optimizer</span>
+                </label>
             </div>
 
             <hr>

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -2189,6 +2189,72 @@ workersai.post('/generate', async (request, response) => {
     }
 });
 
+const minimax = express.Router();
+
+minimax.post('/generate', async (request, response) => {
+    try {
+        const key = readSecret(request.user.directories, SECRET_KEYS.MINIMAX);
+
+        if (!key) {
+            console.warn('MiniMax key not found.');
+            return response.sendStatus(400);
+        }
+
+        /** @type {Record<string, any>} */
+        const body = {
+            model: request.body.model,
+            prompt: request.body.prompt,
+            aspect_ratio: request.body.aspect_ratio,
+            response_format: 'base64',
+            n: 1,
+            prompt_optimizer: !!request.body.prompt_optimizer,
+        };
+
+        if (Number.isInteger(request.body.seed) && request.body.seed >= 0) {
+            body.seed = request.body.seed;
+        }
+
+        if (request.body.model === 'image-01-live' && request.body.style_type) {
+            body.style = {
+                style_type: request.body.style_type,
+                style_weight: 0.8,
+            };
+        }
+
+        console.debug('MiniMax request:', body);
+
+        const result = await fetch('https://api.minimaxi.com/v1/image_generation', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${key}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(body),
+        });
+
+        /** @type {any} */
+        const data = await result.json().catch(() => ({}));
+
+        if (!result.ok || (data?.base_resp && data.base_resp.status_code !== 0)) {
+            const message = data?.base_resp?.status_msg
+                || data?.message
+                || await result.text().catch(() => `HTTP ${result.status}`);
+            console.error('MiniMax error:', message);
+            return response.status(500).json({ error: message });
+        }
+
+        const image = data?.data?.image_base64?.[0];
+        if (!image) {
+            return response.status(500).json({ error: 'MiniMax did not return image data.' });
+        }
+
+        return response.send({ image, format: 'jpeg' });
+    } catch (error) {
+        console.error('MiniMax error:', error);
+        return response.sendStatus(500);
+    }
+});
+
 router.use('/comfy', comfy);
 router.use('/comfyrunpod', comfyRunPod);
 router.use('/together', together);
@@ -2206,3 +2272,4 @@ router.use('/xai', xai);
 router.use('/aimlapi', aimlapi);
 router.use('/zai', zai);
 router.use('/workersai', workersai);
+router.use('/minimax', minimax);


### PR DESCRIPTION
Adds MiniMax image generation API as a new Stable Diffusion source.

- New POST /api/sd/minimax/generate endpoint
- MiniMax option in source dropdown
- Settings: API key, model (image-01 or image-01-live), style type (live only), prompt optimizer
- Negative prompt hidden when MiniMax is selected (API rejects it)
- Style type only shown for image-01-live

188 lines across 3 files. Source-only, no tests in this PR.
