### PR TITLE
Fix streaming tool-call delta merge corrupting non-chunked string fields

### DIFF
--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -580,10 +580,15 @@ export class ToolManager {
             }
 
             if (typeof deltaValue === 'string') {
-                if (typeof targetValue === 'string') {
-                    // Concatenate strings
-                    target[key] = targetValue + deltaValue;
-                } else {
+                if (key === 'arguments') {
+                    // Only `arguments` streams incrementally across chunks and must be concatenated.
+                    target[key] = (typeof targetValue === 'string' ? targetValue : '') + deltaValue;
+                } else if (deltaValue || typeof targetValue !== 'string') {
+                    // Other string fields (id, type, name, ...) are sent whole per chunk, not
+                    // incrementally. Blindly concatenating them corrupts them when a backend
+                    // resends the same value on every delta (e.g. type: 'function' becomes
+                    // 'functionfunctionfunction...'), which then fails strict equality checks
+                    // elsewhere and silently drops the tool call.
                     target[key] = deltaValue;
                 }
             } else if (typeof deltaValue === 'object' && !Array.isArray(deltaValue)) {


### PR DESCRIPTION
## Summary
`ToolManager.#applyToolCallDelta()` blindly concatenates every string field on a streamed `tool_call` delta. That's correct for `arguments`, which legitimately streams incrementally across SSE chunks, but wrong for fields like `type` and `id` that some backends/proxies resend unchanged on every delta instead of sending once.

When that happens, a field like `type: "function"` gets concatenated with itself on every chunk into garbage (e.g. `"functionfunctionfunctionfunction..."`). Since `ToolManager` checks `type === 'function'` before invoking a registered tool, the corrupted value silently fails that check — the tool call is dropped with **zero invocations and zero errors**. Nothing is thrown, nothing is logged; the failure is entirely client-side and easy to miss, since it doesn't show up in any server-side inspection of the raw API request/response.

I ran into this while debugging why a SillyTavern extension's function-tool calls never executed. Confirmed via browser console:
```
[ToolManager] Function tool call: {index: 0, id: 'chatcmpl-tool-b6ade9...b6ade92666f562dc', type: 'functionfunctionfunction...function', function: {…}}
[ToolManager] Function tool result: {invocations: Array(0), errors: Array(0), stealthCalls: Array(0)}
```

## Fix
Only concatenate the `arguments` field. Other string fields take the latest non-empty delta value instead of accumulating, which matches how OpenAI-style streaming APIs actually send these fields (whole, not chunked) while still tolerating a backend that resends them unchanged on every delta.

## Test plan
- [x] `node --check` passes on the modified file
- [x] Confirmed the corrupted-`type` failure mode via live browser console logs before the fix
- [ ] Would appreciate a maintainer or another reporter confirming against a backend known to trigger this (mine was reached via an OpenAI-compatible proxy in front of a GLM model)