### PR TITLE
fix: prevent character mismatch in group chat replies

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3131,10 +3131,17 @@ function cleanGroupMessage(getMessage) {
                 continue;
             }
 
-            const regex = new RegExp(`(^|\n)${escapeRegex(name)}:`);
+            const regex = new RegExp(`(^|\\n)\\s*${escapeRegex(name)}\\s*[:：]`);
             const nameMatch = getMessage.match(regex);
             if (nameMatch) {
-                getMessage = getMessage.substring(0, nameMatch.index);
+                // If another character's name appears at position 0,
+                // the AI is writing for the wrong character entirely.
+                // Discard the whole message — it's not our character's reply.
+                if (nameMatch.index === 0) {
+                    getMessage = '';
+                } else {
+                    getMessage = getMessage.substring(0, nameMatch.index);
+                }
             }
         }
     }

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -531,7 +531,8 @@ export function getGroupCharacterCardsLazy(groupId, characterId) {
         if (typeof preprocess === 'function') {
             value = preprocess(value);
         }
-        const prefix = customTransform(group.generation_mode_join_prefix, fieldName, characterName, false);
+        const prefixTemplate = group.generation_mode_join_prefix || '{{char}}: ';
+        const prefix = customTransform(prefixTemplate, fieldName, characterName, false);
         const suffix = customTransform(group.generation_mode_join_suffix, fieldName, characterName, false);
         value = customTransform(value, fieldName, characterName, true);
         return `${prefix}${value}${suffix}`;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -111,7 +111,7 @@ const default_continue_nudge_prompt = '[Continue your last message without repea
 const default_bias = 'Default (none)';
 const default_personality_format = '{{personality}}';
 const default_scenario_format = '{{scenario}}';
-const default_group_nudge_prompt = '[Write the next reply only as {{char}}.]';
+const default_group_nudge_prompt = '[RULES FOR {{char}}\'s REPLY]\n1. You are {{char}}. You are NOT any other character.\n2. Your tone, style, and behavior must come from {{char}}\'s own personality ONLY. Do NOT borrow attitudes, catchphrases, or behavioral patterns from other characters.\n3. DO NOT write any dialogue, actions, or narration for other characters.\n4. DO NOT use other characters\' names followed by a colon (e.g., "Name:" or "Name：").\n\n[BEFORE FINAL OUTPUT — Self-Review each line of your reply]\n- If any line starts with another character\'s name followed by a colon, DELETE that line.\n- If your reply sounds like it belongs to a DIFFERENT character instead of {{char}}, DISCARD it and rewrite to match {{char}}\'s personality.]';
 const default_bias_presets = {
     [default_bias]: [],
     'Anti-bond': [
@@ -1491,6 +1491,15 @@ async function preparePromptsForChatCompletion({ scenario, charPersonality, name
         systemPrompt.content = systemPromptOverride;
         const mainReplacement = promptManager.preparePrompt(systemPrompt, mainOriginalContent);
         prompts.override(mainReplacement, prompts.index('main'));
+    }
+
+    // Group chat: Replace main prompt with single-character role-play framing
+    if (selected_group && systemPrompt && !systemPromptOverride && !isSystemPromptDisabled) {
+        const rolePlayPrompt = 'You are {{char}}. Write {{char}}\'s next message in a role-play group chat with {{group}} and {{user}}. This is NOT a story or script — you are ONE character. Output ONLY {{char}}\'s words and actions. Do NOT write dialogue, actions, or narration for anyone else.';
+        const originalContent = systemPrompt.content;
+        systemPrompt.content = substituteParams(rolePlayPrompt);
+        const replacement = promptManager.preparePrompt(systemPrompt, originalContent);
+        prompts.override(replacement, prompts.index('main'));
     }
 
     // Apply character-specific jailbreak


### PR DESCRIPTION
Title: fix: prevent character mismatch in group chat replies

Description:
- Enhanced group nudge prompt to enforce single-character role-play rules
- Added role-play framing prompt replacement for group chat scenarios  
- Fixed default join prefix fallback when generation_mode_join_prefix is empty