### PR TITLE
fix: trimToStartSentence() only trimmed when the first sentence ended with a period

### DIFF
--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -910,28 +910,27 @@ export function trimToEndSentence(input) {
     return characters.slice(0, last + 1).join('').trimEnd();
 }
 
+/**
+ * Trims a string to the start of the nearest sentence.
+ * @param {string} input The string to trim.
+ * @returns {string} The trimmed string.
+ * @example
+ * trimToStartSentence('Hello, world! I am from'); // 'I am from'
+ */
 export function trimToStartSentence(input) {
     if (!input) {
         return '';
     }
 
-    let p1 = input.indexOf('.');
-    let p2 = input.indexOf('!');
-    let p3 = input.indexOf('?');
-    let p4 = input.indexOf('\n');
-    let first = p1;
-    let skip1 = false;
-    if (p2 > 0 && p2 < first) { first = p2; }
-    if (p3 > 0 && p3 < first) { first = p3; }
-    if (p4 > 0 && p4 < first) { first = p4; skip1 = true; }
-    if (first > 0) {
-        if (skip1) {
-            return input.substring(first + 1);
-        } else {
-            return input.substring(first + 2);
-        }
+    const indices = ['.', '!', '?', '\n']
+        .map(delimiter => input.indexOf(delimiter))
+        .filter(index => index > 0);
+
+    if (indices.length === 0) {
+        return input;
     }
-    return input;
+
+    return input.substring(Math.min(...indices) + 1).trimStart();
 }
 
 /**

--- a/tests/frontend/TrimToStartSentence.e2e.js
+++ b/tests/frontend/TrimToStartSentence.e2e.js
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { testSetup } from './frontent-test-utils.js';
+
+test.describe('trimToStartSentence', () => {
+    test.beforeEach(testSetup.awaitST);
+
+    test('should trim to the start of the first full sentence', async ({ page }) => {
+        const output = await page.evaluate(async () => {
+            const { trimToStartSentence } = await import('./scripts/utils.js');
+            return [
+                trimToStartSentence('Hello, world. I am from'),
+                trimToStartSentence('Hello, world! I am from'),
+                trimToStartSentence('Hello, world? I am from'),
+                trimToStartSentence('Hello, world\nI am from'),
+                trimToStartSentence('Hello, world!I am from'),
+                trimToStartSentence('Hello, world! And more. I am from'),
+                trimToStartSentence('Hello world'),
+                trimToStartSentence(''),
+            ];
+        });
+
+        expect(output).toEqual([
+            'I am from',
+            'I am from',
+            'I am from',
+            'I am from',
+            'I am from',
+            'And more. I am from',
+            'Hello world',
+            '',
+        ]);
+    });
+});


### PR DESCRIPTION
### Why

Fixes #5886.

`trimToStartSentence()` anchored the search on `input.indexOf('.')`:

```js
let first = p1;                            // -1 when there is no '.'
if (p2 > 0 && p2 < first) { first = p2; }  // never true when first === -1
```

Two consequences:

1. `!`, `?` and `\n` were only considered when they occurred *before* a later period. With no period in the string, `first` stayed `-1` and the input was returned untrimmed.
2. The punctuation branch returned `input.substring(first + 2)`, hard-assuming a single space after the delimiter — without one, the first character of the next sentence was dropped.

This affects the `/trimstart` slash command, the Vector Storage chunk-overlap helper, and the expression classifier's text sampling.

### What

Collect every delimiter position, take the smallest one, and `trimStart()` the remainder instead of skipping a fixed offset. Behaviour for period-terminated input is unchanged. Added the JSDoc block the function was missing, matching `trimToEndSentence()` right above it.

| Input | Before | After |
| --- | --- | --- |
| `Hello, world. I am from` | `I am from` | `I am from` |
| `Hello, world! I am from` | `Hello, world! I am from` | `I am from` |
| `Hello, world? I am from` | `Hello, world? I am from` | `I am from` |
| `Hello, world⏎I am from` | `Hello, world⏎I am from` | `I am from` |
| `Hello, world!I am from` | ` am from` | `I am from` |

### How to test

```
npm run lint
cd tests && npx playwright test frontend/TrimToStartSentence.e2e.js
```

The added test covers all rows above; it fails on `staging` and passes with this change. Manually: run `/trimstart Hello, world! I am from` in the chat input — it should return `I am from`.
