### PR TITLE
Fireworks AI: Set session affinity header for improved caching

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -14,6 +14,7 @@ import {
     extension_prompt_roles,
     extension_prompt_types,
     Generate,
+    getCurrentChatId,
     getExtensionPrompt,
     getExtensionPromptMaxDepth,
     getMediaDisplay,
@@ -2865,6 +2866,10 @@ export async function createGenerationParameters(settings, model, type, messages
     if (settings.chat_completion_source === chat_completion_sources.NANOGPT) {
         generate_data.nanogpt_provider = settings.nanogpt_provider;
         generate_data.nanogpt_payg_override = settings.nanogpt_payg_override;
+    }
+
+    if (settings.chat_completion_source === chat_completion_sources.FIREWORKS && type !== 'quiet') {
+        generate_data.chat_id = getCurrentChatId();
     }
 
     if ([chat_completion_sources.MAKERSUITE, chat_completion_sources.VERTEXAI].includes(settings.chat_completion_source)) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1,4 +1,5 @@
 /* eslint-disable dot-notation */
+import { createHmac } from 'node:crypto';
 import process from 'node:process';
 import util from 'node:util';
 import express from 'express';
@@ -66,6 +67,7 @@ import {
     getWebTokenizer,
 } from '../tokenizers.js';
 import { getVertexAIAuth, getProjectIdFromServiceAccount } from '../google.js';
+import { getCookieSecret } from '../../users.js';
 
 const API_OPENAI = 'https://api.openai.com/v1';
 const API_CLAUDE = 'https://api.anthropic.com/v1';
@@ -107,6 +109,18 @@ const cachingAtDepth = (() => {
     return Number.isInteger(value) && value >= 0 ? value : -1;
 })();
 const enableAdaptiveThinking = getConfigValue('claude.enableAdaptiveThinking', true, 'boolean');
+
+/**
+ * Lazily-cached HMAC key (instance cookie secret) for session-affinity hashing.
+ * @type {string|undefined}
+ */
+let affinityKey;
+function getAffinityKey() {
+    if (affinityKey === undefined) {
+        affinityKey = getCookieSecret(globalThis.DATA_ROOT);
+    }
+    return affinityKey;
+}
 
 /**
  * Cache for cacheable (writing) OpenRouter model IDs.
@@ -2452,6 +2466,9 @@ router.post('/generate', async function (request, response) {
                         strict: request.body.json_schema.strict ?? true,
                     },
                 };
+            }
+            if (request.body.chat_id) {
+                headers['x-session-affinity'] = createHmac('sha256', getAffinityKey()).update(request.body.chat_id).digest('hex').slice(0, 16);
             }
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.NANOGPT) {
             apiUrl = API_NANOGPT;


### PR DESCRIPTION
This change adds a chat-specific "x-session-affinity" HTTP header to requests to Fireworks that use the full prompt. Quiet requests like summarization requests that don't use the same prompt prefix are excluded.

This improves prompt caching by
1. Adding a stable "x-session-affinity" header, which Fireworks AI recommends to route requests to the same replica
2. Separating different chats into different sessions
3. Separating main LLM calls from quiet calls which have a completely different prompt prefix

See https://docs.fireworks.ai/guides/prompt-caching.

This uses an HMAC with the cookie secret instead of simply hashing the chat title to avoid leaking chat titles. Session affinity headers may not fall under zero-data retention in Fireworks or could be cached by proxies on the way. Chat titles are tiny, so the HMAC computation is instant.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
