### PR TITLE
Change default launch opened tab to use localhost

### DIFF
--- a/src/command-line.js
+++ b/src/command-line.js
@@ -342,8 +342,8 @@ export class CommandLineParser {
             },
             getBrowserLaunchHostname: async function ({ useIPv6, useIPv4 }) {
                 if (this.browserLaunchHostname === 'auto') {
-                    if (useIPv6 && useIPv4) {
-                        return this.browserLaunchAvoidLocalhost ? '[::1]' : 'localhost';
+                    if (!this.browserLaunchAvoidLocalhost) {
+                        return 'localhost';
                     }
 
                     if (useIPv6) {


### PR DESCRIPTION
## Causation:
Per #5711 , we should be using localhost IF possible. This is clearer to users that the content is locally hosted and visually slightly more appealing than the ipv6/ipv4 addresses.

### Fixed:
The former logic for localhost opening till updated appeared somewhat wrong, as it demanded BOTH IPv6 and IPv4 be enabled and only then did it check if localhost was to be avoided. Going to the other addresses rather than from localhost, however, is already handled by the other two conditionals, which give a better fallback to IPv6, then IPv4, if localhost is to be avoided.

## Testing:
To test this code, it is as simple as launching a "default settings" Sillytavern using any of the launch commands, whereupon it should open a new tab with the localhost address (which should in full be ``http://localhost:8000/`` which on most browsers like Safari and Chromium-based is shortened to display as simply ``localhost:8000``)

#### Note:
* For a "quick-test" against release, I have tested that while running a default config Sillytavern instance, ``localhost:8000`` is a valid tab for accessing Sillytavern both on android and macOS. (using Chrome and Safari respectively).

* I suggest confirming that this change works on Windows with Microsoft Edge, as I could not myself verify such, due to not using Windows. 
###### I believe this change should work there, as it is still Chromium based, but it's better to be safe than sorry.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
