### PR TITLE
File API /list endpoint

### DIFF
--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -99,3 +99,19 @@ router.post('/verify', async (request, response) => {
         return response.sendStatus(500);
     }
 });
+
+router.get('/list', async (request, response) => {
+    try {
+        // Read all files from the user files directory
+        const files = await fs.readdirSync(request.user.directories.files, {
+            withFileTypes: true,
+        });
+
+        // filter for files only and map to file names
+        const filenames = files.filter(f => f.isFile()).map(f => f.name);
+        return response.send(filenames);
+    } catch (error) {
+        console.error(error);
+        return response.sendStatus(500);
+    }
+});

--- a/src/endpoints/files.js
+++ b/src/endpoints/files.js
@@ -100,15 +100,18 @@ router.post('/verify', async (request, response) => {
     }
 });
 
-router.get('/list', async (request, response) => {
+router.post('/list', async (request, response) => {
+    // Request a list of files stored in the user's files/ directory. Optionally passing a prefix to filter for.
     try {
+        const prefix = request.body?.prefix ?? '';
+
         // Read all files from the user files directory
         const files = await fs.readdirSync(request.user.directories.files, {
             withFileTypes: true,
         });
 
-        // filter for files only and map to file names
-        const filenames = files.filter(f => f.isFile()).map(f => f.name);
+        // filter for files that match the prefix and map to file names
+        const filenames = files.filter(f => f.isFile() && f.name.startsWith(prefix)).map(f => f.name);
         return response.send(filenames);
     } catch (error) {
         console.error(error);


### PR DESCRIPTION
### Description
This adds a `/list` endpoint to the files API, allowing extensions to retrieve a list of files in the user's `files/` directory.
It also accepts an optional `body.prefix` which filters the files found for only those that start with that prefix.

### Motivation
This is intended to address the use case where an extension wants to store and retrieve many dynamically-named files in the user's `files/` directory. Currently, the extension needs to keep an up-to-date index of all files it has previously stored, but this has the potential to get out of sync without the ability to correct it. This could happen if the user manually messes with these files or a failed write/delete is mishandled by the extension.

I understand that security may be a concern, and this endpoint should not allow querying anything outside the directory stored in `request.user.directories.files`. I do not believe that variable can be changed by an extension.

### Testing
This can be tested with the following:
```
const resp = await fetch('/api/files/list', {
    method: 'GET',
    credentials: 'include',
    headers: getRequestHeaders()
})
console.log(await resp.json())

```

### Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
