### PR TITLE
Feat: Add OpenRouter sticky routing key (session_id / prompt_cache_key)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2510,6 +2510,21 @@
                                         <option data-i18n="Unknown" value="unknown">Unknown</option>
                                     </select>
                                 </div>
+                                <div>
+                                    <h4 data-i18n="[title]Pins a chat to one provider so prompt caching keeps hitting. An explicit provider order overrides this." title="Pins a chat to one provider so prompt caching keeps hitting. An explicit provider order overrides this.">
+                                        <span data-i18n="Cache Routing Key">Cache Routing Key</span>
+                                    </h4>
+                                    <select id="openrouter_routing_key_mode_text" class="text_pole">
+                                        <option data-i18n="Disabled" value="off">Disabled</option>
+                                        <option data-i18n="Send as session_id (recommended)" value="session_id">Send as session_id (recommended)</option>
+                                        <option data-i18n="Send as prompt_cache_key" value="prompt_cache_key">Send as prompt_cache_key</option>
+                                    </select>
+                                    <select id="openrouter_routing_key_source_text" class="text_pole marginTopBot5">
+                                        <option data-i18n="Key: chat ID" value="chat_id">Key: chat ID</option>
+                                        <option data-i18n="Key: chat name" value="chat_name">Key: chat name</option>
+                                        <option data-i18n="Key: chat name (hashed)" value="chat_name_hash">Key: chat name (hashed)</option>
+                                    </select>
+                                </div>
                             </div>
                             <div data-tg-type="infermaticai" class="flex-container flexFlowColumn">
                                 <h4 data-i18n="InfermaticAI API Key">InfermaticAI API Key</h4>
@@ -3266,6 +3281,21 @@
                                     <option data-i18n="Brain floating point (16 bit)" value="bf16">Brain floating point (16 bit)</option>
                                     <option data-i18n="Floating point (32 bit)" value="fp32">Floating point (32 bit)</option>
                                     <option data-i18n="Unknown" value="unknown">Unknown</option>
+                                </select>
+                            </div>
+                            <div>
+                                <h4 data-i18n="[title]Pins a chat to one provider so prompt caching keeps hitting. An explicit provider order overrides this." title="Pins a chat to one provider so prompt caching keeps hitting. An explicit provider order overrides this.">
+                                    <span data-i18n="Cache Routing Key">Cache Routing Key</span>
+                                </h4>
+                                <select id="openrouter_routing_key_mode_chat" class="text_pole">
+                                    <option data-i18n="Disabled" value="off">Disabled</option>
+                                    <option data-i18n="Send as session_id (recommended)" value="session_id">Send as session_id (recommended)</option>
+                                    <option data-i18n="Send as prompt_cache_key" value="prompt_cache_key">Send as prompt_cache_key</option>
+                                </select>
+                                <select id="openrouter_routing_key_source_chat" class="text_pole marginTopBot5">
+                                    <option data-i18n="Key: chat ID" value="chat_id">Key: chat ID</option>
+                                    <option data-i18n="Key: chat name" value="chat_name">Key: chat name</option>
+                                    <option data-i18n="Key: chat name (hashed)" value="chat_name_hash">Key: chat name (hashed)</option>
                                 </select>
                             </div>
                         </form>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -81,6 +81,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
 import { syncNanoGptProvidersForModel, syncOpenRouterProvidersForModel, updateNanoGptProvidersWarning, updateOpenRouterProvidersWarning } from './textgen-models.js';
+import { applyOpenRouterRoutingKey, openrouter_routing_key_modes, openrouter_routing_key_sources } from './openrouter-routing.js';
 
 export {
     openai_messages_count,
@@ -322,6 +323,8 @@ export const settingsToUpdate = {
     openrouter_quantizations: ['#openrouter_quantizations_chat', 'openrouter_quantizations', false, true],
     openrouter_allow_fallbacks: ['#openrouter_allow_fallbacks', 'openrouter_allow_fallbacks', true, true],
     openrouter_middleout: ['#openrouter_middleout', 'openrouter_middleout', false, true],
+    openrouter_routing_key_mode: ['#openrouter_routing_key_mode_chat', 'openrouter_routing_key_mode', false, true],
+    openrouter_routing_key_source: ['#openrouter_routing_key_source_chat', 'openrouter_routing_key_source', false, true],
     tool_reasoning_mode: ['#tool_reasoning_mode', 'tool_reasoning_mode', false, false],
     ai21_model: ['#model_ai21_select', 'ai21_model', false, true],
     mistralai_model: ['#model_mistralai_select', 'mistralai_model', false, true],
@@ -481,6 +484,8 @@ const default_settings = {
     openrouter_quantizations: [],
     openrouter_allow_fallbacks: true,
     openrouter_middleout: openrouter_middleout_types.ON,
+    openrouter_routing_key_mode: openrouter_routing_key_modes.OFF,
+    openrouter_routing_key_source: openrouter_routing_key_sources.CHAT_ID,
     tool_reasoning_mode: tool_reasoning_modes.DISABLED,
     reverse_proxy: '',
     chat_completion_source: chat_completion_sources.OPENAI,
@@ -2844,6 +2849,7 @@ export async function createGenerationParameters(settings, model, type, messages
         generate_data.quantizations = settings.openrouter_quantizations;
         generate_data.allow_fallbacks = settings.openrouter_allow_fallbacks;
         generate_data.middleout = settings.openrouter_middleout;
+        applyOpenRouterRoutingKey(generate_data, settings.openrouter_routing_key_mode, settings.openrouter_routing_key_source);
     }
 
     if (settings.chat_completion_source === chat_completion_sources.NANOGPT) {
@@ -6933,6 +6939,16 @@ export function initOpenAI() {
 
     $('#openrouter_middleout').on('input', function () {
         oai_settings.openrouter_middleout = String($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#openrouter_routing_key_mode_chat').on('input', function () {
+        oai_settings.openrouter_routing_key_mode = String($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#openrouter_routing_key_source_chat').on('input', function () {
+        oai_settings.openrouter_routing_key_source = String($(this).val());
         saveSettingsDebounced();
     });
 

--- a/public/scripts/openrouter-routing.js
+++ b/public/scripts/openrouter-routing.js
@@ -1,0 +1,112 @@
+import {
+    chat_metadata,
+    getCurrentChatId,
+} from '../script.js';
+import { getStringHash } from './utils.js';
+
+/**
+ * How the sticky routing key is sent to OpenRouter.
+ * OpenRouter uses session_id directly as the routing key, and only falls back
+ * to prompt_cache_key when session_id and the x-session-id header are absent.
+ */
+export const openrouter_routing_key_modes = {
+    OFF: 'off',
+    SESSION_ID: 'session_id',
+    PROMPT_CACHE_KEY: 'prompt_cache_key',
+};
+
+/** Where the value of the routing key comes from. */
+export const openrouter_routing_key_sources = {
+    CHAT_ID: 'chat_id',
+    CHAT_NAME: 'chat_name',
+    CHAT_NAME_HASH: 'chat_name_hash',
+};
+
+/** OpenRouter's documented maximum length for session_id. */
+const KEY_MAX_LENGTH = 256;
+
+/**
+ * Warnings already emitted, keyed by chat and reason, so a misconfiguration is
+ * visible once instead of on every swipe.
+ * @type {Set<string>}
+ */
+const warnedKeys = new Set();
+
+/**
+ * Resolve the routing key for the current chat.
+ * @param {string} source One of openrouter_routing_key_sources.
+ * @returns {{key: string, reason: string}} Key is empty when unavailable, in which case reason explains why.
+ */
+function resolveRoutingKey(source) {
+    let raw = '';
+    let reason = '';
+
+    switch (source) {
+        case openrouter_routing_key_sources.CHAT_ID:
+            raw = chat_metadata?.integrity ?? '';
+            reason = 'the chat has no integrity UUID yet';
+            break;
+        case openrouter_routing_key_sources.CHAT_NAME:
+            raw = getCurrentChatId() ?? '';
+            reason = 'there is no current chat';
+            break;
+        case openrouter_routing_key_sources.CHAT_NAME_HASH: {
+            const chatId = getCurrentChatId() ?? '';
+            raw = chatId ? getStringHash(chatId).toString(16) : '';
+            reason = 'there is no current chat to hash';
+            break;
+        }
+        default:
+            reason = `unknown key source "${source}"`;
+            break;
+    }
+
+    const key = String(raw ?? '').trim().slice(0, KEY_MAX_LENGTH);
+    return { key, reason: key ? '' : reason };
+}
+
+/**
+ * Warn about a missing routing key at most once per chat and reason.
+ * @param {string} reason Why no key could be resolved.
+ */
+function warnOnce(reason) {
+    const token = `${getCurrentChatId() ?? ''}::${reason}`;
+
+    if (warnedKeys.has(token)) {
+        return;
+    }
+
+    warnedKeys.add(token);
+    console.warn(`OpenRouter routing key not sent: ${reason}.`);
+}
+
+/**
+ * Add the OpenRouter sticky routing key to a request body, if one is configured
+ * and available. Mutates the target in place.
+ *
+ * Pinning a conversation to one upstream provider is what makes prompt caching
+ * pay off; without a key, OpenRouter derives one by hashing the first messages,
+ * which changes whenever the top of the prompt does.
+ * @param {object} target Request body to modify.
+ * @param {string} mode One of openrouter_routing_key_modes.
+ * @param {string} source One of openrouter_routing_key_sources.
+ */
+export function applyOpenRouterRoutingKey(target, mode, source) {
+    if (!target || !mode || mode === openrouter_routing_key_modes.OFF) {
+        return;
+    }
+
+    if (mode !== openrouter_routing_key_modes.SESSION_ID && mode !== openrouter_routing_key_modes.PROMPT_CACHE_KEY) {
+        console.warn(`OpenRouter routing key not sent: unknown mode "${mode}".`);
+        return;
+    }
+
+    const { key, reason } = resolveRoutingKey(source);
+
+    if (!key) {
+        warnOnce(reason);
+        return;
+    }
+
+    target[mode] = key;
+}

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -27,6 +27,7 @@ import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, l
 import { ENCODE_TOKENIZERS, TEXTGEN_TOKENIZERS, TOKENIZER_SUPPORTED_KEY, getTextTokens, getTokenizerBestMatch, tokenizers } from './tokenizers.js';
 import { AbortReason } from './util/AbortReason.js';
 import { getSortableDelay, onlyUnique, arraysEqual, isObject } from './utils.js';
+import { applyOpenRouterRoutingKey, openrouter_routing_key_modes, openrouter_routing_key_sources } from './openrouter-routing.js';
 
 export const textgen_types = {
     OOBA: 'ooba',
@@ -213,6 +214,8 @@ export const textgenerationwebui_settings = {
     openrouter_model: 'openrouter/auto',
     openrouter_providers: [],
     openrouter_quantizations: [],
+    openrouter_routing_key_mode: openrouter_routing_key_modes.OFF,
+    openrouter_routing_key_source: openrouter_routing_key_sources.CHAT_ID,
     vllm_model: '',
     aphrodite_model: '',
     dreamgen_model: 'lucid-v1-extra-large/text',
@@ -593,6 +596,8 @@ export async function loadTextGenSettings(data, loadedSettings) {
     $('#textgen_type').val(textgenerationwebui_settings.type);
     $('#openrouter_providers_text').val(textgenerationwebui_settings.openrouter_providers).trigger('change');
     $('#openrouter_quantizations_text').val(textgenerationwebui_settings.openrouter_quantizations).trigger('change');
+    $('#openrouter_routing_key_mode_text').val(textgenerationwebui_settings.openrouter_routing_key_mode);
+    $('#openrouter_routing_key_source_text').val(textgenerationwebui_settings.openrouter_routing_key_source);
     showSamplerControls(textgenerationwebui_settings.type);
     BIAS_CACHE.delete(BIAS_KEY);
     displayLogitBias(textgenerationwebui_settings.logit_bias, BIAS_KEY);
@@ -1088,6 +1093,16 @@ export function initTextGenSettings() {
 
         textgenerationwebui_settings.openrouter_quantizations = selectedQuantizations;
 
+        saveSettingsDebounced();
+    });
+
+    $('#openrouter_routing_key_mode_text').on('input', function () {
+        textgenerationwebui_settings.openrouter_routing_key_mode = String($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#openrouter_routing_key_source_text').on('input', function () {
+        textgenerationwebui_settings.openrouter_routing_key_source = String($(this).val());
         saveSettingsDebounced();
     });
 
@@ -1753,6 +1768,7 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
         params.provider = settings.openrouter_providers;
         params.quantizations = settings.openrouter_quantizations;
         params.allow_fallbacks = settings.openrouter_allow_fallbacks;
+        applyOpenRouterRoutingKey(params, settings.openrouter_routing_key_mode, settings.openrouter_routing_key_source);
     }
 
     if (settings.type === KOBOLDCPP) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -392,6 +392,8 @@ export const OPENROUTER_KEYS = [
     'stop',
     'provider',
     'include_reasoning',
+    'session_id',
+    'prompt_cache_key',
 ];
 
 // https://github.com/vllm-project/vllm/blob/0f8a91401c89ac0a8018def3756829611b57727f/vllm/entrypoints/openai/protocol.py#L220

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2253,6 +2253,16 @@ router.post('/generate', async function (request, response) {
                 bodyParams['repetition_penalty'] = request.body.repetition_penalty;
             }
 
+            // Sticky routing keys. OpenRouter uses session_id directly as the
+            // routing key, and falls back to prompt_cache_key when it's absent.
+            if (typeof request.body.session_id === 'string' && request.body.session_id) {
+                bodyParams['session_id'] = request.body.session_id.slice(0, 256);
+            }
+
+            if (typeof request.body.prompt_cache_key === 'string' && request.body.prompt_cache_key) {
+                bodyParams['prompt_cache_key'] = request.body.prompt_cache_key;
+            }
+
             if (Array.isArray(request.body.provider) && request.body.provider.length > 0) {
                 bodyParams['provider'] = {
                     allow_fallbacks: request.body.allow_fallbacks ?? true,


### PR DESCRIPTION
**What is the reason for a change?**
OpenRouter routes requests across upstream provider instances, and a prompt cache only hits when consecutive turns land on the same one. Without an explicit key it derives one by hashing the first system and first non-system message — which is defined by the user's Chat Completion Preset, and can change per turn without them realizing. A Main Prompt containing {{char}}, for example, resolves differently for each speaker in a group chat, so routing changes on every character switch.

**What did you do to achieve this?**
Added an opt-in "Cache Routing Key" setting to both OpenRouter connection forms, defaulting to Disabled so existing behavior is unchanged. session_id is OpenRouter-native for sticky routing from the first request; prompt_cache_key, which comes from OpenAI's API spec, is offered as the documented fallback. Exactly one is sent. The key derives from the chat's integrity UUID (default), its name, or a hash of its name, and is capped at OpenRouter's 256-char limit. When no key can be resolved nothing is sent and a warning is logged once, so OpenRouter falls back to its own default.

**How would a reviewer test the change?**
Select OpenRouter under Chat Completion, set Cache Routing Key to session_id with source chat ID, and send a message — the request carries session_id matching chat_metadata.integrity from the chat's .jsonl header. Repeat under the Text Completion OpenRouter type, which is a separate code path. Then check: Disabled sends neither field; prompt_cache_key sends only that one; the key holds steady across turns in a chat and differs between chats; with no chat open nothing is sent. Finally, save and reload a Settings Preset to confirm both settings persist, and export with connection data stripped to confirm they're excluded.  With Observability enabled on OperRouter generation will be grouped in sessions under the logs.


<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
