### PR TITLE
Prevent proxy access keys from triggering password-manager prompts in Chromium-based browsers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2997,8 +2997,8 @@
                                     <br>
                                 </div>
                                 <div class="flex-container width100p">
-                                    <input id="openai_proxy_password" type="password" class="text_pole flex1" placeholder="" form="openai_form" autocomplete="off" />
-                                    <div id="openai_proxy_password_show" title="Peek a password" data-i18n="[title]Peek a password" class="menu_button fa-solid fa-eye-slash fa-fw"></div>
+                                    <input id="openai_proxy_access_key" type="text" class="text_pole flex1 masked-secret" placeholder="" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" />
+                                    <div id="openai_proxy_access_key_show" title="Peek a password" data-i18n="[title]Peek a password" class="menu_button fa-solid fa-eye-slash fa-fw"></div>
                                 </div>
                             </div>
                         </div>
@@ -4006,7 +4006,7 @@
                             <!-- Azure API Key -->
                             <h4><span data-i18n="Azure API Key">Azure API Key</span></h4>
                             <div class="flex-container">
-                                <input id="api_key_azure_openai" data-setting="api_key_azure_openai" class="text_pole flex1" type="password" autocomplete="off">
+                                <input id="api_key_azure_openai" data-setting="api_key_azure_openai" class="text_pole flex1" type="text" autocomplete="off">
                                 <div title="Manage API keys" data-i18n="[title]Manage API keys" class="menu_button fa-solid fa-key fa-fw manage-api-keys" data-key="api_key_azure_openai"></div>
                             </div>
                             <div class="neutral_warning" data-i18n="For privacy reasons, your API key will be hidden after you click 'Connect'." data-for="api_key_azure_openai">

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -6908,6 +6908,12 @@ export function initOpenAI() {
         saveSettingsDebounced();
     });
 
+    $('#openai_proxy_access_key').on('copy cut', function (event) {
+        if ($(this).hasClass('masked-secret')) {
+            event.preventDefault();
+        }
+    });
+
     $('#claude_assistant_prefill').on('input', function () {
         oai_settings.assistant_prefill = String($(this).val());
         saveSettingsDebounced();

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -376,7 +376,7 @@ export const settingsToUpdate = {
     prompts: ['', 'prompts', false, false],
     prompt_order: ['', 'prompt_order', false, false],
     show_external_models: ['#openai_show_external_models', 'show_external_models', true, true],
-    proxy_password: ['#openai_proxy_password', 'proxy_password', false, true],
+    proxy_password: ['#openai_proxy_access_key', 'proxy_password', false, true],
     assistant_prefill: ['#claude_assistant_prefill', 'assistant_prefill', false, false],
     assistant_impersonation: ['#claude_assistant_impersonation', 'assistant_impersonation', false, false],
     use_sysprompt: ['#use_sysprompt', 'use_sysprompt', true, false],
@@ -6115,10 +6115,8 @@ function reconnectOpenAi() {
     }
 }
 
-function onProxyPasswordShowClick() {
-    const $input = $('#openai_proxy_password');
-    const type = $input.attr('type') === 'password' ? 'text' : 'password';
-    $input.attr('type', type);
+function onProxyAccessKeyShowClick() {
+    $('#openai_proxy_access_key').toggleClass('masked-secret');
     $(this).toggleClass('fa-eye-slash fa-eye');
 }
 
@@ -6437,7 +6435,7 @@ function setProxyPreset(name, url, password) {
     oai_settings.reverse_proxy = url;
     $('#openai_reverse_proxy').val(oai_settings.reverse_proxy);
     oai_settings.proxy_password = password;
-    $('#openai_proxy_password').val(oai_settings.proxy_password);
+    $('#openai_proxy_access_key').val(oai_settings.proxy_password);
     reconnectOpenAi();
 }
 
@@ -6456,7 +6454,7 @@ function onProxyPresetChange() {
 $('#save_proxy').on('click', async function () {
     const presetName = $('#openai_reverse_proxy_name').val();
     const reverseProxy = $('#openai_reverse_proxy').val();
-    const proxyPassword = $('#openai_proxy_password').val();
+    const proxyPassword = $('#openai_proxy_access_key').val();
 
     setProxyPreset(presetName, reverseProxy, proxyPassword);
     saveSettingsDebounced();
@@ -6490,7 +6488,7 @@ $('#delete_proxy').on('click', async function () {
         oai_settings.reverse_proxy = selected_proxy.url;
         $('#openai_reverse_proxy').val(selected_proxy.url);
         oai_settings.proxy_password = selected_proxy.password;
-        $('#openai_proxy_password').val(selected_proxy.password);
+        $('#openai_proxy_access_key').val(selected_proxy.password);
 
         saveSettingsDebounced();
         $('#openai_proxy_preset').val(selected_proxy.name);
@@ -6905,7 +6903,7 @@ export function initOpenAI() {
         saveSettingsDebounced();
     });
 
-    $('#openai_proxy_password').on('input', function () {
+    $('#openai_proxy_access_key').on('input', function () {
         oai_settings.proxy_password = String($(this).val());
         saveSettingsDebounced();
     });
@@ -7299,7 +7297,7 @@ export function initOpenAI() {
     $('#openai_logit_bias_export_preset').on('click', onLogitBiasPresetExportClick);
     $('#openai_logit_bias_delete_preset').on('click', onLogitBiasPresetDeleteClick);
     $('#import_oai_preset').on('click', onImportPresetClick);
-    $('#openai_proxy_password_show').on('click', onProxyPasswordShowClick);
+    $('#openai_proxy_access_key_show').on('click', onProxyAccessKeyShowClick);
     $('#customize_additional_parameters').on('click', onCustomizeParametersClick);
     $('#openai_proxy_preset').on('change', onProxyPresetChange);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -2681,6 +2681,11 @@ textarea::placeholder {
     height: fit-content;
 }
 
+/* Keep non-login secrets visually masked without using password input semantics. */
+.masked-secret {
+    -webkit-text-security: disc;
+}
+
 select.text_pole {
     padding-right: 20px;
 }

--- a/tests/secret-inputs.test.js
+++ b/tests/secret-inputs.test.js
@@ -22,6 +22,7 @@ describe('secret inputs', () => {
         expect(openaiJs).not.toContain('#openai_proxy_password');
         expect(openaiJs).toMatch(/proxy_password:\s*\['#openai_proxy_access_key', 'proxy_password'/);
         expect(openaiJs).toMatch(/\$\('#openai_proxy_access_key'\)\.toggleClass\('masked-secret'\)/);
+        expect(openaiJs).toMatch(/\$\('#openai_proxy_access_key'\)\.on\('copy cut', function \(event\) \{\s*if \(\$\(this\)\.hasClass\('masked-secret'\)\) \{\s*event\.preventDefault\(\);/s);
         expect(styleCss).toMatch(/\.masked-secret\s*{[^}]*-webkit-text-security:\s*disc;/s);
     });
 

--- a/tests/secret-inputs.test.js
+++ b/tests/secret-inputs.test.js
@@ -1,0 +1,34 @@
+import { describe, test, expect } from '@jest/globals';
+import fs from 'node:fs';
+
+const indexHtml = fs.readFileSync(new URL('../public/index.html', import.meta.url), 'utf8');
+const openaiJs = fs.readFileSync(new URL('../public/scripts/openai.js', import.meta.url), 'utf8');
+const styleCss = fs.readFileSync(new URL('../public/style.css', import.meta.url), 'utf8');
+const inputTags = indexHtml.match(/<input\b[^>]*>/gi) ?? [];
+
+function getInputById(id) {
+    return inputTags.find(tag => tag.includes(`id="${id}"`));
+}
+
+describe('secret inputs', () => {
+    test('keeps the proxy access key out of password manager form detection', () => {
+        const input = getInputById('openai_proxy_access_key');
+
+        expect(input).toBeDefined();
+        expect(input).toContain('type="text"');
+        expect(input).toContain('masked-secret');
+        expect(input).not.toMatch(/\sform=/i);
+        expect(indexHtml).not.toContain('id="openai_proxy_password"');
+        expect(openaiJs).not.toContain('#openai_proxy_password');
+        expect(openaiJs).toMatch(/proxy_password:\s*\['#openai_proxy_access_key', 'proxy_password'/);
+        expect(openaiJs).toMatch(/\$\('#openai_proxy_access_key'\)\.toggleClass\('masked-secret'\)/);
+        expect(styleCss).toMatch(/\.masked-secret\s*{[^}]*-webkit-text-security:\s*disc;/s);
+    });
+
+    test('uses a regular text input for the Azure API key', () => {
+        const input = getInputById('api_key_azure_openai');
+
+        expect(input).toBeDefined();
+        expect(input).toContain('type="text"');
+    });
+});


### PR DESCRIPTION
## Problem

When the reverse proxy access-key input contains a non-empty value, unrelated actions such as editing World Info or changing any preset can trigger Chrome/Edge's password manager.

On a fresh SillyTavern instance with user authentication disabled, changing a preset produced **“Save password?”** with an empty username and the proxy test key as the password. With a matching browser credential already saved, the same misclassification can instead produce **“Update password?”** and may replace the saved login password if accepted.

The key may be entered directly or loaded from settings/a proxy preset. A successful proxy connection, proxied request, SillyTavern login, or saved SillyTavern account credential is not required.

## Root cause and fix

The proxy credential was represented as a website password: the input used `type="password"`, had the password-like ID `openai_proxy_password`, belonged to `openai_form`, and could be populated by JavaScript. Chromium recognizes both native password inputs and text fields with password-like IDs; `autocomplete="off"` does not exclude a field from that recognition:

- [Credential-form recognition](https://github.com/chromium/chromium/blob/223a31e91fe1873002e7e94e8678a50b343851be/components/password_manager/core/common/password_manager_util.cc#L63-L80)
- [Password-like field-name pattern](https://github.com/chromium/chromium/blob/223a31e91fe1873002e7e94e8678a50b343851be/components/password_manager/core/common/password_manager_constants.h#L51-L72)

This patch:

- changes the proxy input to `type="text"`
- renames its DOM ID to `openai_proxy_access_key`
- removes the unused `openai_form` association
- preserves visual masking with `-webkit-text-security`
- keeps the reveal control without changing the input type
- retains `oai_settings.proxy_password`, proxy preset `password`, and request `proxy_password`, so no migration is required
- changes the Azure OpenAI API key to `type="text"` as a preventative consistency fix; it was the only Secret Manager API-key input using `type="password"` and is not claimed as the observed trigger

## Verification

Manual Chrome A/B on the same origin and test data:

- base [`380e31e8`](https://github.com/SillyTavern/SillyTavern/commit/380e31e8c58d196969b6a0da74f431ba999c7e0a): “Save password?” / “Update password?” reproduced
- fix `166944256`: no password-manager prompt
- proxy preset save/reload and request-data compatibility remained intact
- reveal/remask kept the value and input type unchanged

Automated checks passed:

- `npm run lint`
- `npm run lint --prefix tests`
- `npm run test:unit --prefix tests` — 330/330 tests
- Webpack production compilation
- `git diff --check`

Reviewer reproduction:

1. Start a fresh instance with user authentication disabled.
2. Enter a non-empty proxy test key directly or load one from a proxy preset; no successful connection is required.
3. Change any preset or edit and close a World Info entry.
4. Confirm the prompt appears before the fix and does not appear after it.

## Known boundary

`-webkit-text-security` is non-standard visual masking, although [current Chrome, Edge, Firefox, and Safari support it](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/-webkit-text-security). Unlike a native password input, a CSS-masked text field may expose its underlying value to assistive technology.

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
