### PR TITLE
fix(prompt-manager): remove stray console.log('FOO') debug statement

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -1131,7 +1131,6 @@ class PromptManager {
         if ('global' === this.configuration.promptOrder.strategy) {
             this.activeCharacter = { id: this.configuration.promptOrder.dummyId };
         } else if ('character' === this.configuration.promptOrder.strategy) {
-            console.log('FOO');
             this.activeCharacter = { id: event.detail.id, ...event.detail.character };
             const promptOrder = this.getPromptOrderForCharacter(this.activeCharacter);
 

--- a/tests/prompt-manager-source.test.js
+++ b/tests/prompt-manager-source.test.js
@@ -1,0 +1,18 @@
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const filePath = join(__dirname, '..', 'public', 'scripts', 'PromptManager.js');
+
+describe('PromptManager source code hygiene', () => {
+    test('should not contain stray debug console.log statements', () => {
+        const source = readFileSync(filePath, 'utf8');
+        // Regression guard for the stray `console.log('FOO')` debug statement
+        // accidentally introduced in PR #5249 (commit 7418d272) and removed
+        // by this PR. Other console.log calls gated by `power_user.console_log_prompts`
+        // are legitimate and intentionally preserved.
+        expect(source).not.toMatch(/console\.log\(['"]FOO['"]\)/);
+    });
+});


### PR DESCRIPTION
## Motivation

`PromptManager.handleCharacterSelected` in `public/scripts/PromptManager.js` (line 1134) contains a stray `console.log('FOO')` debug statement that was accidentally introduced in commit `7418d272` (PR #5249, "Split generateRaw into two functions exposing generateRawData").

The debug line fires in the default `promptOrder.strategy === 'character'` branch every time a character is selected, polluting the user's browser DevTools console with a meaningless `FOO` string. It has no functional purpose and should not be in production code.

## Changes

- **`public/scripts/PromptManager.js`**: Remove the stray `console.log('FOO');` line in `handleCharacterSelected`. (-1 line, no functional change.)
- **`tests/prompt-manager-source.test.js`** (new): Jest regression test that reads `PromptManager.js` and asserts it does not contain the `console.log('FOO')` marker, guarding against future re-introduction. (+17 lines, no production code dependency.)

Other `console.log` calls in the file (e.g. those gated by `power_user.console_log_prompts`) are legitimate and intentionally left untouched.

## Diff Summary

```
 2 files changed, 18 insertions(+), 1 deletion(-)
```

- `public/scripts/PromptManager.js` | 1 -
- `tests/prompt-manager-source.test.js` | 17 + (new file)

Well under the 200-line soft limit in `CONTRIBUTING.md`.

## Testing

### Static (recommended for review)

```bash
git clone https://github.com/lxcxjxhx/SillyTavern.git -b fix/prompt-manager-stray-debug-log
cd SillyTavern
# Confirm the FOO log is gone
grep -n "console.log('FOO')" public/scripts/PromptManager.js
# Expected: no output (exit code 1 from grep)
```

### Behavioural (manual, in-browser)

1. Run `npm start`, open `http://localhost:8000`.
2. F12 → Console panel.
3. Settings → confirm **Prompt Order strategy** is set to **Character** (this is the default).
4. Click any character in the character list.
5. **Before the fix:** the string `FOO` is printed to the console.
6. **After the fix:** the console stays clean.

### Automated (jest unit test)

Once `npm install` has been run inside `tests/`:

```bash
cd tests
npm run test:unit -- prompt-manager-source.test.js
# Expected: 1 passed
```

## Target Branch

This PR targets `staging` per `CONTRIBUTING.md` (99% of contributions go there).

## Checklist

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
- [x] I have read the AGPL-3.0 license terms and agree that my contribution is licensed under AGPL-3.0.
- [x] My change does not exceed the 200-line soft limit.
- [x] I have not modified `package.json`, lockfiles, or build configuration.
- [x] I have added a regression test for my change.
- [x] I have manually verified the reproduction steps above.
- [x] I am not using AI-generated content without manual review; this change has been hand-reviewed and tested.
- [x] "Allow edits from maintainers" is enabled.

## Notes

- The change is intentionally tiny so that the PR is easy to review and revert if needed.
- If maintainers prefer a larger scope (e.g. sweep for other stray debug logs across the codebase), I am happy to follow up with a separate PR.
