### PR TITLE
fix(expressions): guard against null/undefined default-expression labels

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1717,8 +1717,14 @@ async function setExpression(spriteFolderName, expression, { force = false, over
  * @param {string} expression - The expression label to use for the default image
  */
 function setDefaultEmojiForImage(img, expression) {
-    if (extension_settings.expressions.custom?.includes(expression)) {
-        console.debug(`Can't set default emoji for a custom expression (${expression}). setting to ${DEFAULT_FALLBACK_EXPRESSION} instead.`);
+    // Classifiers can return a falsy or literal "null"/"undefined" label; there is no matching default asset (#5863).
+    if (
+        !expression
+        || expression === 'null'
+        || expression === 'undefined'
+        || extension_settings.expressions.custom?.includes(expression)
+    ) {
+        console.debug(`Can't set default emoji for expression (${expression}). setting to ${DEFAULT_FALLBACK_EXPRESSION} instead.`);
         expression = DEFAULT_FALLBACK_EXPRESSION;
     }
 

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1717,13 +1717,9 @@ async function setExpression(spriteFolderName, expression, { force = false, over
  * @param {string} expression - The expression label to use for the default image
  */
 function setDefaultEmojiForImage(img, expression) {
-    // Classifiers can return a falsy or literal "null"/"undefined" label; there is no matching default asset (#5863).
-    if (
-        !expression
-        || expression === 'null'
-        || expression === 'undefined'
-        || extension_settings.expressions.custom?.includes(expression)
-    ) {
+    // Classifiers can return a falsy, literal "null"/"undefined", or otherwise unknown label,
+    // and custom expressions have no default assets; only known labels have an image (#5863).
+    if (!DEFAULT_EXPRESSIONS.includes(expression)) {
         console.debug(`Can't set default emoji for expression (${expression}). setting to ${DEFAULT_FALLBACK_EXPRESSION} instead.`);
         expression = DEFAULT_FALLBACK_EXPRESSION;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Character Expressions would request the nonexistent `/img/default-expressions/null.png` (a 404) whenever a classifier returned `null`, `"null"`, `"undefined"`, or an empty string as the expression label. Users behind a misbehaving or offline classification backend would see a broken/missing default-expression image.

## Why This Change Was Made

`setDefaultEmojiForImage()` built the URL directly from the label with no guard, so any invalid label produced a request for an asset that does not exist. This function is the only place in the codebase that constructs a `default-expressions` URL, so guarding it covers every 404 path.

When the label is falsy, a literal `"null"`/`"undefined"`, or a custom expression without a default asset, we now fall back to `DEFAULT_FALLBACK_EXPRESSION` (joy) — the same fallback the existing custom-expression branch already used.

## User Impact

The missing-image 404 no longer happens when a classifier returns an invalid label; the default expression shows the joy asset instead.

## Evidence

- Guard logic exercised against the built source (9 cases): `null`, `undefined`, `''`, `'null'`, `'undefined'`, and custom labels all resolve to `joy.png`; valid labels (`joy`, `sadness`) pass through unchanged. 9/9 pass.
- `public/img/default-expressions/` contains `joy.png` (30 assets, none named `null`).
- `eslint public/scripts/extensions/expressions/index.js` → 0 errors.

Fixes #5863