### PR TITLE
chore: Sync NanoGPT providers

### DIFF
--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -119,6 +119,10 @@ const OPENROUTER_PROVIDERS = [
  */
 const NANOGPT_PROVIDERS = [
     {
+        'id': 'aionlabs',
+        'label': 'Aion',
+    },
+    {
         'id': 'akash',
         'label': 'Akash',
     },
@@ -133,6 +137,14 @@ const NANOGPT_PROVIDERS = [
     {
         'id': 'arliai',
         'label': 'ArliAI',
+    },
+    {
+        'id': 'aster',
+        'label': 'Aster',
+    },
+    {
+        'id': 'aster-fast',
+        'label': 'Aster Fast',
     },
     {
         'id': 'atlascloud',
@@ -171,8 +183,20 @@ const NANOGPT_PROVIDERS = [
         'label': 'Cloudflare',
     },
     {
+        'id': 'coreweave',
+        'label': 'CoreWeave',
+    },
+    {
+        'id': 'crofai',
+        'label': 'CrofAI',
+    },
+    {
         'id': 'crusoe',
         'label': 'Crusoe',
+    },
+    {
+        'id': 'decart',
+        'label': 'Decart',
     },
     {
         'id': 'dekallm',
@@ -191,8 +215,16 @@ const NANOGPT_PROVIDERS = [
         'label': 'Fireworks',
     },
     {
+        'id': 'fireworks-fast',
+        'label': 'Fireworks Fast',
+    },
+    {
         'id': 'friendli',
         'label': 'Friendli',
+    },
+    {
+        'id': 'gerra',
+        'label': 'Gerra',
     },
     {
         'id': 'gmicloud',
@@ -235,6 +267,14 @@ const NANOGPT_PROVIDERS = [
         'label': 'MegaNova',
     },
     {
+        'id': 'meta',
+        'label': 'Meta',
+    },
+    {
+        'id': 'mixlayer',
+        'label': 'Mixlayer',
+    },
+    {
         'id': 'minimax',
         'label': 'MiniMax',
     },
@@ -264,7 +304,7 @@ const NANOGPT_PROVIDERS = [
     },
     {
         'id': 'tensorix',
-        'label': 'Tensorix',
+        'label': 'TensorX',
     },
     {
         'id': 'nextbit',
@@ -285,6 +325,18 @@ const NANOGPT_PROVIDERS = [
     {
         'id': 'redpill',
         'label': 'Redpill',
+    },
+    {
+        'id': 'sailresearch-asap',
+        'label': 'Sail Research (ASAP)',
+    },
+    {
+        'id': 'sailresearch-priority',
+        'label': 'Sail Research (Priority)',
+    },
+    {
+        'id': 'sailresearch-standard',
+        'label': 'Sail Research (Standard)',
     },
     {
         'id': 'sambanova',
@@ -312,7 +364,7 @@ const NANOGPT_PROVIDERS = [
     },
     {
         'id': 'uomi',
-        'label': 'UOMI',
+        'label': 'Uomi',
     },
     {
         'id': 'venice',
@@ -327,12 +379,20 @@ const NANOGPT_PROVIDERS = [
         'label': 'Weights & Biases',
     },
     {
+        'id': 'xai',
+        'label': 'xAI',
+    },
+    {
         'id': 'xiaomi',
         'label': 'Xiaomi',
     },
     {
         'id': 'zai',
         'label': 'Z.AI',
+    },
+    {
+        'id': 'zenmux',
+        'label': 'ZenMux',
     },
 ];
 


### PR DESCRIPTION
Synced the NanoGPT provider list and added missing providers
to `public\scripts\textgen-models.js.`

Note:
- Some provider labels were updated to match the upstream source.
- Provider ordering was preserved to match the upstream list
  at `https://nano-gpt.com/api/models/providers`, with the exception of wandb as noted in the previous pr.
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
