### PR TITLE
Add Claude Opus 4.8, GPT-5.6 models, and migrate Gemini 3.1 Flash Lite and Gemini image models to stable

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3321,11 +3321,11 @@
                                     <optgroup label="Gemini 3.1">
                                         <option value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
                                         <option value="gemini-3.1-flash-lite">gemini-3.1-flash-lite</option>
-                                        <option value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
+                                        <option value="gemini-3.1-flash-image">gemini-3.1-flash-image</option>
                                     </optgroup>
                                     <optgroup label="Gemini 3.0">
                                         <option value="gemini-3-pro-preview">gemini-3-pro-preview</option>
-                                        <option value="gemini-3-pro-image-preview">gemini-3-pro-image-preview</option>
+                                        <option value="gemini-3-pro-image">gemini-3-pro-image</option>
                                         <option value="gemini-3-flash-preview">gemini-3-flash-preview</option>
                                     </optgroup>
                                     <optgroup label="Gemini 2.5">
@@ -3504,11 +3504,11 @@
                                     <optgroup label="Gemini 3.1">
                                         <option value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
                                         <option value="gemini-3.1-flash-lite">gemini-3.1-flash-lite</option>
-                                        <option value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
+                                        <option value="gemini-3.1-flash-image">gemini-3.1-flash-image</option>
                                     </optgroup>
                                     <optgroup label="Gemini 3.0">
                                         <option value="gemini-3-pro-preview">gemini-3-pro-preview</option>
-                                        <option value="gemini-3-pro-image-preview">gemini-3-pro-image-preview</option>
+                                        <option value="gemini-3-pro-image">gemini-3-pro-image</option>
                                         <option value="gemini-3-flash-preview">gemini-3-flash-preview</option>
                                     </optgroup>
                                     <optgroup label="Gemini 2.5">

--- a/public/index.html
+++ b/public/index.html
@@ -3052,6 +3052,12 @@
                             <div>
                                 <h4 data-i18n="OpenAI Model">OpenAI Model</h4>
                                 <select id="model_openai_select">
+                                    <optgroup label="GPT-5.6">
+                                        <option value="gpt-5.6">gpt-5.6</option>
+                                        <option value="gpt-5.6-sol">gpt-5.6-sol</option>
+                                        <option value="gpt-5.6-terra">gpt-5.6-terra</option>
+                                        <option value="gpt-5.6-luna">gpt-5.6-luna</option>
+                                    </optgroup>
                                     <optgroup label="GPT-5.5">
                                         <option value="gpt-5.5">gpt-5.5</option>
                                         <option value="gpt-5.5-2026-04-23">gpt-5.5-2026-04-23</option>

--- a/public/index.html
+++ b/public/index.html
@@ -3177,6 +3177,7 @@
                                 <select id="model_claude_select">
                                     <optgroup label="Versions">
                                         <option value="claude-fable-5">claude-fable-5</option>
+                                        <option value="claude-opus-4-8">claude-opus-4-8</option>
                                         <option value="claude-opus-4-7">claude-opus-4-7</option>
                                         <option value="claude-opus-4-6">claude-opus-4-6</option>
                                         <option value="claude-opus-4-5">claude-opus-4-5</option>

--- a/public/index.html
+++ b/public/index.html
@@ -3320,7 +3320,7 @@
                                     </optgroup>
                                     <optgroup label="Gemini 3.1">
                                         <option value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
-                                        <option value="gemini-3.1-flash-lite-preview">gemini-3.1-flash-lite-preview</option>
+                                        <option value="gemini-3.1-flash-lite">gemini-3.1-flash-lite</option>
                                         <option value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
                                     </optgroup>
                                     <optgroup label="Gemini 3.0">
@@ -3503,7 +3503,7 @@
                                     </optgroup>
                                     <optgroup label="Gemini 3.1">
                                         <option value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
-                                        <option value="gemini-3.1-flash-lite-preview">gemini-3.1-flash-lite-preview</option>
+                                        <option value="gemini-3.1-flash-lite">gemini-3.1-flash-lite</option>
                                         <option value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
                                     </optgroup>
                                     <optgroup label="Gemini 3.0">

--- a/public/index.html
+++ b/public/index.html
@@ -2169,14 +2169,14 @@
                                                 <option data-i18n="openai_reasoning_effort_high" value="high">High</option>
                                                 <option data-i18n="openai_reasoning_effort_maximum" value="max">Maximum</option>
                                             </select>
-                                            <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-style options: low, medium, high. Minimum and maximum are aliased to low and high. Auto does not send an effort level.">
-                                                OpenAI-style options: low, medium, high. Minimum and maximum are aliased to low and high. Auto does not send an effort level.
+                                            <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-compatible effort levels vary by model. Minimum and maximum may use model-specific aliases. Auto does not send an effort level.">
+                                                OpenAI-compatible effort levels vary by model. Minimum and maximum may use model-specific aliases. Auto does not send an effort level.
                                             </div>
                                             <strong class="toggle-description justifyLeft marginBot5" data-source="openrouter">
                                                 Request model reasoning = Off with Reasoning Effort = Minimum disables reasoning entirely on models that support that, but can cause errors with some models.
                                             </strong>
-                                            <div class="toggle-description justifyLeft marginBot5" data-source="claude" data-i18n="Allocates a portion of the response length for thinking (min: 1024 tokens, low: 10%, medium: 25%, high: 50%, max: 95%), but minimum 1024 tokens. Auto does not request thinking.">
-                                                Allocates a portion of the response length for thinking (min: 1024 tokens, low: 10%, medium: 25%, high: 50%, max: 95%), but minimum 1024 tokens. Auto does not request thinking.
+                                            <div class="toggle-description justifyLeft marginBot5" data-source="claude" data-i18n="Selects an effort level on adaptive-thinking models. On older Claude models, it allocates a portion of the response length to thinking. Auto does not request thinking.">
+                                                Selects an effort level on adaptive-thinking models. On older Claude models, it allocates a portion of the response length to thinking. Auto does not request thinking.
                                             </div>
                                             <div class="toggle-description justifyLeft marginBot5" data-source="makersuite,vertexai">
                                                 <span data-i18n="Sets a dynamic reasoning depth level for thinking (Flash 3/Pro 3). High and low are supported by both, minimal and medium are Flash 3 only. Auto lets the model decide.">
@@ -2204,7 +2204,7 @@
                                                 Constrains the verbosity of the model's response.
                                             </div>
                                             <strong class="toggle-description justifyLeft marginBot5" data-source="claude">
-                                                On Opus 4.6 / Sonnet 4.6, a non-automatic Reasoning Effort takes precedence over Verbosity.
+                                                On adaptive-thinking Claude models, a non-automatic Reasoning Effort takes precedence over Verbosity.
                                             </strong>
                                         </div>
                                     </div>

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -40,6 +40,11 @@ function migrateSettings() {
         extension_settings.caption.multimodal_model = 'gpt-4-turbo';
     }
 
+    if (['google', 'vertexai'].includes(extension_settings.caption.multimodal_api)
+        && extension_settings.caption.multimodal_model === 'gemini-3.1-flash-lite-preview') {
+        extension_settings.caption.multimodal_model = 'gemini-3.1-flash-lite';
+    }
+
     if (!extension_settings.caption.multimodal_api) {
         extension_settings.caption.multimodal_api = 'openai';
     }

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -18,6 +18,11 @@ const MODULE_NAME = 'caption';
 
 const PROMPT_DEFAULT = 'What\'s in this image?';
 const TEMPLATE_DEFAULT = '[{{user}} sends {{char}} a picture that contains: {{caption}}]';
+const GOOGLE_MODEL_MIGRATIONS = new Map([
+    ['gemini-3.1-flash-lite-preview', 'gemini-3.1-flash-lite'],
+    ['gemini-3.1-flash-image-preview', 'gemini-3.1-flash-image'],
+    ['gemini-3-pro-image-preview', 'gemini-3-pro-image'],
+]);
 
 /**
  * Migrates old extension settings to the new format.
@@ -40,9 +45,9 @@ function migrateSettings() {
         extension_settings.caption.multimodal_model = 'gpt-4-turbo';
     }
 
-    if (['google', 'vertexai'].includes(extension_settings.caption.multimodal_api)
-        && extension_settings.caption.multimodal_model === 'gemini-3.1-flash-lite-preview') {
-        extension_settings.caption.multimodal_model = 'gemini-3.1-flash-lite';
+    if (['google', 'vertexai'].includes(extension_settings.caption.multimodal_api)) {
+        extension_settings.caption.multimodal_model = GOOGLE_MODEL_MIGRATIONS.get(extension_settings.caption.multimodal_model)
+            ?? extension_settings.caption.multimodal_model;
     }
 
     if (!extension_settings.caption.multimodal_api) {

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -96,6 +96,7 @@
                         <option data-type="openai" value="o4-mini-2025-04-16">o4-mini-2025-04-16</option>
                         <option data-type="openai" value="gpt-4.5-preview">gpt-4.5-preview</option>
                         <option data-type="openai" value="gpt-4.5-preview-2025-02-27">gpt-4.5-preview-2025-02-27</option>
+                        <option data-type="anthropic" value="claude-opus-4-8">claude-opus-4-8</option>
                         <option data-type="anthropic" value="claude-opus-4-7">claude-opus-4-7</option>
                         <option data-type="anthropic" value="claude-opus-4-6">claude-opus-4-6</option>
                         <option data-type="anthropic" value="claude-opus-4-5">claude-opus-4-5</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -54,6 +54,10 @@
                         <option data-type="cohere" value="c4ai-aya-vision-8b">c4ai-aya-vision-8b</option>
                         <option data-type="cohere" value="c4ai-aya-vision-32b">c4ai-aya-vision-32b</option>
                         <option data-type="cohere" value="command-a-vision-07-2025">command-a-vision-07-2025</option>
+                        <option data-type="openai" value="gpt-5.6">gpt-5.6</option>
+                        <option data-type="openai" value="gpt-5.6-sol">gpt-5.6-sol</option>
+                        <option data-type="openai" value="gpt-5.6-terra">gpt-5.6-terra</option>
+                        <option data-type="openai" value="gpt-5.6-luna">gpt-5.6-luna</option>
                         <option data-type="openai" value="gpt-5.5">gpt-5.5</option>
                         <option data-type="openai" value="gpt-5.5-2026-04-23">gpt-5.5-2026-04-23</option>
                         <option data-type="openai" value="gpt-5.4">gpt-5.4</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -128,9 +128,9 @@
                         <option data-type="google" value="gemini-3.5-flash">gemini-3.5-flash</option>
                         <option data-type="google" value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
                         <option data-type="google" value="gemini-3.1-flash-lite">gemini-3.1-flash-lite</option>
-                        <option data-type="google" value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
+                        <option data-type="google" value="gemini-3.1-flash-image">gemini-3.1-flash-image</option>
                         <option data-type="google" value="gemini-3-pro-preview">gemini-3-pro-preview</option>
-                        <option data-type="google" value="gemini-3-pro-image-preview">gemini-3-pro-image-preview</option>
+                        <option data-type="google" value="gemini-3-pro-image">gemini-3-pro-image</option>
                         <option data-type="google" value="gemini-3-flash-preview">gemini-3-flash-preview</option>
                         <option data-type="google" value="gemini-2.5-pro">gemini-2.5-pro</option>
                         <option data-type="google" value="gemini-2.5-pro-preview-06-05">gemini-2.5-pro-preview-06-05</option>
@@ -167,9 +167,9 @@
                         <option data-type="vertexai" value="gemini-3.5-flash">gemini-3.5-flash</option>
                         <option data-type="vertexai" value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
                         <option data-type="vertexai" value="gemini-3.1-flash-lite">gemini-3.1-flash-lite</option>
-                        <option data-type="vertexai" value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
+                        <option data-type="vertexai" value="gemini-3.1-flash-image">gemini-3.1-flash-image</option>
                         <option data-type="vertexai" value="gemini-3-pro-preview">gemini-3-pro-preview</option>
-                        <option data-type="vertexai" value="gemini-3-pro-image-preview">gemini-3-pro-image-preview</option>
+                        <option data-type="vertexai" value="gemini-3-pro-image">gemini-3-pro-image</option>
                         <option data-type="vertexai" value="gemini-3-flash-preview">gemini-3-flash-preview</option>
                         <option data-type="vertexai" value="gemini-2.5-pro">gemini-2.5-pro</option>
                         <option data-type="vertexai" value="gemini-2.5-flash">gemini-2.5-flash</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -127,7 +127,7 @@
                         <option data-type="anthropic" value="claude-3-haiku-20240307">claude-3-haiku-20240307</option>
                         <option data-type="google" value="gemini-3.5-flash">gemini-3.5-flash</option>
                         <option data-type="google" value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
-                        <option data-type="google" value="gemini-3.1-flash-lite-preview">gemini-3.1-flash-lite-preview</option>
+                        <option data-type="google" value="gemini-3.1-flash-lite">gemini-3.1-flash-lite</option>
                         <option data-type="google" value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
                         <option data-type="google" value="gemini-3-pro-preview">gemini-3-pro-preview</option>
                         <option data-type="google" value="gemini-3-pro-image-preview">gemini-3-pro-image-preview</option>
@@ -166,7 +166,7 @@
                         <option data-type="google" value="gemma-3-4b-it">gemma-3-4b-it</option>
                         <option data-type="vertexai" value="gemini-3.5-flash">gemini-3.5-flash</option>
                         <option data-type="vertexai" value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
-                        <option data-type="vertexai" value="gemini-3.1-flash-lite-preview">gemini-3.1-flash-lite-preview</option>
+                        <option data-type="vertexai" value="gemini-3.1-flash-lite">gemini-3.1-flash-lite</option>
                         <option data-type="vertexai" value="gemini-3.1-flash-image-preview">gemini-3.1-flash-image-preview</option>
                         <option data-type="vertexai" value="gemini-3-pro-preview">gemini-3-pro-preview</option>
                         <option data-type="vertexai" value="gemini-3-pro-image-preview">gemini-3-pro-image-preview</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5638,7 +5638,7 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source == chat_completion_sources.CLAUDE) {
         if (oai_settings.max_context_unlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
-        } else if (/^claude-(sonnet-4-5|sonnet-4-6|opus-4-6|opus-4-7|fable)/.test(value)) {
+        } else if (/^claude-(sonnet-4-5|sonnet-4-6|opus-4-6|opus-4-7|opus-4-8|fable)/.test(value)) {
             $('#openai_max_context').attr('max', max_1mil);
         } else if (/^claude-(3|opus|haiku|sonnet)/.test(value)) {
             $('#openai_max_context').attr('max', max_200k);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4219,6 +4219,10 @@ function migrateChatCompletionSettings(settings) {
         { oldKey: 'ai21_model', oldValue: /^j2-/, newKey: 'ai21_model', newValue: 'jamba-large' },
         { oldKey: 'google_model', oldValue: 'gemini-3.1-flash-lite-preview', newKey: 'google_model', newValue: 'gemini-3.1-flash-lite' },
         { oldKey: 'vertexai_model', oldValue: 'gemini-3.1-flash-lite-preview', newKey: 'vertexai_model', newValue: 'gemini-3.1-flash-lite' },
+        { oldKey: 'google_model', oldValue: 'gemini-3.1-flash-image-preview', newKey: 'google_model', newValue: 'gemini-3.1-flash-image' },
+        { oldKey: 'vertexai_model', oldValue: 'gemini-3.1-flash-image-preview', newKey: 'vertexai_model', newValue: 'gemini-3.1-flash-image' },
+        { oldKey: 'google_model', oldValue: 'gemini-3-pro-image-preview', newKey: 'google_model', newValue: 'gemini-3-pro-image' },
+        { oldKey: 'vertexai_model', oldValue: 'gemini-3-pro-image-preview', newKey: 'vertexai_model', newValue: 'gemini-3-pro-image' },
         { oldKey: 'image_inlining', oldValue: false, newKey: 'media_inlining', newValue: false },
         { oldKey: 'image_inlining', oldValue: true, newKey: 'media_inlining', newValue: true },
         { oldKey: 'video_inlining', oldValue: true, newKey: 'media_inlining', newValue: true },
@@ -5060,6 +5064,7 @@ function getGeminiMaxContext(model, isUnlocked) {
     /** @type {[RegExp, number][]} */
     const contextMap = [
         [/gemini-2\.5-flash-image/, max_32k],
+        [/gemini-3\.1-flash-image/, max_128k],
         [/gemini-3-pro-image/, max_64k],
         [/gemini-(?:3[.\d]*|2\.(?:5|0))-(pro|flash)/, max_1mil],
         [/(gemini-exp|learnlm-2\.0-flash|gemini-robotics)/, max_1mil],

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2604,7 +2604,8 @@ function getReasoningEffort(settings = null, model = null) {
             case reasoning_effort_types.max:
                 if ([chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source)
                     && /^gpt-5\.6/.test(model)) {
-                    return reasoning_effort_types.max;
+                    // GPT-5.6 reserves "max" effort for the Responses API.
+                    return 'xhigh';
                 }
                 return reasoning_effort_types.high;
             default:

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -133,6 +133,7 @@ const max_200k = 200 * 1000;
 const max_256k = 256 * 1000;
 const max_400k = 400 * 1000;
 const max_1mil = 1000 * 1000;
+const max_1050k = 1050 * 1000;
 const max_2mil = 2000 * 1000;
 const unlocked_max = max_2mil;
 const oai_max_temp = 2.0;
@@ -2591,7 +2592,7 @@ function getReasoningEffort(settings = null, model = null) {
                 }
 
                 if ([chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source)) {
-                    if (/^gpt-5\.(4|5)/.test(model)) {
+                    if (/^gpt-5\.(4|5|6)/.test(model)) {
                         return 'none';
                     }
                     if (/^gpt-5/.test(model)) {
@@ -2601,6 +2602,10 @@ function getReasoningEffort(settings = null, model = null) {
 
                 return reasoning_effort_types.low;
             case reasoning_effort_types.max:
+                if ([chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source)
+                    && /^gpt-5\.6/.test(model)) {
+                    return reasoning_effort_types.max;
+                }
                 return reasoning_effort_types.high;
             default:
                 return settings.reasoning_effort;
@@ -5003,6 +5008,7 @@ function getMaxContextOpenAI(value) {
 
     /** @type {[RegExp, number][]} */
     const contextMap = [
+        [/^gpt-5\.6/, max_1050k],
         [/^gpt-5\.[45]/, max_1mil],
         [/^gpt-5/, max_400k],
         [/gpt-4\.1/, max_1mil],

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4216,6 +4216,8 @@ function migrateChatCompletionSettings(settings) {
         { oldKey: 'chat_completion_source', oldValue: 'palm', newKey: 'chat_completion_source', newValue: chat_completion_sources.MAKERSUITE },
         { oldKey: 'custom_prompt_post_processing', oldValue: custom_prompt_post_processing_types.CLAUDE, newKey: 'custom_prompt_post_processing', newValue: custom_prompt_post_processing_types.MERGE },
         { oldKey: 'ai21_model', oldValue: /^j2-/, newKey: 'ai21_model', newValue: 'jamba-large' },
+        { oldKey: 'google_model', oldValue: 'gemini-3.1-flash-lite-preview', newKey: 'google_model', newValue: 'gemini-3.1-flash-lite' },
+        { oldKey: 'vertexai_model', oldValue: 'gemini-3.1-flash-lite-preview', newKey: 'vertexai_model', newValue: 'gemini-3.1-flash-lite' },
         { oldKey: 'image_inlining', oldValue: false, newKey: 'media_inlining', newValue: false },
         { oldKey: 'image_inlining', oldValue: true, newKey: 'media_inlining', newValue: true },
         { oldKey: 'video_inlining', oldValue: true, newKey: 'media_inlining', newValue: true },

--- a/src/constants.js
+++ b/src/constants.js
@@ -487,6 +487,10 @@ export const OPENAI_REASONING_EFFORT_MODELS = [
     'gpt-5.4-nano-2026-03-17',
     'gpt-5.5',
     'gpt-5.5-2026-04-23',
+    'gpt-5.6',
+    'gpt-5.6-sol',
+    'gpt-5.6-terra',
+    'gpt-5.6-luna',
 ];
 
 export const OPENAI_REASONING_EFFORT_MAP = {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -493,8 +493,8 @@ async function sendMakerSuiteRequest(request, response) {
             'gemini-2.0-flash-preview-image-generation',
             'gemini-2.5-flash-image-preview',
             'gemini-2.5-flash-image',
-            'gemini-3-pro-image-preview',
-            'gemini-3.1-flash-image-preview',
+            'gemini-3-pro-image',
+            'gemini-3.1-flash-image',
         ];
 
         const isThinkingConfigModel = m => (/^gemini-2.5-(flash|pro)/.test(m) && !/-image(-preview)?$/.test(m)) || (/^gemini-3[.\d]*-(flash|pro)/.test(m));

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -238,10 +238,10 @@ async function sendClaudeRequest(request, response) {
         const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel;
         const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel) && Boolean(request.body.enable_web_search);
         const isLimitedSampling = /^claude-(opus-4-1|sonnet-4-5|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6)/.test(request.body.model);
-        const useVerbosity = /^claude-(opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel;
-        const noPrefillModel = /^claude-(opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel;
-        const isAdaptiveModel = /^claude-(opus-4-7)/.test(request.body.model) || isFableModel || (enableAdaptiveThinking && /^claude-(opus-4-6|sonnet-4-6)/.test(request.body.model));
-        const noSamplingModel = /^claude-(opus-4-7)/.test(request.body.model) || isFableModel;
+        const useVerbosity = /^claude-(opus-4-5|opus-4-6|sonnet-4-6|opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel;
+        const noPrefillModel = /^claude-(opus-4-6|sonnet-4-6|opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel;
+        const isAdaptiveModel = /^claude-(opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel || (enableAdaptiveThinking && /^claude-(opus-4-6|sonnet-4-6)/.test(request.body.model));
+        const noSamplingModel = /^claude-(opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel;
         let fixThinkingPrefill = false;
         // Add custom stop sequences
         const stopSequences = [];

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -172,6 +172,13 @@ describe('calculateGoogleBudgetTokens', () => {
         expect(mod.calculateGoogleBudgetTokens(8192, 'max', 'gemini-3.1-flash-lite')).toBe('high');
     });
 
+    test('stable Gemini 3 image models use Gemini 3 thinking levels', () => {
+        expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.1-flash-image')).toBe('minimal');
+        expect(mod.calculateGoogleBudgetTokens(8192, 'max', 'gemini-3.1-flash-image')).toBe('high');
+        expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3-pro-image')).toBe('low');
+        expect(mod.calculateGoogleBudgetTokens(8192, 'max', 'gemini-3-pro-image')).toBe('high');
+    });
+
     describe('gemini-3 pro', () => {
         test('auto returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'auto', 'gemini-3.0-pro')).toBeNull());
         test('min returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.0-pro')).toBe('low'));

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -166,6 +166,12 @@ describe('calculateGoogleBudgetTokens', () => {
         test('max returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'max', 'gemini-3.5-flash')).toBe('high'));
     });
 
+    test('stable Gemini 3.1 Flash-Lite uses Gemini 3 thinking levels', () => {
+        expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.1-flash-lite')).toBe('minimal');
+        expect(mod.calculateGoogleBudgetTokens(8192, 'medium', 'gemini-3.1-flash-lite')).toBe('medium');
+        expect(mod.calculateGoogleBudgetTokens(8192, 'max', 'gemini-3.1-flash-lite')).toBe('high');
+    });
+
     describe('gemini-3 pro', () => {
         test('auto returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'auto', 'gemini-3.0-pro')).toBeNull());
         test('min returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.0-pro')).toBe('low'));


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-8` to Claude model lists (chat + Image Captioning) and treat it like Opus 4.7 for verbosity, no-prefill, adaptive thinking, no-sampling, and unlocked max context.
- Add OpenAI GPT-5.6 variants (`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) with reasoning-effort support and 1.05M context.
- Replace deprecated `gemini-3.1-flash-lite-preview` with stable `gemini-3.1-flash-lite`, including settings migrations for Google/Vertex chat and caption.

## Why

Keep SillyTavern model selectors and request handling aligned with current provider model IDs so users can select and use these models without manual overrides or broken preview IDs.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
