### PR TITLE
Fix: remove trailing whitespace from variable macros

### DIFF
--- a/public/scripts/macros/definitions/variable-macros.js
+++ b/public/scripts/macros/definitions/variable-macros.js
@@ -388,7 +388,7 @@ export function registerVariableMacros() {
             return '';
         },
     });
-    
+
     // {{getglobalvarkey::name::key}} -> returns value at key
     MacroRegistry.registerMacro('getglobalvarkey', {
         aliases: [{ alias: 'getglobalvarindex' }],


### PR DESCRIPTION
## Summary

Remove trailing whitespace from the variable macro registry so the file satisfies the repository lint rules.

## Verification

- `eslint public/scripts/macros/definitions/variable-macros.js`
- `git diff --check`