### PR TITLE
fix: OpenRouter Latest Claude models work with caching (#5746)

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2277,7 +2277,7 @@ router.post('/generate', async function (request, response) {
                 };
             }
 
-            const isClaude = /^anthropic\/claude/.test(request.body.model);
+            const isClaude = /anthropic\/claude/.test(request.body.model);
             const isGemini = /google\/gemini/.test(request.body.model);
             const isCacheableGemini = isGemini && await isOpenRouterModelCacheable(request.body.model);
             const enableGeminiSystemPromptCache = getConfigValue('gemini.enableSystemPromptCache', false, 'boolean');


### PR DESCRIPTION
This fixes bug #5746.

OpenRouter models selected via the "Latest" option have a tilda prefix to their name (eg. "~anthropic/claude-haiku-latest" vs. "anthropic/claude-haiku-4.5").

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
