### PR TITLE
Update MiniMax default model to M3

### DIFF
--- a/default/content/presets/openai/Default.json
+++ b/default/content/presets/openai/Default.json
@@ -10,7 +10,7 @@
     "mistralai_model": "mistral-large-latest",
     "chutes_model": "deepseek-ai/DeepSeek-V3-0324",
     "chutes_sort_models": "alphabetically",
-    "minimax_model": "MiniMax-M2.7",
+    "minimax_model": "MiniMax-M3",
     "minimax_endpoint": "global",
     "electronhub_model": "gpt-4o-mini",
     "electronhub_sort_models": "alphabetically",

--- a/public/index.html
+++ b/public/index.html
@@ -3583,6 +3583,7 @@
                             </select>
                             <h4 data-i18n="MiniMax Model">MiniMax Model</h4>
                             <select id="model_minimax_select">
+                                <option value="MiniMax-M3">MiniMax-M3</option>
                                 <option value="MiniMax-M2.7">MiniMax-M2.7</option>
                                 <option value="MiniMax-M2.7-highspeed">MiniMax-M2.7-highspeed</option>
                                 <option value="MiniMax-M2.5">MiniMax-M2.5</option>

--- a/public/index.html
+++ b/public/index.html
@@ -3578,8 +3578,10 @@
                             </div>
                             <h4 data-i18n="MiniMax Endpoint">MiniMax Endpoint</h4>
                             <select id="minimax_endpoint">
-                                <option value="global" data-i18n="Global (minimax.io)">Global (minimax.io)</option>
-                                <option value="cn" data-i18n="China (minimaxi.com)">China (minimaxi.com)</option>
+                                <option value="global" data-i18n="Global (OpenAI-compatible)">Global (OpenAI-compatible)</option>
+                                <option value="cn" data-i18n="China (OpenAI-compatible)">China (OpenAI-compatible)</option>
+                                <option value="global-anthropic" data-i18n="Global (Anthropic-compatible)">Global (Anthropic-compatible)</option>
+                                <option value="cn-anthropic" data-i18n="China (Anthropic-compatible)">China (Anthropic-compatible)</option>
                             </select>
                             <h4 data-i18n="MiniMax Model">MiniMax Model</h4>
                             <select id="model_minimax_select">

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2939,9 +2939,9 @@ export async function createGenerationParameters(settings, model, type, messages
 
     if (settings.chat_completion_source === chat_completion_sources.MINIMAX) {
         generate_data.minimax_endpoint = settings.minimax_endpoint || MINIMAX_ENDPOINT.GLOBAL;
-        // MiniMax requires temperature in (0.0, 1.0]; zero is rejected.
         if (Number.isFinite(generate_data.temperature)) {
-            generate_data.temperature = clamp(generate_data.temperature, Number.EPSILON, 1.0);
+            const isM3 = settings.minimax_model === 'MiniMax-M3';
+            generate_data.temperature = clamp(generate_data.temperature, isM3 ? 0 : Number.EPSILON, isM3 ? oai_max_temp : claude_max_temp);
         }
     }
 
@@ -5868,11 +5868,12 @@ async function onModelChange() {
 
     if (oai_settings.chat_completion_source === chat_completion_sources.MINIMAX) {
         const maxContext = oai_settings.minimax_model === 'MiniMax-M3' ? max_1mil : oai_settings.minimax_model === 'M2-her' ? 65536 : 204800;
+        const maxTemperature = oai_settings.minimax_model === 'MiniMax-M3' ? oai_max_temp : claude_max_temp;
         $('#openai_max_context').attr('max', maxContext);
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
-        oai_settings.temp_openai = Math.min(claude_max_temp, oai_settings.temp_openai);
-        $('#temp_openai').attr('max', claude_max_temp).val(oai_settings.temp_openai).trigger('input');
+        oai_settings.temp_openai = Math.min(maxTemperature, oai_settings.temp_openai);
+        $('#temp_openai').attr('max', maxTemperature).val(oai_settings.temp_openai).trigger('input');
     }
 
     if (oai_settings.chat_completion_source == chat_completion_sources.ZAI) {
@@ -6215,6 +6216,8 @@ export function isImageInliningSupported() {
             return visionSupportedModels.some(model => oai_settings.zai_model.includes(model));
         case chat_completion_sources.SILICONFLOW:
             return visionSupportedModels.some(model => oai_settings.siliconflow_model.includes(model));
+        case chat_completion_sources.MINIMAX:
+            return oai_settings.minimax_model === 'MiniMax-M3';
         case chat_completion_sources.WORKERS_AI: {
             const waiModel = Array.isArray(model_list) && model_list.find(m => m.id === oai_settings.workers_ai_model);
             return Boolean(waiModel && Array.isArray(waiModel.properties) && waiModel.properties.some(p => p.property_id === 'vision' && p.value === 'true'));
@@ -6259,6 +6262,8 @@ export function isVideoInliningSupported() {
             return (Array.isArray(model_list) && model_list.find(m => m.id === oai_settings.openrouter_model)?.architecture?.input_modalities?.includes('video'));
         case chat_completion_sources.ZAI:
             return videoSupportedModels.some(model => oai_settings.zai_model.includes(model));
+        case chat_completion_sources.MINIMAX:
+            return oai_settings.minimax_model === 'MiniMax-M3';
         default:
             return false;
     }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -441,7 +441,7 @@ const default_settings = {
     chutes_model: 'deepseek-ai/DeepSeek-V3-0324',
     siliconflow_model: 'deepseek-ai/DeepSeek-V3',
     siliconflow_endpoint: SILICONFLOW_ENDPOINT.GLOBAL,
-    minimax_model: 'MiniMax-M2.7',
+    minimax_model: 'MiniMax-M3',
     minimax_endpoint: MINIMAX_ENDPOINT.GLOBAL,
     electronhub_model: 'gpt-4o-mini',
     nanogpt_model: 'gpt-4o-mini',
@@ -5867,7 +5867,7 @@ async function onModelChange() {
     }
 
     if (oai_settings.chat_completion_source === chat_completion_sources.MINIMAX) {
-        const maxContext = oai_settings.minimax_model === 'M2-her' ? 65536 : 204800;
+        const maxContext = oai_settings.minimax_model === 'MiniMax-M3' ? max_1mil : oai_settings.minimax_model === 'M2-her' ? 65536 : 204800;
         $('#openai_max_context').attr('max', maxContext);
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -275,7 +275,18 @@ export const SILICONFLOW_ENDPOINT = {
 export const MINIMAX_ENDPOINT = {
     GLOBAL: 'global',
     CN: 'cn',
+    GLOBAL_ANTHROPIC: 'global-anthropic',
+    CN_ANTHROPIC: 'cn-anthropic',
 };
+
+/**
+ * Checks whether a MiniMax endpoint uses the Anthropic-compatible API.
+ * @param {string} endpoint MiniMax endpoint
+ * @returns {boolean} Whether the endpoint uses the Anthropic-compatible API
+ */
+export function isMinimaxAnthropicEndpoint(endpoint) {
+    return [MINIMAX_ENDPOINT.GLOBAL_ANTHROPIC, MINIMAX_ENDPOINT.CN_ANTHROPIC].includes(endpoint);
+}
 
 const sensitiveFields = [
     'reverse_proxy',
@@ -2941,7 +2952,8 @@ export async function createGenerationParameters(settings, model, type, messages
         generate_data.minimax_endpoint = settings.minimax_endpoint || MINIMAX_ENDPOINT.GLOBAL;
         if (Number.isFinite(generate_data.temperature)) {
             const isM3 = settings.minimax_model === 'MiniMax-M3';
-            generate_data.temperature = clamp(generate_data.temperature, isM3 ? 0 : Number.EPSILON, isM3 ? oai_max_temp : claude_max_temp);
+            const supportsFullTemperatureRange = isM3 || isMinimaxAnthropicEndpoint(generate_data.minimax_endpoint);
+            generate_data.temperature = clamp(generate_data.temperature, supportsFullTemperatureRange ? 0 : Number.EPSILON, supportsFullTemperatureRange ? oai_max_temp : claude_max_temp);
         }
     }
 
@@ -3067,6 +3079,9 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
         const eventStream = getEventSourceStream();
         response.body.pipeThrough(eventStream);
         const reader = eventStream.readable.getReader();
+        const streamingSource = oai_settings.chat_completion_source === chat_completion_sources.MINIMAX && isMinimaxAnthropicEndpoint(oai_settings.minimax_endpoint)
+            ? chat_completion_sources.CLAUDE
+            : null;
         return async function* streamData() {
             let text = '';
             const swipes = [];
@@ -3083,9 +3098,9 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
                 if (canMultiSwipe && Array.isArray(parsed?.choices) && parsed?.choices?.[0]?.index > 0) {
                     const swipeIndex = parsed.choices[0].index - 1;
                     // FIXME: state.reasoning should be an array to support multi-swipe
-                    swipes[swipeIndex] = (swipes[swipeIndex] || '') + getStreamingReply(parsed, state, { overrideShowThoughts: false });
+                    swipes[swipeIndex] = (swipes[swipeIndex] || '') + getStreamingReply(parsed, state, { chatCompletionSource: streamingSource, overrideShowThoughts: false });
                 } else {
-                    text += getStreamingReply(parsed, state);
+                    text += getStreamingReply(parsed, state, { chatCompletionSource: streamingSource });
                 }
 
                 ToolManager.parseToolCalls(toolCalls, parsed, state.toolSignatures);
@@ -5868,7 +5883,7 @@ async function onModelChange() {
 
     if (oai_settings.chat_completion_source === chat_completion_sources.MINIMAX) {
         const maxContext = oai_settings.minimax_model === 'MiniMax-M3' ? max_1mil : oai_settings.minimax_model === 'M2-her' ? 65536 : 204800;
-        const maxTemperature = oai_settings.minimax_model === 'MiniMax-M3' ? oai_max_temp : claude_max_temp;
+        const maxTemperature = oai_settings.minimax_model === 'MiniMax-M3' || isMinimaxAnthropicEndpoint(oai_settings.minimax_endpoint) ? oai_max_temp : claude_max_temp;
         $('#openai_max_context').attr('max', maxContext);
         oai_settings.openai_max_context = Math.min(Number($('#openai_max_context').attr('max')), oai_settings.openai_max_context);
         $('#openai_max_context').val(oai_settings.openai_max_context).trigger('input');
@@ -7204,6 +7219,7 @@ export function initOpenAI() {
     });
     $('#minimax_endpoint').on('input', function () {
         oai_settings.minimax_endpoint = String($(this).val());
+        $('#model_minimax_select').trigger('change');
         saveSettingsDebounced();
     });
     $('#workers_ai_account_id').on('input', function () {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3177,6 +3177,23 @@ export function getStreamingReply(data, state, { chatCompletionSource = null, ov
             state.reasoning += (data.choices?.filter(x => x?.delta?.reasoning_content)?.[0]?.delta?.reasoning_content || '');
         }
         return data.choices?.[0]?.delta?.content || '';
+    } else if (chat_completion_source === chat_completion_sources.MINIMAX) {
+        if (show_thoughts) {
+            const reasoningContent = data?.choices?.[0]?.delta?.reasoning_content;
+            const reasoningDetails = data?.choices?.[0]?.delta?.reasoning_details;
+
+            if (typeof reasoningContent === 'string') {
+                state.reasoning += reasoningContent;
+            } else if (Array.isArray(reasoningDetails)) {
+                const reasoningText = reasoningDetails.map(detail => detail?.text).filter(text => typeof text === 'string').join('');
+                if (reasoningText.startsWith(state.reasoning)) {
+                    state.reasoning = reasoningText;
+                } else if (reasoningText && !state.reasoning.endsWith(reasoningText)) {
+                    state.reasoning += reasoningText;
+                }
+            }
+        }
+        return data.choices?.[0]?.delta?.content ?? data.choices?.[0]?.message?.content ?? '';
     } else if (chat_completion_source === chat_completion_sources.OPENROUTER) {
         const imageUrls = data?.choices?.[0]?.delta?.images?.filter(x => x.type === 'image_url')?.map(x => x?.image_url?.url) || [];
         if (Array.isArray(imageUrls) && imageUrls.length > 0) {

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -5,7 +5,7 @@ import { chat, closeMessageEditor, event_types, eventSource, main_api, messageFo
 import { getRegexedString, regex_placement } from './extensions/regex/engine.js';
 import { getCurrentLocale, t, translate } from './i18n.js';
 import { macros, MacroCategory } from './macros/macro-system.js';
-import { chat_completion_sources, getChatCompletionModel, oai_settings } from './openai.js';
+import { chat_completion_sources, getChatCompletionModel, isMinimaxAnthropicEndpoint, oai_settings } from './openai.js';
 import { Popup } from './popup.js';
 import { performFuzzySearch, power_user } from './power-user.js';
 import { getPresetManager } from './preset-manager.js';
@@ -123,6 +123,10 @@ export function extractReasoningFromData(data, {
                     return data?.responseContent?.parts?.filter(part => part.thought)?.map(part => part.text)?.join('\n\n') ?? '';
                 case chat_completion_sources.CLAUDE:
                     return data?.content?.filter(part => part.type === 'thinking')?.map(part => part.thinking)?.join('\n\n') ?? '';
+                case chat_completion_sources.MINIMAX:
+                    return isMinimaxAnthropicEndpoint(oai_settings.minimax_endpoint)
+                        ? data?.content?.filter(part => part.type === 'thinking')?.map(part => part.thinking)?.join('\n\n') ?? ''
+                        : data?.choices?.[0]?.message?.reasoning_content ?? '';
                 case chat_completion_sources.MISTRALAI:
                     return data?.choices?.[0]?.message?.content?.[0]?.thinking?.map(part => part.text)?.filter(x => x)?.join('\n\n') ?? '';
                 case chat_completion_sources.AIMLAPI:

--- a/src/constants.js
+++ b/src/constants.js
@@ -569,4 +569,6 @@ export const SILICONFLOW_ENDPOINT = {
 export const MINIMAX_ENDPOINT = {
     GLOBAL: 'global',
     CN: 'cn',
+    GLOBAL_ANTHROPIC: 'global-anthropic',
+    CN_ANTHROPIC: 'cn-anthropic',
 };

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1584,6 +1584,10 @@ async function sendMinimaxRequest(request, response) {
 
         let bodyParams = {};
 
+        if (request.body.model === 'MiniMax-M3') {
+            bodyParams['thinking'] = { type: request.body.include_reasoning ? 'adaptive' : 'disabled' };
+        }
+
         if (Array.isArray(request.body.tools) && request.body.tools.length > 0) {
             bodyParams['tools'] = request.body.tools;
             bodyParams['tool_choice'] = request.body.tool_choice;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1650,6 +1650,7 @@ export async function sendMinimaxRequest(request, response) {
 
         if (request.body.model === 'MiniMax-M3') {
             bodyParams['thinking'] = { type: request.body.include_reasoning ? 'adaptive' : 'disabled' };
+            bodyParams['reasoning_split'] = true;
         }
 
         if (Array.isArray(request.body.tools) && request.body.tools.length > 0) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -92,6 +92,8 @@ const API_SILICONFLOW = 'https://api.siliconflow.com/v1';
 const API_SILICONFLOW_CN = 'https://api.siliconflow.cn/v1';
 const API_MINIMAX = 'https://api.minimax.io/v1';
 const API_MINIMAX_CN = 'https://api.minimaxi.com/v1';
+const API_MINIMAX_ANTHROPIC = 'https://api.minimax.io/anthropic';
+const API_MINIMAX_ANTHROPIC_CN = 'https://api.minimaxi.com/anthropic';
 const API_OPENROUTER = 'https://openrouter.ai/api/v1';
 const API_WORKERS_AI = 'https://api.cloudflare.com/client/v4/accounts';
 
@@ -1561,9 +1563,12 @@ async function sendChutesRequest(request, response) {
  * @param {express.Request} request Express request
  * @param {express.Response} response Express response
  */
-async function sendMinimaxRequest(request, response) {
-    const apiUrl = request.body.minimax_endpoint === MINIMAX_ENDPOINT.CN
-        ? API_MINIMAX_CN : API_MINIMAX;
+export async function sendMinimaxRequest(request, response) {
+    const isAnthropic = [MINIMAX_ENDPOINT.GLOBAL_ANTHROPIC, MINIMAX_ENDPOINT.CN_ANTHROPIC].includes(request.body.minimax_endpoint);
+    const isChina = [MINIMAX_ENDPOINT.CN, MINIMAX_ENDPOINT.CN_ANTHROPIC].includes(request.body.minimax_endpoint);
+    const apiUrl = isAnthropic
+        ? (isChina ? API_MINIMAX_ANTHROPIC_CN : API_MINIMAX_ANTHROPIC)
+        : (isChina ? API_MINIMAX_CN : API_MINIMAX);
     const apiKey = readSecret(request.user.directories, SECRET_KEYS.MINIMAX, request.body.secret_id);
 
     if (!apiKey) {
@@ -1578,6 +1583,65 @@ async function sendMinimaxRequest(request, response) {
     });
 
     try {
+        if (isAnthropic) {
+            const useTools = Array.isArray(request.body.tools) && request.body.tools.length > 0;
+            const convertedPrompt = convertClaudeMessages(structuredClone(request.body.messages), '', true, useTools, getPromptNames(request), { video: true });
+            const bodyParams = {};
+
+            if (request.body.model === 'MiniMax-M3') {
+                bodyParams['thinking'] = { type: request.body.include_reasoning ? 'adaptive' : 'disabled' };
+            }
+
+            if (useTools) {
+                bodyParams['tools'] = request.body.tools
+                    .filter(tool => tool.type === 'function')
+                    .map(tool => tool.function)
+                    .map(fn => ({ name: fn.name, description: fn.description, input_schema: flattenSchema(fn.parameters, request.body.chat_completion_source) }));
+                bodyParams['tool_choice'] = { type: request.body.tool_choice };
+            }
+
+            const requestBody = {
+                'messages': convertedPrompt.messages,
+                'model': request.body.model,
+                'max_tokens': request.body.max_tokens,
+                'stream': request.body.stream,
+                'temperature': request.body.temperature,
+                'top_p': request.body.top_p,
+                ...bodyParams,
+            };
+
+            if (convertedPrompt.systemPrompt.length > 0) {
+                requestBody['system'] = convertedPrompt.systemPrompt;
+            }
+
+            const generateResponse = await fetch(apiUrl + '/v1/messages', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'anthropic-version': '2023-06-01',
+                    'x-api-key': apiKey,
+                },
+                body: JSON.stringify(requestBody),
+                signal: controller.signal,
+            });
+
+            if (request.body.stream) {
+                return await forwardFetchResponse(generateResponse, response);
+            }
+
+            if (!generateResponse.ok) {
+                const errorText = await generateResponse.text();
+                console.warn('MiniMax returned error: ', errorText);
+                const errorJson = tryParse(errorText) ?? { error: true };
+                return response.status(500).send(errorJson);
+            }
+
+            const generateResponseJson = await generateResponse.json();
+            const responseText = generateResponseJson?.content?.filter(block => block.type === 'text').map(block => block.text).join('\n\n') || '';
+            const reply = { choices: [{ index: 0, message: { content: responseText } }], content: generateResponseJson.content };
+            return response.send(reply);
+        }
+
         // MiniMax does not allow consecutive messages with the same role.
         // Merge them into a single message to avoid "invalid chat setting (2013)".
         const messages = postProcessPrompt(request.body.messages, PROMPT_PROCESSING_TYPE.MERGE_TOOLS, getPromptNames(request));

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -192,9 +192,11 @@ export function convertClaudePrompt(messages, addAssistantPostfix, addAssistantP
  * @param {boolean}  useSysPrompt See if we want to use a system prompt
  * @param {boolean}  useTools See if we want to use tools
  * @param {PromptNames} names Prompt names
+ * @param {object} [options] Conversion options
+ * @param {boolean} [options.video=false] Convert OpenAI video URL blocks to Anthropic blocks
  * @returns {{messages: object[], systemPrompt: object[]}} Prompt for Anthropic
  */
-export function convertClaudeMessages(messages, prefillString, useSysPrompt, useTools, names) {
+export function convertClaudeMessages(messages, prefillString, useSysPrompt, useTools, names, { video = false } = {}) {
     let systemPrompt = [];
     if (useSysPrompt) {
         // Collect all the system messages up until the first instance of a non-system message, and then remove them from the messages array.
@@ -285,6 +287,30 @@ export function convertClaudeMessages(messages, prefillString, useSysPrompt, use
 
                     return {
                         type: 'image',
+                        source: {
+                            type: 'base64',
+                            media_type: mimeType,
+                            data: base64Data,
+                        },
+                    };
+                }
+
+                if (video && content.type === 'video_url') {
+                    const videoData = content?.video_url?.url;
+                    if (!videoData?.startsWith('data:')) {
+                        return {
+                            type: 'video',
+                            source: {
+                                type: 'url',
+                                url: videoData,
+                            },
+                        };
+                    }
+                    const mimeType = videoData?.split(';')?.[0].split(':')?.[1];
+                    const base64Data = videoData?.split(',')?.[1];
+
+                    return {
+                        type: 'video',
                         source: {
                             type: 'base64',
                             media_type: mimeType,

--- a/tests/minimax-backend.test.js
+++ b/tests/minimax-backend.test.js
@@ -1,0 +1,120 @@
+import { beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const fetchMock = jest.fn();
+const readSecretMock = jest.fn(() => 'test-key');
+
+jest.unstable_mockModule('node-fetch', () => ({ default: fetchMock }));
+jest.unstable_mockModule('../src/util.js', () => ({
+    color: {
+        blue: value => value,
+        red: value => value,
+        yellow: value => value,
+    },
+    delay: async () => undefined,
+    excludeKeysByYaml: value => value,
+    flattenSchema: value => value,
+    forwardFetchResponse: jest.fn(),
+    getConfigValue: (_key, defaultValue) => defaultValue,
+    isValidUrl: value => URL.canParse(value),
+    mergeObjectWithYaml: value => value,
+    trimTrailingSlash: value => value.replace(/\/+$/, ''),
+    tryParse: value => {
+        try {
+            return JSON.parse(value);
+        } catch {
+            return undefined;
+        }
+    },
+    uuidv4: () => 'test-uuid',
+}));
+jest.unstable_mockModule('../src/endpoints/secrets.js', () => ({
+    readSecret: readSecretMock,
+    SECRET_KEYS: { MINIMAX: 'api_key_minimax' },
+}));
+
+/** @type {import('../src/endpoints/backends/chat-completions.js')} */
+let mod;
+
+beforeAll(async () => {
+    mod = await import('../src/endpoints/backends/chat-completions.js');
+});
+
+beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ content: [{ type: 'text', text: 'Done' }] }),
+    });
+});
+
+function createRequest(endpoint, messages = [{ role: 'user', content: 'Hello' }]) {
+    return {
+        body: {
+            chat_completion_source: 'minimax',
+            minimax_endpoint: endpoint,
+            model: 'MiniMax-M3',
+            messages,
+            max_tokens: 256,
+            stream: false,
+            temperature: 1,
+            top_p: 0.95,
+            include_reasoning: true,
+        },
+        user: { directories: {} },
+        socket: {
+            removeAllListeners: jest.fn(),
+            on: jest.fn(),
+        },
+    };
+}
+
+function createResponse() {
+    return {
+        status: jest.fn().mockReturnThis(),
+        send: jest.fn().mockReturnThis(),
+        end: jest.fn(),
+    };
+}
+
+async function captureRequestUrl(endpoint) {
+    await mod.sendMinimaxRequest(createRequest(endpoint), createResponse());
+    return fetchMock.mock.calls[0][0];
+}
+
+describe('MiniMax chat completion endpoints', () => {
+    test('sends global OpenAI-compatible requests to the expected URL', async () => {
+        expect(await captureRequestUrl('global')).toBe('https://api.minimax.io/v1/chat/completions');
+    });
+
+    test('sends China OpenAI-compatible requests to the expected URL', async () => {
+        expect(await captureRequestUrl('cn')).toBe('https://api.minimaxi.com/v1/chat/completions');
+    });
+
+    test('sends global Anthropic-compatible requests to the expected URL', async () => {
+        expect(await captureRequestUrl('global-anthropic')).toBe('https://api.minimax.io/anthropic/v1/messages');
+    });
+
+    test('sends China Anthropic-compatible requests to the expected URL', async () => {
+        expect(await captureRequestUrl('cn-anthropic')).toBe('https://api.minimaxi.com/anthropic/v1/messages');
+    });
+
+    test('converts Anthropic-compatible messages and preserves the MiniMax API key', async () => {
+        const messages = [
+            { role: 'system', content: 'Be concise.' },
+            { role: 'user', content: [
+                { type: 'text', text: 'Describe this video.' },
+                { type: 'video_url', video_url: { url: 'data:video/mp4;base64,abc123' } },
+            ] },
+        ];
+        await mod.sendMinimaxRequest(createRequest('global-anthropic', messages), createResponse());
+        const options = fetchMock.mock.calls[0][1];
+        const body = JSON.parse(options.body);
+        expect(options.headers['x-api-key']).toBe('test-key');
+        expect(body.system).toEqual([{ type: 'text', text: 'Be concise.' }]);
+        expect(body.thinking).toEqual({ type: 'adaptive' });
+        expect(body.messages[0].content[1]).toEqual({
+            type: 'video',
+            source: { type: 'base64', media_type: 'video/mp4', data: 'abc123' },
+        });
+    });
+});

--- a/tests/minimax-backend.test.js
+++ b/tests/minimax-backend.test.js
@@ -90,6 +90,13 @@ describe('MiniMax chat completion endpoints', () => {
         expect(await captureRequestUrl('cn')).toBe('https://api.minimaxi.com/v1/chat/completions');
     });
 
+    test('requests separated reasoning for MiniMax-M3 OpenAI-compatible responses', async () => {
+        await mod.sendMinimaxRequest(createRequest('global'), createResponse());
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.thinking).toEqual({ type: 'adaptive' });
+        expect(body.reasoning_split).toBe(true);
+    });
+
     test('sends global Anthropic-compatible requests to the expected URL', async () => {
         expect(await captureRequestUrl('global-anthropic')).toBe('https://api.minimax.io/anthropic/v1/messages');
     });

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -651,6 +651,15 @@ describe('mergeMessages', () => {
         expect(types).toContain('text');
         expect(types).toContain('image_url');
     });
+
+    test('flattens array content and preserves video URLs via tokens', () => {
+        const videoContent = { type: 'video_url', video_url: { url: 'data:video/mp4;base64,abc' } };
+        const messages = [
+            { role: 'user', content: [{ type: 'text', text: 'Watch this' }, videoContent] },
+        ];
+        const result = mod.mergeMessages(messages, names);
+        expect(result[0].content).toEqual([{ type: 'text', text: 'Watch this' }, videoContent]);
+    });
 });
 
 

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -899,6 +899,28 @@ describe('convertClaudeMessages', () => {
         expect(imagePart.source.data).toBe('abc123');
     });
 
+    test('converts video_url content when video support is enabled', () => {
+        const messages = [
+            { role: 'user', content: [
+                { type: 'text', text: 'Watch' },
+                { type: 'video_url', video_url: { url: 'data:video/mp4;base64,abc123' } },
+            ] },
+        ];
+        const result = mod.convertClaudeMessages(messages, '', false, false, names, { video: true });
+        const videoPart = result.messages[0].content.find(c => c.type === 'video');
+        expect(videoPart).toEqual({
+            type: 'video',
+            source: { type: 'base64', media_type: 'video/mp4', data: 'abc123' },
+        });
+    });
+
+    test('preserves video_url content by default', () => {
+        const videoPart = { type: 'video_url', video_url: { url: 'https://example.com/video.mp4' } };
+        const messages = [{ role: 'user', content: [videoPart] }];
+        const result = mod.convertClaudeMessages(messages, '', false, false, names);
+        expect(result.messages[0].content[0]).toEqual(videoPart);
+    });
+
     test('moves images from assistant to next user message', () => {
         const messages = [
             { role: 'assistant', content: [


### PR DESCRIPTION
## Problem
The built-in MiniMax chat settings still defaulted to MiniMax-M2.7 and capped model context at 204,800 tokens, leaving MiniMax-M3's 1M context and supported capabilities unavailable.

## Summary
- Set the built-in MiniMax chat completion default model and default preset to MiniMax-M3.
- Add MiniMax-M3 to the model selector and use its documented 1M context and 0-2 temperature limits.
- Enable MiniMax-M3 image and video inputs through the existing media inlining controls.
- Map the existing reasoning toggle to MiniMax-M3 adaptive or disabled thinking while preserving older model behavior.
- Preserve separated MiniMax-M3 reasoning in streamed and non-streamed compatibility responses.
- Add global and China endpoint options for both supported compatibility formats while preserving the existing default.

## Compatibility
- Existing MiniMax-M2.x selections keep their previous context, thinking, and sampling behavior.
- The existing global endpoint remains the default.

## Checks
- `npm run test:unit --prefix tests -- --runInBand` (324 tests)
- `npm run lint`
- `npm run lint --prefix tests`
- `node --check` on all changed JavaScript files
