### PR TITLE
feat: Background Tool Calls

### DIFF
--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -5,6 +5,7 @@ import { extractReasoningFromData } from './reasoning.js';
 import { formatInstructModeChat, formatInstructModePrompt, getInstructStoppingSequences } from './instruct-mode.js';
 import { getStreamingReply, tryParseStreamingError, createGenerationParameters, settingsToUpdate, oai_settings } from './openai.js';
 import EventSourceStream from './sse-stream.js';
+import { ToolManager, ToolDefinition } from './tool-calling.js';
 
 // #region Type Definitions
 /**
@@ -456,10 +457,11 @@ export class ChatCompletionService {
      * @param {ChatCompletionPayload} data Request data
      * @param {boolean?} extractData Extract message from the response. Default true
      * @param {AbortSignal?} signal Abort signal
+     * @param {Map} toolMap map of tool names to ToolDefinition objects
      * @returns {Promise<ExtractedData | (() => AsyncGenerator<StreamResponse>)>} If not streaming, returns extracted data; if streaming, returns a function that creates an AsyncGenerator
      * @throws {Error}
      */
-    static async sendRequest(data, extractData = true, signal = null) {
+    static async sendRequest(data, extractData = true, signal = null, toolMap = null) {
         const response = await fetch('/api/backends/chat-completions/generate', {
             method: 'POST',
             headers: getRequestHeaders(),
@@ -485,6 +487,7 @@ export class ChatCompletionService {
                     textGenType: data.chat_completion_source,
                     ignoreShowThoughts: true,
                 }),
+                tool_calls: toolMap ? await ToolManager.invokeFunctionTools(json, {}, toolMap) : [],
             };
             // Try parse JSON
             if (data.json_schema) {
@@ -536,6 +539,7 @@ export class ChatCompletionService {
      * @param {ChatCompletionPayload} requestData - payload data, overriding preset if given
      * @param {Object} options - Configuration options
      * @param {string?} [options.presetName] - Name of the preset to use for generation settings
+     * @param {array?} [options.tools] - list of custom tool definitions
      * @param {boolean} [extractData=true] - Whether to extract structured data from response
      * @param {AbortSignal?} [signal] - Abort signal
      * @returns {Promise<ExtractedData | (() => AsyncGenerator<StreamResponse>)>} If not streaming, returns extracted data; if streaming, returns a function that creates an AsyncGenerator
@@ -545,6 +549,9 @@ export class ChatCompletionService {
         const { presetName } = options;
         requestData = this.createRequestData(requestData);
 
+        // Tool calling info if present in options
+        const toolMap = this.buildCustomToolMap(options.tools);
+
         // Apply generation preset if specified
         if (presetName) {
             const presetManager = getPresetManager(this.TYPE);
@@ -552,7 +559,7 @@ export class ChatCompletionService {
                 const preset = presetManager.getCompletionPresetByName(presetName);
                 if (preset) {
                     // Convert preset to payload and merge with custom parameters
-                    requestData = await this.presetToGeneratePayload(preset, {}, requestData);
+                    requestData = await this.presetToGeneratePayload(preset, {}, requestData, toolMap);
                 } else {
                     console.warn(`Preset "${presetName}" not found, continuing with default settings`);
                 }
@@ -561,7 +568,7 @@ export class ChatCompletionService {
             }
         }
 
-        return await this.sendRequest(requestData, extractData, signal);
+        return await this.sendRequest(requestData, extractData, signal, toolMap);
     }
 
     /**
@@ -570,9 +577,10 @@ export class ChatCompletionService {
      * @param {Object} preset - The preset configuration
      * @param {Object} overridePreset - Additional parameters to override preset values
      * @param {Object} overridePayload - Additional parameters to override payload values
+     * @param {Map} toolMap - map of tool names to ToolDefinitions to add to the payload
      * @returns {Promise<any>} - Formatted payload for chat completion API
      */
-    static async presetToGeneratePayload(preset, overridePreset = {}, overridePayload = {}) {
+    static async presetToGeneratePayload(preset, overridePreset = {}, overridePayload = {}, toolMap = null) {
         if (!preset || typeof preset !== 'object') {
             throw new Error('Invalid preset: must be an object');
         }
@@ -591,6 +599,12 @@ export class ChatCompletionService {
             settings[settingToUpdate[1]] = value;
         }
 
+        // Now add tools if present
+        // If they are not supported by the CC source, they will be removed by createGenerationParameters()
+        if (toolMap) {
+            await ToolManager.registerFunctionToolsOpenAI(settings, Array.from(toolMap.values()));
+        }
+
         // Ensure api-url is properly applied for all sources that accept it
         ['custom_url', 'vertexai_region', 'zai_endpoint', 'siliconflow_endpoint', 'minimax_endpoint', 'pollinations_endpoint'].forEach(field => {
             // The order is: connection profile => CC preset => CC settings
@@ -603,5 +617,29 @@ export class ChatCompletionService {
 
         // apply overrides
         return this.createRequestData({ ...payload, ...overridePayload });
+    }
+
+    /**
+     * Given an array of tool definitions, build a map of tool names to ToolDefinition objects.
+     * @param tools array of custom tool defintitions
+     * @returns {Map} map of tool names to ToolDefinition objects
+     */
+    static buildCustomToolMap(tools) {
+        const toolMap = new Map();
+        if (!tools) return toolMap;
+        for (let tool of tools) {
+            toolMap.set(tool.name, new ToolDefinition(
+                tool.name,
+                tool.displayName,
+                tool.description,
+                tool.parameters,
+                tool.action,
+                tool.formatMessage,
+                () => true,  // Always considered enabled
+                true,  // Always considered stealth
+            ));
+        }
+
+        return toolMap;
     }
 }

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -416,12 +416,13 @@ export class ConnectionManagerRequestService {
      * @param {boolean?} [custom.extractData=true]
      * @param {boolean?} [custom.includePreset=true]
      * @param {boolean?} [custom.includeInstruct=true]
+     * @param {array?} [custom.tools]  A list of custom tool definitions to use for this request, independent of any registered ToolManager tools.
      * @param {Partial<InstructSettings>?} [custom.instructSettings] Override instruct settings
      * @param {Record<string, any>} [overridePayload] - Override payload for the request
      * @returns {Promise<import('../custom-request.js').ExtractedData | (() => AsyncGenerator<import('../custom-request.js').StreamResponse>)>} If not streaming, returns extracted data; if streaming, returns a function that creates an AsyncGenerator
      */
     static async sendRequest(profileId, prompt, maxTokens, custom = this.defaultSendRequestParams, overridePayload = {}) {
-        const { stream, signal, extractData, includePreset, includeInstruct, instructSettings } = { ...this.defaultSendRequestParams, ...custom };
+        const { stream, signal, extractData, includePreset, includeInstruct, instructSettings, tools } = { ...this.defaultSendRequestParams, ...custom };
 
         const context = SillyTavern.getContext();
         if (context.extensionSettings.disabledExtensions.includes('connection-manager')) {
@@ -460,6 +461,7 @@ export class ConnectionManagerRequestService {
                         ...overridePayload,
                     }, {
                         presetName: includePreset ? profile.preset : undefined,
+                        tools: tools,
                     }, extractData, signal);
                 }
                 case 'textgenerationwebui': {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2790,8 +2790,12 @@ export async function createGenerationParameters(settings, model, type, messages
         }
     }
 
+    // Add registered tools if this generation allows it
     if (!canMultiSwipe && ToolManager.canPerformToolCalls(type, settings, model)) {
         await ToolManager.registerFunctionToolsOpenAI(generate_data);
+    } else {  // otherwise, add any manual tools added (currently can be done by ConnectionManagerRequestService, which always uses quite prompts)
+        generate_data.tools =  settings.tools;
+        generate_data.tool_choice = settings.tool_choice ?? 'auto';
     }
 
     // Empty array will produce a validation error

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -612,13 +612,15 @@ export class ToolManager {
      * Checks if tool calling is supported for the current settings and generation type.
      * @param {ChatCompletionSettings} settings Optional chat completion settings
      * @param {string} model Optional model name
+     * @param {string} api The api being checked, defaults to main_api
      * @returns {boolean} Whether tool calling is supported for the given type
      */
-    static isToolCallingSupported(settings = null, model = null) {
+    static isToolCallingSupported(settings = null, model = null, api = null) {
         settings = settings ?? oai_settings;
         model = model ?? getChatCompletionModel(settings);
+        api = api ?? main_api;
 
-        if (main_api !== 'openai' || !settings.function_calling) {
+        if (api !== 'openai' || !settings.function_calling) {
             return false;
         }
 
@@ -810,7 +812,7 @@ export class ToolManager {
             const message = await ToolManager.formatToolCallMessage(name, parameters, tools);
             const toast = message && toastr.info(message, 'Tool Calling', { timeOut: 0 });
             const toolResult = await ToolManager.invokeFunctionTool(name, parameters, tools);
-            toastr.clear(toast);
+            if (toast) toastr.clear(toast);
             console.log('[ToolManager] Function tool result:', result);
 
             // Handle tool errors — still create an invocation so the LLM sees the failure

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -320,16 +320,18 @@ export class ToolManager {
      * Invokes a tool by name. Returns the result of the tool's action function.
      * @param {string} name The name of the tool to invoke.
      * @param {object} parameters Function parameters. For example, if the tool requires a "name" parameter, you would pass {name: "value"}.
+     * @param {Map} tools Optional custom map of tools. Uses registered tools if null.
      * @returns {Promise<string|Error>} The result of the tool's action function. If an error occurs, null is returned. Non-string results are JSON-stringified.
      */
-    static async invokeFunctionTool(name, parameters) {
+    static async invokeFunctionTool(name, parameters, tools = null) {
+        tools = tools ?? this.#tools;
         try {
-            if (!this.#tools.has(name)) {
+            if (!tools.has(name)) {
                 throw new Error(`No tool with the name "${name}" has been registered.`);
             }
 
             const invokeParameters = this.#parseParameters(parameters);
-            const tool = this.#tools.get(name);
+            const tool = tools.get(name);
             const result = await tool.invoke(invokeParameters);
             return typeof result === 'string' ? result : JSON.stringify(result);
         } catch (error) {
@@ -347,14 +349,16 @@ export class ToolManager {
     /**
      * Checks if a tool is a stealth tool.
      * @param {string} name The name of the tool to check.
+     * @param {Map} tools Optional custom map of tools. Uses registered tools if null.
      * @returns {boolean} Whether the tool is a stealth tool.
      */
-    static isStealthTool(name) {
-        if (!this.#tools.has(name)) {
+    static isStealthTool(name, tools = null) {
+        tools = tools ?? this.#tools;
+        if (!tools.has(name)) {
             return false;
         }
 
-        const tool = this.#tools.get(name);
+        const tool = tools.get(name);
         return !!tool.stealth;
     }
 
@@ -362,15 +366,17 @@ export class ToolManager {
      * Formats a message for a tool call by name.
      * @param {string} name The name of the tool to format the message for.
      * @param {object} parameters Function tool call parameters.
+     * @param {Map} tools Optional custom map of tools. Uses registered tools if null.
      * @returns {Promise<string>} The formatted message for the tool call.
      */
-    static async formatToolCallMessage(name, parameters) {
-        if (!this.#tools.has(name)) {
+    static async formatToolCallMessage(name, parameters, tools = null) {
+        tools = tools ?? this.#tools;
+        if (!tools.has(name)) {
             return `Invoked unknown tool: ${name}`;
         }
 
         try {
-            const tool = this.#tools.get(name);
+            const tool = tools.get(name);
             const formatParameters = this.#parseParameters(parameters);
             return await tool.formatMessage(formatParameters);
         } catch (error) {
@@ -382,25 +388,29 @@ export class ToolManager {
     /**
      * Gets the display name of a tool by name.
      * @param {string} name
+     * @param {Map} tools Optional custom map of tools. Uses registered tools if null.
      * @returns {string} The display name of the tool.
      */
-    static getDisplayName(name) {
-        if (!this.#tools.has(name)) {
+    static getDisplayName(name, tools = null) {
+        tools = tools ?? this.#tools;
+        if (!tools.has(name)) {
             return name;
         }
 
-        const tool = this.#tools.get(name);
+        const tool = tools.get(name);
         return tool.displayName || name;
     }
 
     /**
      * Register function tools for the next chat completion request.
      * @param {object} data Generation data
+     * @param {Map} tool_map Optional custom map of tools. Uses registered tools if null.
      */
-    static async registerFunctionToolsOpenAI(data) {
+    static async registerFunctionToolsOpenAI(data, tool_map = null) {
+        const toolArray = (tool_map === null) ? ToolManager.tools : Array.from(tool_map.values());
         const tools = [];
 
-        for (const tool of ToolManager.tools) {
+        for (const tool of toolArray) {
             const register = await tool.shouldRegister();
             if (!register) {
                 console.log('[ToolManager] Skipping tool registration:', tool);
@@ -410,8 +420,7 @@ export class ToolManager {
         }
 
         if (tools.length) {
-            console.log('[ToolManager] Registered function tools:', tools);
-
+            console.log('[ToolManager] Added function tools to request:', tools);
             data.tools = tools;
             data.tool_choice = 'auto';
         }
@@ -769,9 +778,12 @@ export class ToolManager {
     /**
      * Check for function tool calls in the response data and invoke them.
      * @param {any} data Reply data
+     * @param {Map} tools Optional custom map of tools. Uses registed tools if null.
      * @returns {Promise<ToolInvocationResult>} Successful tool invocations
      */
-    static async invokeFunctionTools(data, { reasoningText = null } = {}) {
+    static async invokeFunctionTools(data, { reasoningText = null } = {}, tools = null) {
+        if (tools === null) tools = this.#tools;
+
         /** @type {ToolInvocationResult} */
         const result = {
             invocations: [],
@@ -793,11 +805,11 @@ export class ToolManager {
             const id = toolCall.id;
             const parameters = toolCall.function.arguments;
             const name = toolCall.function.name;
-            const displayName = ToolManager.getDisplayName(name);
-            const isStealth = ToolManager.isStealthTool(name);
-            const message = await ToolManager.formatToolCallMessage(name, parameters);
+            const displayName = ToolManager.getDisplayName(name, tools);
+            const isStealth = ToolManager.isStealthTool(name, tools);
+            const message = await ToolManager.formatToolCallMessage(name, parameters, tools);
             const toast = message && toastr.info(message, 'Tool Calling', { timeOut: 0 });
-            const toolResult = await ToolManager.invokeFunctionTool(name, parameters);
+            const toolResult = await ToolManager.invokeFunctionTool(name, parameters, tools);
             toastr.clear(toast);
             console.log('[ToolManager] Function tool result:', result);
 

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -112,7 +112,7 @@ function stringify(obj) {
 /**
  * A class that represents a tool definition.
  */
-class ToolDefinition {
+export class ToolDefinition {
     /**
      * A unique name for the tool.
      * @type {string}


### PR DESCRIPTION
#### Description
This PR allows unregistered tool definitions to be passed directly to the `ConnectionManagerRequestService` when using CC and are invoked accordingly.

#### Motivation
Adding tools normally can impact chat performance, especially on smaller models. It is therefore desirable for extensions to be able to perform tool calls independent of the chat context, or even use an entirely different model. This can now be done as follows:

```JS
const tools = [{name, description, parameters, ...}, {...}]
let response = await ConnectionManagerRequestService.send_request(messages, profile_id, undefined, {tools})
```

#### Implementation
This was done by generalizing some `ToolManager` methods to optionally take a custom map of tools in place of its internal map of registered tools. Additionally the logic in `createGenerationParameters` was adjusted to allow tools to be manually passed in.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
