### PR TITLE
Openrouter: Enable logprobs if requested by user

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2699,6 +2699,7 @@ export async function createGenerationParameters(settings, model, type, messages
     const logprobsSupportedSources = [
         chat_completion_sources.OPENAI,
         chat_completion_sources.AZURE_OPENAI,
+        chat_completion_sources.OPENROUTER,
         chat_completion_sources.CUSTOM,
         chat_completion_sources.DEEPSEEK,
         chat_completion_sources.XAI,
@@ -3240,6 +3241,7 @@ function parseChatCompletionLogprobs(data) {
                 : parseOpenAITextLogprobs(data.choices[0]?.logprobs);
         case chat_completion_sources.OPENAI:
         case chat_completion_sources.AZURE_OPENAI:
+        case chat_completion_sources.OPENROUTER:
         case chat_completion_sources.DEEPSEEK:
         case chat_completion_sources.XAI:
         case chat_completion_sources.CUSTOM:

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2230,6 +2230,11 @@ router.post('/generate', async function (request, response) {
                 },
             };
 
+            if (request.body.logprobs > 0) {
+                bodyParams['top_logprobs'] = request.body.logprobs;
+                bodyParams['logprobs'] = true;
+            }
+
             if (request.body.min_p !== undefined) {
                 bodyParams['min_p'] = request.body.min_p;
             }


### PR DESCRIPTION
Hello Everyone,
This adds logprob support to openrouter. It is treated equivalently to the OpenAI API.

Note, not all providers support this, some will not return logprobs.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
