### PR TITLE
DeepSeek: Add/enable low reasoning effort

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2557,6 +2557,9 @@ function getReasoningEffort(settings = null, model = null) {
             switch (settings.reasoning_effort) {
                 case reasoning_effort_types.auto:
                     return undefined;
+                case reasoning_effort_types.min:
+                case reasoning_effort_types.low:
+                    return reasoning_effort_types.low;
                 case reasoning_effort_types.max:
                     return reasoning_effort_types.max;
                 default:


### PR DESCRIPTION
## Why?

On [Aug 13, 2026](https://api-docs.deepseek.com/updates#date-2026-08-13), DeepSeek released V4-Pro-0813 and alongside that is a change to their thinking mode effort. It now includes "low" as a level for it.

Reference: https://api-docs.deepseek.com/guides/thinking_mode <sup>([archive](https://web.archive.org/web/20260814114013/https://api-docs.deepseek.com/guides/thinking_mode/))</sup>

I've also added "minimum" to be mapped to low, as it makes sense to do so.

Just to recap the change, here's the UI's mapping comparison

| Effort* | staging (380e31e8c58d196969b6a0da74f431ba999c7e0a) | this PR |
| :---: | :---: | :---: |
| Auto | undefined | undefined |
| Minimum | high | **_low_** |
| Low | high | **_low_** |
| Medium | high | high |
| High | high | high |
| Maximum | max | max |

<small><sup>*the label on the "Reasoning Effort" dropdown</sup></small>


## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
