### PR TITLE
Fix Gemini reasoning extraction when `responseContent` is not mutated

### DIFF
--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -119,8 +119,10 @@ export function extractReasoningFromData(data, {
                         ?? data?.choices?.[0]?.message?.reasoning_content
                         ?? '';
                 case chat_completion_sources.MAKERSUITE:
-                case chat_completion_sources.VERTEXAI:
-                    return data?.responseContent?.parts?.filter(part => part.thought)?.map(part => part.text)?.join('\n\n') ?? '';
+                case chat_completion_sources.VERTEXAI: {
+                    const parts = data?.responseContent?.parts ?? data?.candidates?.[0]?.content?.parts ?? [];
+                    return parts.filter(part => part.thought).map(part => part.text).join('\n\n') || '';
+                }
                 case chat_completion_sources.CLAUDE:
                     return data?.content?.filter(part => part.type === 'thinking')?.map(part => part.thinking)?.join('\n\n') ?? '';
                 case chat_completion_sources.MISTRALAI:


### PR DESCRIPTION
### What is the reason for a change?
In `reasoning.js`, the `extractReasoningFromData` function for `MAKERSUITE` and `VERTEXAI` relies entirely on `data?.responseContent?.parts`. However, `responseContent` is not a native property of the Google api response, it is manually injected elsewhere by `extractMessageFromData()`. If a third-party extension requests data extraction without triggering that specific mutation first, Gemini thoughts are completely lost in non-streaming mode

### What did you do to achieve this?
Updated the extraction logic in `extractReasoningFromData` to gracefully fallback to the native Google api json structure (`data?.candidates?.[0]?.content?.parts`) if `responseContent` is undefined

### How would a reviewer test the change?
1. Use an extension that calls `ChatCompletionService.sendRequest` with `extractData: true`
2. Disable streaming
3. Trigger a generation with a Gemini model that supports reasonin.
4. Without this PR, the returned `reasoning` string is empty. With this PR, the thoughts are correctly extracted

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
