### PR TITLE
Optimize World Info entry sorting to avoid O(n^2) lookups

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4991,14 +4991,19 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
         console.debug(`[WI] Search done. Found ${activatedNow.size} possible entries.`);
 
         // Sort the entries for the probability and the budget limit checks
-        const sortedEntriesIndex = new Map(sortedEntries.map((entry, index) => [entry, index]));
-        const newEntries = [...activatedNow]
-            .sort((a, b) => {
-                const isASticky = timedEffects.isEffectActive('sticky', a) ? 1 : 0;
-                const isBSticky = timedEffects.isEffectActive('sticky', b) ? 1 : 0;
-                return isBSticky - isASticky
-                    || (sortedEntriesIndex.get(a) ?? -1) - (sortedEntriesIndex.get(b) ?? -1);
-            });
+        let newEntries;
+        if (activatedNow.size > 1) {
+            const sortedEntriesIndex = new Map(sortedEntries.map((entry, index) => [entry, index]));
+            newEntries = [...activatedNow]
+                .sort((a, b) => {
+                    const isASticky = timedEffects.isEffectActive('sticky', a) ? 1 : 0;
+                    const isBSticky = timedEffects.isEffectActive('sticky', b) ? 1 : 0;
+                    return isBSticky - isASticky
+                        || (sortedEntriesIndex.get(a) ?? -1) - (sortedEntriesIndex.get(b) ?? -1);
+                });
+        } else {
+            newEntries = [...activatedNow];
+        }
 
 
         let newContent = '';

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4742,7 +4742,6 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
     console.debug(`[WI] Context size: ${maxContext}; WI budget: ${budget} (max% = ${world_info_budget}%, cap = ${world_info_budget_cap})`);
     const sortedEntries = await getSortedEntries();
-    const sortedEntriesIndex = new Map(sortedEntries.map((entry, index) => [entry, index]));
     const timedEffects = new WorldInfoTimedEffects(chat, sortedEntries, isDryRun);
 
     timedEffects.checkTimedEffects();
@@ -4992,11 +4991,13 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
         console.debug(`[WI] Search done. Found ${activatedNow.size} possible entries.`);
 
         // Sort the entries for the probability and the budget limit checks
+        const sortedEntriesIndex = new Map(sortedEntries.map((entry, index) => [entry, index]));
         const newEntries = [...activatedNow]
             .sort((a, b) => {
                 const isASticky = timedEffects.isEffectActive('sticky', a) ? 1 : 0;
                 const isBSticky = timedEffects.isEffectActive('sticky', b) ? 1 : 0;
-                return isBSticky - isASticky || sortedEntriesIndex.get(a) - sortedEntriesIndex.get(b);
+                return isBSticky - isASticky
+                    || (sortedEntriesIndex.get(a) ?? -1) - (sortedEntriesIndex.get(b) ?? -1);
             });
 
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -4742,6 +4742,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
 
     console.debug(`[WI] Context size: ${maxContext}; WI budget: ${budget} (max% = ${world_info_budget}%, cap = ${world_info_budget_cap})`);
     const sortedEntries = await getSortedEntries();
+    const sortedEntriesIndex = new Map(sortedEntries.map((entry, index) => [entry, index]));
     const timedEffects = new WorldInfoTimedEffects(chat, sortedEntries, isDryRun);
 
     timedEffects.checkTimedEffects();
@@ -4995,7 +4996,7 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
             .sort((a, b) => {
                 const isASticky = timedEffects.isEffectActive('sticky', a) ? 1 : 0;
                 const isBSticky = timedEffects.isEffectActive('sticky', b) ? 1 : 0;
-                return isBSticky - isASticky || sortedEntries.indexOf(a) - sortedEntries.indexOf(b);
+                return isBSticky - isASticky || sortedEntriesIndex.get(a) - sortedEntriesIndex.get(b);
             });
 
 


### PR DESCRIPTION
### What is the reason for a change?

In `checkWorldInfo`, the comparator used to sort activated entries called `sortedEntries.indexOf()` twice per comparison. Since `indexOf` is O(n), the sort degrades to O(n² log n). With large lorebooks where many entries activate during a generation, this adds avoidable CPU work on a hot path that runs on every generation (and every recursion step).

### What did you do to achieve this?

Build a `Map<entry, index>` once, right after `sortedEntries` is created, and look up the stored index in the comparator instead of scanning the array. This brings the sort back to O(n log n). Entry references are stable within the scan, so the map keys are valid, and the resulting sort order is identical to before.

### How would a reviewer test the change?

- Load a World Info book with many entries and keys so that a large number of entries activate during generation.
- Trigger generation and confirm the set of activated entries and their ordering is unchanged from before the patch.
- Optionally observe the `[WI]` debug timings to confirm reduced scan time on large books.
