### PR TITLE
Use provider error fields instead of statusText for HTTP 200 errors

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -1623,6 +1623,21 @@ export async function prepareOpenAIMessages({
 }
 
 /**
+ * Extracts a human-readable message from a Chat Completion error response.
+ * Providers can return an error object without a message field, or the error as
+ * a plain string. statusText is only used for non-2xx responses, since for an
+ * HTTP 200 carrying an error payload it is just "OK" (#5647).
+ * @param {object} data Parsed response body
+ * @param {Response} response Fetch response
+ * @returns {string} Error message to display and throw
+ */
+function getChatCompletionErrorMessage(data, response) {
+    const error = data?.error ?? data?.detail?.error;
+    const message = typeof error === 'string' ? error : (error?.message || error?.code || error?.type);
+    return String(message || (!response.ok && response.statusText) || t`Unknown error`);
+}
+
+/**
  * Handles errors during streaming requests.
  * @param {Response} response
  * @param {string} decoded - response text or decoded stream data
@@ -1644,7 +1659,7 @@ export function tryParseStreamingError(response, decoded, { quiet = false } = {}
         // if trying to fix "[object Object]" displayed to users, start here
 
         if (data.error) {
-            !quiet && toastr.error(data.error.message || response.statusText, 'Chat Completion API');
+            !quiet && toastr.error(getChatCompletionErrorMessage(data, response), 'Chat Completion API');
             throw new Error(data);
         }
 
@@ -1654,7 +1669,7 @@ export function tryParseStreamingError(response, decoded, { quiet = false } = {}
         }
 
         if (data.detail) {
-            !quiet && toastr.error(data.detail?.error?.message || response.statusText, 'Chat Completion API');
+            !quiet && toastr.error(getChatCompletionErrorMessage(data, response), 'Chat Completion API');
             throw new Error(data);
         }
     } catch {
@@ -3135,7 +3150,7 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } =
         checkModerationError(data);
 
         if (data.error) {
-            const message = data.error.message || response.statusText || t`Unknown error`;
+            const message = getChatCompletionErrorMessage(data, response);
             toastr.error(message, t`API returned an error`);
             throw new Error(message);
         }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Description

Fixes #5647.

When a Chat Completion provider returns HTTP 200 with an error object that has no message field, the error message fell back to response.statusText, which for any 200 response is the string "OK". Extensions calling generateQuietPrompt got the famously unhelpful "Error: OK", and the same fallback exists in both streaming error toasts, where the response is always 200 by definition once the stream has opened.

A small shared helper now resolves the display message in order: the error's message, its code, its type, the error itself when it is a plain string, then statusText only for non-2xx responses (where it actually says something like "Too Many Requests"), and finally a generic "Unknown error". All three sites (non-streaming request, both streaming toasts) use it.

On the exposure question raised in the issue thread: this stays within SillyTavern's existing convention. Text Completion already shows the provider's error text verbatim (data.response in textgen-settings.js and script.js), and the Chat Completion path already displays error.message verbatim. The new fallbacks are the same trust class of short provider-controlled fields, shown to the user who configured that provider. No SillyTavern internals are involved in these payloads.

Verified with a live A/B against a mock OpenAI-compatible provider returning 200 with {"error": {"code": "insufficient_quota"}}: current staging throws "Error: OK" through the exact generateQuietPrompt path from the report; with the fix the thrown error and toast read "insufficient_quota". Lint clean.
