### PR TITLE
change novelai user information to be called from image.novelai.net

### DIFF
--- a/src/endpoints/novelai.js
+++ b/src/endpoints/novelai.js
@@ -140,7 +140,7 @@ router.post('/status', async function (req, res) {
     }
 
     try {
-        const response = await fetch(API_NOVELAI + '/user/subscription', {
+        const response = await fetch(IMAGE_NOVELAI + '/user/subscription', {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
"for 3rd party API customers: GET /user/information, GET /user/data, GET /user/subscription should now be called from https://image.novelai.net. The old URL will be non-functional in a couple of hours. The old URL is currently non-functional."

from NAI devs, this change has already been implemented from NAI side, no backward compat.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
