### PR TITLE
Add claude-fable-5 support to Claude and OpenAI-compatible request builders

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3176,6 +3176,7 @@
                                 <h4 data-i18n="Claude Model">Claude Model</h4>
                                 <select id="model_claude_select">
                                     <optgroup label="Versions">
+                                        <option value="claude-fable-5">claude-fable-5</option>
                                         <option value="claude-opus-4-7">claude-opus-4-7</option>
                                         <option value="claude-opus-4-6">claude-opus-4-6</option>
                                         <option value="claude-opus-4-5">claude-opus-4-5</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3036,6 +3036,22 @@ export async function createGenerationParameters(settings, model, type, messages
         }
     }
 
+    // Claude Fable models removed sampling parameters and reject them with HTTP 400,
+    // including via OpenAI-compatible proxies. Unanchored to also match prefixed ids
+    // like 'anthropic/claude-fable-5'.
+    if (/claude-fable/.test(model)) {
+        delete generate_data.temperature;
+        delete generate_data.top_p;
+        delete generate_data.top_k;
+        delete generate_data.frequency_penalty;
+        delete generate_data.presence_penalty;
+        // Keep reasoning_effort for the native Claude source, where the backend maps it to
+        // adaptive thinking; proxies may translate it into a thinking budget that Fable rejects.
+        if (settings.chat_completion_source !== chat_completion_sources.CLAUDE) {
+            delete generate_data.reasoning_effort;
+        }
+    }
+
     if (jsonSchema) {
         generate_data.json_schema = jsonSchema;
     }
@@ -5619,7 +5635,7 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source == chat_completion_sources.CLAUDE) {
         if (oai_settings.max_context_unlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
-        } else if (/^claude-(sonnet-4-5|sonnet-4-6|opus-4-6|opus-4-7)/.test(value)) {
+        } else if (/^claude-(sonnet-4-5|sonnet-4-6|opus-4-6|opus-4-7|fable)/.test(value)) {
             $('#openai_max_context').attr('max', max_1mil);
         } else if (/^claude-(3|opus|haiku|sonnet)/.test(value)) {
             $('#openai_max_context').attr('max', max_200k);
@@ -6138,6 +6154,7 @@ export function isImageInliningSupported() {
         'o4-mini',
         // Claude
         'claude-3',
+        'claude-fable',
         'claude-opus-4',
         'claude-sonnet-4',
         'claude-haiku-4',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -325,13 +325,13 @@ async function sendClaudeRequest(request, response) {
         }
 
         const reasoningEffort = request.body.reasoning_effort;
+        const includeReasoning = Boolean(request.body.include_reasoning);
         const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream, isAdaptiveModel);
 
         // Adaptive thinking: returns a string effort level (like Gemini 3)
         if (useThinking && typeof budgetTokens === 'string') {
             fixThinkingPrefill = true;
             requestBody.thinking = { type: 'adaptive' };
-            const includeReasoning = Boolean(request.body.include_reasoning);
             if (noSamplingModel && includeReasoning) {
                 requestBody.thinking.display = 'summarized';
             }
@@ -339,6 +339,10 @@ async function sendClaudeRequest(request, response) {
             requestBody.output_config.effort = budgetTokens;
             // top_k is not allowed in adaptive mode
             delete requestBody.top_k;
+        } else if (useThinking && isFableModel && reasoningEffort === 'auto' && includeReasoning) {
+            // Fable auto thinking is already enabled, but readable summaries require an explicit display request.
+            fixThinkingPrefill = true;
+            requestBody.thinking = { type: 'adaptive', display: 'summarized' };
         } else if (useThinking && Number.isInteger(budgetTokens)) {
             // Traditional thinking: returns a numeric budget
             fixThinkingPrefill = true;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -233,13 +233,15 @@ async function sendClaudeRequest(request, response) {
         const useTools = Array.isArray(request.body.tools) && request.body.tools.length > 0;
         const useSystemPrompt = Boolean(request.body.use_sysprompt);
         const convertedPrompt = convertClaudeMessages(request.body.messages, request.body.assistant_prefill, useSystemPrompt, useTools, getPromptNames(request));
-        const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model);
-        const useWebSearch = /^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) && Boolean(request.body.enable_web_search);
+        // Unanchored to also match prefixed ids passed through proxies, e.g. 'anthropic/claude-fable-5'
+        const isFableModel = /claude-fable/.test(request.body.model);
+        const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel;
+        const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel) && Boolean(request.body.enable_web_search);
         const isLimitedSampling = /^claude-(opus-4-1|sonnet-4-5|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6)/.test(request.body.model);
-        const useVerbosity = /^claude-(opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model);
-        const noPrefillModel = /^claude-(opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model);
-        const isAdaptiveModel = /^claude-(opus-4-7)/.test(request.body.model) || (enableAdaptiveThinking && /^claude-(opus-4-6|sonnet-4-6)/.test(request.body.model));
-        const noSamplingModel = /^claude-(opus-4-7)/.test(request.body.model);
+        const useVerbosity = /^claude-(opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel;
+        const noPrefillModel = /^claude-(opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel;
+        const isAdaptiveModel = /^claude-(opus-4-7)/.test(request.body.model) || isFableModel || (enableAdaptiveThinking && /^claude-(opus-4-6|sonnet-4-6)/.test(request.body.model));
+        const noSamplingModel = /^claude-(opus-4-7)/.test(request.body.model) || isFableModel;
         let fixThinkingPrefill = false;
         // Add custom stop sequences
         const stopSequences = [];


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## What this does

Adds `claude-fable-5` to the Claude request builders. Fable removed `temperature`/`top_p`/`top_k` from the API (sending any of them returns HTTP 400), supports only adaptive thinking (an explicit `thinking` object of any other type is rejected; the key must be omitted when unused), rejects assistant prefill, and has a 1M context window with vision support.

## Changes

- `src/endpoints/backends/chat-completions.js`: add an `isFableModel` flag and include it in `useThinking`, `useWebSearch`, `useVerbosity`, `noPrefillModel`, `isAdaptiveModel` (unconditional, like opus-4-7 — adaptive is the only thinking mode), and `noSamplingModel` (samplers are removed from the API). The flag is unanchored so prefixed ids passed through proxies (e.g. `anthropic/claude-fable-5`) are also matched.
- `public/scripts/openai.js`:
  - Strip sampling parameters for fable models in `createGenerationParameters` so OpenAI-compatible sources don't send them either. `reasoning_effort` is kept for the native Claude source (the backend maps it to adaptive thinking) and stripped for other sources, where a proxy may translate it into a thinking budget that fable rejects.
  - Add `fable` to the 1M-context regex and `claude-fable` to `visionSupportedModels`.
- `public/index.html`: add `claude-fable-5` to the Claude model dropdown.

## Why the existing flags are enough

With `isAdaptiveModel` true, `calculateClaudeBudgetTokens` returns a string effort (→ `thinking: { type: 'adaptive' }` + `output_config.effort`) or `null` for auto (→ no `thinking` key at all), so the rejected `budget_tokens` and explicit-`thinking` shapes are unreachable for fable. `noPrefillModel` re-roles a trailing assistant message, and `noSamplingModel` drops the removed samplers.

Verified against the live API: minimal request 200; any of `temperature`/`top_p`/`top_k` 400; `thinking: { type: 'adaptive' }` + `output_config.effort` 200; explicit non-adaptive `thinking` 400; existing beta headers accepted. Payloads for opus-4-7 / opus-4-6 / sonnet-4-6 / sonnet-4-5 are unchanged (regression-checked).
