### PR TITLE
Skip extension folders without a manifest during discovery

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -1797,6 +1797,15 @@ export async function loadExtensionSettings(settings, versionChanged, enableAuto
     extensionTypes = Object.fromEntries(extensions.map(x => [x.name, x.type]));
     manifests = await getManifests(extensionNames);
 
+    // An extension without a loadable manifest cannot be used: drop it so state queries
+    // and the extensions list do not report a ghost entry (e.g. leftover folder on disk)
+    const namesWithoutManifest = extensionNames.filter(name => !Object.hasOwn(manifests, name));
+    if (namesWithoutManifest.length) {
+        console.warn('Ignoring extensions without a loadable manifest.json:', namesWithoutManifest);
+        extensionNames = extensionNames.filter(name => Object.hasOwn(manifests, name));
+        namesWithoutManifest.forEach(name => delete extensionTypes[name]);
+    }
+
     if (versionChanged && enableAutoUpdate) {
         await autoUpdateExtensions(false);
     }

--- a/src/endpoints/extensions.js
+++ b/src/endpoints/extensions.js
@@ -6,7 +6,7 @@ import sanitize from 'sanitize-filename';
 import { CheckRepoActions, default as simpleGit } from 'simple-git';
 
 import { PUBLIC_DIRECTORIES } from '../constants.js';
-import { getConfigValue, isValidUrl } from '../util.js';
+import { color, getConfigValue, isValidUrl } from '../util.js';
 import { createGitClient } from '../git/client.js';
 
 const gitBackend = getConfigValue('git.backend', 'auto');
@@ -486,17 +486,35 @@ router.get('/discover', function (request, response) {
         fs.mkdirSync(PUBLIC_DIRECTORIES.globalExtensions);
     }
 
+    /**
+     * A directory without a manifest.json is not a usable extension: typically a leftover
+     * from a manual deletion (e.g. a locked .git directory on Windows). Listing it would
+     * make the client report a ghost extension and request its manifest in vain on every load.
+     * @param {string} parentDirectory Directory containing extension folders
+     * @param {string} folder Extension folder name
+     * @returns {boolean} Whether the folder contains a manifest
+     */
+    const hasManifest = (parentDirectory, folder) => {
+        const manifestExists = fs.existsSync(path.join(parentDirectory, folder, 'manifest.json'));
+        if (!manifestExists) {
+            console.warn(color.yellow(`Extension folder "${path.join(parentDirectory, folder)}" has no manifest.json and was skipped. Remove the folder to get rid of this warning.`));
+        }
+        return manifestExists;
+    };
+
     // Get all folders in system extensions folder, excluding third-party
     const builtInExtensions = fs
         .readdirSync(PUBLIC_DIRECTORIES.extensions)
         .filter(f => fs.statSync(path.join(PUBLIC_DIRECTORIES.extensions, f)).isDirectory())
         .filter(f => f !== 'third-party')
+        .filter(f => hasManifest(PUBLIC_DIRECTORIES.extensions, f))
         .map(f => ({ type: 'system', name: f }));
 
     // Get all folders in local extensions folder
     const userExtensions = fs
         .readdirSync(path.join(request.user.directories.extensions))
         .filter(f => fs.statSync(path.join(request.user.directories.extensions, f)).isDirectory())
+        .filter(f => hasManifest(request.user.directories.extensions, f))
         .map(f => ({ type: 'local', name: `third-party/${f}` }));
 
     // Get all folders in global extensions folder
@@ -504,6 +522,7 @@ router.get('/discover', function (request, response) {
     const globalExtensions = fs
         .readdirSync(PUBLIC_DIRECTORIES.globalExtensions)
         .filter(f => fs.statSync(path.join(PUBLIC_DIRECTORIES.globalExtensions, f)).isDirectory())
+        .filter(f => hasManifest(PUBLIC_DIRECTORIES.globalExtensions, f))
         .map(f => ({ type: 'global', name: `third-party/${f}` }))
         .filter(f => !userExtensions.some(e => e.name === f.name));
 

--- a/tests/extensions-discover.test.js
+++ b/tests/extensions-discover.test.js
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
+
+// extensions.js reads this config value at module load; the env var override avoids
+// needing a config.yaml in the test environment
+process.env.SILLYTAVERN_GIT_BACKEND = 'auto';
+
+// The extensions endpoint resolves the built-in extensions folder relative to the repo root
+const originalCwd = process.cwd();
+beforeAll(() => process.chdir(path.resolve(originalCwd, '..')));
+afterAll(() => process.chdir(originalCwd));
+
+describe('extensions discover', () => {
+    /** @type {import('node:http').Server} */
+    let server;
+    let baseUrl;
+    let userExtensionsDir;
+
+    beforeAll(async () => {
+        userExtensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'st-extensions-'));
+
+        // A valid extension with a manifest
+        fs.mkdirSync(path.join(userExtensionsDir, 'Valid-Extension'));
+        fs.writeFileSync(path.join(userExtensionsDir, 'Valid-Extension', 'manifest.json'), JSON.stringify({ display_name: 'Valid' }));
+
+        // A leftover folder without a manifest (e.g. locked .git remnant after manual deletion)
+        fs.mkdirSync(path.join(userExtensionsDir, 'Deleted-Husk'));
+        fs.mkdirSync(path.join(userExtensionsDir, 'Deleted-Husk', '.git'));
+
+        const { default: express } = await import('express');
+        const { router } = await import('../src/endpoints/extensions.js');
+        const app = express();
+        app.use((req, _res, next) => {
+            req.user = {
+                profile: { handle: 'test-user' },
+                directories: { extensions: userExtensionsDir },
+            };
+            next();
+        });
+        app.use(router);
+        server = app.listen(0, '127.0.0.1');
+        await new Promise(resolve => server.once('listening', resolve));
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+    });
+
+    afterAll(async () => {
+        await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+        fs.rmSync(userExtensionsDir, { recursive: true, force: true });
+    });
+
+    test('lists folders with a manifest and skips folders without one', async () => {
+        const response = await fetch(`${baseUrl}/discover`);
+        expect(response.status).toBe(200);
+        const extensions = await response.json();
+        const names = extensions.map(x => x.name);
+        expect(names).toContain('third-party/Valid-Extension');
+        expect(names).not.toContain('third-party/Deleted-Husk');
+    });
+});


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Description

Fixes a state desync reported on Discord: after manually deleting an installed extension from disk, `/extension-exists` and `/extension-state` still returned true after a fresh page load, and the console showed a manifest 404 on every load.

The root cause is on disk, not in the settings file. A manual deletion often leaves a folder husk behind, most commonly because Windows fails to remove locked files inside .git. The discover endpoint listed any directory without checking for a manifest, so the husk kept being reported as an installed extension: state queries answered from that list, while the client's manifest fetch produced a 404 on every single load.

Two layers:

- Server: discovery now skips folders without a `manifest.json` in all three scopes (system, user, global) and logs a warning naming the exact folder path with instructions to remove it.
- Client: after manifest loading, any discovered name that ended up without a loadable manifest is dropped from the extension name registry with a console warning, so state queries cannot report ghost entries through any other path.

Reproduced and verified live: installed a small official extension through the UI, deleted its files leaving the folder, and confirmed the reported symptoms on a fresh load (exists true, state true, manifest 404). With the fix, the same husk reports exists false, produces zero manifest requests, and the server log names the leftover folder. Healthy extensions are unaffected.

Includes a regression test that runs the real discover route against a temp directory containing one valid extension and one manifest-less husk.

Stale entries in the disabledExtensions settings list for deleted extensions are left as is: they are harmless, and pruning them risks losing a user's disabled preference on transient discovery states.
