### PR TITLE
fix: correct malformed multimodal caption request for oobabooga

### DIFF
--- a/src/endpoints/openai.js
+++ b/src/endpoints/openai.js
@@ -235,19 +235,6 @@ router.post('/caption-image', async (request, response) => {
             apiUrl = `${trimV1(request.body.server_url)}/v1/chat/completions`;
         }
 
-        if (request.body.api === 'ooba') {
-            const imgMessage = body.messages.pop();
-            body.messages.push({
-                role: 'user',
-                content: imgMessage?.content?.[0]?.text,
-            });
-            body.messages.push({
-                role: 'user',
-                content: [],
-                image_url: imgMessage?.content?.[1]?.image_url?.url,
-            });
-        }
-
         setAdditionalHeaders(request, { headers }, apiUrl);
         console.debug('Multimodal captioning request', body);
 


### PR DESCRIPTION
Fixes #4448

## Context
#4448 was auto-closed by the inactivity bot after 6 months, **not because it was fixed** — no code change addressed it at the time of closing. The malformed request structure described in that report is still present on `staging` today.

## What
The `'ooba'` special case in `/api/openai/caption-image` took the correctly structured message (a single user message with a `content` array containing `text` + `image_url` items) and split it into two messages, moving `image_url` to a top-level property on a message with an empty `content: []`.

## Why this breaks captioning
oobabooga's own multimodal image handling (`modules/image_utils.py`) only looks for images inside `content` array items with `type: 'image_url'`. A stray top-level `image_url` field is never read, so the image is silently dropped — matching the exact symptoms in #4448 (hallucinated captions, or the model saying it can't see an image, even though the payload appears to contain valid image data).

## Fix
Remove the special case. `'ooba'` now uses the same already-correct message structure as every other multimodal-capable API (openai, anthropic, google, groq, etc.).

## How to test
Point Image Captioning → API at "Text Generation WebUI (oobabooga)" with a vision-capable model + mmproj loaded, then use the wand menu's "Generate Caption" on a real photo.

## Verification
Tested locally against oobabooga (llama.cpp/GGUF loader) with a vision-capable GGUF + mmproj pair. Before the fix: captions ignored the attached image entirely. After the fix: captions accurately describe real photos, and the character correctly reacts to the captioned image in the following chat turn.

---
*Analysis and fix done in collaboration with Claude Code.*
