### PR TITLE
fix: never resize avatars option does not work for group chat avatar

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1908,7 +1908,8 @@ async function uploadGroupAvatar(event) {
 
     $('#dialogue_popup').addClass('large_dialogue_popup wide_dialogue_popup');
 
-    const croppedImage = await callGenericPopup('Set the crop position of the avatar image', POPUP_TYPE.CROP, '', { cropImage: result });
+    const croppedImage = power_user.never_resize_avatars ? result :
+        await callGenericPopup('Set the crop position of the avatar image', POPUP_TYPE.CROP, '', { cropImage: result });
 
     if (!croppedImage) {
         return;

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1915,7 +1915,7 @@ async function uploadGroupAvatar(event) {
         return;
     }
 
-    let thumbnail = await createThumbnail(String(croppedImage), 200, 300);
+    let thumbnail = await createThumbnail(String(croppedImage), 300, 300);
     //remove data:image/whatever;base64
     thumbnail = thumbnail.replace(/^data:image\/[a-z]+;base64,/, '');
     let _thisGroup = groups.find((x) => x.id == openGroupId);


### PR DESCRIPTION
## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

---

## What is the reason for a change?

If you have the 'Never Resize Avatars' option selected, it will not ask you for cropping char avatars. However, it will still ask for group avatar images. This change makes it so it won't ask you for cropping if that option is selected. Also changed the max width and height to allow 1:1 avatar.

## What did you do to achieve this?

Checked the user option to see if it is selected before opening the crop window. There was no check before, it would always ask. I also changed the max width from 200 to 300 so that it matches the 300 max height, allowing for square avatars.

I left the variable check in a ternary if so that it the `croppedImage` variable can remain a `const`.

## How would a reviewer test the change?

Toggle on and off the 'Never Resize Avatars' option and edit a group chat. If the option is on, it should not ask to crop the avatar and square images should be usable without cropping.