### PR TITLE
Add Custom source video inlining and reduce browser memory use for large media

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2062,7 +2062,7 @@
                                                     <i class="icon-supported fa-solid fa-image" title="Supported by the current model" data-i18n="[title]Supported by the current model"></i>
                                                     <i class="icon-unsupported fa-solid fa-image" title="Unsupported by the current model" data-i18n="[title]Unsupported by the current model"></i>
                                                 </div>
-                                                <div id="openai_video_inlining_supported" data-source="makersuite,vertexai,openrouter,zai">
+                                                <div id="openai_video_inlining_supported" data-source="makersuite,vertexai,openrouter,zai,custom">
                                                     <i class="icon-supported fa-solid fa-film" title="Supported by the current model" data-i18n="[title]Supported by the current model"></i>
                                                     <i class="icon-unsupported fa-solid fa-film" title="Unsupported by the current model" data-i18n="[title]Unsupported by the current model"></i>
                                                 </div>

--- a/public/script.js
+++ b/public/script.js
@@ -4254,6 +4254,41 @@ function removeLastMessage() {
  */
 
 /**
+ * Builds a sanitized copy of a chat-completion prompt for itemized-prompt storage,
+ * replacing any inline base64 media (image/video/audio data URLs) with a short
+ * placeholder so large media is never persisted with the itemized prompts.
+ * Copy-on-write: the original messages and their content arrays are never mutated.
+ * Non-array prompts (e.g. text-completion `input` strings) are returned unchanged.
+ * @param {any} prompt The prompt to sanitize (messages array or a string).
+ * @returns {any} A sanitized copy for storage, or the original for non-array prompts.
+ */
+function sanitizeRawPromptForItemization(prompt) {
+    if (!Array.isArray(prompt)) {
+        return prompt;
+    }
+    const mediaKeys = { image_url: 'image', video_url: 'video', audio_url: 'audio' };
+    return prompt.map((message) => {
+        if (!message || !Array.isArray(message.content)) {
+            return message;
+        }
+        let changed = false;
+        const content = message.content.map((part) => {
+            const kind = part && mediaKeys[part.type];
+            const media = kind && part[part.type];
+            const url = media?.url;
+            if (kind && typeof url === 'string' && url.startsWith('data:')) {
+                changed = true;
+                const base64Length = url.length - (url.indexOf(',') + 1);
+                const megabytes = (base64Length * 3 / 4 / (1024 * 1024)).toFixed(1);
+                return { ...part, [part.type]: { ...media, url: `[inline ${kind} omitted: ${megabytes} MB]` } };
+            }
+            return part;
+        });
+        return changed ? { ...message, content } : message;
+    });
+}
+
+/**
  * MARK:Generate()
  * Runs a generation using the current chat context.
  * @param {string} type Generation type
@@ -5313,7 +5348,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         let currentArrayEntry = Number(thisPromptBits.length - 1);
         let additionalPromptStuff = {
             ...thisPromptBits[currentArrayEntry],
-            rawPrompt: generate_data.prompt || generate_data.input,
+            rawPrompt: sanitizeRawPromptForItemization(generate_data.prompt) || generate_data.input,
             mesId: getNextMessageId(type),
             allAnchors: await getAllExtensionPrompts(),
             chatInjects: injectedIndices?.map(index => arrMes[arrMes.length - index - 1])?.join('') || '',

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -328,19 +328,23 @@ export async function getFileAttachment(url) {
  * @returns {Promise<boolean>} True if file is valid, false otherwise.
  */
 async function validateFile(file) {
-    const fileText = await file.text();
     const isMedia = file.type.startsWith('image/') || file.type.startsWith('video/') || file.type.startsWith('audio/');
-    const isBinary = /^[\x00-\x08\x0E-\x1F\x7F-\xFF]*$/.test(fileText);
 
     if (!isMedia && file.size > fileSizeLimit) {
         toastr.error(t`File is too big. Maximum size is ${humanFileSize(fileSizeLimit)}.`);
         return false;
     }
 
-    // If file is binary
-    if (isBinary && !isMedia && !isConvertible(file.type)) {
-        toastr.error(t`Binary files are not supported. Select a text file or image.`);
-        return false;
+    // Media files don't need to be read to be validated; skip the binary content check
+    if (!isMedia) {
+        const fileText = await file.text();
+        const isBinary = /^[\x00-\x08\x0E-\x1F\x7F-\xFF]*$/.test(fileText);
+
+        // If file is binary
+        if (isBinary && !isConvertible(file.type)) {
+            toastr.error(t`Binary files are not supported. Select a text file or image.`);
+            return false;
+        }
     }
 
     return true;

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -39,7 +39,7 @@ import {
     getBase64Async,
     getStringHash,
     humanFileSize,
-    saveBase64AsFile,
+    saveFileAsMediaToServer,
     extractTextFromOffice,
     download,
     getFileText,
@@ -205,13 +205,12 @@ export async function populateFileAttachment(message, inputId = 'file_form_input
         for (const file of fileInput.files) {
             const slug = getStringHash(file.name);
             const fileNamePrefix = `${Date.now()}_${slug}`;
-            const fileBase64 = await getBase64Async(file);
-            let base64Data = fileBase64.split(',')[1];
             const extension = getFileExtension(file);
 
             const mediaType = MEDIA_TYPE.getFromMime(file.type);
             if (mediaType) {
-                const imageUrl = await saveBase64AsFile(base64Data, name2, fileNamePrefix, extension);
+                // Upload media files as-is to avoid materializing large base64 strings in memory
+                const imageUrl = await saveFileAsMediaToServer(file, name2, fileNamePrefix, extension);
                 if (!Array.isArray(message.extra.media)) {
                     message.extra.media = [];
                 }
@@ -227,6 +226,8 @@ export async function populateFileAttachment(message, inputId = 'file_form_input
                 message.extra.inline_image = true;
             } else {
                 const uniqueFileName = `${fileNamePrefix}.txt`;
+                const fileBase64 = await getBase64Async(file);
+                let base64Data = fileBase64.split(',')[1];
 
                 if (isConvertible(file.type)) {
                     try {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -3446,6 +3446,37 @@ class InvalidCharacterNameError extends Error {
 }
 
 /**
+ * Determines whether a media URL points to a local file served by this server
+ * (e.g. '/user/images/...'). Such files can be inlined server-side instead of
+ * being fetched and base64-encoded in the browser.
+ * @param {string} url The media URL to inspect.
+ * @returns {string|null} The server-rooted path (starting with '/') if local, otherwise null.
+ */
+function getLocalServerMediaPath(url) {
+    if (typeof url !== 'string' || !url) {
+        return null;
+    }
+    // Protocol-relative URLs (//host/...) are not local.
+    if (url.startsWith('//')) {
+        return null;
+    }
+    // Server-rooted relative path.
+    if (url.startsWith('/')) {
+        return url;
+    }
+    // Absolute URL pointing at the same origin: use its path only.
+    try {
+        const parsed = new URL(url, window.location.origin);
+        if (parsed.origin === window.location.origin) {
+            return parsed.pathname + parsed.search;
+        }
+    } catch {
+        // Not a parseable URL - treat as non-local.
+    }
+    return null;
+}
+
+/**
  * Used for creating, managing, and interacting with a specific message object.
  */
 class Message {
@@ -3598,25 +3629,35 @@ class Message {
     async addVideo(video) {
         this.content = this.ensureContentIsArray();
         const isDataUrl = isDataURL(video);
-        if (!isDataUrl) {
-            try {
-                const response = await fetch(video, { method: 'GET', cache: 'force-cache' });
-                if (!response.ok) throw new Error('Failed to fetch video');
-                const blob = await response.blob();
-                video = await getBase64Async(blob);
-            } catch (error) {
-                console.error('Video adding skipped', error);
-                return;
-            }
-        }
-
+        const localPath = isDataUrl ? null : getLocalServerMediaPath(video);
         // Note: No compression for videos (unlike images)
         const quality = oai_settings.inline_image_quality || default_settings.inline_image_quality;
-        this.content.push({ type: 'video_url', video_url: { 'url': video, 'detail': quality } });
+
+        if (localPath) {
+            // Local server file: keep the path as-is and let the server inline the
+            // base64 at generation time. This avoids loading large videos into the
+            // browser JS heap on every generation.
+            this.content.push({ type: 'video_url', video_url: { 'url': localPath, 'detail': quality } });
+        } else {
+            if (!isDataUrl) {
+                try {
+                    const response = await fetch(video, { method: 'GET', cache: 'force-cache' });
+                    if (!response.ok) throw new Error('Failed to fetch video');
+                    const blob = await response.blob();
+                    video = await getBase64Async(blob);
+                } catch (error) {
+                    console.error('Video adding skipped', error);
+                    return;
+                }
+            }
+            this.content.push({ type: 'video_url', video_url: { 'url': video, 'detail': quality } });
+        }
 
         try {
-            // Using Gemini calculation (263 tokens per second)
-            const duration = await getVideoDurationFromDataURL(video);
+            // Using Gemini calculation (263 tokens per second).
+            // getVideoDurationFromDataURL accepts any video src (data URL or local path)
+            // and reads only metadata, so token accounting stays consistent.
+            const duration = await getVideoDurationFromDataURL(localPath || video);
             this.tokens += 263 * Math.ceil(duration);
         } catch (error) {
             // Convservative estimate for video token cost without knowing duration

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -6309,6 +6309,16 @@ export function isVideoInliningSupported() {
             return (Array.isArray(model_list) && model_list.find(m => m.id === oai_settings.openrouter_model)?.architecture?.input_modalities?.includes('video'));
         case chat_completion_sources.ZAI:
             return videoSupportedModels.some(model => oai_settings.zai_model.includes(model));
+        case chat_completion_sources.CUSTOM: {
+            const customModel = oai_settings.custom_model?.toLowerCase();
+            if (!customModel) {
+                return false;
+            }
+            return videoSupportedModels.some(model => {
+                const prefix = model.includes('-') ? model.slice(0, model.indexOf('-')) : model;
+                return customModel.includes(prefix.toLowerCase());
+            });
+        }
         default:
             return false;
     }

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -1675,6 +1675,45 @@ export async function saveBase64AsFile(base64Data, subFolder, fileName, extensio
 }
 
 /**
+ * Sends a media file to the backend to be saved as-is, without base64 encoding.
+ * Use this instead of saveBase64AsFile for large media files to avoid
+ * materializing the file contents as a base64 string in memory.
+ *
+ * @param {File} file - The file to upload.
+ * @param {string} subFolder - The character name to determine the sub-directory for saving.
+ * @param {string} fileName - The name of the file to save the media as (without extension).
+ * @param {string} extension - The file extension for the media (e.g., 'jpg', 'png', 'mp4').
+ *
+ * @returns {Promise<string>} - Resolves to the saved media file's path on the server.
+ *                              Rejects with an error if the upload fails.
+ */
+export async function saveFileAsMediaToServer(file, subFolder, fileName, extension) {
+    const formData = new FormData();
+    formData.append('avatar', file);
+    formData.append('format', extension);
+    formData.append('filename', String(fileName).replace(/\./g, '_'));
+    if (subFolder) {
+        formData.append('ch_name', subFolder);
+    }
+
+    const response = await fetch('/api/images/upload-form', {
+        method: 'POST',
+        headers: getRequestHeaders({ omitContentType: true }),
+        cache: 'no-cache',
+        body: formData,
+    });
+
+    // If the response is successful, get the saved media path from the server's response
+    if (response.ok) {
+        const responseData = await response.json();
+        return responseData.path;
+    } else {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || 'Failed to upload the file to the server');
+    }
+}
+
+/**
  * Gets the file extension from a File object.
  * @param {File} file The file to get the extension from
  * @returns {string} The file extension of the given file

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -32,6 +32,7 @@ import {
     color,
     trimTrailingSlash,
     flattenSchema,
+    inlineLocalVideoMedia,
 } from '../../util.js';
 import {
     convertClaudeMessages,
@@ -2166,6 +2167,13 @@ router.post('/bias', async function (request, response) {
 router.post('/generate', async function (request, response) {
     try {
         if (!request.body) return response.status(400).send({ error: true });
+
+        // Inline local video files into base64 data URLs on the server so that
+        // large videos never enter the browser JS heap at generation time.
+        // Runs before provider branching so downstream converters see data URLs.
+        if (Array.isArray(request.body.messages)) {
+            inlineLocalVideoMedia(request.body.messages, request.user.directories);
+        }
 
         const postProcessingType = request.body.custom_prompt_post_processing;
         if (Array.isArray(request.body.messages) && postProcessingType) {

--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -6,6 +6,7 @@ import sanitize from 'sanitize-filename';
 import { sync as writeFileSyncAtomic } from 'write-file-atomic';
 
 import { validateAssetFileName } from './assets.js';
+import { moveUploadedFile } from './images.js';
 import { clientRelativePath } from '../util.js';
 
 export const router = express.Router();
@@ -47,6 +48,48 @@ router.post('/upload', async (request, response) => {
         return response.send({ path: url });
     } catch (error) {
         console.error(error);
+        return response.sendStatus(500);
+    }
+});
+
+/**
+ * Endpoint to handle raw multipart file uploads.
+ * The file should be provided as a multipart form field named 'avatar'.
+ * Avoids buffering the file contents in memory by moving the uploaded temp file into place.
+ *
+ * @route POST /api/files/upload-form
+ * @param {Object} request.body - The multipart form fields.
+ * @param {string} request.body.name - The name to save the file as.
+ * @returns {Object} response - The response object containing the path where the file was saved.
+ */
+router.post('/upload-form', async (request, response) => {
+    try {
+        if (!request.file) {
+            return response.status(400).send('No file uploaded');
+        }
+
+        if (!request.body.name) {
+            await fs.promises.unlink(request.file.path).catch(() => { });
+            return response.status(400).send('No upload name specified');
+        }
+
+        // Validate filename
+        const validation = validateAssetFileName(request.body.name);
+        if (validation.error) {
+            await fs.promises.unlink(request.file.path).catch(() => { });
+            return response.status(400).send(validation.message);
+        }
+
+        const pathToUpload = path.join(request.user.directories.files, request.body.name);
+        await moveUploadedFile(request.file.path, pathToUpload);
+        const url = clientRelativePath(request.user.directories.root, pathToUpload);
+        console.info(`Uploaded file: ${url} from ${request.user.profile.handle}`);
+        return response.send({ path: url });
+    } catch (error) {
+        console.error(error);
+        if (request.file?.path) {
+            await fs.promises.unlink(request.file.path).catch(() => { });
+        }
         return response.sendStatus(500);
     }
 });

--- a/src/endpoints/images.js
+++ b/src/endpoints/images.js
@@ -23,6 +23,55 @@ function ensureDirectoryExistence(filePath) {
     fs.mkdirSync(dirname);
 }
 
+/**
+ * Builds a sanitized destination path for an uploaded image.
+ * Returns null if the requested format is not a supported media extension.
+ *
+ * @param {import('../users.js').UserDirectoryList} directories - User directories
+ * @param {string} format - File extension of the image
+ * @param {string} [filename] - Optional filename (extension is ignored)
+ * @param {string} [chName] - Optional character name for a sub-folder
+ * @returns {string|null} The full path to save the image to, or null if the format is invalid
+ */
+function getUploadedImagePath(directories, format, filename, chName) {
+    if (!MEDIA_EXTENSIONS.includes(format)) {
+        return null;
+    }
+
+    // Constructing filename and path
+    const finalName = filename
+        ? `${removeFileExtension(filename)}.${format}`
+        : `${Date.now()}.${format}`;
+
+    // if character is defined, save to a sub folder for that character
+    if (chName) {
+        return path.join(directories.userImages, sanitize(chName), sanitize(finalName));
+    }
+
+    return path.join(directories.userImages, sanitize(finalName));
+}
+
+/**
+ * Moves an uploaded temp file to its destination.
+ * Falls back to copy+unlink when renaming across devices.
+ *
+ * @param {string} sourcePath - Path to the uploaded temp file
+ * @param {string} destinationPath - Path to move the file to
+ * @returns {Promise<void>}
+ */
+export async function moveUploadedFile(sourcePath, destinationPath) {
+    try {
+        await fs.promises.rename(sourcePath, destinationPath);
+    } catch (error) {
+        if (error.code === 'EXDEV') {
+            await fs.promises.copyFile(sourcePath, destinationPath);
+            await fs.promises.unlink(sourcePath);
+        } else {
+            throw error;
+        }
+    }
+}
+
 export const router = express.Router();
 
 /**
@@ -48,23 +97,9 @@ router.post('/upload', async (request, response) => {
             return response.status(400).send({ error: 'No image data provided' });
         }
 
-        const validFormat = MEDIA_EXTENSIONS.includes(format);
-        if (!validFormat) {
+        const pathToNewFile = getUploadedImagePath(request.user.directories, format, request.body.filename, request.body.ch_name);
+        if (!pathToNewFile) {
             return response.status(400).send({ error: 'Invalid image format' });
-        }
-
-        // Constructing filename and path
-        let filename;
-        if (request.body.filename) {
-            filename = `${removeFileExtension(request.body.filename)}.${format}`;
-        } else {
-            filename = `${Date.now()}.${format}`;
-        }
-
-        // if character is defined, save to a sub folder for that character
-        let pathToNewFile = path.join(request.user.directories.userImages, sanitize(filename));
-        if (request.body.ch_name) {
-            pathToNewFile = path.join(request.user.directories.userImages, sanitize(request.body.ch_name), sanitize(filename));
         }
 
         ensureDirectoryExistence(pathToNewFile);
@@ -73,6 +108,42 @@ router.post('/upload', async (request, response) => {
         response.send({ path: clientRelativePath(request.user.directories.root, pathToNewFile) });
     } catch (error) {
         console.error(error);
+        response.status(500).send({ error: 'Failed to save the image' });
+    }
+});
+
+/**
+ * Endpoint to handle raw multipart image/media uploads.
+ * The file should be provided as a multipart form field named 'avatar'.
+ * Avoids buffering the file contents in memory by moving the uploaded temp file into place.
+ *
+ * @route POST /api/images/upload-form
+ * @param {Object} request.body - The multipart form fields.
+ * @param {string} request.body.format - The file extension of the media file.
+ * @param {string} [request.body.filename] - Optional filename (extension is ignored).
+ * @param {string} [request.body.ch_name] - Optional character name to determine the sub-directory.
+ * @returns {Object} response - The response object containing the path where the file was saved.
+ */
+router.post('/upload-form', async (request, response) => {
+    try {
+        if (!request.file) {
+            return response.status(400).send({ error: 'No file provided' });
+        }
+
+        const pathToNewFile = getUploadedImagePath(request.user.directories, request.body.format, request.body.filename, request.body.ch_name);
+        if (!pathToNewFile) {
+            await fs.promises.unlink(request.file.path).catch(() => { });
+            return response.status(400).send({ error: 'Invalid image format' });
+        }
+
+        ensureDirectoryExistence(pathToNewFile);
+        await moveUploadedFile(request.file.path, pathToNewFile);
+        response.send({ path: clientRelativePath(request.user.directories.root, pathToNewFile) });
+    } catch (error) {
+        console.error(error);
+        if (request.file?.path) {
+            await fs.promises.unlink(request.file.path).catch(() => { });
+        }
         response.status(500).send({ error: 'Failed to save the image' });
     }
 });

--- a/src/util.js
+++ b/src/util.js
@@ -1400,6 +1400,122 @@ export function isPathUnderParent(parentPath, childPath) {
 }
 
 /**
+ * Maps server-relative user media URL prefixes to the corresponding
+ * user directory key. Mirrors the static routes served from users.js.
+ * @type {ReadonlyArray<{ prefix: string, dir: string }>}
+ */
+const LOCAL_MEDIA_URL_PREFIXES = Object.freeze([
+    { prefix: 'user/images/', dir: 'userImages' },
+    { prefix: 'user/files/', dir: 'files' },
+    { prefix: 'characters/', dir: 'characters' },
+    { prefix: 'backgrounds/', dir: 'backgrounds' },
+    { prefix: 'assets/', dir: 'assets' },
+    { prefix: 'user avatars/', dir: 'avatars' },
+]);
+
+/**
+ * Resolves a server-relative user media URL (e.g. '/user/images/foo.mp4') to an
+ * absolute path on disk, verifying the resolved path stays inside the matching
+ * user data subdirectory. Returns null for anything that is not a safe local
+ * file path (data: URLs, http(s):, protocol-relative, unknown prefixes,
+ * traversal attempts, absolute/UNC paths, or malformed encodings).
+ * @param {string} url The media URL from a message content part.
+ * @param {Record<string, string>} directories The requesting user's directories (request.user.directories).
+ * @returns {string|null} Absolute file path inside the user data root, or null if invalid/unsafe.
+ */
+export function resolveLocalUserMediaPath(url, directories) {
+    if (typeof url !== 'string' || !url || !directories) {
+        return null;
+    }
+    // Must be a server-rooted relative path; reject protocol-relative and any URL with a scheme.
+    if (!url.startsWith('/') || url.startsWith('//')) {
+        return null;
+    }
+    // Reject raw backslashes (Windows/UNC style) before decoding.
+    if (url.includes('\\')) {
+        return null;
+    }
+
+    // Drop any query string or fragment, then strip the leading slash.
+    const withoutQuery = url.replace(/[?#].*$/, '');
+    let relative;
+    try {
+        relative = decodeURIComponent(withoutQuery.slice(1));
+    } catch {
+        // Malformed percent-encoding.
+        return null;
+    }
+    // Reject decoded backslashes, NUL bytes, or empty results.
+    if (!relative || relative.includes('\\') || relative.includes('\0')) {
+        return null;
+    }
+
+    const lower = relative.toLowerCase();
+    const mapping = LOCAL_MEDIA_URL_PREFIXES.find(m => lower.startsWith(m.prefix));
+    if (!mapping) {
+        return null;
+    }
+    const baseDir = directories[mapping.dir];
+    if (!baseDir) {
+        return null;
+    }
+    const subRelative = relative.slice(mapping.prefix.length);
+    if (!subRelative) {
+        return null;
+    }
+
+    const resolvedBase = path.resolve(baseDir);
+    const fullPath = path.resolve(resolvedBase, subRelative);
+    if (!isPathUnderParent(resolvedBase, fullPath)) {
+        return null;
+    }
+    return fullPath;
+}
+
+/**
+ * Walks a chat-completion messages array and, for any 'video_url' content part
+ * whose URL is a local user-file path, reads the file and replaces the URL with
+ * a base64 data URL. Mutates the provided messages in place. Parts that are
+ * already data: URLs, remote URLs, or fail the path-safety check are left as-is
+ * (unsafe local paths are skipped with a warning).
+ * @param {any[]} messages The request.body.messages array.
+ * @param {Record<string, string>} directories The requesting user's directories.
+ * @returns {void}
+ */
+export function inlineLocalVideoMedia(messages, directories) {
+    if (!Array.isArray(messages) || !directories) {
+        return;
+    }
+    for (const message of messages) {
+        if (!message || !Array.isArray(message.content)) {
+            continue;
+        }
+        for (const part of message.content) {
+            if (!part || part.type !== 'video_url') {
+                continue;
+            }
+            const url = part.video_url?.url;
+            if (typeof url !== 'string' || url.startsWith('data:') || /^[a-z][a-z0-9+.-]*:/i.test(url)) {
+                // Already inlined or a remote/scheme URL - leave untouched.
+                continue;
+            }
+            const filePath = resolveLocalUserMediaPath(url, directories);
+            if (!filePath) {
+                console.warn('Skipping video inlining for unsafe or unknown media path:', url);
+                continue;
+            }
+            try {
+                const data = fs.readFileSync(filePath);
+                const mimeType = mime.lookup(filePath) || 'video/mp4';
+                part.video_url.url = `data:${mimeType};base64,${data.toString('base64')}`;
+            } catch (error) {
+                console.warn('Failed to inline local video media:', url, error?.message ?? error);
+            }
+        }
+    }
+}
+
+/**
  * Checks if the given request is a file URL.
  * @param {string | URL | Request} request The request to check
  * @return {boolean} Returns true if the request is a file URL, false otherwise


### PR DESCRIPTION
## What this does

1. **Custom source video inlining**: `isVideoInliningSupported()` gains a CUSTOM case that matches the configured model name against the known video-capable model prefixes (case-insensitive; returns false when no model is set). The video indicator icon is enabled for the Custom source in the UI.

2. **Multipart media upload**: chat attachments now upload the raw file via multipart form data to new `/api/images/upload-form` and `/api/files/upload-form` endpoints, using the existing global multer middleware. Previously the client converted the file to a base64 data URL and posted it as JSON, holding several full-size copies in the browser heap. The server moves the multer temp file into place without buffering it in memory, reusing the same filename sanitization as the base64 endpoints (which remain unchanged for existing callers). `validateFile` also skips reading media files as text for its binary-content check.

3. **Server-side video inlining**: at generation time the client sends the local server path for a video attachment instead of fetching and base64-encoding it in the browser. The server resolves the path, restricted to the matching user media subdirectory with traversal attempts rejected, and replaces it with a base64 data URL before provider branching, so all provider converters see the same payload shape as before. Remote URLs and data URLs keep the previous client-side behavior.

4. **Itemized prompt storage**: `rawPrompt` entries now replace inline base64 media with a short placeholder (`[inline video omitted: N MB]`) via copy-on-write, so prompt itemization no longer retains or persists full media payloads per generation.

## Why

Attaching a video of roughly 100MB produced several concurrent full-size copies of the data in the browser heap (base64 data URL at upload, JSON request body, a re-encoded copy at every generation, and the serialized payload), which crashed the tab with an out-of-memory error. With these changes the video bytes stay out of the browser JS heap: upload streams the raw file, generation sends a short path string, and the Node server performs the single base64 encoding.

## Testing

- `npm run lint` passes.
- Manual: attached a ~100MB video with a Custom (OpenAI-compatible) endpoint; upload and generation succeed without a memory spike, and prompt itemization shows the placeholder. Small images, text file attachments, and external http(s) media URLs behave as before.
- Upload endpoints smoke-tested with curl: valid upload returns the expected path; invalid format returns 400 and the temp file is removed.
- The path-safety helper was exercised against traversal attempts (raw and percent-encoded `..`, absolute paths, UNC paths, NUL bytes, unknown prefixes); all were rejected.

## Related work

This change supports a companion PR against KoboldCPP that adds video embedding support over its OpenAI-compatible API, to be posted shortly. The Custom-source video inlining here is what allows SillyTavern to deliver inline video to that endpoint.
