### PR TITLE
Implement case conversion macros (uppercase/lowercase/titlecase)

### DIFF
--- a/public/scripts/macros/definitions/core-macros.js
+++ b/public/scripts/macros/definitions/core-macros.js
@@ -317,7 +317,7 @@ export function registerCoreMacros() {
                 description: 'The string to titlecase.',
             },
         ],
-        description: 'Uppercases the first character of each word the characters of the argument provided.',
+        description: 'Uppercases the first character of each word of the argument provided.',
         returns: 'Titlecased string.',
         exampleUsage: ['{{titlecase::some TEXT}}'], // => "Some Text"
         handler: ({ unnamedArgs: [value] }) => value.replace(/\w\S*/g, text => {

--- a/public/scripts/macros/definitions/core-macros.js
+++ b/public/scripts/macros/definitions/core-macros.js
@@ -320,8 +320,11 @@ export function registerCoreMacros() {
         description: 'Uppercases the first character of each word of the argument provided.',
         returns: 'Titlecased string.',
         exampleUsage: ['{{titlecase::some TEXT}}'], // => "Some Text"
-        handler: ({ unnamedArgs: [value] }) => value.replace(/\w\S*/g, text => {
-            return text.charAt(0).toUpperCase() + text.slice(1).toLowerCase();
+
+        // `/([\p{L}\p{N}_])(\S*)/gu` is roughly the unicode-aware version of `/(\w)(\S*)/g`,
+        // which lets e.g. "{{titlecase::éowyn}}" become "Éowyn", rather than "éOwyn".
+        handler: ({ unnamedArgs: [value] }) => value.replace(/([\p{L}\p{N}_])(\S*)/gu, (_, first, rest) => {
+            return first.toUpperCase() + rest.toLowerCase();
         }),
     });
 

--- a/public/scripts/macros/definitions/core-macros.js
+++ b/public/scripts/macros/definitions/core-macros.js
@@ -278,6 +278,53 @@ export function registerCoreMacros() {
         handler: ({ unnamedArgs: [value] }) => Array.from(value).reverse().join(''),
     });
 
+    MacroRegistry.registerMacro('uppercase', {
+        category: MacroCategory.UTILITY,
+        unnamedArgs: [
+            {
+                name: 'value',
+                type: MacroValueType.STRING,
+                description: 'The string to uppercase.',
+            },
+        ],
+        description: 'Uppercases the characters of the argument provided.',
+        returns: 'Uppercased string.',
+        exampleUsage: ['{{uppercase::I am Lana}}'],
+        handler: ({ unnamedArgs: [value] }) => value.toUpperCase(),
+    });
+
+    MacroRegistry.registerMacro('lowercase', {
+        category: MacroCategory.UTILITY,
+        unnamedArgs: [
+            {
+                name: 'value',
+                type: MacroValueType.STRING,
+                description: 'The string to lowercase.',
+            },
+        ],
+        description: 'Lowercases the characters of the argument provided.',
+        returns: 'Lowercased string.',
+        exampleUsage: ['{{lowercase::I am Lana}}'], // => "i am lana"`
+        handler: ({ unnamedArgs: [value] }) => value.toLowerCase(),
+    });
+
+    MacroRegistry.registerMacro('titlecase', {
+        category: MacroCategory.UTILITY,
+        unnamedArgs: [
+            {
+                name: 'value',
+                type: MacroValueType.STRING,
+                description: 'The string to titlecase.',
+            },
+        ],
+        description: 'Uppercases the first character of each word the characters of the argument provided.',
+        returns: 'Titlecased string.',
+        exampleUsage: ['{{titlecase::some TEXT}}'], // => "Some Text"
+        handler: ({ unnamedArgs: [value] }) => value.replace(/\w\S*/g, text => {
+            return text.charAt(0).toUpperCase() + text.slice(1).toLowerCase();
+        }),
+    });
+
     // Comment macro: {{// ...}} -> '' (consumes any arguments)
     MacroRegistry.registerMacro('//', {
         aliases: [{ alias: 'comment', visible: false }],

--- a/tests/frontend/MacroEngine.e2e.js
+++ b/tests/frontend/MacroEngine.e2e.js
@@ -232,6 +232,11 @@ test.describe('MacroEngine', () => {
             const output = await evaluateWithEngine(page, input);
             expect(output).toBe('Abc Resu Ihg Fed Jkl');
         });
+        test('should titlecase unicode correctly', async ({ page }) => {
+            const input = '{{titlecase::éOWYN åSTRÖM}}`';
+            const output = await evaluateWithEngine(page, input);
+            expect(output).toBe('Éowyn Åström');
+        })
     });
 
     test.describe('Legacy compatibility', () => {

--- a/tests/frontend/MacroEngine.e2e.js
+++ b/tests/frontend/MacroEngine.e2e.js
@@ -196,6 +196,44 @@ test.describe('MacroEngine', () => {
         });
     });
 
+    test.describe('Case macros', () => {
+        test('should uppercase plain text', async ({ page }) => {
+            const input = 'foo{{uppercase::blaHblah}}bar';
+            const output = await evaluateWithEngine(page, input);
+            expect(output).toBe('fooBLAHBLAHbar');
+        });
+        test('should uppercase nested macro', async ({ page }) => {
+            const input = 'HI {{uppercase::{{user}}}}!';
+            const output = await evaluateWithEngine(page, input);
+            expect(output).toBe('HI USER!');
+        });
+        test('should lowercase plain text', async ({ page }) => {
+            const input = '{{lowercase::X Y z 1 2 3 a B}} c';
+            const output = await evaluateWithEngine(page, input);
+            expect(output).toBe('x y z 1 2 3 a b c');
+        });
+        test('should lowercase nested macro', async ({ page }) => {
+            const input = 'She sent the text message: `{{lowercase::{{user}} did it lol}}`';
+            const output = await evaluateWithEngine(page, input);
+            expect(output).toBe('She sent the text message: `user did it lol`');
+        });
+        test('should titlecase single word plain text', async ({ page }) => {
+            const input = '{{titlecase::abcDE}}';
+            const output = await evaluateWithEngine(page, input);
+            expect(output).toBe('Abcde');
+        });
+        test('should titlecase multi-word plain text', async ({ page }) => {
+            const input = '{{titlecase::abCde fhGi JkLmN}}';
+            const output = await evaluateWithEngine(page, input);
+            expect(output).toBe('Abcde Fghi Jklmn');
+        });
+        test('should titlecase multi-word nested macro', async ({ page }) => {
+            const input = '{{titlecase::abc {{reverse::def GHI {{user}}}} JKL}}`';
+            const output = await evaluateWithEngine(page, input);
+            expect(output).toBe('Abc Resu Ihg Fed Jkl');
+        });
+    });
+
     test.describe('Legacy compatibility', () => {
         test('should strip trim macro and surrounding newlines (legacy behavior)', async ({ page }) => {
             const input = 'foo\n\n{{trim}}\n\nbar';


### PR DESCRIPTION
## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

---

Fixes https://github.com/SillyTavern/SillyTavern/issues/5695.

See that issue for why I think this is useful. Fingers crossed that you agree.

Sadly, I wasn't able to get the e2e tests working on my machine 😢 (to be clear: I can't get them working without my changes either). So I tested things manually, and this stuff all worked just fine when I did.

I noticed there were slash commands for uppercasing and lowercasing (not titlecasing, though). I don't think there's a way for those to be useful for me (I need them to be macros), but... IDK, I've never really used the slash commands.

The titlecase impl I wrote for this is intended to balance simplicity with (unicode) correctness. Concretely, it isn't *fully* Unicode correct (see the last commit message for full details), but it's pretty simple, and should avoid mangling Unicode it sees (in other words: I think having a name with an accent in it is plausibly common enough in something like ST to be worth supporting. The other cases it doesn't handle... probably don't matter in practice). If you'd rather the version in the first commit (which has a slightly simpler regex, but would convert something like `"Übel"` to `"üBel"`), then I don't mind dropping the last commit (the main use case for I have for the titlecase macro isn't actually names).

All hand-coded (no AI), and I've carefully thought about it all.