### PR TITLE
Mint a fresh integrity slug for new branches and checkpoints

### DIFF
--- a/public/scripts/bookmarks.js
+++ b/public/scripts/bookmarks.js
@@ -41,6 +41,7 @@ import { t } from './i18n.js';
 import {
     getUniqueName,
     isTrueBoolean,
+    uuidv4,
 } from './utils.js';
 
 const bookmarkNameToken = 'Checkpoint #';
@@ -196,7 +197,8 @@ export async function createBranch(mesId, { swipeId = null } = {}) {
 
     const lastMes = chat[mesId];
     const mainChatName = (getCurrentChatDetails()).sessionName;
-    const newMetadata = { main_chat: mainChatName };
+    // Mint a fresh integrity slug so the branch is distinguishable from its parent (#5942)
+    const newMetadata = { main_chat: mainChatName, integrity: uuidv4() };
     const selectedSwipeId = swipeId === null ? null : Number(swipeId);
 
     if (selectedSwipeId !== null && (!Number.isInteger(selectedSwipeId) || selectedSwipeId < 0 || selectedSwipeId >= (lastMes?.swipes?.length ?? 0))) {
@@ -278,7 +280,8 @@ export async function createNewBookmark(mesId, { forceName = null } = {}) {
     }
 
     const mainChat = selected_group ? groups?.find(x => x.id == selected_group)?.chat_id : characters[this_chid].chat;
-    const newMetadata = { main_chat: mainChat };
+    // Mint a fresh integrity slug so the checkpoint is distinguishable from its parent (#5942)
+    const newMetadata = { main_chat: mainChat, integrity: uuidv4() };
     await saveItemizedPrompts(name);
 
     if (selected_group) {


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Description

Fixes #5942.

Branches and checkpoints inherited the parent chat's integrity UUID: createBranch and createNewBookmark only set main_chat in their new metadata, and both save paths spread the parent's chat_metadata underneath, carrying the integrity slug across. Since the loader only backfills a missing slug, every file in a branch family shared one slug forever, and the integrity guard (which is pure slug equality) could not distinguish any member from any other. A save carrying one family member's content but another's filename would pass validation, which is exactly the misdirected-save scenario the guard exists to stop.

The fix mints a fresh slug in the new metadata at creation time, for both branches and checkpoints, covering solo and group chats through the same two call sites. Existing files are not touched: already-shared slugs behave exactly as before, and the guard simply starts working for anything created after this change.

Verified live in a browser on the Testing User: created a branch and a checkpoint from a chat, confirmed on disk that each new file carries its own distinct integrity slug while main_chat still points to the parent, and that the parent file is unmodified.
