### PR TITLE
Verify GPT-5.6 support and refresh OpenAI model list

### DIFF
--- a/default/content/presets/openai/Default.json
+++ b/default/content/presets/openai/Default.json
@@ -1,6 +1,6 @@
 {
     "chat_completion_source": "openai",
-    "openai_model": "gpt-4-turbo",
+    "openai_model": "gpt-5.6-terra",
     "claude_model": "claude-sonnet-4-5",
     "openrouter_model": "OR_Website",
     "openrouter_use_fallback": false,

--- a/public/index.html
+++ b/public/index.html
@@ -3071,12 +3071,12 @@
                                         <option value="gpt-5.4-nano-2026-03-17">gpt-5.4-nano-2026-03-17</option>
                                     </optgroup>
                                     <optgroup label="GPT-5.3">
-                                        <option value="gpt-5.3-chat-latest">gpt-5.3-chat-latest</option>
+                                        <option value="gpt-5.3-chat-latest">gpt-5.3-chat-latest (deprecated)</option>
                                     </optgroup>
                                     <optgroup label="GPT-5.2">
                                         <option value="gpt-5.2">gpt-5.2</option>
                                         <option value="gpt-5.2-2025-12-11">gpt-5.2-2025-12-11</option>
-                                        <option value="gpt-5.2-chat-latest">gpt-5.2-chat-latest</option>
+                                        <option value="gpt-5.2-chat-latest">gpt-5.2-chat-latest (deprecated)</option>
                                     </optgroup>
                                     <optgroup label="GPT-5.1">
                                         <option value="gpt-5.1">gpt-5.1</option>
@@ -3085,69 +3085,56 @@
                                     </optgroup>
                                     <optgroup label="GPT-5">
                                         <option value="gpt-5">gpt-5</option>
-                                        <option value="gpt-5-2025-08-07">gpt-5-2025-08-07</option>
+                                        <option value="gpt-5-2025-08-07">gpt-5-2025-08-07 (deprecated)</option>
                                         <option value="gpt-5-chat-latest">gpt-5-chat-latest</option>
                                         <option value="gpt-5-mini">gpt-5-mini</option>
-                                        <option value="gpt-5-mini-2025-08-07">gpt-5-mini-2025-08-07</option>
+                                        <option value="gpt-5-mini-2025-08-07">gpt-5-mini-2025-08-07 (deprecated)</option>
                                         <option value="gpt-5-nano">gpt-5-nano</option>
-                                        <option value="gpt-5-nano-2025-08-07">gpt-5-nano-2025-08-07</option>
-                                    </optgroup>
-                                    <optgroup label="GPT-4o">
-                                        <option value="gpt-4o">gpt-4o</option>
-                                        <option value="gpt-4o-2024-11-20">gpt-4o-2024-11-20</option>
-                                        <option value="gpt-4o-2024-08-06">gpt-4o-2024-08-06</option>
-                                        <option value="gpt-4o-2024-05-13">gpt-4o-2024-05-13</option>
-                                        <option value="chatgpt-4o-latest">chatgpt-4o-latest</option>
-                                    </optgroup>
-                                    <optgroup label="GPT-4o mini">
-                                        <option value="gpt-4o-mini">gpt-4o-mini</option>
-                                        <option value="gpt-4o-mini-2024-07-18">gpt-4o-mini-2024-07-18</option>
+                                        <option value="gpt-5-nano-2025-08-07">gpt-5-nano-2025-08-07 (deprecated)</option>
                                     </optgroup>
                                     <optgroup label="GPT-4.1">
                                         <option value="gpt-4.1">gpt-4.1</option>
                                         <option value="gpt-4.1-2025-04-14">gpt-4.1-2025-04-14</option>
                                         <option value="gpt-4.1-mini">gpt-4.1-mini</option>
                                         <option value="gpt-4.1-mini-2025-04-14">gpt-4.1-mini-2025-04-14</option>
-                                        <option value="gpt-4.1-nano">gpt-4.1-nano</option>
-                                        <option value="gpt-4.1-nano-2025-04-14">gpt-4.1-nano-2025-04-14</option>
+                                        <option value="gpt-4.1-nano">gpt-4.1-nano (deprecated)</option>
+                                        <option value="gpt-4.1-nano-2025-04-14">gpt-4.1-nano-2025-04-14 (deprecated)</option>
                                     </optgroup>
-                                    <optgroup label="o1">
-                                        <option value="o1">o1</option>
-                                        <option value="o1-2024-12-17">o1-2024-12-17</option>
-                                        <option value="o1-mini">o1-mini</option>
-                                        <option value="o1-mini-2024-09-12">o1-mini-2024-09-12</option>
-                                        <option value="o1-preview">o1-preview</option>
-                                        <option value="o1-preview-2024-09-12">o1-preview-2024-09-12</option>
+                                    <optgroup label="o4">
+                                        <option value="o4-mini">o4-mini (deprecated)</option>
+                                        <option value="o4-mini-2025-04-16">o4-mini-2025-04-16 (deprecated)</option>
                                     </optgroup>
                                     <optgroup label="o3">
                                         <option value="o3">o3</option>
-                                        <option value="o3-2025-04-16">o3-2025-04-16</option>
-                                        <option value="o3-mini">o3-mini</option>
-                                        <option value="o3-mini-2025-01-31">o3-mini-2025-01-31</option>
+                                        <option value="o3-2025-04-16">o3-2025-04-16 (deprecated)</option>
+                                        <option value="o3-mini">o3-mini (deprecated)</option>
+                                        <option value="o3-mini-2025-01-31">o3-mini-2025-01-31 (deprecated)</option>
                                     </optgroup>
-                                    <optgroup label="o4">
-                                        <option value="o4-mini">o4-mini</option>
-                                        <option value="o4-mini-2025-04-16">o4-mini-2025-04-16</option>
+                                    <optgroup label="o1">
+                                        <option value="o1">o1 (deprecated)</option>
+                                        <option value="o1-2024-12-17">o1-2024-12-17 (deprecated)</option>
                                     </optgroup>
-                                    <optgroup label="GPT-4.5">
-                                        <option value="gpt-4.5-preview">gpt-4.5-preview</option>
-                                        <option value="gpt-4.5-preview-2025-02-27">gpt-4.5-preview-2025-02-27</option>
+                                    <optgroup label="GPT-4o">
+                                        <option value="gpt-4o">gpt-4o</option>
+                                        <option value="gpt-4o-2024-11-20">gpt-4o-2024-11-20</option>
+                                        <option value="gpt-4o-2024-08-06">gpt-4o-2024-08-06</option>
+                                        <option value="gpt-4o-2024-05-13">gpt-4o-2024-05-13</option>
+                                    </optgroup>
+                                    <optgroup label="GPT-4o mini">
+                                        <option value="gpt-4o-mini">gpt-4o-mini</option>
+                                        <option value="gpt-4o-mini-2024-07-18">gpt-4o-mini-2024-07-18</option>
                                     </optgroup>
                                     <optgroup label="GPT-4 Turbo and GPT-4">
-                                        <option value="gpt-4-turbo">gpt-4-turbo</option>
-                                        <option value="gpt-4-turbo-2024-04-09">gpt-4-turbo-2024-04-09</option>
-                                        <option value="gpt-4-turbo-preview">gpt-4-turbo-preview</option>
-                                        <option value="gpt-4-0125-preview">gpt-4-0125-preview (2024)</option>
-                                        <option value="gpt-4-1106-preview">gpt-4-1106-preview (2023)</option>
-                                        <option value="gpt-4">gpt-4</option>
-                                        <option value="gpt-4-0613">gpt-4-0613 (2023)</option>
-                                        <option value="gpt-4-0314">gpt-4-0314 (2023)</option>
+                                        <option value="gpt-4-turbo">gpt-4-turbo (deprecated)</option>
+                                        <option value="gpt-4-turbo-2024-04-09">gpt-4-turbo-2024-04-09 (deprecated)</option>
+                                        <option value="gpt-4">gpt-4 (deprecated)</option>
+                                        <option value="gpt-4-0613">gpt-4-0613 (2023, deprecated)</option>
                                     </optgroup>
                                     <optgroup label="GPT-3.5 Turbo">
-                                        <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
-                                        <option value="gpt-3.5-turbo-0125">gpt-3.5-turbo-0125 (2024)</option>
-                                        <option value="gpt-3.5-turbo-1106">gpt-3.5-turbo-1106 (2023)</option>
-                                        <option value="gpt-3.5-turbo-instruct">gpt-3.5-turbo-instruct</option>
+                                        <option value="gpt-3.5-turbo">gpt-3.5-turbo (deprecated)</option>
+                                        <option value="gpt-3.5-turbo-0125">gpt-3.5-turbo-0125 (2024, deprecated)</option>
+                                        <option value="gpt-3.5-turbo-1106">gpt-3.5-turbo-1106 (2023, deprecated)</option>
+                                        <option value="gpt-3.5-turbo-instruct">gpt-3.5-turbo-instruct (deprecated)</option>
                                     </optgroup>
                                     <optgroup label="Other">
                                         <option value="babbage-002">babbage-002</option>

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -42,7 +42,7 @@ function migrateSettings() {
     if (extension_settings.caption.source === 'openai') {
         extension_settings.caption.source = 'multimodal';
         extension_settings.caption.multimodal_api = 'openai';
-        extension_settings.caption.multimodal_model = 'gpt-4-turbo';
+        extension_settings.caption.multimodal_model = 'gpt-5.6-luna';
     }
 
     if (['google', 'vertexai'].includes(extension_settings.caption.multimodal_api)) {
@@ -55,7 +55,7 @@ function migrateSettings() {
     }
 
     if (!extension_settings.caption.multimodal_model) {
-        extension_settings.caption.multimodal_model = 'gpt-4-turbo';
+        extension_settings.caption.multimodal_model = 'gpt-5.6-luna';
     }
 
     if (!extension_settings.caption.prompt) {

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -86,20 +86,16 @@
                         <option data-type="openai" value="gpt-4.1-mini-2025-04-14">gpt-4.1-mini-2025-04-14</option>
                         <option data-type="openai" value="gpt-4.1-nano">gpt-4.1-nano</option>
                         <option data-type="openai" value="gpt-4.1-nano-2025-04-14">gpt-4.1-nano-2025-04-14</option>
-                        <option data-type="openai" value="gpt-4-vision-preview">gpt-4-vision-preview</option>
                         <option data-type="openai" value="gpt-4-turbo">gpt-4-turbo</option>
                         <option data-type="openai" value="gpt-4o">gpt-4o</option>
                         <option data-type="openai" value="gpt-4o-mini">gpt-4o-mini</option>
                         <option data-type="openai" value="gpt-4o-mini-2024-07-18">gpt-4o-mini-2024-07-18</option>
-                        <option data-type="openai" value="chatgpt-4o-latest">chatgpt-4o-latest</option>
                         <option data-type="openai" value="o1">o1</option>
                         <option data-type="openai" value="o1-2024-12-17">o1-2024-12-17</option>
                         <option data-type="openai" value="o3">o3</option>
                         <option data-type="openai" value="o3-2025-04-16">o3-2025-04-16</option>
                         <option data-type="openai" value="o4-mini">o4-mini</option>
                         <option data-type="openai" value="o4-mini-2025-04-16">o4-mini-2025-04-16</option>
-                        <option data-type="openai" value="gpt-4.5-preview">gpt-4.5-preview</option>
-                        <option data-type="openai" value="gpt-4.5-preview-2025-02-27">gpt-4.5-preview-2025-02-27</option>
                         <option data-type="anthropic" value="claude-opus-4-8">claude-opus-4-8</option>
                         <option data-type="anthropic" value="claude-opus-4-7">claude-opus-4-7</option>
                         <option data-type="anthropic" value="claude-opus-4-6">claude-opus-4-6</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -436,7 +436,7 @@ const default_settings = {
     personality_format: default_personality_format,
     sort_models: 'alphabetically',
     group_models: false,
-    openai_model: 'gpt-4-turbo',
+    openai_model: 'gpt-5.6-terra',
     claude_model: 'claude-sonnet-4-5',
     google_model: 'gemini-2.5-pro',
     vertexai_model: 'gemini-2.5-pro',


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Description

Verifies GPT-5.6 (Sol, Terra, Luna) support end to end and refreshes the OpenAI model dropdown: newest models first, models that OpenAI has shut down removed, deprecated models labeled, and stale defaults bumped to the current generation.

## GPT-5.6 verification

The GPT-5.6 wiring from #5845 was verified live against the API with a funded key. All three models (gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna) generate successfully through the ST pipeline, plus the following contract checks on Chat Completions:

- The `gpt-5.6` alias works for requests even though it is not listed by the models endpoint, so it stays in the dropdown.
- `reasoning_effort` accepts `none`, `low`, and `xhigh` (Maximum maps to `xhigh` because `max` is reserved for the Responses API, matching the existing mapping).
- `temperature` and `top_p` are hard-rejected with 400, even with `reasoning_effort: none`. The existing sampler stripping for 5.6 is correct and necessary, and unlike 5.1-5.4 there is no reasoning-off exception.
- Vision works (image input answered correctly on gpt-5.6-luna), covered by the existing `gpt-5` prefix in the vision support list.
- The client correctly sends `max_completion_tokens`, and tool calling is available source-wide.

Sources: [GPT-5.6 announcement](https://openai.com/index/gpt-5-6/), [model catalog](https://developers.openai.com/), [deprecations](https://developers.openai.com/api/docs/deprecations), plus live API probes for every claim above.

## Dropdown refresh

**Removed** (shut down by OpenAI, confirmed against the live models endpoint; a request to them returns 404): chatgpt-4o-latest (Feb 2026), o1-preview and o1-mini with snapshots (2025), gpt-4.5-preview with snapshot (Jul 2025), gpt-4-turbo-preview, gpt-4-0125-preview, gpt-4-1106-preview, gpt-4-0314. Same cleanup in the captioning model list, which also dropped the long-gone gpt-4-vision-preview.

**Labeled deprecated** (label only, values untouched, so saved selections keep working): the October 23, 2026 shutdown batch (gpt-3.5-turbo family, gpt-4/gpt-4-turbo family, gpt-4.1-nano, o1, o3-mini, o4-mini) and the December 11, 2026 batch (gpt-5 dated snapshots, o3-2025-04-16), plus gpt-5.3-chat-latest and gpt-5.2-chat-latest per the model catalog.

**Reordered** newest first: GPT-5.6 down through GPT-3.5, with current models (GPT-4.1) ahead of the deprecated o-series.

**Defaults bumped** off the dying gpt-4-turbo (shuts down Oct 23, 2026): new-install chat default and the shipped Default preset are now gpt-5.6-terra, captioning default is gpt-5.6-luna (cheapest tier with verified vision). Existing users are unaffected.

Deliberately unchanged: the vision/max-context/tokenizer matching lists still contain retired OpenAI model names, because aggregator sources (OpenRouter, ElectronHub, CometAPI and friends) still route those IDs and match against the same lists. Pro and Codex models are not added to the dropdown since they are Responses-API-only and would fail through the Chat Completions pipeline.

## Verification

- Live generation on all three GPT-5.6 models at low reasoning effort, plus the alias.
- Live negative probes for the sampler and effort contract (each rejection above observed directly).
- Dropdown verified in the browser after the change: group order, 22 deprecation labels, removed entries gone, saved model selection preserved, generation still working.
- Full unit suite (376 tests) and ESLint pass.
