### PR TITLE
Fix to a minor issue where extensions reading reasoning could race ST's event to clear traces.

### DIFF
--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -1579,7 +1579,7 @@ function registerReasoningAppEvents() {
     }
 
     for (const event of [event_types.GENERATION_STOPPED, event_types.GENERATION_ENDED, event_types.CHAT_CHANGED]) {
-        eventSource.on(event, () => PromptReasoning.clearLatest());
+        eventSource.makeFirst(event, () => PromptReasoning.clearLatest());
     }
 
     eventSource.makeFirst(event_types.IMPERSONATE_READY, async () => {


### PR DESCRIPTION
Fixed a possible race when extensions are expecting ST to have already cleared reasoning traces, it's possible that ST will clear *after* extensions read the event, rather than before. This small change just guarantees that extensions will not race silly tavern and there's no way to read stale reasoning as an extension by ordering the clear first.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
