### PR TITLE
Support WAV responses in OpenAI-compatible TTS

### DIFF
--- a/public/scripts/extensions/tts/openai-compatible.js
+++ b/public/scripts/extensions/tts/openai-compatible.js
@@ -15,6 +15,7 @@ class OpenAICompatibleTtsProvider {
         voiceMap: {},
         model: 'tts-1',
         speed: 1,
+        response_format: 'mp3',
         available_voices: ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'],
         provider_endpoint: 'http://127.0.0.1:8000/v1/audio/speech',
     };
@@ -33,6 +34,11 @@ class OpenAICompatibleTtsProvider {
         </div>
         <label for="openai_compatible_model">Model:</label>
         <input id="openai_compatible_model" type="text" class="text_pole" maxlength="500" value="${this.defaultSettings.model}"/>
+        <label for="openai_compatible_tts_response_format">Audio Format:</label>
+        <select id="openai_compatible_tts_response_format" class="text_pole">
+            <option value="mp3">MP3</option>
+            <option value="wav">WAV</option>
+        </select>
         <label for="openai_compatible_tts_voices">Available Voices (comma separated):</label>
         <input id="openai_compatible_tts_voices" type="text" class="text_pole" value="${this.defaultSettings.available_voices.join()}"/>
         <label for="openai_compatible_tts_speed">Speed: <span id="openai_compatible_tts_speed_output"></span></label>
@@ -77,6 +83,9 @@ class OpenAICompatibleTtsProvider {
         $('#openai_compatible_model').val(this.defaultSettings.model);
         $('#openai_compatible_model').on('input', () => { this.onSettingsChange(); });
 
+        $('#openai_compatible_tts_response_format').val(this.settings.response_format);
+        $('#openai_compatible_tts_response_format').on('change', () => { this.onSettingsChange(); });
+
         $('#openai_compatible_tts_voices').val(this.settings.available_voices.join());
         $('#openai_compatible_tts_voices').on('input', () => { this.onSettingsChange(); });
 
@@ -101,6 +110,7 @@ class OpenAICompatibleTtsProvider {
         // Update dynamically
         this.settings.provider_endpoint = String($('#openai_compatible_tts_endpoint').val());
         this.settings.model = String($('#openai_compatible_model').val());
+        this.settings.response_format = String($('#openai_compatible_tts_response_format').val());
         this.settings.available_voices = String($('#openai_compatible_tts_voices').val()).split(',');
         this.settings.speed = Number($('#openai_compatible_tts_speed').val());
         $('#openai_compatible_tts_speed_output').text(this.settings.speed);
@@ -166,7 +176,7 @@ class OpenAICompatibleTtsProvider {
                 model: this.settings.model,
                 input: inputText,
                 voice: voiceId,
-                response_format: 'mp3',
+                response_format: this.settings.response_format,
                 speed: this.settings.speed,
             }),
         });

--- a/src/endpoints/openai.js
+++ b/src/endpoints/openai.js
@@ -798,7 +798,9 @@ custom.post('/generate-voice', async (request, response) => {
         }
 
         const buffer = await result.arrayBuffer();
-        response.setHeader('Content-Type', 'audio/mpeg');
+        const contentType = result.headers.get('content-type')
+            ?? (response_format === 'wav' ? 'audio/wav' : 'audio/mpeg');
+        response.setHeader('Content-Type', contentType);
         return response.send(Buffer.from(buffer));
     } catch (error) {
         console.error('OpenAI TTS generation failed', error);


### PR DESCRIPTION
## Why

The custom OpenAI-compatible TTS provider currently always requests MP3 and always labels the proxy response as `audio/mpeg`. OpenAI-compatible local servers that intentionally expose uncompressed WAV therefore fail even though the browser can play their output.

## What changed

- add an MP3/WAV format selector to the existing provider settings
- keep MP3 as the default for existing users
- send the selected `response_format` to the provider
- preserve the upstream audio content type, with a format-based fallback

```text
TTS settings [MP3 | WAV] -> /v1/audio/speech -> upstream MIME -> browser audio
```

This is provider-agnostic and enables WAV-only local implementations such as the endpoint proposed in [soniqo/speech-core#118](https://github.com/soniqo/speech-core/pull/118).

## Regression risk

Low. Existing saved settings inherit `mp3`, and the request/response behavior is unchanged unless WAV is selected. The change is scoped to the custom OpenAI-compatible TTS provider.

## Validation

- `npx eslint public/scripts/extensions/tts/openai-compatible.js src/endpoints/openai.js`
- `node --check` for both changed files
- `git diff --check`