### PR TITLE
Fix reasoning_effort leaking "auto" for unsupported api sources

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2548,7 +2548,7 @@ function getReasoningEffort(settings = null, model = null) {
     ];
 
     if (!reasoningEffortSources.includes(settings.chat_completion_source)) {
-        return undefined;
+        return settings.reasoning_effort === reasoning_effort_types.auto ? undefined : settings.reasoning_effort;
     }
 
     function resolveReasoningEffort() {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2548,7 +2548,7 @@ function getReasoningEffort(settings = null, model = null) {
     ];
 
     if (!reasoningEffortSources.includes(settings.chat_completion_source)) {
-        return settings.reasoning_effort;
+        return undefined;
     }
 
     function resolveReasoningEffort() {


### PR DESCRIPTION
### What is the reason for a change?
When using OpenAI-compatible or other custom/proxied endpoints that do not officially support `reasoning_effort`, Sillytavern currently falls back to returning the raw setting value (`"auto"`) in `getReasoningEffort()`. This causes strict api endpoints (like deepseek or custom OpenAI-like routers) to crash with a 400 Bad Request error because `"auto"` is not a valid enum variant for their json deserializers

### What did you do to achieve this?
Changed the fallback return value in `getReasoningEffort` (inside `public/scripts/openai.js`) from `settings.reasoning_effort` to `undefined` when the source is not in the `reasoningEffortSources` array. This ensures that the key is cleanly omitted from the json payload when sending requests to unsupported sources

### How would a reviewer test the change?
1. Configure an api connection using a custom or proxy source pointing to a strict json-validating endpoint (deepseek's official api)
2. Set the `reasoning_effort` parameter to `auto` in the UI
3. Send a message and verify it no longer throws a deserialization error


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
