### PR TITLE
This PR adds provider-specific field capture to Connection Manager profiles.

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -1161,3 +1161,4 @@ export async function init() {
         `,
     }));
 }
+

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -179,6 +179,11 @@ const profilesProvider = () => [
  * @property {string} [secret-id] Secret ID
  * @property {string} [regex-preset] Regex Preset ID
  * @property {string[]} [exclude] Commands to exclude
+ * @property {string[]} [openrouter_providers] OpenRouter Selected Providers
+ * @property {boolean} [openrouter_use_fallback] OpenRouter Use Fallback Model
+ * @property {boolean} [openrouter_allow_fallbacks] OpenRouter Allow Fallback Providers
+ * @property {string[]} [openrouter_quantizations] OpenRouter Selected Quantizations
+ * @property {string} [openrouter_middleout] OpenRouter Middleout Setting
  */
 
 /**

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -1,28 +1,63 @@
-import { DOMPurify, Fuse } from '../../../lib.js';
+import { DOMPurify, Fuse } from "../../../lib.js";
 
-import { activateSendButtons, deactivateSendButtons, event_types, eventSource, main_api, online_status, saveSettingsDebounced } from '../../../script.js';
-import { extension_settings, getContext, renderExtensionTemplateAsync } from '../../extensions.js';
-import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from '../../popup.js';
-import { SlashCommand } from '../../slash-commands/SlashCommand.js';
-import { SlashCommandAbortController } from '../../slash-commands/SlashCommandAbortController.js';
-import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from '../../slash-commands/SlashCommandArgument.js';
-import { commonEnumProviders, enumIcons } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
-import { SlashCommandDebugController } from '../../slash-commands/SlashCommandDebugController.js';
-import { enumTypes, SlashCommandEnumValue } from '../../slash-commands/SlashCommandEnumValue.js';
-import { SlashCommandClosure } from '../../slash-commands/SlashCommandClosure.js';
-import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
-import { SlashCommandScope } from '../../slash-commands/SlashCommandScope.js';
-import { collapseSpaces, getUniqueName, isFalseBoolean, isTrueBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
-import { t } from '../../i18n.js';
-import { getSecretLabelById } from '../../secrets.js';
-import { performFuzzySearch } from '/scripts/power-user.js';
-import { StreamingDisplay } from '/scripts/streaming-display.js';
-import { ConnectionManagerRequestService } from '../shared.js';
-import { formatReasoning } from '/scripts/reasoning.js';
+import {
+    activateSendButtons,
+    deactivateSendButtons,
+    event_types,
+    eventSource,
+    main_api,
+    online_status,
+    saveSettingsDebounced,
+} from "../../../script.js";
+import {
+    extension_settings,
+    getContext,
+    renderExtensionTemplateAsync,
+} from "../../extensions.js";
+import {
+    callGenericPopup,
+    Popup,
+    POPUP_RESULT,
+    POPUP_TYPE,
+} from "../../popup.js";
+import { SlashCommand } from "../../slash-commands/SlashCommand.js";
+import { SlashCommandAbortController } from "../../slash-commands/SlashCommandAbortController.js";
+import {
+    ARGUMENT_TYPE,
+    SlashCommandArgument,
+    SlashCommandNamedArgument,
+} from "../../slash-commands/SlashCommandArgument.js";
+import {
+    commonEnumProviders,
+    enumIcons,
+} from "../../slash-commands/SlashCommandCommonEnumsProvider.js";
+import { SlashCommandDebugController } from "../../slash-commands/SlashCommandDebugController.js";
+import {
+    enumTypes,
+    SlashCommandEnumValue,
+} from "../../slash-commands/SlashCommandEnumValue.js";
+import { SlashCommandClosure } from "../../slash-commands/SlashCommandClosure.js";
+import { SlashCommandParser } from "../../slash-commands/SlashCommandParser.js";
+import { SlashCommandScope } from "../../slash-commands/SlashCommandScope.js";
+import {
+    collapseSpaces,
+    getUniqueName,
+    isFalseBoolean,
+    isTrueBoolean,
+    uuidv4,
+    waitUntilCondition,
+} from "../../utils.js";
+import { t } from "../../i18n.js";
+import { getSecretLabelById } from "../../secrets.js";
+import { performFuzzySearch } from "/scripts/power-user.js";
+import { StreamingDisplay } from "/scripts/streaming-display.js";
+import { ConnectionManagerRequestService } from "../shared.js";
+import { formatReasoning } from "/scripts/reasoning.js";
+import { oai_settings, chat_completion_sources } from "../../openai.js";
 
-const MODULE_NAME = 'connection-manager';
-const NONE = '<None>';
-const EMPTY = '<Empty>';
+const MODULE_NAME = "connection-manager";
+const NONE = "<None>";
+const EMPTY = "<Empty>";
 
 const DEFAULT_SETTINGS = {
     profiles: [],
@@ -30,63 +65,125 @@ const DEFAULT_SETTINGS = {
 };
 
 // Commands that can record an empty value into the profile
-const ALLOW_EMPTY = [
-    'stop-strings',
-    'start-reply-with',
-];
+const ALLOW_EMPTY = ["stop-strings", "start-reply-with"];
 
 const CC_COMMANDS = [
-    'api',
-    'preset',
+    "api",
+    "preset",
     // Do not fix; CC needs to set the API twice because it could be overridden by the preset
-    'api',
-    'api-url',
-    'model',
-    'proxy',
-    'stop-strings',
-    'start-reply-with',
-    'reasoning-template',
-    'prompt-post-processing',
-    'secret-id',
-    'regex-preset',
+    "api",
+    "api-url",
+    "model",
+    "proxy",
+    "stop-strings",
+    "start-reply-with",
+    "reasoning-template",
+    "prompt-post-processing",
+    "secret-id",
+    "regex-preset",
 ];
 
 const TC_COMMANDS = [
-    'api',
-    'preset',
-    'api-url',
-    'model',
-    'sysprompt',
-    'sysprompt-state',
-    'instruct',
-    'context',
-    'instruct-state',
-    'tokenizer',
-    'stop-strings',
-    'start-reply-with',
-    'reasoning-template',
-    'secret-id',
-    'regex-preset',
+    "api",
+    "preset",
+    "api-url",
+    "model",
+    "sysprompt",
+    "sysprompt-state",
+    "instruct",
+    "context",
+    "instruct-state",
+    "tokenizer",
+    "stop-strings",
+    "start-reply-with",
+    "reasoning-template",
+    "secret-id",
+    "regex-preset",
 ];
 
 const FANCY_NAMES = {
-    'api': 'API',
-    'api-url': 'Server URL',
-    'preset': 'Settings Preset',
-    'model': 'Model',
-    'proxy': 'Proxy Preset',
-    'sysprompt-state': 'Use System Prompt',
-    'sysprompt': 'System Prompt Name',
-    'instruct-state': 'Instruct Mode',
-    'instruct': 'Instruct Template',
-    'context': 'Context Template',
-    'tokenizer': 'Tokenizer',
-    'stop-strings': 'Custom Stopping Strings',
-    'start-reply-with': 'Start Reply With',
-    'reasoning-template': 'Reasoning Template',
-    'prompt-post-processing': 'Prompt Post-Processing',
-    'secret-id': 'Secret',
-    'regex-preset': 'Regex Preset',
+    api: "API",
+    "api-url": "Server URL",
+    preset: "Settings Preset",
+    model: "Model",
+    proxy: "Proxy Preset",
+    "sysprompt-state": "Use System Prompt",
+    sysprompt: "System Prompt Name",
+    "instruct-state": "Instruct Mode",
+    instruct: "Instruct Template",
+    context: "Context Template",
+    tokenizer: "Tokenizer",
+    "stop-strings": "Custom Stopping Strings",
+    "start-reply-with": "Start Reply With",
+    "reasoning-template": "Reasoning Template",
+    "prompt-post-processing": "Prompt Post-Processing",
+    "secret-id": "Secret",
+    "regex-preset": "Regex Preset",
+    openrouter_providers: "OpenRouter Providers", // Provider-specific fields
+    openrouter_use_fallback: "OpenRouter Use Fallback",
+    openrouter_allow_fallbacks: "OpenRouter Allow Fallbacks",
+    openrouter_quantizations: "OpenRouter Quantizations",
+    openrouter_middleout: "OpenRouter Middle Out",
+    nanogpt_provider: "NanoGPT Provider",
+    nanogpt_payg_override: "NanoGPT PayG Override",
+    custom_url: "Custom API URL",
+    custom_include_body: "Custom Include Body",
+    custom_exclude_body: "Custom Exclude Body",
+    custom_include_headers: "Custom Include Headers",
+    azure_base_url: "Azure Base URL",
+    azure_deployment_name: "Azure Deployment Name",
+    azure_api_version: "Azure API Version",
+    azure_openai_model: "Azure OpenAI Model",
+    vertexai_auth_mode: "Vertex AI Auth Mode",
+    vertexai_region: "Vertex AI Region",
+    vertexai_express_project_id: "Vertex AI Project ID",
+    siliconflow_endpoint: "SiliconFlow Endpoint",
+    minimax_endpoint: "MiniMax Endpoint",
+    zai_endpoint: "Z.AI Endpoint",
+    workers_ai_account_id: "Workers AI Account ID",
+    reverse_proxy: "Reverse Proxy",
+    proxy_password: "Proxy Password",
+    show_external_models: "Show External Models",
+    bypass_status_check: "Bypass Status Check",
+};
+
+// Maps each field to its UI section for display in the popup
+const FIELD_SOURCES = {
+    // Connection Settings (main API panel)
+    api: "Connection Settings",
+    "api-url": "Connection Settings",
+    model: "Connection Settings",
+    preset: "Connection Settings",
+    proxy: "Connection Settings",
+    "secret-id": "Connection Settings",
+
+    // OpenRouter Specific
+    openrouter_providers: "OpenRouter Settings",
+    openrouter_use_fallback: "OpenRouter Settings",
+    openrouter_allow_fallbacks: "OpenRouter Settings",
+    openrouter_quantizations: "OpenRouter Settings",
+    openrouter_middleout: "OpenRouter Settings",
+
+    // Advanced Formatting
+    "stop-strings": "Advanced Formatting",
+    "start-reply-with": "Advanced Formatting",
+    "reasoning-template": "Advanced Formatting",
+    "prompt-post-processing": "Advanced Formatting",
+    "regex-preset": "Advanced Formatting",
+
+    // Text Completion Specific
+    "sysprompt-state": "Text Completion",
+    sysprompt: "Text Completion",
+    "instruct-state": "Text Completion",
+    instruct: "Text Completion",
+    context: "Text Completion",
+    tokenizer: "Text Completion",
+
+    // Generic/Advanced Settings
+    reverse_proxy: "Advanced Settings",
+    proxy_password: "Advanced Settings",
+    show_external_models: "Advanced Settings",
+    bypass_status_check: "Advanced Settings",
 };
 
 /**
@@ -106,17 +203,19 @@ class ConnectionManagerSpinner {
 
     constructor() {
         // @ts-ignore
-        this.spinnerElement = document.getElementById('connection_profile_spinner');
+        this.spinnerElement = document.getElementById(
+            "connection_profile_spinner",
+        );
         this.abortController = new AbortController();
     }
 
     start() {
         ConnectionManagerSpinner.abortControllers.push(this.abortController);
-        this.spinnerElement.classList.remove('hidden');
+        this.spinnerElement.classList.remove("hidden");
     }
 
     stop() {
-        this.spinnerElement.classList.add('hidden');
+        this.spinnerElement.classList.add("hidden");
     }
 
     isAborted() {
@@ -145,7 +244,7 @@ function getNamedArguments(args = {}) {
         _debugController: new SlashCommandDebugController(),
         _parserFlags: {},
         _hasUnnamedArgument: false,
-        quiet: 'true',
+        quiet: "true",
         ...args,
     };
 }
@@ -153,7 +252,15 @@ function getNamedArguments(args = {}) {
 /** @type {() => SlashCommandEnumValue[]} */
 const profilesProvider = () => [
     new SlashCommandEnumValue(NONE),
-    ...extension_settings.connectionManager.profiles.map(p => new SlashCommandEnumValue(p.name, null, enumTypes.name, enumIcons.server)),
+    ...extension_settings.connectionManager.profiles.map(
+        (p) =>
+            new SlashCommandEnumValue(
+                p.name,
+                null,
+                enumTypes.name,
+                enumIcons.server,
+            ),
+    ),
 ];
 
 /**
@@ -184,7 +291,263 @@ const profilesProvider = () => [
  * @property {boolean} [openrouter_allow_fallbacks] OpenRouter Allow Fallback Providers
  * @property {string[]} [openrouter_quantizations] OpenRouter Selected Quantizations
  * @property {string} [openrouter_middleout] OpenRouter Middleout Setting
+ * @property {string} [regex-preset] Regex Preset ID
+ * @property {string[]} [exclude] Commands to exclude
+ * // Provider-specific fields (OpenRouter)
+ * @property {string[]} [openrouter_providers] OpenRouter Selected Providers
+ * @property {boolean} [openrouter_use_fallback] OpenRouter Use Fallback Model
+ * @property {boolean} [openrouter_allow_fallbacks] OpenRouter Allow Fallback Providers
+ * @property {string[]} [openrouter_quantizations] OpenRouter Selected Quantizations
+ * @property {string} [openrouter_middleout] OpenRouter Middleout Setting
+ * // Provider-specific fields (NanoGPT)
+ * @property {string} [nanogpt_provider] NanoGPT Provider
+ * @property {boolean} [nanogpt_payg_override] NanoGPT Pay-as-you-go Override
+ * // Provider-specific fields (Custom API)
+ * @property {string} [custom_url] Custom API URL
+ * @property {string} [custom_include_body] Custom API Include Body
+ * @property {string} [custom_exclude_body] Custom API Exclude Body
+ * @property {string} [custom_include_headers] Custom API Include Headers
+ * // Provider-specific fields (Azure OpenAI)
+ * @property {string} [azure_base_url] Azure Base URL
+ * @property {string} [azure_deployment_name] Azure Deployment Name
+ * @property {string} [azure_api_version] Azure API Version
+ * @property {string} [azure_openai_model] Azure OpenAI Model
+ * // Provider-specific fields (Vertex AI)
+ * @property {string} [vertexai_auth_mode] Vertex AI Auth Mode
+ * @property {string} [vertexai_region] Vertex AI Region
+ * @property {string} [vertexai_express_project_id] Vertex AI Express Project ID
+ * // Provider-specific fields (SiliconFlow)
+ * @property {string} [siliconflow_endpoint] SiliconFlow Endpoint
+ * // Provider-specific fields (MiniMax)
+ * @property {string} [minimax_endpoint] MiniMax Endpoint
+ * // Provider-specific fields (Z.AI)
+ * @property {string} [zai_endpoint] Z.AI Endpoint
+ * // Provider-specific fields (Workers AI)
+ * @property {string} [workers_ai_account_id] Workers AI Account ID
+ * // Generic provider fields
+ * @property {string} [reverse_proxy] Reverse Proxy URL
+ * @property {string} [proxy_password] Proxy Password
+ * @property {boolean} [show_external_models] Show External Models
+ * @property {boolean} [bypass_status_check] Bypass Status Check
  */
+
+/**
+ * Capture provider-specific fields from oai_settings into a profile object.
+ * @param {ConnectionProfile} profile - The profile object to populate
+ */
+function captureProviderFields(profile) {
+    // Only capture if we're using OpenAI API
+    if (main_api !== "openai") {
+        return;
+    }
+
+    const source = oai_settings.chat_completion_source;
+
+    // OpenRouter fields
+    if (source === chat_completion_sources.OPENROUTER) {
+        profile.openrouter_providers = oai_settings.openrouter_providers;
+        profile.openrouter_use_fallback = oai_settings.openrouter_use_fallback;
+        profile.openrouter_allow_fallbacks =
+            oai_settings.openrouter_allow_fallbacks;
+        profile.openrouter_quantizations =
+            oai_settings.openrouter_quantizations;
+        profile.openrouter_middleout = oai_settings.openrouter_middleout;
+    }
+
+    // NanoGPT fields
+    if (source === chat_completion_sources.NANOGPT) {
+        profile.nanogpt_provider = oai_settings.nanogpt_provider;
+        profile.nanogpt_payg_override = oai_settings.nanogpt_payg_override;
+    }
+
+    // Custom API fields
+    if (source === chat_completion_sources.CUSTOM) {
+        profile.custom_url = oai_settings.custom_url;
+        profile.custom_include_body = oai_settings.custom_include_body;
+        profile.custom_exclude_body = oai_settings.custom_exclude_body;
+        profile.custom_include_headers = oai_settings.custom_include_headers;
+    }
+
+    // Azure OpenAI fields
+    if (source === chat_completion_sources.AZURE_OPENAI) {
+        profile.azure_base_url = oai_settings.azure_base_url;
+        profile.azure_deployment_name = oai_settings.azure_deployment_name;
+        profile.azure_api_version = oai_settings.azure_api_version;
+        profile.azure_openai_model = oai_settings.azure_openai_model;
+    }
+
+    // Vertex AI fields
+    if (source === chat_completion_sources.VERTEXAI) {
+        profile.vertexai_auth_mode = oai_settings.vertexai_auth_mode;
+        profile.vertexai_region = oai_settings.vertexai_region;
+        profile.vertexai_express_project_id =
+            oai_settings.vertexai_express_project_id;
+    }
+
+    // SiliconFlow fields
+    if (source === chat_completion_sources.SILICONFLOW) {
+        profile.siliconflow_endpoint = oai_settings.siliconflow_endpoint;
+    }
+
+    // MiniMax fields
+    if (source === chat_completion_sources.MINIMAX) {
+        profile.minimax_endpoint = oai_settings.minimax_endpoint;
+    }
+
+    // Z.AI fields
+    if (source === chat_completion_sources.ZAI) {
+        profile.zai_endpoint = oai_settings.zai_endpoint;
+    }
+
+    // Workers AI fields
+    if (source === chat_completion_sources.WORKERS_AI) {
+        profile.workers_ai_account_id = oai_settings.workers_ai_account_id;
+    }
+
+    // Generic connection fields (apply to all sources)
+    profile.reverse_proxy = oai_settings.reverse_proxy;
+    profile.proxy_password = oai_settings.proxy_password;
+    profile.show_external_models = oai_settings.show_external_models;
+    profile.bypass_status_check = oai_settings.bypass_status_check;
+
+    console.log("Connection Manager: Provider fields captured");
+}
+
+/**
+ * Restore provider-specific fields from a profile object to oai_settings.
+ * @param {ConnectionProfile} profile - The profile object to read from
+ */
+function restoreProviderFields(profile) {
+    // Only restore if we're using OpenAI API
+    if (main_api !== "openai") {
+        return;
+    }
+
+    const source = oai_settings.chat_completion_source;
+
+    // OpenRouter fields
+    if (source === chat_completion_sources.OPENROUTER) {
+        if (profile.openrouter_providers !== undefined) {
+            oai_settings.openrouter_providers = profile.openrouter_providers;
+        }
+        if (profile.openrouter_use_fallback !== undefined) {
+            oai_settings.openrouter_use_fallback =
+                profile.openrouter_use_fallback;
+        }
+        if (profile.openrouter_allow_fallbacks !== undefined) {
+            oai_settings.openrouter_allow_fallbacks =
+                profile.openrouter_allow_fallbacks;
+        }
+        if (profile.openrouter_quantizations !== undefined) {
+            oai_settings.openrouter_quantizations =
+                profile.openrouter_quantizations;
+        }
+        if (profile.openrouter_middleout !== undefined) {
+            oai_settings.openrouter_middleout = profile.openrouter_middleout;
+        }
+    }
+
+    // NanoGPT fields
+    if (source === chat_completion_sources.NANOGPT) {
+        if (profile.nanogpt_provider !== undefined) {
+            oai_settings.nanogpt_provider = profile.nanogpt_provider;
+        }
+        if (profile.nanogpt_payg_override !== undefined) {
+            oai_settings.nanogpt_payg_override = profile.nanogpt_payg_override;
+        }
+    }
+
+    // Custom API fields
+    if (source === chat_completion_sources.CUSTOM) {
+        if (profile.custom_url !== undefined) {
+            oai_settings.custom_url = profile.custom_url;
+        }
+        if (profile.custom_include_body !== undefined) {
+            oai_settings.custom_include_body = profile.custom_include_body;
+        }
+        if (profile.custom_exclude_body !== undefined) {
+            oai_settings.custom_exclude_body = profile.custom_exclude_body;
+        }
+        if (profile.custom_include_headers !== undefined) {
+            oai_settings.custom_include_headers =
+                profile.custom_include_headers;
+        }
+    }
+
+    // Azure OpenAI fields
+    if (source === chat_completion_sources.AZURE_OPENAI) {
+        if (profile.azure_base_url !== undefined) {
+            oai_settings.azure_base_url = profile.azure_base_url;
+        }
+        if (profile.azure_deployment_name !== undefined) {
+            oai_settings.azure_deployment_name = profile.azure_deployment_name;
+        }
+        if (profile.azure_api_version !== undefined) {
+            oai_settings.azure_api_version = profile.azure_api_version;
+        }
+        if (profile.azure_openai_model !== undefined) {
+            oai_settings.azure_openai_model = profile.azure_openai_model;
+        }
+    }
+
+    // Vertex AI fields
+    if (source === chat_completion_sources.VERTEXAI) {
+        if (profile.vertexai_auth_mode !== undefined) {
+            oai_settings.vertexai_auth_mode = profile.vertexai_auth_mode;
+        }
+        if (profile.vertexai_region !== undefined) {
+            oai_settings.vertexai_region = profile.vertexai_region;
+        }
+        if (profile.vertexai_express_project_id !== undefined) {
+            oai_settings.vertexai_express_project_id =
+                profile.vertexai_express_project_id;
+        }
+    }
+
+    // SiliconFlow fields
+    if (source === chat_completion_sources.SILICONFLOW) {
+        if (profile.siliconflow_endpoint !== undefined) {
+            oai_settings.siliconflow_endpoint = profile.siliconflow_endpoint;
+        }
+    }
+
+    // MiniMax fields
+    if (source === chat_completion_sources.MINIMAX) {
+        if (profile.minimax_endpoint !== undefined) {
+            oai_settings.minimax_endpoint = profile.minimax_endpoint;
+        }
+    }
+
+    // Z.AI fields
+    if (source === chat_completion_sources.ZAI) {
+        if (profile.zai_endpoint !== undefined) {
+            oai_settings.zai_endpoint = profile.zai_endpoint;
+        }
+    }
+
+    // Workers AI fields
+    if (source === chat_completion_sources.WORKERS_AI) {
+        if (profile.workers_ai_account_id !== undefined) {
+            oai_settings.workers_ai_account_id = profile.workers_ai_account_id;
+        }
+    }
+
+    // Generic connection fields (apply to all sources)
+    if (profile.reverse_proxy !== undefined) {
+        oai_settings.reverse_proxy = profile.reverse_proxy;
+    }
+    if (profile.proxy_password !== undefined) {
+        oai_settings.proxy_password = profile.proxy_password;
+    }
+    if (profile.show_external_models !== undefined) {
+        oai_settings.show_external_models = profile.show_external_models;
+    }
+    if (profile.bypass_status_check !== undefined) {
+        oai_settings.bypass_status_check = profile.bypass_status_check;
+    }
+
+    console.log("Connection Manager: Provider fields restored");
+}
 
 /**
  * Finds the best match for the search value.
@@ -193,14 +556,18 @@ const profilesProvider = () => [
  */
 function findProfileByName(value) {
     // Try to find exact match
-    const profile = extension_settings.connectionManager.profiles.find(p => p.name === value);
+    const profile = extension_settings.connectionManager.profiles.find(
+        (p) => p.name === value,
+    );
 
     if (profile) {
         return profile;
     }
 
     // Try to find fuzzy match
-    const fuse = new Fuse(extension_settings.connectionManager.profiles, { keys: ['name'] });
+    const fuse = new Fuse(extension_settings.connectionManager.profiles, {
+        keys: ["name"],
+    });
     const results = fuse.search(value);
 
     if (results.length === 0) {
@@ -218,8 +585,8 @@ function findProfileByName(value) {
  * @param {boolean} [cleanUp] Whether to clean up the profile
  */
 async function readProfileFromCommands(mode, profile, cleanUp = false) {
-    const commands = mode === 'cc' ? CC_COMMANDS : TC_COMMANDS;
-    const opposingCommands = mode === 'cc' ? TC_COMMANDS : CC_COMMANDS;
+    const commands = mode === "cc" ? CC_COMMANDS : TC_COMMANDS;
+    const opposingCommands = mode === "cc" ? TC_COMMANDS : CC_COMMANDS;
     const excludeList = Array.isArray(profile.exclude) ? profile.exclude : [];
     for (const command of commands) {
         try {
@@ -229,8 +596,11 @@ async function readProfileFromCommands(mode, profile, cleanUp = false) {
 
             const allowEmpty = ALLOW_EMPTY.includes(command);
             const args = getNamedArguments();
-            const result = await SlashCommandParser.commands[command].callback(args, '');
-            if (result || (allowEmpty && result === '')) {
+            const result = await SlashCommandParser.commands[command].callback(
+                args,
+                "",
+            );
+            if (result || (allowEmpty && result === "")) {
                 profile[command] = result;
                 continue;
             }
@@ -241,8 +611,8 @@ async function readProfileFromCommands(mode, profile, cleanUp = false) {
 
     if (cleanUp) {
         for (const command of commands) {
-            if (command.endsWith('-state') && profile[command] === 'false') {
-                delete profile[command.replace('-state', '')];
+            if (command.endsWith("-state") && profile[command] === "false") {
+                delete profile[command.replace("-state", "")];
             }
         }
         for (const command of opposingCommands) {
@@ -261,7 +631,7 @@ async function readProfileFromCommands(mode, profile, cleanUp = false) {
  * @returns {Promise<ConnectionProfile>} Created connection profile
  */
 async function createConnectionProfile(forceName = null) {
-    const mode = main_api === 'openai' ? 'cc' : 'tc';
+    const mode = main_api === "openai" ? "cc" : "tc";
     const id = uuidv4();
     /** @type {ConnectionProfile} */
     const profile = {
@@ -271,14 +641,40 @@ async function createConnectionProfile(forceName = null) {
     };
 
     await readProfileFromCommands(mode, profile);
+    captureProviderFields(profile);
 
     const profileForDisplay = makeFancyProfile(profile);
-    const template = $(await renderExtensionTemplateAsync(MODULE_NAME, 'profile', { profile: profileForDisplay }));
-    template.find('input[name="exclude"]').on('input', function () {
+
+    // prettier-ignore
+    const template = $(
+        await renderExtensionTemplateAsync(MODULE_NAME, "profile", {
+            profile: profileForDisplay,
+            sources: FIELD_SOURCES
+        }));
+
+    // Inject source labels after template renders
+    console.log("Template HTML:", template.html().substring(0, 500));
+    console.log(
+        "Source elements found:",
+        template.find('[id^="source-"]').length,
+    );
+
+    for (const [field, source] of Object.entries(FIELD_SOURCES)) {
+        const fancyName = FANCY_NAMES[field]; // Get the display name (e.g., "API" not "api")
+        const sourceElement = template.find(`[id="source-${fancyName}"]`); // Use fancy name!
+
+        if (sourceElement.length && profile[field] !== undefined) {
+            sourceElement.text(`(${source})`);
+        }
+    }
+
+    template.find('input[name="exclude"]').on("input", function () {
         const fancyName = String($(this).val());
-        const keyName = Object.entries(FANCY_NAMES).find(x => x[1] === fancyName)?.[0];
+        const keyName = Object.entries(FANCY_NAMES).find(
+            (x) => x[1] === fancyName,
+        )?.[0];
         if (!keyName) {
-            console.warn('Key not found for fancy name:', fancyName);
+            console.warn("Key not found for fancy name:", fancyName);
             return;
         }
 
@@ -286,7 +682,7 @@ async function createConnectionProfile(forceName = null) {
             profile.exclude = [];
         }
 
-        const excludeState = !$(this).prop('checked');
+        const excludeState = !$(this).prop("checked");
         if (excludeState) {
             profile.exclude.push(keyName);
         } else {
@@ -294,21 +690,29 @@ async function createConnectionProfile(forceName = null) {
             index !== -1 && profile.exclude.splice(index, 1);
         }
     });
-    const isNameTaken = (n) => extension_settings.connectionManager.profiles.some(p => p.name === n);
-    const suggestedName = getUniqueName(collapseSpaces(`${profile.api ?? ''} ${profile.model ?? ''} - ${profile.preset ?? ''}`), isNameTaken);
-    let name = forceName ?? await callGenericPopup(template, POPUP_TYPE.INPUT, suggestedName);
+    const isNameTaken = (n) =>
+        extension_settings.connectionManager.profiles.some((p) => p.name === n);
+    const suggestedName = getUniqueName(
+        collapseSpaces(
+            `${profile.api ?? ""} ${profile.model ?? ""} - ${profile.preset ?? ""}`,
+        ),
+        isNameTaken,
+    );
+    let name =
+        forceName ??
+        (await callGenericPopup(template, POPUP_TYPE.INPUT, suggestedName));
     // If it's cancelled, it will be false
     if (!name) {
         return null;
     }
     name = DOMPurify.sanitize(String(name));
     if (!name) {
-        toastr.error('Name cannot be empty.');
+        toastr.error("Name cannot be empty.");
         return null;
     }
 
     if (isNameTaken(name) || name === NONE) {
-        toastr.error('A profile with the same name already exists.');
+        toastr.error("A profile with the same name already exists.");
         return null;
     }
 
@@ -327,19 +731,25 @@ async function createConnectionProfile(forceName = null) {
  * @returns {Promise<void>}
  */
 async function deleteConnectionProfile() {
-    const selectedProfile = extension_settings.connectionManager.selectedProfile;
+    const selectedProfile =
+        extension_settings.connectionManager.selectedProfile;
     if (!selectedProfile) {
         return;
     }
 
-    const index = extension_settings.connectionManager.profiles.findIndex(p => p.id === selectedProfile);
+    const index = extension_settings.connectionManager.profiles.findIndex(
+        (p) => p.id === selectedProfile,
+    );
     if (index === -1) {
         return;
     }
 
     const profile = extension_settings.connectionManager.profiles[index];
     const name = profile.name;
-    const confirm = await Popup.show.confirm(t`Are you sure you want to delete the selected profile?`, name);
+    const confirm = await Popup.show.confirm(
+        t`Are you sure you want to delete the selected profile?`,
+        name,
+    );
 
     if (!confirm) {
         return;
@@ -358,32 +768,115 @@ async function deleteConnectionProfile() {
  * @returns {Object} Fancy profile
  */
 function makeFancyProfile(profile) {
+    console.log("makeFancyProfile INPUT profile:", profile);
+    const source =
+        main_api === "openai" ? oai_settings.chat_completion_source : null;
+
+    const genericFields = [
+        "reverse_proxy",
+        "proxy_password",
+        "show_external_models",
+        "bypass_status_check",
+    ];
+
+    const providerFieldGroups = {
+        [chat_completion_sources.OPENROUTER]: [
+            "openrouter_providers",
+            "openrouter_use_fallback",
+            "openrouter_allow_fallbacks",
+            "openrouter_quantizations",
+            "openrouter_middleout",
+        ],
+        [chat_completion_sources.NANOGPT]: [
+            "nanogpt_provider",
+            "nanogpt_payg_override",
+        ],
+        [chat_completion_sources.CUSTOM]: [
+            "custom_url",
+            "custom_include_body",
+            "custom_exclude_body",
+            "custom_include_headers",
+        ],
+        [chat_completion_sources.AZURE_OPENAI]: [
+            "azure_base_url",
+            "azure_deployment_name",
+            "azure_api_version",
+            "azure_openai_model",
+        ],
+        [chat_completion_sources.VERTEXAI]: [
+            "vertexai_auth_mode",
+            "vertexai_region",
+            "vertexai_express_project_id",
+        ],
+        [chat_completion_sources.SILICONFLOW]: ["siliconflow_endpoint"],
+        [chat_completion_sources.MINIMAX]: ["minimax_endpoint"],
+        [chat_completion_sources.ZAI]: ["zai_endpoint"],
+        [chat_completion_sources.WORKERS_AI]: ["workers_ai_account_id"],
+    };
+
+    const allowedFields = new Set([
+        "api",
+        "api-url",
+        "preset",
+        "model",
+        "proxy",
+        "sysprompt-state",
+        "sysprompt",
+        "instruct-state",
+        "instruct",
+        "context",
+        "tokenizer",
+        "stop-strings",
+        "start-reply-with",
+        "reasoning-template",
+        "prompt-post-processing",
+        "secret-id",
+        "regex-preset",
+        ...genericFields,
+    ]);
+
+    if (source && providerFieldGroups[source]) {
+        for (const field of providerFieldGroups[source]) {
+            allowedFields.add(field);
+        }
+    }
+
     return Object.entries(FANCY_NAMES).reduce((acc, [key, value]) => {
-        const allowEmpty = ALLOW_EMPTY.includes(key);
-        if (!profile[key]) {
-            if (profile[key] === '' && allowEmpty) {
-                acc[value] = EMPTY;
-            }
+        if (!allowedFields.has(key)) {
             return acc;
         }
 
-        // UUID is not very useful in the UI, so we replace it with a label (if available)
-        if (key === 'secret-id') {
+        const allowEmpty = ALLOW_EMPTY.includes(key);
+
+        if (profile[key] === undefined) {
+            return acc;
+        }
+
+        if (profile[key] === "" && allowEmpty) {
+            acc[value] = EMPTY;
+            return acc;
+        }
+
+        if (profile[key] === "") {
+            return acc;
+        }
+
+        if (key === "secret-id") {
             const label = getSecretLabelById(profile[key]);
             if (label) {
                 acc[value] = label;
                 return acc;
             }
         }
-
-        if (key === 'regex-preset') {
-            const label = extension_settings.regex_presets?.find(p => p.id === profile[key])?.name;
+        if (key === "regex-preset") {
+            const label = extension_settings.regex_presets?.find(
+                (p) => p.id === profile[key],
+            )?.name;
             if (label) {
                 acc[value] = label;
                 return acc;
             }
         }
-
         acc[value] = profile[key];
         return acc;
     }, {});
@@ -403,29 +896,33 @@ async function applyConnectionProfile(profile) {
     ConnectionManagerSpinner.abort();
 
     const mode = profile.mode;
-    const commands = mode === 'cc' ? CC_COMMANDS : TC_COMMANDS;
+    const commands = mode === "cc" ? CC_COMMANDS : TC_COMMANDS;
     const spinner = new ConnectionManagerSpinner();
     spinner.start();
 
     for (const command of commands) {
         if (spinner.isAborted()) {
-            throw new Error('Profile application aborted');
+            throw new Error("Profile application aborted");
         }
 
         const argument = profile[command];
         const allowEmpty = ALLOW_EMPTY.includes(command);
-        if (!argument && !(allowEmpty && argument === '')) {
+        if (!argument && !(allowEmpty && argument === "")) {
             continue;
         }
         try {
-            const args = getNamedArguments(allowEmpty ? { force: 'true' } : {});
+            const args = getNamedArguments(allowEmpty ? { force: "true" } : {});
             await SlashCommandParser.commands[command].callback(args, argument);
         } catch (error) {
-            console.error(`Failed to execute command: ${command} ${argument}`, error);
+            console.error(
+                `Failed to execute command: ${command} ${argument}`,
+                error,
+            );
         }
     }
 
     spinner.stop();
+    restoreProviderFields(profile); // Add provider-specific fields
 }
 
 /**
@@ -434,8 +931,9 @@ async function applyConnectionProfile(profile) {
  * @returns {Promise<void>}
  */
 async function updateConnectionProfile(profile) {
-    profile.mode = main_api === 'openai' ? 'cc' : 'tc';
+    profile.mode = main_api === "openai" ? "cc" : "tc";
     await readProfileFromCommands(profile.mode, profile, true);
+    captureProviderFields(profile); // Add provider-specific fields to the profile
 }
 
 /**
@@ -443,19 +941,22 @@ async function updateConnectionProfile(profile) {
  * @param {HTMLSelectElement} profiles Select element containing connection profiles
  */
 function renderConnectionProfiles(profiles) {
-    profiles.innerHTML = '';
-    const noneOption = document.createElement('option');
+    profiles.innerHTML = "";
+    const noneOption = document.createElement("option");
 
-    noneOption.value = '';
+    noneOption.value = "";
     noneOption.textContent = NONE;
     noneOption.selected = !extension_settings.connectionManager.selectedProfile;
     profiles.appendChild(noneOption);
 
-    for (const profile of extension_settings.connectionManager.profiles.sort((a, b) => a.name.localeCompare(b.name))) {
-        const option = document.createElement('option');
+    for (const profile of extension_settings.connectionManager.profiles.sort(
+        (a, b) => a.name.localeCompare(b.name),
+    )) {
+        const option = document.createElement("option");
         option.value = profile.id;
         option.textContent = profile.name;
-        option.selected = profile.id === extension_settings.connectionManager.selectedProfile;
+        option.selected =
+            profile.id === extension_settings.connectionManager.selectedProfile;
         profiles.appendChild(option);
     }
 }
@@ -465,19 +966,28 @@ function renderConnectionProfiles(profiles) {
  * @param {HTMLElement} detailsContent Content element of the details
  */
 async function renderDetailsContent(detailsContent) {
-    detailsContent.innerHTML = '';
-    if (detailsContent.classList.contains('hidden')) {
+    detailsContent.innerHTML = "";
+    if (detailsContent.classList.contains("hidden")) {
         return;
     }
-    const selectedProfile = extension_settings.connectionManager.selectedProfile;
-    const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
+    const selectedProfile =
+        extension_settings.connectionManager.selectedProfile;
+    const profile = extension_settings.connectionManager.profiles.find(
+        (p) => p.id === selectedProfile,
+    );
     if (profile) {
         const profileForDisplay = makeFancyProfile(profile);
         const templateParams = { profile: profileForDisplay };
         if (Array.isArray(profile.exclude) && profile.exclude.length > 0) {
-            templateParams.omitted = profile.exclude.map(e => FANCY_NAMES[e]).join(', ');
+            templateParams.omitted = profile.exclude
+                .map((e) => FANCY_NAMES[e])
+                .join(", ");
         }
-        const template = await renderExtensionTemplateAsync(MODULE_NAME, 'view', templateParams);
+        const template = await renderExtensionTemplateAsync(
+            MODULE_NAME,
+            "view",
+            templateParams,
+        );
         detailsContent.innerHTML = template;
     } else {
         detailsContent.textContent = t`No profile selected`;
@@ -493,32 +1003,51 @@ async function renderDetailsContent(detailsContent) {
  */
 async function generateStreamCallback(args, value) {
     if (!value) {
-        console.warn('WARN: No argument provided for /profile-genstream command');
-        return '';
+        console.warn(
+            "WARN: No argument provided for /profile-genstream command",
+        );
+        return "";
     }
 
     // Check if Connection Manager is available
     const context = getContext();
-    if (context.extensionSettings.disabledExtensions.includes('connection-manager')) {
-        toastr.error(t`Connection Manager is required for /profile-genstream. Use /gen or /genraw instead.`);
-        return '';
+    if (
+        context.extensionSettings.disabledExtensions.includes(
+            "connection-manager",
+        )
+    ) {
+        toastr.error(
+            t`Connection Manager is required for /profile-genstream. Use /gen or /genraw instead.`,
+        );
+        return "";
     }
 
     const profileIdOrName = args?.profile;
     const includeReasoning = isTrueBoolean(args?.reasoning);
-    const systemPrompt = typeof args?.system == 'string' ? args.system : '';
+    const systemPrompt = typeof args?.system == "string" ? args.system : "";
     const maxTokens = Number(args?.length ?? 2048) || 2048;
     const lock = isTrueBoolean(args?.lock);
-    const generatingLabel = typeof args?.generating === 'string' ? args.generating : 'Generating...';
-    const completedLabel = typeof args?.completed === 'string' ? args.completed : 'Generated';
+    const generatingLabel =
+        typeof args?.generating === "string"
+            ? args.generating
+            : "Generating...";
+    const completedLabel =
+        typeof args?.completed === "string" ? args.completed : "Generated";
     const enableStop = !isFalseBoolean(args?.stop);
-    const onStopClosure = args?.onStop instanceof SlashCommandClosure ? args.onStop : null;
-    const onCompleteClosure = args?.onComplete instanceof SlashCommandClosure ? args.onComplete : null;
+    const onStopClosure =
+        args?.onStop instanceof SlashCommandClosure ? args.onStop : null;
+    const onCompleteClosure =
+        args?.onComplete instanceof SlashCommandClosure
+            ? args.onComplete
+            : null;
 
     // Parse delay: 'infinite' or negative = null (stay open), number = delay in ms
     let completeDelay = 3000; // Default 3 seconds
     if (args?.delay !== undefined) {
-        if (typeof args.delay === 'string' && args.delay.toLowerCase() === 'infinite') {
+        if (
+            typeof args.delay === "string" &&
+            args.delay.toLowerCase() === "infinite"
+        ) {
             completeDelay = null; // Stay until user closes
         } else {
             const parsed = Number(args.delay);
@@ -534,18 +1063,23 @@ async function generateStreamCallback(args, value) {
     const abortController = enableStop ? new AbortController() : null;
 
     // Compose the stop handler: abort the request + optionally invoke user closure
-    const onStopHandler = enableStop ? async () => {
-        abortController.abort();
-        if (onStopClosure) {
-            try {
-                const localClosure = onStopClosure.getCopy();
-                localClosure.onProgress = () => { };
-                await localClosure.execute();
-            } catch (e) {
-                console.error('[GenStream] Error executing onStop closure', e);
-            }
-        }
-    } : null;
+    const onStopHandler = enableStop
+        ? async () => {
+              abortController.abort();
+              if (onStopClosure) {
+                  try {
+                      const localClosure = onStopClosure.getCopy();
+                      localClosure.onProgress = () => {};
+                      await localClosure.execute();
+                  } catch (e) {
+                      console.error(
+                          "[GenStream] Error executing onStop closure",
+                          e,
+                      );
+                  }
+              }
+          }
+        : null;
 
     try {
         if (lock) {
@@ -554,55 +1088,70 @@ async function generateStreamCallback(args, value) {
 
         // Determine which profile to use
         // Use the currently selected profile if no profile specified
-        let effectiveProfileId = context.extensionSettings.connectionManager.selectedProfile;
+        let effectiveProfileId =
+            context.extensionSettings.connectionManager.selectedProfile;
 
         const profiles = context.extensionSettings.connectionManager.profiles;
 
         if (profileIdOrName) {
             // Use try to find profile by id first, then fuse search
-            const profile = profiles.find(p => p.id === profileIdOrName);
+            const profile = profiles.find((p) => p.id === profileIdOrName);
             if (profile) {
                 effectiveProfileId = profile.id;
             } else {
-                const keys = [
-                    { name: 'name', weight: 10 },
-                ];
-                const fuseResults = performFuzzySearch('profile', profiles, keys, profileIdOrName);
+                const keys = [{ name: "name", weight: 10 }];
+                const fuseResults = performFuzzySearch(
+                    "profile",
+                    profiles,
+                    keys,
+                    profileIdOrName,
+                );
                 if (fuseResults.length > 0) {
                     effectiveProfileId = fuseResults[0].item.id;
                 } else {
-                    toastr.warning(t`Connection profile not found: ${profileIdOrName}`);
-                    return '';
+                    toastr.warning(
+                        t`Connection profile not found: ${profileIdOrName}`,
+                    );
+                    return "";
                 }
             }
         }
 
         if (!effectiveProfileId) {
-            toastr.error(t`No connection profile specified or selected. Use profile= argument or select a profile in Connection Manager.`);
-            return '';
+            toastr.error(
+                t`No connection profile specified or selected. Use profile= argument or select a profile in Connection Manager.`,
+            );
+            return "";
         }
 
         // Create streaming display
         const display = new StreamingDisplay();
         display.show({
             label: generatingLabel,
-            icon: ConnectionManagerRequestService.getProfileIcon(effectiveProfileId),
+            icon: ConnectionManagerRequestService.getProfileIcon(
+                effectiveProfileId,
+            ),
             onStop: onStopHandler,
         });
 
         const messages = [
-            ...(systemPrompt ? [{ role: 'system', content: systemPrompt }] : []),
-            { role: 'user', content: value },
+            ...(systemPrompt
+                ? [{ role: "system", content: systemPrompt }]
+                : []),
+            { role: "user", content: value },
         ];
 
-        let finalText = '';
-        let finalReasoning = '';
+        let finalText = "";
+        let finalReasoning = "";
 
         /** Gets the final (if requested, formatted) text to return for this command @returns {string} */
         function buildResultText() {
             // Format output with reasoning if requested
             if (includeReasoning && finalReasoning) {
-                const { formatted } = formatReasoning(finalReasoning, finalText);
+                const { formatted } = formatReasoning(
+                    finalReasoning,
+                    finalText,
+                );
                 return formatted;
             }
 
@@ -611,26 +1160,32 @@ async function generateStreamCallback(args, value) {
 
         try {
             // Attempt streaming first
-            const streamResponse = await ConnectionManagerRequestService.sendRequest(
-                effectiveProfileId,
-                messages,
-                maxTokens,
-                { extractData: true, includePreset: true, stream: true, signal: abortController?.signal ?? undefined },
-            );
+            const streamResponse =
+                await ConnectionManagerRequestService.sendRequest(
+                    effectiveProfileId,
+                    messages,
+                    maxTokens,
+                    {
+                        extractData: true,
+                        includePreset: true,
+                        stream: true,
+                        signal: abortController?.signal ?? undefined,
+                    },
+                );
 
-            if (typeof streamResponse === 'function') {
+            if (typeof streamResponse === "function") {
                 const generator = streamResponse();
                 for await (const chunk of generator) {
                     finalText = chunk.text;
-                    finalReasoning = chunk.state?.reasoning || '';
+                    finalReasoning = chunk.state?.reasoning || "";
                     display.updateReasoning(finalReasoning);
                     display.updateContent(finalText);
                 }
             } else {
                 // Non-streaming fallback within the try block
                 const extracted = streamResponse;
-                finalText = extracted?.content || '';
-                finalReasoning = extracted?.reasoning || '';
+                finalText = extracted?.content || "";
+                finalReasoning = extracted?.reasoning || "";
                 if (finalReasoning) {
                     display.updateReasoning(finalReasoning);
                 }
@@ -643,7 +1198,10 @@ async function generateStreamCallback(args, value) {
                 return buildResultText();
             }
 
-            console.warn('[Slash Commands] Streaming failed, falling back to non-streaming:', error);
+            console.warn(
+                "[Slash Commands] Streaming failed, falling back to non-streaming:",
+                error,
+            );
             display.hide({ instant: true });
 
             // Retry with non-streaming
@@ -654,14 +1212,19 @@ async function generateStreamCallback(args, value) {
                 { extractData: true, includePreset: true, stream: false },
             );
 
-            const extracted = /** @type {import('../../custom-request.js').ExtractedData} */ (response);
-            finalText = extracted?.content || '';
-            finalReasoning = extracted?.reasoning || '';
+            const extracted =
+                /** @type {import('../../custom-request.js').ExtractedData} */ (
+                    response
+                );
+            finalText = extracted?.content || "";
+            finalReasoning = extracted?.reasoning || "";
 
             // Show quick non-streaming display
             display.show({
                 label: generatingLabel,
-                icon: ConnectionManagerRequestService.getProfileIcon(effectiveProfileId),
+                icon: ConnectionManagerRequestService.getProfileIcon(
+                    effectiveProfileId,
+                ),
             });
             if (finalReasoning) {
                 display.updateReasoning(finalReasoning);
@@ -676,23 +1239,26 @@ async function generateStreamCallback(args, value) {
         if (onCompleteClosure) {
             try {
                 const localClosure = onCompleteClosure.getCopy();
-                localClosure.onProgress = () => { };
+                localClosure.onProgress = () => {};
                 await localClosure.execute();
             } catch (e) {
-                console.error('[GenStream] Error executing onComplete closure', e);
+                console.error(
+                    "[GenStream] Error executing onComplete closure",
+                    e,
+                );
             }
         }
 
         if (!finalText) {
             toastr.warning(t`Generation returned empty result`);
-            return '';
+            return "";
         }
 
         return buildResultText();
     } catch (err) {
-        console.error('Error on /genstream generation', err);
+        console.error("Error on /genstream generation", err);
         toastr.error(err.message, t`API Error`, { preventDuplicates: true });
-        return '';
+        return "";
     } finally {
         if (lock) {
             activateSendButtons();
@@ -701,7 +1267,9 @@ async function generateStreamCallback(args, value) {
 }
 
 export async function init() {
-    extension_settings.connectionManager = extension_settings.connectionManager || structuredClone(DEFAULT_SETTINGS);
+    extension_settings.connectionManager =
+        extension_settings.connectionManager ||
+        structuredClone(DEFAULT_SETTINGS);
 
     for (const key of Object.keys(DEFAULT_SETTINGS)) {
         if (extension_settings.connectionManager[key] === undefined) {
@@ -709,23 +1277,34 @@ export async function init() {
         }
     }
 
-    const container = document.getElementById('rm_api_block');
-    const settings = await renderExtensionTemplateAsync(MODULE_NAME, 'settings');
-    container.insertAdjacentHTML('afterbegin', settings);
+    const container = document.getElementById("rm_api_block");
+    const settings = await renderExtensionTemplateAsync(
+        MODULE_NAME,
+        "settings",
+    );
+    container.insertAdjacentHTML("afterbegin", settings);
 
     /** @type {HTMLSelectElement} */
     // @ts-ignore
-    const profiles = document.getElementById('connection_profiles');
+    const profiles = document.getElementById("connection_profiles");
     renderConnectionProfiles(profiles);
 
     function toggleProfileSpecificButtons() {
         const profileId = extension_settings.connectionManager.selectedProfile;
-        const profileSpecificButtons = ['update_connection_profile', 'reload_connection_profile', 'delete_connection_profile'];
-        profileSpecificButtons.forEach(id => document.getElementById(id).classList.toggle('disabled', !profileId));
+        const profileSpecificButtons = [
+            "update_connection_profile",
+            "reload_connection_profile",
+            "delete_connection_profile",
+        ];
+        profileSpecificButtons.forEach((id) =>
+            document
+                .getElementById(id)
+                .classList.toggle("disabled", !profileId),
+        );
     }
     toggleProfileSpecificButtons();
 
-    profiles.addEventListener('change', async function () {
+    profiles.addEventListener("change", async function () {
         const selectedProfile = profiles.selectedOptions[0];
         if (!selectedProfile) {
             // Safety net for preventing the command getting stuck
@@ -746,7 +1325,9 @@ export async function init() {
             return;
         }
 
-        const profile = extension_settings.connectionManager.profiles.find(p => p.id === profileId);
+        const profile = extension_settings.connectionManager.profiles.find(
+            (p) => p.id === profileId,
+        );
 
         if (!profile) {
             console.log(`Profile not found: ${profileId}`);
@@ -754,25 +1335,34 @@ export async function init() {
         }
 
         await applyConnectionProfile(profile);
-        await eventSource.emit(event_types.CONNECTION_PROFILE_LOADED, profile.name);
+        await eventSource.emit(
+            event_types.CONNECTION_PROFILE_LOADED,
+            profile.name,
+        );
     });
 
-    const reloadButton = document.getElementById('reload_connection_profile');
-    reloadButton.addEventListener('click', async () => {
-        const selectedProfile = extension_settings.connectionManager.selectedProfile;
-        const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
+    const reloadButton = document.getElementById("reload_connection_profile");
+    reloadButton.addEventListener("click", async () => {
+        const selectedProfile =
+            extension_settings.connectionManager.selectedProfile;
+        const profile = extension_settings.connectionManager.profiles.find(
+            (p) => p.id === selectedProfile,
+        );
         if (!profile) {
-            console.log('No profile selected');
+            console.log("No profile selected");
             return;
         }
         await applyConnectionProfile(profile);
         await renderDetailsContent(detailsContent);
-        await eventSource.emit(event_types.CONNECTION_PROFILE_LOADED, profile.name);
-        toastr.success('Connection profile reloaded', '', { timeOut: 1500 });
+        await eventSource.emit(
+            event_types.CONNECTION_PROFILE_LOADED,
+            profile.name,
+        );
+        toastr.success("Connection profile reloaded", "", { timeOut: 1500 });
     });
 
-    const createButton = document.getElementById('create_connection_profile');
-    createButton.addEventListener('click', async () => {
+    const createButton = document.getElementById("create_connection_profile");
+    createButton.addEventListener("click", async () => {
         const profile = await createConnectionProfile();
         if (!profile) {
             return;
@@ -783,40 +1373,56 @@ export async function init() {
         renderConnectionProfiles(profiles);
         await renderDetailsContent(detailsContent);
         await eventSource.emit(event_types.CONNECTION_PROFILE_CREATED, profile);
-        await eventSource.emit(event_types.CONNECTION_PROFILE_LOADED, profile.name);
+        await eventSource.emit(
+            event_types.CONNECTION_PROFILE_LOADED,
+            profile.name,
+        );
     });
 
-    const updateButton = document.getElementById('update_connection_profile');
-    updateButton.addEventListener('click', async () => {
-        const selectedProfile = extension_settings.connectionManager.selectedProfile;
-        const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
+    const updateButton = document.getElementById("update_connection_profile");
+    updateButton.addEventListener("click", async () => {
+        const selectedProfile =
+            extension_settings.connectionManager.selectedProfile;
+        const profile = extension_settings.connectionManager.profiles.find(
+            (p) => p.id === selectedProfile,
+        );
         if (!profile) {
-            console.log('No profile selected');
+            console.log("No profile selected");
             return;
         }
         const oldProfile = structuredClone(profile);
         await updateConnectionProfile(profile);
         await renderDetailsContent(detailsContent);
         saveSettingsDebounced();
-        await eventSource.emit(event_types.CONNECTION_PROFILE_UPDATED, oldProfile, profile);
-        await eventSource.emit(event_types.CONNECTION_PROFILE_LOADED, profile.name);
-        toastr.success('Connection profile updated', '', { timeOut: 1500 });
+        await eventSource.emit(
+            event_types.CONNECTION_PROFILE_UPDATED,
+            oldProfile,
+            profile,
+        );
+        await eventSource.emit(
+            event_types.CONNECTION_PROFILE_LOADED,
+            profile.name,
+        );
+        toastr.success("Connection profile updated", "", { timeOut: 1500 });
     });
 
-    const deleteButton = document.getElementById('delete_connection_profile');
-    deleteButton.addEventListener('click', async () => {
+    const deleteButton = document.getElementById("delete_connection_profile");
+    deleteButton.addEventListener("click", async () => {
         await deleteConnectionProfile();
         renderConnectionProfiles(profiles);
         await renderDetailsContent(detailsContent);
         await eventSource.emit(event_types.CONNECTION_PROFILE_LOADED, NONE);
     });
 
-    const editButton = document.getElementById('edit_connection_profile');
-    editButton.addEventListener('click', async () => {
-        const selectedProfile = extension_settings.connectionManager.selectedProfile;
-        const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
+    const editButton = document.getElementById("edit_connection_profile");
+    editButton.addEventListener("click", async () => {
+        const selectedProfile =
+            extension_settings.connectionManager.selectedProfile;
+        const profile = extension_settings.connectionManager.profiles.find(
+            (p) => p.id === selectedProfile,
+        );
         if (!profile) {
-            console.log('No profile selected');
+            console.log("No profile selected");
             return;
         }
         if (!Array.isArray(profile.exclude)) {
@@ -824,24 +1430,41 @@ export async function init() {
         }
 
         let saveChanges = false;
-        const sortByViewOrder = (a, b) => Object.keys(FANCY_NAMES).indexOf(a) - Object.keys(FANCY_NAMES).indexOf(b);
-        const commands = profile.mode === 'cc' ? CC_COMMANDS : TC_COMMANDS;
-        const settings = commands.slice().sort(sortByViewOrder).reduce((acc, command) => {
-            const fancyName = FANCY_NAMES[command];
-            acc[fancyName] = !profile.exclude.includes(command);
-            return acc;
-        }, {});
-        const template = $(await renderExtensionTemplateAsync(MODULE_NAME, 'edit', { name: profile.name, settings }));
-        let newName = await callGenericPopup(template, POPUP_TYPE.INPUT, profile.name, {
-            customButtons: [{
-                text: t`Save and Update`,
-                classes: ['popup-button-ok'],
-                result: POPUP_RESULT.AFFIRMATIVE,
-                action: () => {
-                    saveChanges = true;
-                },
-            }],
-        });
+        const sortByViewOrder = (a, b) =>
+            Object.keys(FANCY_NAMES).indexOf(a) -
+            Object.keys(FANCY_NAMES).indexOf(b);
+        const commands = profile.mode === "cc" ? CC_COMMANDS : TC_COMMANDS;
+        const settings = commands
+            .slice()
+            .sort(sortByViewOrder)
+            .reduce((acc, command) => {
+                const fancyName = FANCY_NAMES[command];
+                acc[fancyName] = !profile.exclude.includes(command);
+                return acc;
+            }, {});
+        const template = $(
+            await renderExtensionTemplateAsync(MODULE_NAME, "edit", {
+                name: profile.name,
+                settings,
+            }),
+        );
+        let newName = await callGenericPopup(
+            template,
+            POPUP_TYPE.INPUT,
+            profile.name,
+            {
+                customButtons: [
+                    {
+                        text: t`Save and Update`,
+                        classes: ["popup-button-ok"],
+                        result: POPUP_RESULT.AFFIRMATIVE,
+                        action: () => {
+                            saveChanges = true;
+                        },
+                    },
+                ],
+            },
+        );
 
         // If it's cancelled, it will be false
         if (!newName) {
@@ -849,21 +1472,34 @@ export async function init() {
         }
         newName = DOMPurify.sanitize(String(newName));
         if (!newName) {
-            toastr.error('Name cannot be empty.');
+            toastr.error("Name cannot be empty.");
             return;
         }
 
-        if (profile.name !== newName && extension_settings.connectionManager.profiles.some(p => p.name === newName)) {
-            toastr.error('A profile with the same name already exists.');
+        if (
+            profile.name !== newName &&
+            extension_settings.connectionManager.profiles.some(
+                (p) => p.name === newName,
+            )
+        ) {
+            toastr.error("A profile with the same name already exists.");
             return;
         }
 
-        const newExcludeList = template.find('input[name="exclude"]:not(:checked)').map(function () {
-            return Object.entries(FANCY_NAMES).find(x => x[1] === String($(this).val()))?.[0];
-        }).get();
+        const newExcludeList = template
+            .find('input[name="exclude"]:not(:checked)')
+            .map(function () {
+                return Object.entries(FANCY_NAMES).find(
+                    (x) => x[1] === String($(this).val()),
+                )?.[0];
+            })
+            .get();
 
         const oldProfile = structuredClone(profile);
-        if (newExcludeList.length !== profile.exclude.length || !newExcludeList.every(e => profile.exclude.includes(e))) {
+        if (
+            newExcludeList.length !== profile.exclude.length ||
+            !newExcludeList.every((e) => profile.exclude.includes(e))
+        ) {
             profile.exclude = newExcludeList;
             for (const command of newExcludeList) {
                 delete profile[command];
@@ -871,266 +1507,350 @@ export async function init() {
             if (saveChanges) {
                 await updateConnectionProfile(profile);
             } else {
-                toastr.info('Press "Update" to record them into the profile.', 'Included settings list updated');
+                toastr.info(
+                    'Press "Update" to record them into the profile.',
+                    "Included settings list updated",
+                );
             }
         }
 
         if (profile.name !== newName) {
-            toastr.success('Connection profile renamed.');
+            toastr.success("Connection profile renamed.");
             profile.name = newName;
         }
 
         saveSettingsDebounced();
-        await eventSource.emit(event_types.CONNECTION_PROFILE_UPDATED, oldProfile, profile);
+        await eventSource.emit(
+            event_types.CONNECTION_PROFILE_UPDATED,
+            oldProfile,
+            profile,
+        );
         renderConnectionProfiles(profiles);
         await renderDetailsContent(detailsContent);
     });
 
     /** @type {HTMLElement} */
-    const viewDetails = document.getElementById('view_connection_profile');
-    const detailsContent = document.getElementById('connection_profile_details_content');
-    viewDetails.addEventListener('click', async () => {
-        viewDetails.classList.toggle('active');
-        detailsContent.classList.toggle('hidden');
+    const viewDetails = document.getElementById("view_connection_profile");
+    const detailsContent = document.getElementById(
+        "connection_profile_details_content",
+    );
+    viewDetails.addEventListener("click", async () => {
+        viewDetails.classList.toggle("active");
+        detailsContent.classList.toggle("hidden");
         await renderDetailsContent(detailsContent);
     });
 
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'profile',
-        helpString: 'Switch to a connection profile or return the name of the current profile in no argument is provided. Use <code>&lt;None&gt;</code> to switch to no profile.',
-        returns: 'name of the profile',
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'Name of the connection profile',
-                enumProvider: profilesProvider,
-                isRequired: false,
-            }),
-        ],
-        namedArgumentList: [
-            SlashCommandNamedArgument.fromProps({
-                name: 'await',
-                description: 'Wait for the connection profile to be applied before returning.',
-                isRequired: false,
-                typeList: [ARGUMENT_TYPE.BOOLEAN],
-                defaultValue: 'true',
-                enumList: commonEnumProviders.boolean('trueFalse')(),
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'timeout',
-                description: 'Maximum time to wait for the API connection to be established, in milliseconds. Set to 0 to disable. Only applies when await=true.',
-                isRequired: false,
-                typeList: [ARGUMENT_TYPE.NUMBER],
-                defaultValue: '2000',
-            }),
-        ],
-        callback: async (args, value) => {
-            if (!value || typeof value !== 'string') {
-                const selectedProfile = extension_settings.connectionManager.selectedProfile;
-                const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
-                if (!profile) {
+    SlashCommandParser.addCommandObject(
+        SlashCommand.fromProps({
+            name: "profile",
+            helpString:
+                "Switch to a connection profile or return the name of the current profile in no argument is provided. Use <code>&lt;None&gt;</code> to switch to no profile.",
+            returns: "name of the profile",
+            unnamedArgumentList: [
+                SlashCommandArgument.fromProps({
+                    description: "Name of the connection profile",
+                    enumProvider: profilesProvider,
+                    isRequired: false,
+                }),
+            ],
+            namedArgumentList: [
+                SlashCommandNamedArgument.fromProps({
+                    name: "await",
+                    description:
+                        "Wait for the connection profile to be applied before returning.",
+                    isRequired: false,
+                    typeList: [ARGUMENT_TYPE.BOOLEAN],
+                    defaultValue: "true",
+                    enumList: commonEnumProviders.boolean("trueFalse")(),
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "timeout",
+                    description:
+                        "Maximum time to wait for the API connection to be established, in milliseconds. Set to 0 to disable. Only applies when await=true.",
+                    isRequired: false,
+                    typeList: [ARGUMENT_TYPE.NUMBER],
+                    defaultValue: "2000",
+                }),
+            ],
+            callback: async (args, value) => {
+                if (!value || typeof value !== "string") {
+                    const selectedProfile =
+                        extension_settings.connectionManager.selectedProfile;
+                    const profile =
+                        extension_settings.connectionManager.profiles.find(
+                            (p) => p.id === selectedProfile,
+                        );
+                    if (!profile) {
+                        return NONE;
+                    }
+                    return profile.name;
+                }
+
+                if (value === NONE) {
+                    profiles.selectedIndex = 0;
+                    profiles.dispatchEvent(new Event("change"));
                     return NONE;
                 }
-                return profile.name;
-            }
 
-            if (value === NONE) {
-                profiles.selectedIndex = 0;
-                profiles.dispatchEvent(new Event('change'));
-                return NONE;
-            }
+                const profile = findProfileByName(value);
 
-            const profile = findProfileByName(value);
-
-            if (!profile) {
-                return '';
-            }
-
-            const shouldAwait = !isFalseBoolean(String(args?.await));
-            const awaitPromise = new Promise((resolve) => eventSource.once(event_types.CONNECTION_PROFILE_LOADED, resolve));
-
-            profiles.selectedIndex = Array.from(profiles.options).findIndex(o => o.value === profile.id);
-            profiles.dispatchEvent(new Event('change'));
-
-            if (shouldAwait) {
-                await awaitPromise;
-
-                // We should also await the connection to be established
-                const parsedTimeout = parseInt(args?.timeout?.toString());
-                const timeout = !isNaN(parsedTimeout) ? Math.max(0, parsedTimeout) : 2000;
-                if (timeout > 0) {
-                    await waitUntilCondition(() => online_status !== 'no_connection', timeout, 100, { rejectOnTimeout: false });
-                }
-            }
-
-            return profile.name;
-        },
-    }));
-
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'profile-list',
-        helpString: 'List all connection profile names.',
-        returns: 'list of profile names',
-        callback: () => JSON.stringify(extension_settings.connectionManager.profiles.map(p => p.name)),
-    }));
-
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'profile-create',
-        returns: 'name of the new profile',
-        helpString: 'Create a new connection profile using the current settings.',
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'name of the new connection profile',
-                isRequired: true,
-                typeList: [ARGUMENT_TYPE.STRING],
-            }),
-        ],
-        callback: async (_args, name) => {
-            if (!name || typeof name !== 'string') {
-                toastr.warning('Please provide a name for the new connection profile.');
-                return '';
-            }
-            const profile = await createConnectionProfile(name);
-            if (!profile) {
-                return '';
-            }
-            extension_settings.connectionManager.profiles.push(profile);
-            extension_settings.connectionManager.selectedProfile = profile.id;
-            saveSettingsDebounced();
-            renderConnectionProfiles(profiles);
-            await renderDetailsContent(detailsContent);
-            await eventSource.emit(event_types.CONNECTION_PROFILE_CREATED, profile);
-            return profile.name;
-        },
-    }));
-
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'profile-update',
-        helpString: 'Update the selected connection profile.',
-        callback: async () => {
-            const selectedProfile = extension_settings.connectionManager.selectedProfile;
-            const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
-            if (!profile) {
-                toastr.warning('No profile selected.');
-                return '';
-            }
-            const oldProfile = structuredClone(profile);
-            await updateConnectionProfile(profile);
-            await renderDetailsContent(detailsContent);
-            saveSettingsDebounced();
-            await eventSource.emit(event_types.CONNECTION_PROFILE_UPDATED, oldProfile, profile);
-            return profile.name;
-        },
-    }));
-
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'profile-get',
-        helpString: 'Get the details of the connection profile. Returns the selected profile if no argument is provided.',
-        returns: 'object of the selected profile',
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'Name of the connection profile',
-                enumProvider: profilesProvider,
-                isRequired: false,
-            }),
-        ],
-        callback: async (_args, value) => {
-            if (!value || typeof value !== 'string') {
-                const selectedProfile = extension_settings.connectionManager.selectedProfile;
-                const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
                 if (!profile) {
-                    return '';
+                    return "";
+                }
+
+                const shouldAwait = !isFalseBoolean(String(args?.await));
+                const awaitPromise = new Promise((resolve) =>
+                    eventSource.once(
+                        event_types.CONNECTION_PROFILE_LOADED,
+                        resolve,
+                    ),
+                );
+
+                profiles.selectedIndex = Array.from(profiles.options).findIndex(
+                    (o) => o.value === profile.id,
+                );
+                profiles.dispatchEvent(new Event("change"));
+
+                if (shouldAwait) {
+                    await awaitPromise;
+
+                    // We should also await the connection to be established
+                    const parsedTimeout = parseInt(args?.timeout?.toString());
+                    const timeout = !isNaN(parsedTimeout)
+                        ? Math.max(0, parsedTimeout)
+                        : 2000;
+                    if (timeout > 0) {
+                        await waitUntilCondition(
+                            () => online_status !== "no_connection",
+                            timeout,
+                            100,
+                            { rejectOnTimeout: false },
+                        );
+                    }
+                }
+
+                return profile.name;
+            },
+        }),
+    );
+
+    SlashCommandParser.addCommandObject(
+        SlashCommand.fromProps({
+            name: "profile-list",
+            helpString: "List all connection profile names.",
+            returns: "list of profile names",
+            callback: () =>
+                JSON.stringify(
+                    extension_settings.connectionManager.profiles.map(
+                        (p) => p.name,
+                    ),
+                ),
+        }),
+    );
+
+    SlashCommandParser.addCommandObject(
+        SlashCommand.fromProps({
+            name: "profile-create",
+            returns: "name of the new profile",
+            helpString:
+                "Create a new connection profile using the current settings.",
+            unnamedArgumentList: [
+                SlashCommandArgument.fromProps({
+                    description: "name of the new connection profile",
+                    isRequired: true,
+                    typeList: [ARGUMENT_TYPE.STRING],
+                }),
+            ],
+            callback: async (_args, name) => {
+                if (!name || typeof name !== "string") {
+                    toastr.warning(
+                        "Please provide a name for the new connection profile.",
+                    );
+                    return "";
+                }
+                const profile = await createConnectionProfile(name);
+                if (!profile) {
+                    return "";
+                }
+                extension_settings.connectionManager.profiles.push(profile);
+                extension_settings.connectionManager.selectedProfile =
+                    profile.id;
+                saveSettingsDebounced();
+                renderConnectionProfiles(profiles);
+                await renderDetailsContent(detailsContent);
+                await eventSource.emit(
+                    event_types.CONNECTION_PROFILE_CREATED,
+                    profile,
+                );
+                return profile.name;
+            },
+        }),
+    );
+
+    SlashCommandParser.addCommandObject(
+        SlashCommand.fromProps({
+            name: "profile-update",
+            helpString: "Update the selected connection profile.",
+            callback: async () => {
+                const selectedProfile =
+                    extension_settings.connectionManager.selectedProfile;
+                const profile =
+                    extension_settings.connectionManager.profiles.find(
+                        (p) => p.id === selectedProfile,
+                    );
+                if (!profile) {
+                    toastr.warning("No profile selected.");
+                    return "";
+                }
+                const oldProfile = structuredClone(profile);
+                await updateConnectionProfile(profile);
+                await renderDetailsContent(detailsContent);
+                saveSettingsDebounced();
+                await eventSource.emit(
+                    event_types.CONNECTION_PROFILE_UPDATED,
+                    oldProfile,
+                    profile,
+                );
+                return profile.name;
+            },
+        }),
+    );
+
+    SlashCommandParser.addCommandObject(
+        SlashCommand.fromProps({
+            name: "profile-get",
+            helpString:
+                "Get the details of the connection profile. Returns the selected profile if no argument is provided.",
+            returns: "object of the selected profile",
+            unnamedArgumentList: [
+                SlashCommandArgument.fromProps({
+                    description: "Name of the connection profile",
+                    enumProvider: profilesProvider,
+                    isRequired: false,
+                }),
+            ],
+            callback: async (_args, value) => {
+                if (!value || typeof value !== "string") {
+                    const selectedProfile =
+                        extension_settings.connectionManager.selectedProfile;
+                    const profile =
+                        extension_settings.connectionManager.profiles.find(
+                            (p) => p.id === selectedProfile,
+                        );
+                    if (!profile) {
+                        return "";
+                    }
+                    return JSON.stringify(profile);
+                }
+
+                const profile = findProfileByName(value);
+                if (!profile) {
+                    return "";
                 }
                 return JSON.stringify(profile);
-            }
+            },
+        }),
+    );
 
-            const profile = findProfileByName(value);
-            if (!profile) {
-                return '';
-            }
-            return JSON.stringify(profile);
-        },
-    }));
-
-    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
-        name: 'profile-genstream',
-        callback: generateStreamCallback,
-        returns: t`generated text`,
-        namedArgumentList: [
-            new SlashCommandNamedArgument(
-                'lock', t`lock user input during generation`, [ARGUMENT_TYPE.BOOLEAN], false, false, 'off', commonEnumProviders.boolean('onOff')(),
-            ),
-            SlashCommandNamedArgument.fromProps({
-                name: 'profile',
-                description: t`connection profile ID to use for generation`,
-                typeList: [ARGUMENT_TYPE.STRING],
-                enumProvider: commonEnumProviders.connectionProfiles(),
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'reasoning',
-                description: t`include formatted reasoning in the output`,
-                typeList: [ARGUMENT_TYPE.BOOLEAN],
-                defaultValue: 'false',
-                enumProvider: commonEnumProviders.boolean('trueFalse'),
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'system',
-                description: t`system prompt at the start`,
-                typeList: [ARGUMENT_TYPE.STRING],
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'length',
-                description: t`API response length in tokens`,
-                typeList: [ARGUMENT_TYPE.NUMBER],
-                defaultValue: '2048',
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'generating',
-                description: t`label/title for the generation display`,
-                typeList: [ARGUMENT_TYPE.STRING],
-                defaultValue: 'Generating...',
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'completed',
-                description: t`updated label/title for when generation completes`,
-                typeList: [ARGUMENT_TYPE.STRING],
-                defaultValue: 'Generated',
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'delay',
-                description: t`auto-hide delay in ms after generation completes. Use "infinite" or negative to keep until manually closed`,
-                typeList: [ARGUMENT_TYPE.NUMBER],
-                defaultValue: '3000',
-                enumList: [
-                    new SlashCommandEnumValue('infinite', 'Keep the streaming display open until manually closed', 'command', '♾️'),
-                    new SlashCommandEnumValue('any delay in seconds', null, 'number', '⌚', () => true, input => input),
-                ],
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'stop',
-                description: t`show a stop button on the streaming display that aborts generation when clicked`,
-                typeList: [ARGUMENT_TYPE.BOOLEAN],
-                defaultValue: 'true',
-                enumProvider: commonEnumProviders.boolean('trueFalse'),
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'onStop',
-                description: t`closure to execute when the stop button is clicked (in addition to aborting the request)`,
-                typeList: [ARGUMENT_TYPE.CLOSURE],
-            }),
-            SlashCommandNamedArgument.fromProps({
-                name: 'onComplete',
-                description: t`closure to execute after generation completes successfully`,
-                typeList: [ARGUMENT_TYPE.CLOSURE],
-            }),
-        ],
-        unnamedArgumentList: [
-            SlashCommandArgument.fromProps({
-                description: 'prompt',
-                typeList: [ARGUMENT_TYPE.STRING],
-                isRequired: true,
-            }),
-        ],
-        helpString: `
+    SlashCommandParser.addCommandObject(
+        SlashCommand.fromProps({
+            name: "profile-genstream",
+            callback: generateStreamCallback,
+            returns: t`generated text`,
+            namedArgumentList: [
+                new SlashCommandNamedArgument(
+                    "lock",
+                    t`lock user input during generation`,
+                    [ARGUMENT_TYPE.BOOLEAN],
+                    false,
+                    false,
+                    "off",
+                    commonEnumProviders.boolean("onOff")(),
+                ),
+                SlashCommandNamedArgument.fromProps({
+                    name: "profile",
+                    description: t`connection profile ID to use for generation`,
+                    typeList: [ARGUMENT_TYPE.STRING],
+                    enumProvider: commonEnumProviders.connectionProfiles(),
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "reasoning",
+                    description: t`include formatted reasoning in the output`,
+                    typeList: [ARGUMENT_TYPE.BOOLEAN],
+                    defaultValue: "false",
+                    enumProvider: commonEnumProviders.boolean("trueFalse"),
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "system",
+                    description: t`system prompt at the start`,
+                    typeList: [ARGUMENT_TYPE.STRING],
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "length",
+                    description: t`API response length in tokens`,
+                    typeList: [ARGUMENT_TYPE.NUMBER],
+                    defaultValue: "2048",
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "generating",
+                    description: t`label/title for the generation display`,
+                    typeList: [ARGUMENT_TYPE.STRING],
+                    defaultValue: "Generating...",
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "completed",
+                    description: t`updated label/title for when generation completes`,
+                    typeList: [ARGUMENT_TYPE.STRING],
+                    defaultValue: "Generated",
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "delay",
+                    description: t`auto-hide delay in ms after generation completes. Use "infinite" or negative to keep until manually closed`,
+                    typeList: [ARGUMENT_TYPE.NUMBER],
+                    defaultValue: "3000",
+                    enumList: [
+                        new SlashCommandEnumValue(
+                            "infinite",
+                            "Keep the streaming display open until manually closed",
+                            "command",
+                            "♾️",
+                        ),
+                        new SlashCommandEnumValue(
+                            "any delay in seconds",
+                            null,
+                            "number",
+                            "⌚",
+                            () => true,
+                            (input) => input,
+                        ),
+                    ],
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "stop",
+                    description: t`show a stop button on the streaming display that aborts generation when clicked`,
+                    typeList: [ARGUMENT_TYPE.BOOLEAN],
+                    defaultValue: "true",
+                    enumProvider: commonEnumProviders.boolean("trueFalse"),
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "onStop",
+                    description: t`closure to execute when the stop button is clicked (in addition to aborting the request)`,
+                    typeList: [ARGUMENT_TYPE.CLOSURE],
+                }),
+                SlashCommandNamedArgument.fromProps({
+                    name: "onComplete",
+                    description: t`closure to execute after generation completes successfully`,
+                    typeList: [ARGUMENT_TYPE.CLOSURE],
+                }),
+            ],
+            unnamedArgumentList: [
+                SlashCommandArgument.fromProps({
+                    description: "prompt",
+                    typeList: [ARGUMENT_TYPE.STRING],
+                    isRequired: true,
+                }),
+            ],
+            helpString: `
             <div>
                 ${t`Generates text using Connection Manager with streaming display. Shows live generation progress including reasoning (thinking) and content.`}
             </div>
@@ -1159,6 +1879,6 @@ export async function init() {
                 ${t`Example with custom stop handler: <pre><code>/profile-genstream onStop={: /echo "Generation stopped!" :} Tell me a story</code></pre>`}
             </div>
         `,
-    }));
+        }),
+    );
 }
-

--- a/public/scripts/extensions/connection-manager/profile.html
+++ b/public/scripts/extensions/connection-manager/profile.html
@@ -5,18 +5,22 @@
     <div class="justifyLeft flex-container flexFlowColumn flexNoGap">
         {{#each profile}}
         <label class="checkbox_label">
-            <input type="checkbox" value="{{@key}}" name="exclude" checked>
-            <span><strong data-i18n="{{@key}}">{{@key}}:</strong>&nbsp;{{this}}</span>
+            <input type="checkbox" value="{{@key}}" name="exclude" checked />
+            <span>
+                <strong data-i18n="{{@key}}">{{@key}}:</strong>&nbsp;{{this}}
+                <small class="textMuted" id="source-{{@key}}"></small>
+            </span>
         </label>
         {{/each}}
     </div>
     <div class="marginTop5">
         <small>
             <b data-i18n="Hint:">Hint:</b>
-            <i data-i18n="Click on the setting name to omit it from the profile.">Click on the setting name to omit it from the profile.</i>
+            <i
+                data-i18n="Click on the setting name to omit it from the profile."
+                >Click on the setting name to omit it from the profile.</i
+            >
         </small>
     </div>
-    <h3 data-i18n="Enter a name:">
-        Enter a name:
-    </h3>
+    <h3 data-i18n="Enter a name:">Enter a name:</h3>
 </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -7249,7 +7249,7 @@ export function initOpenAI() {
     $('#openai_proxy_preset').on('change', onProxyPresetChange);
 }
 
-// Connection Profile Support (OpenRouter)
+// Connection Profile Support (OpenRouter, NanoGPT, etc.)
 
 // Helper function to attach OpenRouter settings to a profile
 function attachOpenRouterSettings(profile) {
@@ -7303,5 +7303,54 @@ eventSource.on(event_types.CONNECTION_PROFILE_LOADED, (profileName) => {
         $('#openrouter_allow_fallbacks').prop('checked', oai_settings.openrouter_allow_fallbacks).trigger('change');
 
         console.log('Connection Manager: OpenRouter settings restored from profile');
+    }
+});
+
+// Connection Profile Support (NanoGPT)
+
+// Helper function to attach NanoGPT settings to a profile
+function attachNanoGptSettings(profile) {
+    // Only attach NanoGPT settings if we are currently using NanoGPT
+    if (main_api === 'openai' && oai_settings.chat_completion_source === 'nanogpt') {
+        profile.nanogpt_provider = oai_settings.nanogpt_provider;
+        profile.nanogpt_payg_override = oai_settings.nanogpt_payg_override;
+        console.log('Connection Manager: NanoGPT settings attached to profile');
+    }
+}
+
+// 1. SAVE (Create): When a new profile is created
+eventSource.on(event_types.CONNECTION_PROFILE_CREATED, (profile) => {
+    attachNanoGptSettings(profile);
+});
+
+// 2. SAVE (Update): When an existing profile is updated
+eventSource.on(event_types.CONNECTION_PROFILE_UPDATED, (oldProfile, profile) => {
+    attachNanoGptSettings(profile);
+});
+
+// 3. LOAD: When a profile is loaded, restore NanoGPT settings
+eventSource.on(event_types.CONNECTION_PROFILE_LOADED, (profileName) => {
+    // Only restore if we are using OpenAI API
+    if (main_api !== 'openai') {
+        return;
+    }
+
+    // Find the profile object by name
+    const profile = extension_settings.connectionManager.profiles.find(p => p.name === profileName);
+    if (!profile) {
+        return;
+    }
+
+    // Check if this profile has NanoGPT settings (Backwards Compatibility)
+    if (profile.nanogpt_provider !== undefined) {
+        // Restore settings to memory
+        oai_settings.nanogpt_provider = profile.nanogpt_provider;
+        oai_settings.nanogpt_payg_override = profile.nanogpt_payg_override ?? false;
+
+        // Update the UI dropdowns/checkboxes so the user sees the change
+        $('#nanogpt_provider').val(oai_settings.nanogpt_provider).trigger('change');
+        $('#nanogpt_payg_override').prop('checked', oai_settings.nanogpt_payg_override).trigger('change');
+
+        console.log('Connection Manager: NanoGPT settings restored from profile');
     }
 });

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -7301,7 +7301,7 @@ eventSource.on(event_types.CONNECTION_PROFILE_LOADED, (profileName) => {
         $('#openrouter_quantizations_chat').val(oai_settings.openrouter_quantizations).trigger('change');
         $('#openrouter_use_fallback').prop('checked', oai_settings.openrouter_use_fallback).trigger('change');
         $('#openrouter_allow_fallbacks').prop('checked', oai_settings.openrouter_allow_fallbacks).trigger('change');
-        
+
         console.log('Connection Manager: OpenRouter settings restored from profile');
     }
 });

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -33,6 +33,7 @@ import {
     this_chid,
 } from '../script.js';
 import { getGroupNames, selected_group } from './group-chats.js';
+import { extension_settings } from './extensions.js';
 
 import {
     chatCompletionDefaultPrompts,
@@ -7247,3 +7248,60 @@ export function initOpenAI() {
     $('#customize_additional_parameters').on('click', onCustomizeParametersClick);
     $('#openai_proxy_preset').on('change', onProxyPresetChange);
 }
+
+// Connection Profile Support (OpenRouter)
+
+// Helper function to attach OpenRouter settings to a profile
+function attachOpenRouterSettings(profile) {
+    // Only attach OpenRouter settings if we are currently using OpenRouter
+    if (main_api === 'openai' && oai_settings.chat_completion_source === 'openrouter') {
+        profile.openrouter_providers = oai_settings.openrouter_providers;
+        profile.openrouter_use_fallback = oai_settings.openrouter_use_fallback;
+        profile.openrouter_allow_fallbacks = oai_settings.openrouter_allow_fallbacks;
+        profile.openrouter_quantizations = oai_settings.openrouter_quantizations;
+        profile.openrouter_middleout = oai_settings.openrouter_middleout;
+        console.log('Connection Manager: OpenRouter settings attached to profile');
+    }
+}
+
+// 1. SAVE (Create): When a new profile is created
+eventSource.on(event_types.CONNECTION_PROFILE_CREATED, (profile) => {
+    attachOpenRouterSettings(profile);
+});
+
+// 2. SAVE (Update): When an existing profile is updated
+eventSource.on(event_types.CONNECTION_PROFILE_UPDATED, (oldProfile, profile) => {
+    attachOpenRouterSettings(profile);
+});
+
+// 3. LOAD: When a profile is loaded, restore OpenRouter settings
+eventSource.on(event_types.CONNECTION_PROFILE_LOADED, (profileName) => {
+    // Only restore if we are using OpenAI API
+    if (main_api !== 'openai') {
+        return;
+    }
+
+    // Find the profile object by name
+    const profile = extension_settings.connectionManager.profiles.find(p => p.name === profileName);
+    if (!profile) {
+        return;
+    }
+
+    // Check if this profile has OpenRouter settings (Backwards Compatibility)
+    if (profile.openrouter_providers) {
+        // Restore settings to memory
+        oai_settings.openrouter_providers = profile.openrouter_providers;
+        oai_settings.openrouter_use_fallback = profile.openrouter_use_fallback ?? false;
+        oai_settings.openrouter_allow_fallbacks = profile.openrouter_allow_fallbacks ?? true;
+        oai_settings.openrouter_quantizations = profile.openrouter_quantizations;
+        oai_settings.openrouter_middleout = profile.openrouter_middleout ?? 'auto';
+
+        // Update the UI dropdowns/checkboxes so the user sees the change
+        $('#openrouter_providers_chat').val(oai_settings.openrouter_providers).trigger('change');
+        $('#openrouter_quantizations_chat').val(oai_settings.openrouter_quantizations).trigger('change');
+        $('#openrouter_use_fallback').prop('checked', oai_settings.openrouter_use_fallback).trigger('change');
+        $('#openrouter_allow_fallbacks').prop('checked', oai_settings.openrouter_allow_fallbacks).trigger('change');
+        
+        console.log('Connection Manager: OpenRouter settings restored from profile');
+    }
+});


### PR DESCRIPTION
Changes
- ✅ Provider fields (OpenRouter, Azure, NanoGPT, etc.) are now saved with profiles
- ✅ Provider fields are restored when applying profiles
- ✅ Source labels show where each field comes from in the UI
- ✅ Popup filters to show only relevant fields for current provider
- ✅ Users can exclude any field from being saved

Testing
- Created profiles with OpenRouter settings - fields saved correctly
- Applied profiles - fields restored correctly
- Verified source labels appear in popup
- Tested with multiple providers (OpenRouter, Azure, etc.)

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
