### PR TITLE
Fix connection profile switch leaving the previous chat completion source active

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4939,6 +4939,23 @@ async function onLogitBiasPresetDeleteClick() {
     saveSettingsDebounced();
 }
 
+/**
+ * Promise that resolves when the most recently started preset application has fully completed.
+ * The change handler defers the actual apply behind an event emission, so programmatic preset
+ * switches (e.g. /preset, connection profiles) must await this to sequence follow-up commands
+ * such as /api and /model correctly.
+ * @type {Promise<void>}
+ */
+let presetApplicationPromise = Promise.resolve();
+
+/**
+ * Gets a promise that resolves when the currently pending preset application completes.
+ * @returns {Promise<void>} Promise that resolves when the preset is fully applied.
+ */
+export function getPresetApplicationPromise() {
+    return presetApplicationPromise;
+}
+
 // Load OpenAI preset settings
 function onSettingsPresetChange() {
     const presetNameBefore = oai_settings.preset_settings_openai;
@@ -4954,7 +4971,7 @@ function onSettingsPresetChange() {
     const updateCheckbox = (selector, value) => $(selector).prop('checked', value).trigger('input', { source: 'preset' });
 
     // Allow subscribers to alter the preset before applying deltas
-    eventSource.emit(event_types.OAI_PRESET_CHANGED_BEFORE, {
+    presetApplicationPromise = eventSource.emit(event_types.OAI_PRESET_CHANGED_BEFORE, {
         preset: preset,
         presetName: presetName,
         settingsToUpdate: settingsToUpdate,

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -23,7 +23,7 @@ import { t } from './i18n.js';
 import { instruct_presets } from './instruct-mode.js';
 import { kai_settings } from './kai-settings.js';
 import { convertNovelPreset } from './nai-settings.js';
-import { oai_settings, openai_setting_names, openai_settings } from './openai.js';
+import { getPresetApplicationPromise, oai_settings, openai_setting_names, openai_settings } from './openai.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup } from './popup.js';
 import { context_presets, getContextSettings, power_user } from './power-user.js';
 import { reasoning_templates } from './reasoning.js';
@@ -406,14 +406,21 @@ class PresetManager {
 
     /**
      * Selects a preset by option value.
+     * The returned promise resolves when the preset is fully applied. Chat Completion presets
+     * apply asynchronously after the change event, so callers that run follow-up commands
+     * (e.g. /preset followed by /api) must await it to avoid overriding their own changes.
      * @param {string} value Preset option value
+     * @returns {Promise<void>}
      */
-    selectPreset(value) {
+    async selectPreset(value) {
         const option = $(this.select).filter(function () {
             return $(this).val() === value;
         });
         option.prop('selected', true);
         $(this.select).val(value).trigger('change');
+        if (this.apiId === 'openai') {
+            await getPresetApplicationPromise();
+        }
     }
 
     /**
@@ -938,7 +945,7 @@ async function presetCommandCallback(_, name) {
             const presetValue = presetManager.findPreset(exactMatch);
 
             if (presetValue) {
-                presetManager.selectPreset(presetValue);
+                await presetManager.selectPreset(presetValue);
                 shouldReconnect && await waitForConnection();
             }
         }
@@ -961,7 +968,7 @@ async function presetCommandCallback(_, name) {
             console.log('Found fuzzy preset match', fuzzyPresetName);
 
             if (currentPreset !== fuzzyPresetName) {
-                presetManager.selectPreset(fuzzyPresetValue);
+                await presetManager.selectPreset(fuzzyPresetValue);
                 shouldReconnect && await waitForConnection();
             }
         }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Description

Fixes the connection profile switch sending prompts to the previous provider. When switching between two Chat Completion profiles with different sources, the source dropdown and all downstream state could stay on the old provider, so the next request silently went to the wrong endpoint with the wrong model. That has privacy and billing consequences, not just broken generation.

The root cause is a sequencing race, not the source dropdown handler. Applying a CC preset runs inside an event continuation that nothing can await, so the /preset command resolves before the preset is actually applied. A profile switch runs /api, /preset, /api in order, and that second /api exists precisely to win against the preset (see the old comment in the connection manager). But when the preset application lands late, it re-applies the chat_completion_source stored inside the preset after the final /api already checked it, reverting the source to the previous provider. It reliably hits profiles that reference a preset last saved on a different source, which is the common "one shared sampler preset for several providers" setup. That also explains why most users never see it while affected users see it constantly.

The fix makes preset application awaitable: openai.js captures the application chain in a promise exposed via getPresetApplicationPromise(), and PresetManager.selectPreset awaits it for Chat Completion. The /preset command now resolves only once the preset is fully applied, so the follow-up /api and /model commands sequence correctly. This also fixes the same race for STscript chains like /preset X | /api Y | /model Z.

Compatibility: selectPreset is now async, but the body up to the first await (including the change trigger) still runs synchronously, so extensions calling it without awaiting get exactly the previous behavior. The UI dropdown path is unchanged.

Verified live on staging with a scripted reproduction (Custom-flavored preset plus an xAI profile): before the fix the switch consistently ended on custom with the preset's model active; after the fix it deterministically ends on xai. The connection manager path was verified end to end via /profile-create and /profile.

Fixes #5926
Fixes #5147
