### PR TITLE
fix: show full Generic textgen model list in a select

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2593,8 +2593,19 @@
                                     <small data-i18n="Example: http://127.0.0.1:5000">Example: http://127.0.0.1:5000</small>
                                     <input id="generic_api_url_text" name="generic_api_url" class="text_pole wide100p" value="" autocomplete="off" data-server-history="generic">
                                 </div>
-                                <datalist id="generic_model_fill"></datalist>
-                                <input id="generic_model_textgenerationwebui" list="generic_model_fill" class="text_pole wide100p" placeholder="Model ID (optional)" data-i18n="[placeholder]Model ID (optional)" type="text">
+                                <h4 data-i18n="Enter a Model ID">Enter a Model ID</h4>
+                                <div class="flex-container">
+                                    <input list="generic_model_fill" id="generic_model_textgenerationwebui" class="text_pole wide100p" placeholder="Model ID (optional)" data-i18n="[placeholder]Model ID (optional)" type="text" autocomplete="off">
+                                    <datalist id="generic_model_fill"></datalist>
+                                </div>
+                                <h4 data-i18n="Available Models">Available Models</h4>
+                                <div class="flex-container">
+                                    <select id="generic_model_select" class="text_pole wide100p">
+                                        <option value="" data-i18n="-- Connect to the API --">
+                                            -- Connect to the API --
+                                        </option>
+                                    </select>
+                                </div>
                             </div>
                             <div data-tg-type="ooba" class="flex-container flexFlowColumn">
                                 <div class="flex-container flexFlowColumn">

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -610,15 +610,37 @@ export function loadGenericModels(data) {
         return;
     }
 
-    data.sort((a, b) => a.id.localeCompare(b.id));
+    const models = data
+        .filter(model => model && typeof model.id === 'string' && model.id.length > 0)
+        .sort((a, b) => a.id.localeCompare(b.id));
+
     const dataList = $('#generic_model_fill');
     dataList.empty();
 
-    for (const model of data) {
+    const modelSelect = $('#generic_model_select');
+    modelSelect.empty();
+    modelSelect.append($('<option>', { value: '' }));
+
+    for (const model of models) {
         const option = document.createElement('option');
         option.value = model.id;
         option.text = model.id;
         dataList.append(option);
+
+        const selectOption = document.createElement('option');
+        selectOption.value = model.id;
+        selectOption.text = model.id;
+        selectOption.selected = model.id === textgen_settings.generic_model;
+        modelSelect.append(selectOption);
+    }
+
+    // Keep free-text entry for IDs that are not in the /v1/models list
+    if (textgen_settings.generic_model && !models.find(x => x.id === textgen_settings.generic_model)) {
+        modelSelect.append($('<option>', {
+            value: textgen_settings.generic_model,
+            text: textgen_settings.generic_model,
+            selected: true,
+        }));
     }
 }
 
@@ -1051,6 +1073,13 @@ function onLlamaCppModelSelect() {
     $('#api_button_textgenerationwebui').trigger('click');
 }
 
+function onGenericModelSelect() {
+    const modelId = String($('#generic_model_select').val() ?? '');
+    textgen_settings.generic_model = modelId;
+    $('#generic_model_textgenerationwebui').val(modelId);
+    $('#api_button_textgenerationwebui').trigger('click');
+}
+
 function onOpenRouterModelSelect() {
     const modelId = String($('#openrouter_model').val());
     textgen_settings.openrouter_model = modelId;
@@ -1368,6 +1397,7 @@ export function initTextGenModels() {
     $('#tabby_download_model').on('click', downloadTabbyModel);
     $('#tabby_model').on('change', onTabbyModelSelect);
     $('#llamacpp_model').on('change', onLlamaCppModelSelect);
+    $('#generic_model_select').on('change', onGenericModelSelect);
     $('#featherless_model').on('change', () => onFeatherlessModelSelect(String($('#featherless_model').val())));
 
     const providersSelect = $('.openrouter_providers');
@@ -1416,6 +1446,13 @@ export function initTextGenModels() {
         });
         $('#llamacpp_model').select2({
             placeholder: t`[Currently loaded]`,
+            searchInputPlaceholder: t`Search models...`,
+            searchInputCssClass: 'text_pole',
+            width: '100%',
+            allowClear: true,
+        });
+        $('#generic_model_select').select2({
+            placeholder: t`Select a model`,
             searchInputPlaceholder: t`Search models...`,
             searchInputCssClass: 'text_pole',
             width: '100%',


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Summary

Text Completion → **Generic** (OpenAI-compatible) already fetched the full `/v1/models` list, but the UI only filled a `<datalist>`. Browsers filter datalist options against the current input value, so with one saved Model ID it looked like only a single model was available. Chat Completion → Custom already uses a real `<select>` (“Available Models”), so the same backend (e.g. llama-swap) showed every model there.

This adds an **Available Models** `<select>` for Generic textgen, wired like other text-completion backends (llama.cpp / Tabby): select2 with clear, change updates the setting and reconnects. The optional free-text Model ID field is kept.

## How to test

1. Run SillyTavern against an OpenAI-compatible text-completion server that lists multiple models (e.g. llama-swap).
2. API → Text Completion → Generic → connect.
3. Confirm **Available Models** shows the full list (not just the currently typed/saved ID).
4. Pick another model, send a message, and confirm generation uses that model (llama-swap should load/swap on the completion request, not on `/v1/models` alone).

## Notes

- No dedicated “load model” call on select — same as other textgen backends; activation is on generate.
- Does not change Chat Completion Custom.

Made with [Cursor](https://cursor.com)