### PR TITLE
Update TTS model from Gemini 2.5 to 3.1 in TTS Extension (#5778)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3951,6 +3951,7 @@
                             </select>
                             <h4 data-i18n="Z.AI Model">Z.AI Model</h4>
                             <select id="model_zai_select">
+                                <option value="glm-5.2">glm-5.2</option>
                                 <option value="glm-5-turbo">glm-5-turbo</option>
                                 <option value="glm-5v-turbo">glm-5v-turbo</option>
                                 <option value="glm-5.1">glm-5.1</option>

--- a/public/scripts/extensions/tts/google-native.js
+++ b/public/scripts/extensions/tts/google-native.js
@@ -12,7 +12,7 @@ export class GoogleNativeTtsProvider {
 
     defaultSettings = {
         voiceMap: {},
-        model: 'gemini-2.5-flash-preview-tts',
+        model: 'gemini-3.1-flash-tts-preview',
         apiType: 'makersuite',
     };
 
@@ -32,6 +32,7 @@ export class GoogleNativeTtsProvider {
                 <select id="google-tts-model">
                     <option value="gemini-2.5-flash-preview-tts">Gemini 2.5 Flash Preview TTS</option>
                     <option value="gemini-2.5-pro-preview-tts">Gemini 2.5 Pro Preview TTS</option>
+                    <option value="gemini-3.1-flash-tts-preview">Gemini 3.1 Flash TTS Preview</option>
                 </select>
             </div>
         </div>`;


### PR DESCRIPTION
Merging my fuck-up merge from here to staging... #5778

-----

* Update TTS model from Gemini 2.5 to 3.1 in TTS Extension

Added New versions and new Default model

* Add glm-5.2 option to model selection dropdown

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
