### PR TITLE
Batch accessibility observer callbacks and combine rule selectors

### DIFF
--- a/public/scripts/a11y.js
+++ b/public/scripts/a11y.js
@@ -84,22 +84,79 @@ const a11yRules = {
     },
 };
 
+const a11yRuleEntries = Object.entries(a11yRules);
+const combinedA11ySelector = Object.keys(a11yRules).join(', ');
+
 /**
- * Apply accessibility rules to an element.
+ * Apply the matching accessibility rules to a single element.
+ * @param {Element} element Element to process.
+ */
+function applyMatchingRules(element) {
+    for (const [selector, rule] of a11yRuleEntries) {
+        if (element.matches(selector)) {
+            rule(element);
+        }
+    }
+}
+
+/**
+ * Apply accessibility rules to an element and its descendants.
  * @param {Element} element Element to process.
  */
 function applyA11yRules(element) {
     try {
-        for (const [selector, rule] of Object.entries(a11yRules)) {
-            // Apply if the element directly matches the selector
-            if (element.matches(selector)) {
-                rule(element);
-            }
-            // Apply the rule to descendants
-            element.querySelectorAll(selector).forEach(rule);
+        // Single combined query, then dispatch rules only on actual matches
+        if (element.matches(combinedA11ySelector)) {
+            applyMatchingRules(element);
         }
+        element.querySelectorAll(combinedA11ySelector).forEach(applyMatchingRules);
     } catch (error) {
         console.error('Error applying accessibility rules to element:', element, error);
+    }
+}
+
+/** @type {Set<Element>} */
+const pendingElements = new Set();
+let flushScheduled = false;
+
+/**
+ * Check if any ancestor of the element is also queued for processing.
+ * @param {Element} element Element to check.
+ * @param {Set<Element>} queued Set of queued elements.
+ * @returns {boolean} True if a queued ancestor exists.
+ */
+function hasQueuedAncestor(element, queued) {
+    for (let parent = element.parentElement; parent; parent = parent.parentElement) {
+        if (queued.has(parent)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function flushPendingElements() {
+    flushScheduled = false;
+    const elements = new Set(pendingElements);
+    pendingElements.clear();
+
+    for (const element of elements) {
+        // Skip elements that were removed or are covered by a queued ancestor
+        if (!element.isConnected || hasQueuedAncestor(element, elements)) {
+            continue;
+        }
+        applyA11yRules(element);
+    }
+}
+
+/**
+ * Queue an element for rule application on the next animation frame.
+ * @param {Element} element Element to process.
+ */
+function queueElement(element) {
+    pendingElements.add(element);
+    if (!flushScheduled) {
+        flushScheduled = true;
+        requestAnimationFrame(flushPendingElements);
     }
 }
 
@@ -112,8 +169,8 @@ function setAccessibilityObserver() {
         for (const mutation of mutationsList) {
             if (mutation.type === 'childList') {
                 for (const addedNode of mutation.addedNodes) {
-                    if (addedNode instanceof Element && addedNode.nodeType === Node.ELEMENT_NODE) {
-                        applyA11yRules(addedNode);
+                    if (addedNode instanceof Element) {
+                        queueElement(addedNode);
                     }
                 }
             }


### PR DESCRIPTION
### What is the reason for a change?

The accessibility module attaches a `MutationObserver` to `document.body` with `subtree: true`, and its callback runs `applyA11yRules` synchronously for every added node. For each node, the old code looped over all 7 a11y rules and executed both `element.matches()` and `element.querySelectorAll()` per rule (14 selector evaluations per node, each against large multi-selector strings). During streaming generation, DOM nodes are appended many times per frame, so this added measurable CPU work on the hottest rendering path.

### What did you do to achieve this?

Two changes, both behavior-preserving:

1. **Combined selector query.** All rule selectors are joined into one combined selector once at module load. `applyA11yRules` now runs a single `matches()` + single `querySelectorAll()` per element, and only dispatches the individual rules on elements that actually matched. Descendant scans go from 7 full-subtree queries to 1.
2. **Batched observer callback.** Instead of processing every added node synchronously inside the observer callback, nodes are collected into a `Set` and flushed once per animation frame. The flush skips nodes that were already removed from the DOM and nodes covered by a queued ancestor (the ancestor's subtree query handles them), so bursts of mutations from streaming collapse into one pass.

Roles are still applied within one frame of insertion, which makes no practical difference for assistive technology, and the initial full-document pass on startup is unchanged.

### How would a reviewer test the change?

- Open the app and check that roles are still applied: menu buttons get `role="button"`, the character list gets `role="list"`/`role="listitem"`, toasts get `role="status"`, etc. (inspect with dev tools or an accessibility tree viewer).
- Trigger dynamic content: open drawers, switch characters, show a toast, paginate the character list, and confirm newly created elements receive their roles.
- Run a streaming generation with the performance profiler recording and confirm `applyA11yRules` no longer shows up repeatedly inside mutation observer callbacks during token streaming.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
