### PR TITLE
Fix: ignore local third-party extensions during core linting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -70,6 +70,7 @@ module.exports = {
         '**/dist/**',
         '**/.git/**',
         'public/lib/**',
+        'public/scripts/extensions/third-party/**',
         'backups/**',
         'data/**',
         'cache/**',

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ whitelist.txt
 .vscode/**
 !.vscode/extensions.json
 .idea/
+.windsurf/
 secrets.json
 /dist
 /backups/


### PR DESCRIPTION
## Summary

- Exclude locally installed third-party extensions from the root ESLint run.
- Ignore the local `.windsurf` IDE workspace directory.

## Why

The root lint script expands `public/**/*.js`, which includes Git-ignored user-installed extensions. Those extensions can contain generated or independently styled source, causing unrelated errors to prevent validation of the core codebase.

## Verification

- `npm run lint`
- `git diff --check`