### PR TITLE
fix: fetch only current prompt from ComfyUI history endpoint

### DIFF
--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -586,7 +586,7 @@ comfy.post('/generate', async (request, response) => {
         /** @type {any} */
         const data = await promptResult.json();
         const id = data.prompt_id;
-        const historyUrl = new URL(urlJoin(request.body.url, '/history'));
+        const historyUrl = new URL(urlJoin(request.body.url, `/history/${id}`));
         while (true) {
             const result = await fetch(historyUrl);
             if (!result.ok) {


### PR DESCRIPTION
## Problem

The ComfyUI image generation polling loop (`/generate` in `stable-diffusion.js`) fetches the full `/history` endpoint every 100ms while waiting for a prompt to complete. ComfyUI's history grows unboundedly across the session, so after ~170 generations, the JSON response exceeds Node.js's 512 MB string length limit, crashing the server:

```
RangeError: Invalid string length
```

## Fix

Request `/history/{id}` instead of `/history`. This is a supported ComfyUI API endpoint that returns only the single prompt entry being polled, regardless of how many other prompts have been processed.

The response structure is identical (`history[id]`), so the existing parsing code works unchanged.

## Test plan

- [x] Verified fix locally across 200+ ComfyUI generations without crash (previously crashed at ~170)
- [x] Confirmed `/history/{id}` returns the same data shape as `/history` filtered by id
- [x] No other code paths in ST depend on the full history response