### PR TITLE
fix: clear embedded character book when world book association is rem…

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -641,6 +641,9 @@ function charaFormatData(data, directories) {
         } catch {
             console.warn(`Failed to read world info file: ${data.world}. Character book will not be available.`);
         }
+    } else {
+        // User removed the world book association - clear the embedded character book
+        _.unset(char, 'data.character_book');
     }
 
     if (data.extensions) {


### PR DESCRIPTION
## Problem

When a user removes a world book association from a character card and saves, the embedded `character_book` data in the PNG is not cleared. This causes the old world info entries to persist in API responses and be served to the AI even after the user explicitly unlinked it.

## Root Cause

In `src/endpoints/characters.js`, `charaFormatData()` function: when `data.world` is falsy (user unlinked the world), the old `character_book` parsed from the request JSON is never removed from the `char` object, so it gets written back to the PNG file unchanged.

## Fix

Added an `else` clause after the `if (data.world)` block to clear the embedded `character_book` when the world association is removed.

## Testing

1. Link a world book to a character → save → verify `character_book` appears in API response
2. Unlink the world book → save → verify `character_book` is cleared from API response
3. Re-link a different world book → save → verify new entries appear correctly