### PR TITLE
docs: note Custom OpenAI-compatible gateway base URL (DaoXE)

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -68,6 +68,22 @@ For detailed installation instructions, please visit our documentation:
 * **[Android (Termux) Installation Guide](https://docs.sillytavern.app/installation/android-(termux)/)**
 * **[Docker Installation Guide](https://docs.sillytavern.app/installation/docker/)**
 
+## OpenAI-compatible gateways (Chat Completion)
+
+SillyTavern already supports **Chat Completion → Custom (OpenAI-compatible)**. Point it at any OpenAI-compatible multi-model gateway without a custom build:
+
+1. API type: **Chat Completion**
+2. Source: **Custom (OpenAI-compatible)**
+3. **Custom Endpoint (Base URL):** `https://daoxe.com/v1` (example: [DaoXE](https://daoxe.com))
+4. API key: your gateway key
+5. Model ID: an exact ID available to your account (`GET /v1/models` / dashboard) — do not rely on a static list
+
+Notes:
+
+- Uses OpenAI Chat Completions. Other protocols (for example Anthropic Messages) need a different client path.
+- DaoXE is not available in mainland China.
+- Full docs: [docs.sillytavern.app](https://docs.sillytavern.app/)
+
 ## License and credits
 
 **This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
## Summary

Documents the existing **Chat Completion → Custom (OpenAI-compatible)** path with a concrete multi-model gateway example ([DaoXE](https://daoxe.com), `https://daoxe.com/v1`).

- `.github/readme.md` — short setup steps only (no code changes)

### Why

Users already have Custom (OpenAI-compatible) in the UI (`custom_url` / Base URL). This makes that path discoverable in the README with a real gateway example.

### Notes

- Account-scoped model IDs (no static catalog)
- Chat Completions only
- DaoXE not available in mainland China
- Contributor is affiliated with DaoXE

## Test plan

- [ ] README section renders on GitHub
- [ ] Manual: Chat Completion → Custom → Base URL `https://daoxe.com/v1` + key + account model ID