### PR TITLE
fix: convert OpenAI tool format to Claude native for custom endpoints

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2347,8 +2347,21 @@ router.post('/generate', async function (request, response) {
         });
 
         if (!isTextCompletion && Array.isArray(request.body.tools) && request.body.tools.length > 0) {
-            bodyParams['tools'] = request.body.tools;
-            bodyParams['tool_choice'] = request.body.tool_choice;
+            if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM && /^claude/i.test(request.body.model)) {
+                bodyParams['tools'] = request.body.tools.map(tool => {
+                    if (tool.type === 'function' && tool.function) {
+                        return {
+                            name: tool.function.name,
+                            description: tool.function.description,
+                            input_schema: tool.function.parameters,
+                        };
+                    }
+                    return tool;
+                });
+            } else {
+                bodyParams['tools'] = request.body.tools;
+                bodyParams['tool_choice'] = request.body.tool_choice;
+            }
         }
 
         if (request.body.json_schema && !bodyParams['response_format']) {


### PR DESCRIPTION
## Summary

When using a Custom (OpenAI Compatible) endpoint pointed at a Claude proxy (e.g. [clewdr](https://github.com/Xerxes-2/clewdr), or other OpenAI-to-Claude bridges), tool calling fails with HTTP 400 because tools are sent in OpenAI format (`"type": "function"`) which Claude API rejects.

This PR converts tool definitions to Claude's native format (`name`/`description`/`input_schema`) when:
- The chat completion source is **Custom**
- The model name starts with `claude` (case-insensitive)

All other sources and non-Claude custom endpoints are **unchanged**.

### Error before fix
```
tools.0: Input tag 'function' found using 'type' does not match any of the expected tags:
'bash_20250124', 'custom', 'text_editor_20250124', ...
```

### Related issues
- Xerxes-2/clewdr#52 — N8N OpenAI Compatible Node fails with `missing field name` in tools
- Xerxes-2/clewdr#126 — `tool_choice` format mismatch (string vs enum)
- Xerxes-2/clewdr#142 — Unstable tool calling with custom Anthropic providers

## Test plan
- [x] Custom endpoint + Claude model + tools enabled → tools sent in Claude native format, no 400 error
- [x] Custom endpoint + non-Claude model + tools → unchanged OpenAI format (no regression)
- [x] Non-custom sources (OpenAI, OpenRouter, etc.) + tools → unchanged (no regression)