### PR TITLE
Add Claude Opus 5 and Sonnet 5, refresh Claude model list

### DIFF
--- a/default/content/presets/openai/Default.json
+++ b/default/content/presets/openai/Default.json
@@ -1,7 +1,7 @@
 {
     "chat_completion_source": "openai",
     "openai_model": "gpt-4-turbo",
-    "claude_model": "claude-sonnet-4-5",
+    "claude_model": "claude-sonnet-5",
     "openrouter_model": "OR_Website",
     "openrouter_use_fallback": false,
     "openrouter_group_models": false,

--- a/default/content/settings.json
+++ b/default/content/settings.json
@@ -622,7 +622,7 @@
         },
         "wi_format": "{0}",
         "openai_model": "gpt-4-turbo",
-        "claude_model": "claude-sonnet-4-5",
+        "claude_model": "claude-sonnet-5",
         "ai21_model": "jamba-large",
         "openrouter_model": "OR_Website",
         "reverse_proxy": "",

--- a/public/index.html
+++ b/public/index.html
@@ -3183,6 +3183,8 @@
                                 <select id="model_claude_select">
                                     <optgroup label="Versions">
                                         <option value="claude-fable-5">claude-fable-5</option>
+                                        <option value="claude-opus-5">claude-opus-5</option>
+                                        <option value="claude-sonnet-5">claude-sonnet-5</option>
                                         <option value="claude-opus-4-8">claude-opus-4-8</option>
                                         <option value="claude-opus-4-7">claude-opus-4-7</option>
                                         <option value="claude-opus-4-6">claude-opus-4-6</option>
@@ -3193,21 +3195,10 @@
                                         <option value="claude-sonnet-4-5-20250929">claude-sonnet-4-5-20250929</option>
                                         <option value="claude-haiku-4-5">claude-haiku-4-5</option>
                                         <option value="claude-haiku-4-5-20251001">claude-haiku-4-5-20251001</option>
-                                        <option value="claude-opus-4-1">claude-opus-4-1</option>
-                                        <option value="claude-opus-4-1-20250805">claude-opus-4-1-20250805</option>
-                                        <option value="claude-opus-4-0">claude-opus-4-0</option>
-                                        <option value="claude-opus-4-20250514">claude-opus-4-20250514</option>
-                                        <option value="claude-sonnet-4-0">claude-sonnet-4-0</option>
-                                        <option value="claude-sonnet-4-20250514">claude-sonnet-4-20250514</option>
-                                        <option value="claude-3-7-sonnet-latest">claude-3-7-sonnet-latest</option>
-                                        <option value="claude-3-7-sonnet-20250219">claude-3-7-sonnet-20250219</option>
-                                        <option value="claude-3-5-sonnet-latest">claude-3-5-sonnet-latest</option>
-                                        <option value="claude-3-5-sonnet-20241022">claude-3-5-sonnet-20241022</option>
-                                        <option value="claude-3-5-sonnet-20240620">claude-3-5-sonnet-20240620</option>
-                                        <option value="claude-3-5-haiku-latest">claude-3-5-haiku-latest</option>
-                                        <option value="claude-3-5-haiku-20241022">claude-3-5-haiku-20241022</option>
-                                        <option value="claude-3-opus-20240229">claude-3-opus-20240229</option>
-                                        <option value="claude-3-haiku-20240307">claude-3-haiku-20240307</option>
+                                        <option value="claude-opus-4-0">claude-opus-4-0 (deprecated)</option>
+                                        <option value="claude-opus-4-20250514">claude-opus-4-20250514 (deprecated)</option>
+                                        <option value="claude-sonnet-4-0">claude-sonnet-4-0 (deprecated)</option>
+                                        <option value="claude-sonnet-4-20250514">claude-sonnet-4-20250514 (deprecated)</option>
                                     </optgroup>
                                 </select>
                             </div>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -100,6 +100,9 @@
                         <option data-type="openai" value="o4-mini-2025-04-16">o4-mini-2025-04-16</option>
                         <option data-type="openai" value="gpt-4.5-preview">gpt-4.5-preview</option>
                         <option data-type="openai" value="gpt-4.5-preview-2025-02-27">gpt-4.5-preview-2025-02-27</option>
+                        <option data-type="anthropic" value="claude-fable-5">claude-fable-5</option>
+                        <option data-type="anthropic" value="claude-opus-5">claude-opus-5</option>
+                        <option data-type="anthropic" value="claude-sonnet-5">claude-sonnet-5</option>
                         <option data-type="anthropic" value="claude-opus-4-8">claude-opus-4-8</option>
                         <option data-type="anthropic" value="claude-opus-4-7">claude-opus-4-7</option>
                         <option data-type="anthropic" value="claude-opus-4-6">claude-opus-4-6</option>
@@ -110,21 +113,10 @@
                         <option data-type="anthropic" value="claude-sonnet-4-5-20250929">claude-sonnet-4-5-20250929</option>
                         <option data-type="anthropic" value="claude-haiku-4-5">claude-haiku-4-5</option>
                         <option data-type="anthropic" value="claude-haiku-4-5-20251001">claude-haiku-4-5-20251001</option>
-                        <option data-type="anthropic" value="claude-opus-4-1">claude-opus-4-1</option>
-                        <option data-type="anthropic" value="claude-opus-4-1-20250805">claude-opus-4-1-20250805</option>
                         <option data-type="anthropic" value="claude-opus-4-0">claude-opus-4-0</option>
                         <option data-type="anthropic" value="claude-opus-4-20250514">claude-opus-4-20250514</option>
                         <option data-type="anthropic" value="claude-sonnet-4-0">claude-sonnet-4-0</option>
                         <option data-type="anthropic" value="claude-sonnet-4-20250514">claude-sonnet-4-20250514</option>
-                        <option data-type="anthropic" value="claude-3-7-sonnet-latest">claude-3-7-sonnet-latest</option>
-                        <option data-type="anthropic" value="claude-3-7-sonnet-20250219">claude-3-7-sonnet-20250219</option>
-                        <option data-type="anthropic" value="claude-3-5-sonnet-latest">claude-3-5-sonnet-latest</option>
-                        <option data-type="anthropic" value="claude-3-5-sonnet-20241022">claude-3-5-sonnet-20241022</option>
-                        <option data-type="anthropic" value="claude-3-5-sonnet-20240620">claude-3-5-sonnet-20240620</option>
-                        <option data-type="anthropic" value="claude-3-5-haiku-latest">claude-3-5-haiku-latest</option>
-                        <option data-type="anthropic" value="claude-3-5-haiku-20241022">claude-3-5-haiku-20241022</option>
-                        <option data-type="anthropic" value="claude-3-opus-20240229">claude-3-opus-20240229</option>
-                        <option data-type="anthropic" value="claude-3-haiku-20240307">claude-3-haiku-20240307</option>
                         <option data-type="google" value="gemini-3.5-flash">gemini-3.5-flash</option>
                         <option data-type="google" value="gemini-3.1-pro-preview">gemini-3.1-pro-preview</option>
                         <option data-type="google" value="gemini-3.1-flash-lite">gemini-3.1-flash-lite</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -437,7 +437,7 @@ const default_settings = {
     sort_models: 'alphabetically',
     group_models: false,
     openai_model: 'gpt-4-turbo',
-    claude_model: 'claude-sonnet-4-5',
+    claude_model: 'claude-sonnet-5',
     google_model: 'gemini-2.5-pro',
     vertexai_model: 'gemini-2.5-pro',
     ai21_model: 'jamba-large',
@@ -3046,10 +3046,10 @@ export async function createGenerationParameters(settings, model, type, messages
         }
     }
 
-    // Claude Fable models removed sampling parameters and reject them with HTTP 400,
-    // including via OpenAI-compatible proxies. Unanchored to also match prefixed ids
-    // like 'anthropic/claude-fable-5'.
-    if (/claude-fable/.test(model)) {
+    // Claude Fable and Claude 5 generation models removed sampling parameters and reject
+    // them with HTTP 400, including via OpenAI-compatible proxies. Unanchored to also match
+    // prefixed ids like 'anthropic/claude-fable-5'.
+    if (/claude-(fable|opus-5|sonnet-5)/.test(model)) {
         delete generate_data.temperature;
         delete generate_data.top_p;
         delete generate_data.top_k;
@@ -5672,7 +5672,7 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source == chat_completion_sources.CLAUDE) {
         if (oai_settings.max_context_unlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
-        } else if (/^claude-(sonnet-4-5|sonnet-4-6|opus-4-6|opus-4-7|opus-4-8|fable)/.test(value)) {
+        } else if (/^claude-(sonnet-4-5|sonnet-4-6|opus-4-6|opus-4-7|opus-4-8|fable|opus-5|sonnet-5)/.test(value)) {
             $('#openai_max_context').attr('max', max_1mil);
         } else if (/^claude-(3|opus|haiku|sonnet)/.test(value)) {
             $('#openai_max_context').attr('max', max_200k);
@@ -6192,6 +6192,8 @@ export function isImageInliningSupported() {
         // Claude
         'claude-3',
         'claude-fable',
+        'claude-opus-5',
+        'claude-sonnet-5',
         'claude-opus-4',
         'claude-sonnet-4',
         'claude-haiku-4',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -235,13 +235,15 @@ async function sendClaudeRequest(request, response) {
         const convertedPrompt = convertClaudeMessages(request.body.messages, request.body.assistant_prefill, useSystemPrompt, useTools, getPromptNames(request));
         // Unanchored to also match prefixed ids passed through proxies, e.g. 'anthropic/claude-fable-5'
         const isFableModel = /claude-fable/.test(request.body.model);
-        const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel;
-        const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel) && Boolean(request.body.enable_web_search);
+        // Claude 5 generation (opus-5, sonnet-5): adaptive-only thinking, sampling parameters removed, no prefill
+        const isClaude5Model = /^claude-(opus-5|sonnet-5)/.test(request.body.model);
+        const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel || isClaude5Model;
+        const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel || isClaude5Model) && Boolean(request.body.enable_web_search);
         const isLimitedSampling = /^claude-(opus-4-1|sonnet-4-5|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6)/.test(request.body.model);
-        const useVerbosity = /^claude-(opus-4-5|opus-4-6|sonnet-4-6|opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel;
-        const noPrefillModel = /^claude-(opus-4-6|sonnet-4-6|opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel;
-        const isAdaptiveModel = /^claude-(opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel || (enableAdaptiveThinking && /^claude-(opus-4-6|sonnet-4-6)/.test(request.body.model));
-        const noSamplingModel = /^claude-(opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel;
+        const useVerbosity = /^claude-(opus-4-5|opus-4-6|sonnet-4-6|opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel || isClaude5Model;
+        const noPrefillModel = /^claude-(opus-4-6|sonnet-4-6|opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel || isClaude5Model;
+        const isAdaptiveModel = /^claude-(opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel || isClaude5Model || (enableAdaptiveThinking && /^claude-(opus-4-6|sonnet-4-6)/.test(request.body.model));
+        const noSamplingModel = /^claude-(opus-4-7|opus-4-8)/.test(request.body.model) || isFableModel || isClaude5Model;
         let fixThinkingPrefill = false;
         // Add custom stop sequences
         const stopSequences = [];


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Description

Adds the Claude 5 generation models (claude-opus-5, claude-sonnet-5) to the Claude source, wires their API behavior everywhere models get special-cased, and cleans up the Claude model dropdowns: retired models removed, deprecated models labeled.

Claude Fable 5 support already landed in #5757; this PR completes the generation.

## What the Claude 5 generation changes at the API level

Per Anthropic's current docs, the whole 5 generation shares Fable's contract: sampling parameters (temperature, top_p, top_k) are removed and rejected with 400, budget_tokens thinking is removed (adaptive only), and assistant prefill returns 400. Opus 5 additionally runs thinking on by default. All five effort levels work through the existing Reasoning Effort mapping (Auto sends nothing, Minimum/Low map to low, Medium/High map through, Maximum maps to max).

Wired accordingly:

- Server (sendClaudeRequest): both models classified as adaptive-only, no-sampling, no-prefill, thinking-capable, web-search-capable, and verbosity/effort-capable via a new isClaude5Model flag next to the existing isFableModel.
- Client: the Fable sampler-stripping block (which also covers OpenAI-compatible proxy routes) now covers claude-opus-5 and claude-sonnet-5; both added to the 1M context window regex and the vision support list.
- Note ST never sends thinking type disabled to Claude, so Opus 5's quirk of rejecting disabled thinking at xhigh/max effort cannot trigger.

## Verified live (funded key, real requests through the ST pipeline)

- Generation succeeds on all three 5-generation models at low effort; server logs confirm the outbound bodies carry no sampling parameters and use thinking adaptive with the mapped effort.
- Effort max accepted (mapping's top tier verified on claude-sonnet-5).
- Vision works on claude-sonnet-5 (image input answered correctly).
- Web search works on claude-opus-5 with the existing web_search_20250305 tool version, so no tool version bump is needed.
- Responses that start with a thinking block are handled correctly by the client's text extraction (extractMessageFromData joins text blocks), verified with the web search and vision responses.

## Dropdown cleanup

- Removed retired models (each past its announced retirement, and claude-opus-4-1 verified live: the API now returns 404 not_found_error for it): claude-opus-4-1 with snapshot, all claude-3-7-sonnet, claude-3-5-sonnet, claude-3-5-haiku entries, claude-3-opus-20240229, claude-3-haiku-20240307. Same cleanup in the captioning model list.
- Labeled deprecated (label only, values untouched, saved selections keep working): claude-opus-4-0, claude-opus-4-20250514, claude-sonnet-4-0, claude-sonnet-4-20250514.
- Captioning list also gains claude-fable-5, claude-opus-5, and claude-sonnet-5 (all vision-capable).
- New-install defaults move from claude-sonnet-4-5 to claude-sonnet-5 (settings.json, oai_settings default, and the shipped Default preset). Existing users are unaffected.

Sources: Anthropic model catalog and deprecation docs (via docs.claude.com), plus the live API probes above for every load-bearing claim.
