### PR TITLE
Document TrustedRouter custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 LLM Frontend for Power Users
 
+TrustedRouter can be used through the Custom OpenAI-compatible connection with
+the base URL `https://api.trustedrouter.com/v1`.
+
 ## Resources
 
 - GitHub: <https://github.com/SillyTavern/SillyTavern>

--- a/public/index.html
+++ b/public/index.html
@@ -3803,10 +3803,11 @@
                         <form id="custom_form" data-source="custom">
                             <h4 data-i18n="Custom Endpoint (Base URL)">Custom Endpoint (Base URL)</h4>
                             <div class="flex-container">
-                                <input id="custom_api_url_text" class="text_pole wide100p" value="" autocomplete="off" data-i18n="[placeholder]Example: http://localhost:1234/v1" placeholder="Example: http://localhost:1234/v1">
+                                <input id="custom_api_url_text" class="text_pole wide100p" value="" autocomplete="off" data-i18n="[placeholder]Example: https://api.trustedrouter.com/v1 or http://localhost:1234/v1" placeholder="Example: https://api.trustedrouter.com/v1 or http://localhost:1234/v1">
                             </div>
                             <div>
                                 <small>
+                                    <span>TrustedRouter uses</span> <code>https://api.trustedrouter.com/v1</code><span>.</span>
                                     <span data-i18n="Doesn't work? Try adding">Doesn't work? Try adding</span> <code>/v1</code> <span data-i18n="at the end!">at the end!</span>
                                     <b data-i18n="completions note prefix"></b><code>/chat/completions</code> <b data-i18n="suffix will be added automatically.">suffix will be added automatically.</b>
                                 </small>


### PR DESCRIPTION
## Summary
- mention TrustedRouter in the README as a Custom OpenAI-compatible endpoint
- add https://api.trustedrouter.com/v1 to the custom endpoint placeholder and help text

## Testing
- git diff --check