### PR TITLE
feat: Allow configuring SameSite and Secure session cookie attributes

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -44,6 +44,9 @@ heartbeatInterval: 0
 # Enable HTTP/HTTPS keep-alive globally.
 # Disabling restores old Node 18 behavior, can help if ECONNRESET and other network errors occur.
 enableKeepAlive: false
+# Trust X-Forwarded-* headers from a reverse proxy. Required for secure cookies behind TLS termination.
+# Only enable when SillyTavern is not directly reachable except through your trusted proxy.
+trustProxy: false
 # -- SSL options --
 ssl:
   # Enable SSL/TLS encryption
@@ -176,6 +179,12 @@ privateAddressWhitelist:
 ## Set to 0 to expire session when the browser is closed
 ## Set to a negative number to disable session expiration
 sessionTimeout: -1
+# Session cookie attributes. Cross-site fetch/XHR requires sameSite: none and secure: true.
+sessionCookie:
+  # Allowed values: lax, strict, none
+  sameSite: lax
+  # Set to true when sameSite is none. Requires HTTPS from the browser's perspective.
+  secure: false
 # Disable CSRF protection - NOT RECOMMENDED
 disableCsrfProtection: false
 # Disable startup security checks - NOT RECOMMENDED

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -101,6 +101,9 @@ http.globalAgent = new http.Agent({ keepAlive: cliArgs.enableKeepAlive });
 https.globalAgent = new https.Agent({ keepAlive: cliArgs.enableKeepAlive });
 
 const app = express();
+if (getConfigValue('trustProxy', false, 'boolean')) {
+    app.set('trust proxy', true);
+}
 app.use(helmet({
     contentSecurityPolicy: false,
 }));
@@ -153,9 +156,19 @@ if (cliArgs.listen) {
     app.use(accessLoggerMiddleware());
 }
 
+const SESSION_COOKIE_SAME_SITE = {
+    LAX: 'lax',
+    STRICT: 'strict',
+    NONE: 'none',
+};
+const SESSION_COOKIE_SAME_SITE_VALUES = Object.values(SESSION_COOKIE_SAME_SITE);
+const sessionCookieSameSite = getConfigValue('sessionCookie.sameSite', SESSION_COOKIE_SAME_SITE.LAX, SESSION_COOKIE_SAME_SITE_VALUES);
+const sessionCookieSecure = getConfigValue('sessionCookie.secure', sessionCookieSameSite === SESSION_COOKIE_SAME_SITE.NONE, 'boolean');
+
 app.use(cookieSession({
     name: getCookieSessionName(),
-    sameSite: 'lax',
+    sameSite: sessionCookieSameSite,
+    secure: sessionCookieSecure,
     httpOnly: true,
     maxAge: getSessionCookieAge(),
     secret: getCookieSecret(globalThis.DATA_ROOT),

--- a/src/util.js
+++ b/src/util.js
@@ -82,7 +82,7 @@ export function getConfig() {
  * Returns the value for the given key from the config object.
  * @param {string} key - Key to get from the config object
  * @param {any} defaultValue - Default value to return if the key is not found
- * @param {'number'|'boolean'|null} typeConverter - Type to convert the value to
+ * @param {'number'|'boolean'|string[]|null} typeConverter - Type to convert the value to, or allowed normalized string values
  * @returns {any} Value for the given key
  */
 export function getConfigValue(key, defaultValue = null, typeConverter = null) {
@@ -98,6 +98,11 @@ export function getConfigValue(key, defaultValue = null, typeConverter = null) {
     }
 
     const value = _getValue();
+    if (Array.isArray(typeConverter)) {
+        const normalized = String(value).trim().toLowerCase();
+        return typeConverter.includes(normalized) ? normalized : defaultValue;
+    }
+
     switch (typeConverter) {
         case 'number':
             return isNaN(parseFloat(value)) ? defaultValue : parseFloat(value);


### PR DESCRIPTION
Currently, SillyTavern hardcodes the session cookie to `SameSite=Lax`. 

Browsers do not send `SameSite=Lax` cookies in cross-site `fetch` / XHR requests. Even if CORS credentials are correctly enabled on both the server and the frontend, a third-party page can only successfully request `/csrf-token`. Any subsequent cross-site POST requests will fail to include that same session cookie. As a result, the server cannot read the previously stored `csrfToken` from the session, ultimately returning an `Invalid CSRF token` error.

Because of this limitation, server plugin developers who want to integrate with SillyTavern's routes cannot use third-party web pages (or are forced to run under the exact same hostname). This means that if plugin developers want to connect to a third-party dashboard/panel, they have to spin up their own standalone HTTP server, completely bypassing SillyTavern's built-in security mechanisms.

## Changes

- Extended `getConfigValue()` to support string enum validation.
- Added new configuration options for session cookies:
  - `sessionCookie.sameSite`
  - `sessionCookie.secure`
- Added a `trustProxy` configuration option to support reverse proxy deployments.
- **Default behavior remains unchanged:** `SameSite=Lax`.

## Impact

 Advanced users can opt into cross-site session cookies for trusted deployments, while the default behavior remains unchanged for existing users.

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
