### PR TITLE
feat: add OpenAI-compatible custom STT transcription endpoint

### DIFF
--- a/src/endpoints/openai.js
+++ b/src/endpoints/openai.js
@@ -806,6 +806,57 @@ custom.post('/generate-voice', async (request, response) => {
     }
 });
 
+custom.post('/transcribe-audio', async (request, response) => {
+    try {
+        const { provider_endpoint, model, language, api_key } = request.body;
+
+        if (!provider_endpoint) {
+            console.warn('No OpenAI-compatible STT provider endpoint provided');
+            return response.sendStatus(400);
+        }
+
+        if (!request.file) {
+            console.warn('No audio file found');
+            return response.sendStatus(400);
+        }
+
+        console.info('Processing audio file with OpenAI-compatible STT provider', provider_endpoint);
+        const formData = new FormData();
+        formData.append('file', fs.createReadStream(request.file.path), { filename: 'audio.wav', contentType: 'audio/wav' });
+        formData.append('model', model || 'whisper-1');
+
+        if (language) {
+            formData.append('language', language);
+        }
+
+        const headers = { ...formData.getHeaders() };
+        if (api_key) {
+            headers.Authorization = `Bearer ${api_key}`;
+        }
+
+        const result = await fetch(provider_endpoint, {
+            method: 'POST',
+            headers,
+            body: formData,
+        });
+
+        fs.unlinkSync(request.file.path);
+
+        if (!result.ok) {
+            const text = await result.text();
+            console.warn('OpenAI-compatible STT request failed', result.statusText, text);
+            return response.status(500).send(text);
+        }
+
+        const data = await result.json();
+        console.debug('OpenAI-compatible STT transcription response', data);
+        return response.json(data);
+    } catch (error) {
+        console.error('OpenAI-compatible STT transcription failed', error);
+        response.status(500).send('Internal server error');
+    }
+});
+
 router.use('/custom', custom);
 
 /**


### PR DESCRIPTION
Closes #3027

## What
Adds `POST /api/openai/custom/transcribe-audio`, mirroring the existing `/api/openai/custom/generate-voice` route used by the "OpenAI Compatible" TTS provider. It forwards an uploaded audio file plus `model`/`language` (and an optional bearer `api_key`) to any user-supplied `provider_endpoint`.

## Why
#3027 asks for a "Whisper (OpenAI Compatible)" STT provider with a free-text endpoint, analogous to the existing OpenAI Compatible TTS provider — so self-hosted OpenAI-API-compatible STT servers (e.g. [openedai-whisper](https://github.com/matatonic/openedai-whisper), speaches, faster-whisper-server) can be used without a hardcoded provider URL.

## How to test
Pair with the companion PR to [Extension-Speech-Recognition](https://github.com/SillyTavern/Extension-Speech-Recognition) (adds an "OpenAI Compatible" provider that calls this route). Point "Provider Endpoint" at any local OpenAI-compatible `/v1/audio/transcriptions` server and record a message.

Alternatively, test the endpoint directly with a multipart curl request against `/api/openai/custom/transcribe-audio` (audio file + `provider_endpoint` pointing at any local OpenAI-compatible `/v1/audio/transcriptions` server).

---
*Analysis and initial implementation done in collaboration with Claude Code.*
