### PR TITLE
fix(tags): drop filters for tags with no assigned entities

### DIFF
--- a/public/scripts/tags.js
+++ b/public/scripts/tags.js
@@ -2289,28 +2289,32 @@ function printViewTagList(tagContainer, empty = true) {
 function removeMissingTagFilters() {
     const tagIds = new Set(tags.map(tag => tag.id));
     const assignedTagIds = new Set(Object.values(tag_map).flat());
-    const openBogusFolderIds = new Set(getOpenBogusFolders().map(tag => tag.id));
-    const isEmptyOpenBogusFolder = (tagId) => openBogusFolderIds.has(tagId) && !assignedTagIds.has(tagId);
+    // Filter lists only print tags that are assigned to at least one entity. A filter on an unassigned
+    // tag therefore has no element to toggle, and "Clear all filters" can't reset it either, because it
+    // works by clicking the printed elements. Drop those filters instead of leaving them stuck.
+    const isUnclearable = (tagId) => !tagIds.has(tagId) || !assignedTagIds.has(tagId);
 
     for (const helper of [groupCandidatesFilter, groupMembersFilter, entitiesFilter]) {
         const { selected, excluded } = helper.getFilterData(FILTER_TYPES.TAG);
+        const storagePrefix = getFilterStorageKey(helper);
         let anyRemoved = false;
 
-        if (Array.isArray(selected)) {
-            for (let i = selected.length - 1; i >= 0; i--) {
-                if (!tagIds.has(selected[i]) || isEmptyOpenBogusFolder(selected[i])) {
-                    selected.splice(i, 1);
-                    anyRemoved = true;
-                }
+        for (const tagIdList of [selected, excluded]) {
+            if (!Array.isArray(tagIdList)) {
+                continue;
             }
-        }
 
-        if (Array.isArray(excluded)) {
-            for (let i = excluded.length - 1; i >= 0; i--) {
-                if (!tagIds.has(excluded[i]) || isEmptyOpenBogusFolder(excluded[i])) {
-                    excluded.splice(i, 1);
-                    anyRemoved = true;
+            for (let i = tagIdList.length - 1; i >= 0; i--) {
+                if (!isUnclearable(tagIdList[i])) {
+                    continue;
                 }
+
+                if (storagePrefix) {
+                    accountStorage.removeItem(`${storagePrefix}_tag_${tagIdList[i]}`);
+                }
+
+                tagIdList.splice(i, 1);
+                anyRemoved = true;
             }
         }
 


### PR DESCRIPTION
### What is the reason for this change?

A persisted tag filter for a tag that has no assigned characters empties the character list permanently, and there is no way to clear it from the UI.

`printTagFilters()` only prints tags that appear in `tag_map`:

```js
const characterTagIds = Object.values(tag_map).flat();
tagsToDisplay = tags.filter(x => characterTagIds.includes(x.id)).sort(compareTagsForSort);
```

`loadFilterStatesForContext()` restores persisted filter states by iterating over all `tags`, without that restriction. So a filter can be restored for a tag that is never printed. The tag matches no entity, so every entity is filtered out.

The filter is then impossible to clear:

- There is no tag element to click.
- "Clear all filters" iterates over the printed elements (`$(context.selector).find('.tag')`), so it skips it.
- `updateTagFilterIndicator()` also reads the DOM, so the filter indicator on the tag list button stays off.

The only workaround is toggling an unrelated tag, because `runTagFilters()` rebuilds the whole selection from the DOM. That does not survive a reload, since the account storage entry is untouched.

This is the same failure mode as #5222, which #5225 fixed for open bogus folders only. A plain tag has no `folder_type`, so `isEmptyOpenBogusFolder()` does not catch it.

I ran into this on my own install: I deleted the last characters carrying a tag while that tag was selected as a filter. Since then my character list came up empty on every start, reporting "928 characters hidden", with no filter visible anywhere in the UI.

### What did you do to achieve this?

`removeMissingTagFilters()` already removes filters for tags that no longer exist and for empty open bogus folders. I generalized that condition to any tag with no assigned entities, which is exactly the set of tags that cannot be printed, and therefore the set of filters a user cannot clear. The old bogus folder check is a strict subset of it, so #5225 keeps working.

I also remove the matching account storage entry, otherwise the same filter comes back on the next reload.

### How would a reviewer test this?

To reproduce without the patch:

1. Create a tag and assign it to a character.
2. Select that tag in the character list tag filter.
3. Remove the tag from that character, so no character carries it anymore.
4. Reload the page.

The character list stays empty and shows "N characters hidden". "Clear all filters" has no effect. Toggling any other tag brings the characters back, until the next reload.

With the patch, the stale filter is dropped during load and the list renders normally.

I tested this on a local 1.18.0 instance with four characters. Without the patch I got the empty list, the missing tag element, the no-op "Clear all filters" and the workaround that dies on the next reload. With the patch:

| Case | Setup | Result |
| --- | --- | --- |
| A | selected filter on a tag with 0 characters | all 4 characters shown, stale storage key removed |
| B | selected filter on a tag with 2 characters, plus an excluded filter on an empty tag | correct 2 characters shown, real filter still persisted across reload, only the empty one dropped |
| C | empty tag that is an open bogus folder (#5222) | all 4 characters shown, unchanged from before the patch |

`npx eslint public/scripts/tags.js` is clean.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
