### PR TITLE
Add support for Featherless chat completion

### DIFF
--- a/default/content/presets/openai/Default.json
+++ b/default/content/presets/openai/Default.json
@@ -12,6 +12,7 @@
     "chutes_sort_models": "alphabetically",
     "minimax_model": "MiniMax-M2.7",
     "minimax_endpoint": "global",
+    "featherless_model": "TheDrummer/Rocinante-X-12B-v1",
     "electronhub_model": "gpt-4o-mini",
     "electronhub_sort_models": "alphabetically",
     "electronhub_group_models": false,

--- a/public/index.html
+++ b/public/index.html
@@ -697,7 +697,7 @@
                                         </span>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai">
+                                <div class="range-block" data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai,featherless">
                                     <div class="range-block-title" data-i18n="Temperature">
                                         Temperature
                                     </div>
@@ -710,7 +710,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai">
+                                <div class="range-block" data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai,featherless">
                                     <div class="range-block-title" data-i18n="Frequency Penalty">
                                         Frequency Penalty
                                     </div>
@@ -723,7 +723,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai">
+                                <div class="range-block" data-source="openai,aimlapi,openrouter,custom,cohere,perplexity,groq,siliconflow,mistralai,electronhub,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,chutes,workers_ai,featherless">
                                     <div class="range-block-title" data-i18n="Presence Penalty">
                                         Presence Penalty
                                     </div>
@@ -736,7 +736,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="claude,aimlapi,openrouter,makersuite,vertexai,cohere,perplexity,electronhub,chutes,nanogpt,workers_ai">
+                                <div class="range-block" data-source="claude,aimlapi,openrouter,makersuite,vertexai,cohere,perplexity,electronhub,chutes,nanogpt,workers_ai,featherless">
                                     <div class="range-block-title" data-i18n="Top K">
                                         Top K
                                     </div>
@@ -749,7 +749,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai">
+                                <div class="range-block" data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai,featherless">
                                     <div class="range-block-title" data-i18n="Top P">
                                         Top P
                                     </div>
@@ -762,7 +762,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openrouter,nanogpt,chutes,workers_ai">
+                                <div class="range-block" data-source="openrouter,nanogpt,chutes,workers_ai,featherless">
                                     <div class="range-block-title" data-i18n="Repetition Penalty">
                                         Repetition Penalty
                                     </div>
@@ -775,7 +775,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openrouter,nanogpt,chutes">
+                                <div class="range-block" data-source="openrouter,nanogpt,chutes,featherless">
                                     <div class="range-block-title" data-i18n="Min P">
                                         Min P
                                     </div>
@@ -989,7 +989,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="range-block" data-source="openai,openrouter,mistralai,custom,cohere,groq,electronhub,chutes,nanogpt,xai,pollinations,aimlapi,makersuite,vertexai,azure_openai,workers_ai">
+                                <div class="range-block" data-source="openai,openrouter,mistralai,custom,cohere,groq,electronhub,chutes,nanogpt,xai,pollinations,aimlapi,makersuite,vertexai,azure_openai,workers_ai,featherless">
                                     <div class="range-block-title justifyLeft" data-i18n="Seed">
                                         Seed
                                     </div>
@@ -2000,7 +2000,7 @@
                                             </b>
                                         </div>
                                     </div>
-                                    <div class="range-block" data-source="openai,cohere,mistralai,custom,claude,aimlapi,openrouter,groq,siliconflow,minimax,deepseek,makersuite,vertexai,ai21,xai,pollinations,moonshot,fireworks,cometapi,electronhub,chutes,azure_openai,zai,nanogpt,workers_ai">
+                                    <div class="range-block" data-source="openai,cohere,mistralai,custom,claude,aimlapi,openrouter,groq,siliconflow,minimax,deepseek,makersuite,vertexai,ai21,xai,pollinations,moonshot,fireworks,cometapi,electronhub,chutes,azure_openai,zai,nanogpt,workers_ai,featherless">
                                         <label for="openai_function_calling" class="checkbox_label flexWrap widthFreeExpand">
                                             <input id="openai_function_calling" type="checkbox" />
                                             <span data-i18n="Enable function calling">Enable function calling</span>
@@ -2625,6 +2625,9 @@
                                 <input id="custom_model_textgenerationwebui" class="text_pole wide100p" placeholder="Custom model (optional)" data-i18n="[placeholder]Custom model (optional)" type="text">
                             </div>
                             <div data-tg-type="featherless" class="flex-container flexFlowColumn">
+                                <div class="neutral_warning">
+                                    Featherless recommends using Chat Completions
+                                </div>
                                 <div class="flex-container flexFlowColumn">
                                     <a href="https://featherless.ai/models/" target="_blank" rel="noopener noreferrer">
                                         featherless.ai
@@ -2632,11 +2635,11 @@
                                 </div>
                                 <h4 data-i18n="API key (optional)">API key</h4>
                                 <div class="flex-container">
-                                    <input id="api_key_featherless" name="api_key_featherless" class="text_pole flex1 wide100p" type="text" autocomplete="off">
+                                    <input id="api_key_featherless-tg" name="api_key_featherless" class="text_pole flex1 wide100p api_key_featherless" type="text" autocomplete="off">
                                     <div title="Manage API keys" data-i18n="[title]Manage API keys" class="menu_button fa-solid fa-key fa-fw manage-api-keys" data-key="api_key_featherless">
                                     </div>
                                 </div>
-                                <div data-for="api_key_featherless" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'.">
+                                <div data-for="api_key_featherless-tg" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'.">
                                     For privacy reasons, your API key will be hidden after you click 'Connect'.
                                 </div>
                                 <hr>
@@ -2922,6 +2925,7 @@
                                 <!-- <option value="cometapi">CometAPI</option> -->
                                 <option value="deepseek">DeepSeek</option>
                                 <option value="electronhub">Electron Hub</option>
+                                <option value="featherless">Featherless</option>
                                 <option value="fireworks">Fireworks AI</option>
                                 <option value="groq">Groq</option>
                                 <option value="makersuite">Google AI Studio</option>
@@ -3620,6 +3624,52 @@
                             <div>
                                 <h4 data-i18n="Electron Hub Model">Electron Hub Model</h4>
                                 <select id="model_electronhub_select">
+                                    <option value="" data-i18n="-- Connect to the API --">-- Connect to the API --</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div id="featherless_chat_form" data-source="featherless">
+                            <div class="flex-container flexFlowColumn">
+                                <a href="https://featherless.ai" target="_blank" rel="noopener noreferrer">featherless.ai</a>
+                            </div>
+                            <h4>Featherless API Key</h4>
+                            <div class="flex-container">
+                                <input id="api_key_featherless" name="api_key_featherless" class="text_pole flex1 api_key_featherless" value="" type="text" autocomplete="off">
+                                <div title="Manage API keys" data-i18n="[title]Manage API keys" class="menu_button fa-solid fa-key fa-fw manage-api-keys" data-key="api_key_featherless"></div>
+                            </div>
+                            <div data-for="api_key_featherless" class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'.">
+                                For privacy reasons, your API key will be hidden after you click 'Connect'.
+                            </div>
+                            <div>
+                                <h4 data-i18n="Featherless Model Selection">Featherless Model Selection</h4>
+                                <div class="flex-container wide100p flexGap10">
+                                    <div class="flex1 overflowHidden wide100p">
+                                        <div class="flex-container marginBot10 alignitemscenter">
+                                            <input id="featherless_chat_model_search_bar" class="text_pole width100p flex1 margin0" type="search" data-i18n="[placeholder]Search..." placeholder="Search...">
+                                            <select id="featherless_chat_model_sort_order" class="margin0 text_pole">
+                                                <option value="search" data-i18n="Search" hidden>A-Z</option>
+                                                <option value="asc">A-Z</option>
+                                                <option value="desc">Z-A</option>
+                                                <option data-i18n="Date Asc" value="date_asc">Date Asc</option>
+                                                <option data-i18n="Date Desc" value="date_desc">Date Desc</option>
+                                            </select>
+                                            <select id="featherless_chat_category_selection" class="text_pole">
+                                                <option value="" disabled selected data-i18n="category">category</option>
+                                                <option value="Top" data-i18n="Top">Top</option>
+                                                <option value="New" data-i18n="New">New</option>
+                                                <option value="All" data-i18n="All">All</option>
+                                            </select>
+                                            <select id="featherless_chat_class_selection" class="text_pole">
+                                                <option value="" selected data-i18n="All Classes">All Classes</option>
+                                            </select>
+                                            <div id="featherless_chat_model_pagination_container" class="flex1"></div>
+                                            <i id="featherless_chat_model_grid_toggle" class="fa-solid fa-table-cells-large menu_button" data-i18n="[title]Toggle grid view" title="Toggle grid view"></i>
+                                        </div>
+                                        <div id="featherless_chat_model_card_block" data-i18n="[no_desc_text]No model description" no_desc_text="[No description]"></div>
+                                    </div>
+                                </div>
+                                <!-- Do not remove. Backs the connection profile setting and /model command -->
+                                <select id="model_featherless_chat_select" class="displayNone">
                                     <option value="" data-i18n="-- Connect to the API --">-- Connect to the API --</option>
                                 </select>
                             </div>

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -409,6 +409,7 @@ function RA_autoconnect(PrevApi) {
                     || ((secret_state[SECRET_KEYS.POLLINATIONS] || oai_settings.pollinations_endpoint === POLLINATIONS_ENDPOINT.ANONYMOUS) && oai_settings.chat_completion_source === chat_completion_sources.POLLINATIONS)
                     || (secret_state[SECRET_KEYS.WORKERS_AI] && oai_settings.chat_completion_source == chat_completion_sources.WORKERS_AI)
                     || (secret_state[SECRET_KEYS.MINIMAX] && oai_settings.chat_completion_source == chat_completion_sources.MINIMAX)
+                    || (secret_state[SECRET_KEYS.FEATHERLESS] && oai_settings.chat_completion_source == chat_completion_sources.FEATHERLESS)
                     || (isValidUrl(oai_settings.custom_url) && oai_settings.chat_completion_source == chat_completion_sources.CUSTOM)
                     || (secret_state[SECRET_KEYS.AZURE_OPENAI] && oai_settings.chat_completion_source == chat_completion_sources.AZURE_OPENAI)
                 ) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -61,6 +61,8 @@ import {
     isDataURL,
     isUuid,
     isValidUrl,
+    localizePagination,
+    PAGINATION_TEMPLATE,
     parseJsonFile,
     resetScrollHeight,
     stringFormat,
@@ -80,7 +82,7 @@ import { t } from './i18n.js';
 import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
-import { syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
+import { fetchFeatherlessNew, fetchFeatherlessStats, syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
 
 export {
     openai_messages_count,
@@ -199,6 +201,7 @@ export const chat_completion_sources = {
     SILICONFLOW: 'siliconflow',
     WORKERS_AI: 'workers_ai',
     MINIMAX: 'minimax',
+    FEATHERLESS: 'featherless',
 };
 
 const character_names_behavior = {
@@ -333,6 +336,7 @@ export const settingsToUpdate = {
     minimax_model: ['#model_minimax_select', 'minimax_model', false, true],
     minimax_endpoint: ['#minimax_endpoint', 'minimax_endpoint', false, true],
     electronhub_model: ['#model_electronhub_select', 'electronhub_model', false, true],
+    featherless_model: ['#model_featherless_chat_select', 'featherless_model', false, true],
     nanogpt_model: ['#model_nanogpt_select', 'nanogpt_model', false, true],
     nanogpt_provider: ['#nanogpt_provider', 'nanogpt_provider', false, true],
     nanogpt_payg_override: ['#nanogpt_payg_override', 'nanogpt_payg_override', true, true],
@@ -450,6 +454,7 @@ const default_settings = {
     minimax_model: 'MiniMax-M2.7',
     minimax_endpoint: MINIMAX_ENDPOINT.GLOBAL,
     electronhub_model: 'gpt-4o-mini',
+    featherless_model: 'TheDrummer/Rocinante-X-12B-v1',
     nanogpt_model: 'gpt-4o-mini',
     nanogpt_provider: '',
     nanogpt_payg_override: false,
@@ -1758,6 +1763,8 @@ export function getChatCompletionModel(settings = null) {
             return settings.zai_model;
         case chat_completion_sources.WORKERS_AI:
             return settings.workers_ai_model;
+        case chat_completion_sources.FEATHERLESS:
+            return settings.featherless_model;
         default:
             console.error(`Unknown chat completion source: ${source}`);
             return '';
@@ -2132,6 +2139,10 @@ function saveModelList(data) {
         $('#model_electronhub_select').val(oai_settings.electronhub_model).trigger('change');
     }
 
+    if (oai_settings.chat_completion_source === chat_completion_sources.FEATHERLESS) {
+        loadFeatherlessChatModels(model_list);
+    }
+
     if (oai_settings.chat_completion_source == chat_completion_sources.CHUTES) {
         model_list = model_list.filter(model => typeof model.id === 'string' && !model.id.toLowerCase().includes('affine'));
         model_list = sortModelsBy(model_list, oai_settings.sort_models, chat_completion_sources.CHUTES);
@@ -2388,6 +2399,236 @@ function saveModelList(data) {
         }
 
         $('#model_moonshot_select').val(oai_settings.moonshot_model).trigger('change');
+    }
+}
+
+let featherlessChatCurrentPage = 1;
+
+/**
+ * Commits a Featherless model selection made from the card browser.
+ * Mirrors the Text Completion behavior: stores the setting and drives the
+ * hidden select that backs the connection profile and change handler.
+ * @param {string} modelId - The selected model id
+ */
+function onFeatherlessChatModelSelect(modelId) {
+    oai_settings.featherless_model = modelId;
+    $('#model_featherless_chat_select').val(modelId).trigger('change');
+}
+
+/**
+ * Renders the Featherless Chat Completion model browser (search, filters,
+ * sorting and client-side pagination). Ported from loadFeatherlessModels in
+ * textgen-models.js, adapted to oai_settings and the chat-prefixed element ids.
+ * @param {object[]} data - Array of Featherless model objects from /v1/models
+ */
+function loadFeatherlessChatModels(data) {
+    const searchBar = document.getElementById('featherless_chat_model_search_bar');
+    const modelCardBlock = document.getElementById('featherless_chat_model_card_block');
+    const paginationContainer = $('#featherless_chat_model_pagination_container');
+    const sortOrderSelect = document.getElementById('featherless_chat_model_sort_order');
+    const classSelect = document.getElementById('featherless_chat_class_selection');
+    const categoriesSelect = document.getElementById('featherless_chat_category_selection');
+    const storageKey = 'FeatherlessChatModels_PerPage';
+
+    if (!Array.isArray(data)) {
+        console.error('Invalid Featherless models data', data);
+        return;
+    }
+
+    const originalModels = data;
+
+    if (!data.find(x => x.id === oai_settings.featherless_model)) {
+        oai_settings.featherless_model = data[0]?.id || '';
+    }
+
+    // Populate the hidden select that backs the setting and the change handler
+    $('#model_featherless_chat_select').empty();
+    for (const model of data) {
+        $('#model_featherless_chat_select').append($('<option>', { value: model.id, text: model.id }));
+    }
+    $('#model_featherless_chat_select').val(oai_settings.featherless_model).trigger('change');
+
+    // Populate class select options with unique classes
+    populateClassSelection(data);
+
+    // Retrieve the stored number of items per page or default to 10
+    const perPage = Number(accountStorage.getItem(storageKey)) || 10;
+
+    // Initialize pagination
+    applyFiltersAndSort();
+
+    // Function to set up pagination (also used for filtered results)
+    function setupPagination(models, perPage, pageNumber = featherlessChatCurrentPage) {
+        paginationContainer.pagination({
+            dataSource: models,
+            pageSize: perPage,
+            pageNumber: pageNumber,
+            sizeChangerOptions: [6, 10, 26, 50, 100, 250, 500, 1000],
+            pageRange: 1,
+            showPageNumbers: true,
+            showSizeChanger: false,
+            prevText: '<',
+            nextText: '>',
+            formatNavigator: PAGINATION_TEMPLATE,
+            showNavigator: true,
+            callback: function (modelsOnPage, pagination) {
+                modelCardBlock.innerHTML = '';
+
+                modelsOnPage.forEach(model => {
+                    const card = document.createElement('div');
+                    card.classList.add('model-card');
+
+                    const modelNameContainer = document.createElement('div');
+                    modelNameContainer.classList.add('model-name-container');
+
+                    const modelTitle = document.createElement('div');
+                    modelTitle.classList.add('model-title');
+                    modelTitle.textContent = model.id.replace(/_/g, '_\u200B');
+                    modelNameContainer.appendChild(modelTitle);
+
+                    const detailsContainer = document.createElement('div');
+                    detailsContainer.classList.add('details-container');
+
+                    const modelClassDiv = document.createElement('div');
+                    modelClassDiv.classList.add('model-class');
+                    modelClassDiv.textContent = t`Class` + `: ${model.model_class || 'N/A'}`;
+
+                    const contextLengthDiv = document.createElement('div');
+                    contextLengthDiv.classList.add('model-context-length');
+                    contextLengthDiv.textContent = t`Context Length` + `: ${model.context_length}`;
+
+                    const dateAddedDiv = document.createElement('div');
+                    dateAddedDiv.classList.add('model-date-added');
+                    dateAddedDiv.textContent = t`Added On` + `: ${new Date(model.created * 1000).toLocaleDateString()}`;
+
+                    detailsContainer.appendChild(modelClassDiv);
+                    detailsContainer.appendChild(contextLengthDiv);
+                    detailsContainer.appendChild(dateAddedDiv);
+
+                    card.appendChild(modelNameContainer);
+                    card.appendChild(detailsContainer);
+
+                    modelCardBlock.appendChild(card);
+
+                    if (model.id === oai_settings.featherless_model) {
+                        card.classList.add('selected');
+                    }
+
+                    card.addEventListener('click', function () {
+                        modelCardBlock.querySelectorAll('.model-card').forEach(c => c.classList.remove('selected'));
+                        card.classList.add('selected');
+                        onFeatherlessChatModelSelect(model.id);
+                    });
+                });
+
+                // Update the current page value whenever the page changes
+                featherlessChatCurrentPage = pagination.pageNumber;
+                localizePagination(paginationContainer);
+            },
+            afterSizeSelectorChange: function (e) {
+                const newPerPage = e.target.value;
+                accountStorage.setItem(storageKey, newPerPage);
+                setupPagination(models, Number(newPerPage), featherlessChatCurrentPage); // Use the stored current page number
+            },
+        });
+    }
+
+    // Unset previously added listeners
+    $(searchBar).off('input');
+    $(sortOrderSelect).off('change');
+    $(classSelect).off('change');
+    $(categoriesSelect).off('change');
+
+    // Add event listener for input on the search bar
+    searchBar.addEventListener('input', function () {
+        applyFiltersAndSort();
+    });
+
+    // Add event listener for the sort order select
+    sortOrderSelect.addEventListener('change', function () {
+        applyFiltersAndSort();
+    });
+
+    // Add event listener for the class select
+    classSelect.addEventListener('change', function () {
+        applyFiltersAndSort();
+    });
+
+    categoriesSelect.addEventListener('change', function () {
+        applyFiltersAndSort();
+    });
+
+    // Function to populate class selection dropdown
+    function populateClassSelection(models) {
+        // Clear out stale options from a previous load, keeping the default "All Classes"
+        $(classSelect).find('option:not([value=""])').remove();
+        const uniqueClasses = [...new Set(models.map(model => model.model_class).filter(Boolean))]; // Get unique class names
+        uniqueClasses.sort((a, b) => a.localeCompare(b));
+        uniqueClasses.forEach(className => {
+            const option = document.createElement('option');
+            option.value = className;
+            option.textContent = className;
+            classSelect.appendChild(option);
+        });
+    }
+
+    // Function to apply sorting and filtering based on user input
+    async function applyFiltersAndSort() {
+        if (!(searchBar instanceof HTMLInputElement) ||
+            !(sortOrderSelect instanceof HTMLSelectElement) ||
+            !(classSelect instanceof HTMLSelectElement) ||
+            !(categoriesSelect instanceof HTMLSelectElement)) {
+            return;
+        }
+        const searchQuery = searchBar.value.toLowerCase();
+        const selectedSortOrder = sortOrderSelect.value;
+        const selectedClass = classSelect.value;
+        const selectedCategory = categoriesSelect.value;
+        let featherlessTop = [];
+        let featherlessNew = [];
+
+        if (selectedCategory === 'Top') {
+            featherlessTop = await fetchFeatherlessStats();
+        }
+        const featherlessIds = featherlessTop.map(stat => stat.id);
+
+        if (selectedCategory === 'New') {
+            featherlessNew = await fetchFeatherlessNew();
+        }
+        const featherlessNewIds = featherlessNew.map(stat => stat.id);
+
+        let filteredModels = originalModels.filter(model => {
+            const matchesSearch = model.id.toLowerCase().includes(searchQuery);
+            const matchesClass = selectedClass ? model.model_class === selectedClass : true;
+            const matchesTop = featherlessIds.includes(model.id);
+            const matchesNew = featherlessNewIds.includes(model.id);
+
+            if (selectedCategory === 'All') {
+                return matchesSearch && matchesClass;
+            } else if (selectedCategory === 'Top') {
+                return matchesSearch && matchesClass && matchesTop;
+            } else if (selectedCategory === 'New') {
+                return matchesSearch && matchesClass && matchesNew;
+            } else {
+                return matchesSearch && matchesClass;
+            }
+        });
+
+        if (selectedSortOrder === 'asc') {
+            filteredModels.sort((a, b) => a.id.localeCompare(b.id));
+        } else if (selectedSortOrder === 'desc') {
+            filteredModels.sort((a, b) => b.id.localeCompare(a.id));
+        } else if (selectedSortOrder === 'date_asc') {
+            filteredModels.sort((a, b) => a.created - b.created);
+        } else if (selectedSortOrder === 'date_desc') {
+            filteredModels.sort((a, b) => b.created - a.created);
+        }
+
+        const currentPerPage = Number(accountStorage.getItem(storageKey)) || perPage;
+        const currentModelIndex = filteredModels.findIndex(x => x.id === oai_settings.featherless_model);
+        featherlessChatCurrentPage = currentModelIndex >= 0 ? Math.floor(currentModelIndex / currentPerPage) + 1 : 1;
+
+        setupPagination(filteredModels, currentPerPage, featherlessChatCurrentPage);
     }
 }
 
@@ -2954,6 +3195,16 @@ export async function createGenerationParameters(settings, model, type, messages
         if (Number.isFinite(generate_data.temperature)) {
             generate_data.temperature = clamp(generate_data.temperature, Number.EPSILON, 1.0);
         }
+    }
+
+    if (settings.chat_completion_source === chat_completion_sources.FEATHERLESS) {
+        generate_data.top_k = settings.top_k_openai > 0 ? Number(settings.top_k_openai) : undefined;
+        generate_data.repetition_penalty = Number(settings.repetition_penalty_openai);
+        generate_data.frequency_penalty = Number(settings.freq_pen_openai);
+        generate_data.seed = settings.seed >= 1 ? Number(settings.seed) : undefined;
+        generate_data.top_p = clamp(Number(settings.top_p_openai), 0.001, 1.0);
+        generate_data.stop = getCustomStoppingStrings();
+        generate_data.min_p = clamp(Number(settings.min_p_openai), 0, 1.0);
     }
 
     if (settings.chat_completion_source === chat_completion_sources.WORKERS_AI) {
@@ -5473,6 +5724,15 @@ async function onModelChange() {
         oai_settings.electronhub_model = value;
     }
 
+    if ($(this).is('#model_featherless_chat_select')) {
+        if (!value || !hasModelsLoaded) {
+            console.debug('Null Featherless model selected. Ignoring.');
+            return;
+        }
+        console.log('Featherless model changed to', value);
+        oai_settings.featherless_model = value;
+    }
+
     if ($(this).is('#model_chutes_select')) {
         if (!value || !hasModelsLoaded) {
             console.debug('Null Chutes model selected. Ignoring.');
@@ -5614,6 +5874,24 @@ async function onModelChange() {
         }
 
         calculateOpenRouterCost();
+    }
+
+    if (oai_settings.chat_completion_source == chat_completion_sources.FEATHERLESS) {
+        if (oai_settings.max_context_unlocked) {
+            $('#openai_max_context').attr('max', unlocked_max);
+        } else {
+            const model = model_list.find(m => m.id == oai_settings.featherless_model);
+            if (model?.context_length) {
+                $('#openai_max_context').attr('max', model.context_length);
+            } else {
+                $('#openai_max_context').attr('max', max_128k);
+            }
+        }
+        oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
+        $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
+
+        oai_settings.temp_openai = Math.min(oai_max_temp, oai_settings.temp_openai);
+        $('#temp_openai').attr('max', oai_max_temp).val(oai_settings.temp_openai).trigger('input');
     }
 
     if (oai_settings.chat_completion_source == chat_completion_sources.CLAUDE) {
@@ -5952,6 +6230,7 @@ async function onConnectButtonClick(e) {
         [chat_completion_sources.POLLINATIONS]: { key: SECRET_KEYS.POLLINATIONS, selector: '#api_key_pollinations', proxy: false, keyless: oai_settings.pollinations_endpoint === POLLINATIONS_ENDPOINT.ANONYMOUS },
         [chat_completion_sources.WORKERS_AI]: { key: SECRET_KEYS.WORKERS_AI, selector: '#api_key_workers_ai', proxy: false },
         [chat_completion_sources.MINIMAX]: { key: SECRET_KEYS.MINIMAX, selector: '#api_key_minimax', proxy: false },
+        [chat_completion_sources.FEATHERLESS]: { key: SECRET_KEYS.FEATHERLESS, selector: '#api_key_featherless', proxy: false },
     };
 
     // Vertex AI Express version - use API key
@@ -6046,6 +6325,8 @@ function toggleChatCompletionForms() {
         $('#model_zai_select').trigger('change');
     } else if (oai_settings.chat_completion_source == chat_completion_sources.WORKERS_AI) {
         $('#model_workers_ai_select').trigger('change');
+    } else if (oai_settings.chat_completion_source == chat_completion_sources.FEATHERLESS) {
+        $('#model_featherless_chat_select').trigger('change');
     }
 
     $('[data-source]').each(function () {
@@ -6654,6 +6935,25 @@ export function initOpenAI() {
 
     $('#test_api_button').on('click', testApiConnection);
 
+    // Featherless Chat Completion model browser: grid/list view toggle
+    const featherlessChatCardBlock = document.getElementById('featherless_chat_model_card_block');
+    if (featherlessChatCardBlock) {
+        featherlessChatCardBlock.classList.add('list-view');
+        let isGridView = false;
+        document.getElementById('featherless_chat_model_grid_toggle')?.addEventListener('click', function () {
+            if (isGridView) {
+                featherlessChatCardBlock.classList.remove('grid-view');
+                featherlessChatCardBlock.classList.add('list-view');
+                this.title = 'Toggle to grid view';
+            } else {
+                featherlessChatCardBlock.classList.remove('list-view');
+                featherlessChatCardBlock.classList.add('grid-view');
+                this.title = 'Toggle to list view';
+            }
+            isGridView = !isGridView;
+        });
+    }
+
     $('#temp_openai').on('input', function () {
         oai_settings.temp_openai = Number($(this).val());
         $('#temp_counter_openai').val(Number($(this).val()).toFixed(2));
@@ -7240,6 +7540,7 @@ export function initOpenAI() {
     $('#model_siliconflow_select').on('change', onModelChange);
     $('#model_minimax_select').on('change', onModelChange);
     $('#model_electronhub_select').on('change', onModelChange);
+    $('#model_featherless_chat_select').on('change', onModelChange);
     $('#model_nanogpt_select').on('change', onModelChange);
     $('#model_deepseek_select').on('change', onModelChange);
     $('#model_aimlapi_select').on('change', onModelChange);

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -6265,6 +6265,7 @@ function getModelOptions(quiet) {
         { id: 'model_siliconflow_select', api: 'openai', type: chat_completion_sources.SILICONFLOW },
         { id: 'model_minimax_select', api: 'openai', type: chat_completion_sources.MINIMAX },
         { id: 'model_electronhub_select', api: 'openai', type: chat_completion_sources.ELECTRONHUB },
+        { id: 'model_featherless_chat_select', api: 'openai', type: chat_completion_sources.FEATHERLESS },
         { id: 'model_nanogpt_select', api: 'openai', type: chat_completion_sources.NANOGPT },
         { id: 'model_deepseek_select', api: 'openai', type: chat_completion_sources.DEEPSEEK },
         { id: 'model_aimlapi_select', api: 'openai', type: chat_completion_sources.AIMLAPI },

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -929,10 +929,11 @@ export async function loadFeatherlessModels(data) {
             filteredModels.sort((a, b) => b.created - a.created);
         }
 
+        const currentPerPage = Number(accountStorage.getItem(storageKey)) || perPage;
         const currentModelIndex = filteredModels.findIndex(x => x.id === textgen_settings.featherless_model);
-        featherlessCurrentPage = currentModelIndex >= 0 ? (currentModelIndex / perPage) + 1 : 1;
+        featherlessCurrentPage = currentModelIndex >= 0 ? Math.floor(currentModelIndex / currentPerPage) + 1 : 1;
 
-        setupPagination(filteredModels, Number(accountStorage.getItem(storageKey)) || perPage, featherlessCurrentPage);
+        setupPagination(filteredModels, currentPerPage, featherlessCurrentPage);
     }
 
     // Required to keep the /model command function
@@ -946,13 +947,13 @@ export async function loadFeatherlessModels(data) {
     }
 }
 
-async function fetchFeatherlessStats() {
+export async function fetchFeatherlessStats() {
     const response = await fetch('https://api.featherless.ai/feather/popular');
     const data = await response.json();
     return data.popular;
 }
 
-async function fetchFeatherlessNew() {
+export async function fetchFeatherlessNew() {
     const response = await fetch('https://api.featherless.ai/feather/models?sort=-created_at&perPage=20');
     const data = await response.json();
     return data.items;

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -1104,7 +1104,7 @@ export function initTextGenSettings() {
             { id: 'api_key_openrouter-tg', secret: SECRET_KEYS.OPENROUTER },
             { id: 'api_key_koboldcpp', secret: SECRET_KEYS.KOBOLDCPP },
             { id: 'api_key_llamacpp', secret: SECRET_KEYS.LLAMACPP },
-            { id: 'api_key_featherless', secret: SECRET_KEYS.FEATHERLESS },
+            { id: 'api_key_featherless-tg', secret: SECRET_KEYS.FEATHERLESS },
             { id: 'api_key_huggingface', secret: SECRET_KEYS.HUGGINGFACE },
             { id: 'api_key_generic', secret: SECRET_KEYS.GENERIC },
         ];

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -699,6 +699,28 @@ export function getTokenizerModel() {
         return 'gpt-3.5-turbo';
     }
 
+    if (oai_settings.chat_completion_source == chat_completion_sources.FEATHERLESS && oai_settings.featherless_model) {
+        const model = oai_settings.featherless_model.toLowerCase();
+
+        if (model.includes('deepseek')) {
+            return deepseekTokenizer;
+        } else if (model.includes('qwen') || model.includes('qwq') || model.includes('kimi')) {
+            return qwen2Tokenizer;
+        } else if (model.includes('llama-3') || model.includes('llama3') || model.includes('llama-4')) {
+            return llama3Tokenizer;
+        } else if (model.includes('llama')) {
+            return llamaTokenizer;
+        } else if (model.includes('gemma')) {
+            return gemmaTokenizer;
+        } else if (model.includes('nemo')) {
+            return nemoTokenizer;
+        } else if (model.includes('mistral')) {
+            return mistralTokenizer;
+        } else if (model.includes('gpt-oss')) {
+            return gpt4oTokenizer;
+        }
+    }
+
     if (oai_settings.chat_completion_source == chat_completion_sources.WORKERS_AI && oai_settings.workers_ai_model) {
         const model = oai_settings.workers_ai_model.toLowerCase();
 

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -668,6 +668,7 @@ export class ToolManager {
             chat_completion_sources.NANOGPT,
             chat_completion_sources.WORKERS_AI,
             chat_completion_sources.MINIMAX,
+            chat_completion_sources.FEATHERLESS,
         ];
         return supportedSources.includes(settings.chat_completion_source);
     }

--- a/public/style.css
+++ b/public/style.css
@@ -6262,11 +6262,13 @@ body:not(.movingUI) .drawer-content.maximized {
     margin-bottom: 5px;
 }
 
-#featherless_model_pagination_container .paginationjs-nav {
+#featherless_model_pagination_container .paginationjs-nav,
+#featherless_chat_model_pagination_container .paginationjs-nav {
     min-width: max-content;
 }
 
-#featherless_model_card_block.grid-view {
+#featherless_model_card_block.grid-view,
+#featherless_chat_model_card_block.grid-view {
     grid-template-columns: repeat(2, 1fr);
     display: flex;
     flex-wrap: wrap;
@@ -6275,31 +6277,37 @@ body:not(.movingUI) .drawer-content.maximized {
 }
 
 /* Grid-view card */
-#featherless_model_card_block.grid-view .model-card {
+#featherless_model_card_block.grid-view .model-card,
+#featherless_chat_model_card_block.grid-view .model-card {
     flex-direction: column;
     flex: 1 1 calc(50% - 30px);
 }
 
-#featherless_model_search_bar {
+#featherless_model_search_bar,
+#featherless_chat_model_search_bar {
     width: 15ch;
     flex-grow: 0;
     align-self: center;
 }
 
-#featherless_model_sort_order {
+#featherless_model_sort_order,
+#featherless_chat_model_sort_order {
     width: auto;
     flex-shrink: 0;
     align-self: center;
 }
 
-#featherless_model_grid_toggle {
+#featherless_model_grid_toggle,
+#featherless_chat_model_grid_toggle {
     flex-shrink: 0;
     width: auto;
     cursor: pointer;
 }
 
 #featherless_category_selection,
-#featherless_class_selection {
+#featherless_class_selection,
+#featherless_chat_category_selection,
+#featherless_chat_class_selection {
     display: flex;
     width: auto;
     align-self: center;
@@ -6318,7 +6326,8 @@ body:not(.movingUI) .drawer-content.maximized {
         text-align: left;
     }
 
-    #featherless_model_search_bar {
+    #featherless_model_search_bar,
+    #featherless_chat_model_search_bar {
         flex: 1;
         flex-basis: 100%;
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -211,6 +211,7 @@ export const CHAT_COMPLETION_SOURCES = {
     SILICONFLOW: 'siliconflow',
     MINIMAX: 'minimax',
     WORKERS_AI: 'workers_ai',
+    FEATHERLESS: 'featherless',
 };
 
 /**

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -9,6 +9,7 @@ import {
     AIMLAPI_HEADERS,
     AZURE_OPENAI_KEYS,
     CHAT_COMPLETION_SOURCES,
+    FEATHERLESS_HEADERS,
     GEMINI_SAFETY,
     NANOGPT_REASONING_EFFORT_MAP,
     OPENAI_FIXED_REASONING_EFFORT,
@@ -79,6 +80,7 @@ const API_VERTEX_AI = 'https://us-central1-aiplatform.googleapis.com';
 const API_AI21 = 'https://api.ai21.com/studio/v1';
 const API_CHUTES = 'https://llm.chutes.ai/v1';
 const API_ELECTRONHUB = 'https://api.electronhub.ai/v1';
+const API_FEATHERLESS = 'https://api.featherless.ai/v1';
 const API_NANOGPT = 'https://nano-gpt.com/api/v1';
 const API_DEEPSEEK = 'https://api.deepseek.com/beta';
 const API_XAI = 'https://api.x.ai/v1';
@@ -1773,6 +1775,10 @@ router.post('/status', async function (request, statusResponse) {
             apiUrl = API_ELECTRONHUB;
             apiKey = readSecret(request.user.directories, SECRET_KEYS.ELECTRONHUB, request.body.secret_id);
             headers = {};
+        } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.FEATHERLESS) {
+            apiUrl = API_FEATHERLESS;
+            apiKey = readSecret(request.user.directories, SECRET_KEYS.FEATHERLESS, request.body.secret_id);
+            headers = { ...FEATHERLESS_HEADERS };
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.NANOGPT) {
             apiUrl = API_NANOGPT;
             apiKey = readSecret(request.user.directories, SECRET_KEYS.NANOGPT, request.body.secret_id);
@@ -2380,6 +2386,11 @@ router.post('/generate', async function (request, response) {
                     },
                 };
             }
+        } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.FEATHERLESS) {
+            apiUrl = API_FEATHERLESS;
+            apiKey = readSecret(request.user.directories, SECRET_KEYS.FEATHERLESS, request.body.secret_id);
+            headers = { ...FEATHERLESS_HEADERS };
+            bodyParams = {};
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.NANOGPT) {
             apiUrl = API_NANOGPT;
             apiKey = readSecret(request.user.directories, SECRET_KEYS.NANOGPT, request.body.secret_id);


### PR DESCRIPTION
### Summary

Featherless recommends that clients use its **chat completion** endpoint. This adds a Featherless Chat Completion source (the previous text-completion path is marked deprecated), with a full model-selection UX and several correctness fixes.

This branch builds on and supersedes #5654 (the original submission), so it includes those commits plus the additions below.

### What's included

**Chat Completion model browser** — ported from the existing text-completion Featherless UI
- Search, model-class filter, Top/New/All category filters, and A–Z / date sorting
- Client-side pagination with a selectable page size, plus a grid/list view toggle
- Replaces the bare `<select>` that dumped every model in unfiltered (unusable with Featherless's catalog size)

**Integration fixes**
- Require an API key on connect — drop `keyless: true`, which let users "connect" with no key and only fail later at generation time
- Remove the dangling `featherless_endpoint` connection-profile mapping (no setting, UI, or custom-request field ever backed it)
- Add a Featherless tokenizer case so token counts use the correct per-model tokenizer instead of the coarse OpenAI estimate
- Drop Featherless from the media-inlining source lists — `isImageInliningSupported()` has no Featherless case, so the checkbox was inert

### Notes
- Both the chat- and text-completion paths hit the same `https://api.featherless.ai/v1/models` endpoint, so the model objects (`model_class`, `context_length`, `created`) render identically — no backend/model-shape changes needed for the browser.
- Supersedes #5654; happy to rebase or squash authorship however maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
