### PR TITLE
fix(chat): delete associated tool calls with messages

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -604,6 +604,7 @@ export let is_send_press = false; //Send generation
 export const isGenerating = () => (is_send_press || is_group_generating);
 
 let this_del_mes = -1;
+let deleteToolCallsInDeleteMode = true;
 
 /** @type {string} */
 let this_edit_mes_chname = '';
@@ -1610,13 +1611,32 @@ export async function deleteLastMessage() {
     await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
 }
 
+function getMessageDeletionStartId(id, deleteToolCalls = true) {
+    const message = chat[id];
+    if (!deleteToolCalls || message?.is_user || message?.is_system) {
+        return id;
+    }
+
+    let startId = id;
+    while (startId > 0) {
+        const previousMessage = chat[startId - 1];
+        if (!previousMessage?.is_system || !Array.isArray(previousMessage.extra?.tool_invocations)) {
+            break;
+        }
+        startId--;
+    }
+
+    return startId;
+}
+
 /**
  * Deletes a message from the chat by its ID, optionally asking for confirmation.
  * @param {number} id The ID of the message to delete.
  * @param {number} [swipeDeletionIndex] Deletes the swipe with that index.
  * @param {boolean} [askConfirmation=false] Whether to ask for confirmation before deleting.
+ * @param {boolean} [deleteToolCalls=true] Whether to delete preceding tool-call messages.
  */
-export async function deleteMessage(id, swipeDeletionIndex = undefined, askConfirmation = false) {
+export async function deleteMessage(id, swipeDeletionIndex = undefined, askConfirmation = false, deleteToolCalls = true) {
     const canDeleteSwipe = swipeDeletionIndex !== undefined && swipeDeletionIndex !== null;
     if (canDeleteSwipe) {
         if (swipeDeletionIndex < 0) {
@@ -1654,13 +1674,19 @@ export async function deleteMessage(id, swipeDeletionIndex = undefined, askConfi
         return;
     }
 
-    chat.splice(id, 1);
-    messageElement.remove();
+    const firstMessageId = getMessageDeletionStartId(id, deleteToolCalls);
+    const messageIds = Array.from({ length: id - firstMessageId + 1 }, (_, index) => id - index);
+
+    // Delete from the end so earlier indices remain stable.
+    for (const messageId of messageIds) {
+        chat.splice(messageId, 1);
+        chatElement.find(`.mes[mesid="${messageId}"]`).remove();
+        deleteItemizedPromptForMessage(messageId);
+    }
 
     chat_metadata.tainted = true;
 
-    const startIndex = [0, minId].includes(id) ? id : null;
-    deleteItemizedPromptForMessage(id);
+    const startIndex = firstMessageId <= minId ? firstMessageId : null;
     updateViewMessageIds(startIndex);
     saveChatDebounced();
 
@@ -8166,7 +8192,7 @@ function updateMessage(div) {
     return { mesBlock, text, mes, bias };
 }
 
-function openMessageDelete(fromSlashCommand) {
+function openMessageDelete(fromSlashCommand, deleteToolCalls = true) {
     closeMessageEditor();
     hideSwipeButtons();
     if (fromSlashCommand || (!is_send_press) || (selected_group && !is_group_generating)) {
@@ -8185,6 +8211,7 @@ function openMessageDelete(fromSlashCommand) {
             is_group_generating: ${is_group_generating}`);
     }
     this_del_mes = -1;
+    deleteToolCallsInDeleteMode = deleteToolCalls;
     is_delete_mode = true;
 }
 
@@ -11229,6 +11256,7 @@ jQuery(async function () {
         });
         $(this).addClass('selected'); //sets the bg of the mes selected for deletion
         var i = Number($(this).attr('mesid')); //checks the message ID in the chat
+        i = getMessageDeletionStartId(i, deleteToolCallsInDeleteMode);
         this_del_mes = i;
         //as long as the current message ID is less than the total chat length
         while (i < chat.length) {
@@ -11553,6 +11581,7 @@ jQuery(async function () {
     ///////////// OPTIMIZED LISTENERS FOR LEFT SIDE OPTIONS POPUP MENU //////////////////////
     $('#options [id]').on('click', async function (event, customData) {
         const fromSlashCommand = customData?.fromSlashCommand || false;
+        const deleteToolCalls = customData?.deleteToolCalls ?? true;
         var id = $(this).attr('id');
 
         // Check whether a custom prompt was provided via custom data (for example through a slash command)
@@ -11631,7 +11660,7 @@ jQuery(async function () {
                 Generate('continue', buildOrFillAdditionalArgs());
             }
         } else if (id == 'option_delete_mes') {
-            setTimeout(() => openMessageDelete(fromSlashCommand), animation_duration);
+            setTimeout(() => openMessageDelete(fromSlashCommand, deleteToolCalls), animation_duration);
         } else if (id == 'option_close_chat') {
             await closeCurrentChat();
         } else if (id === 'option_settings') {

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -2818,9 +2818,10 @@ async function loadUntilMesId(mesId) {
     return target;
 }
 
-async function doMesCut(_, text) {
+async function doMesCut(args, text) {
     console.debug(`was asked to cut message id #${text}`);
     const range = stringToRange(text, 0, chat.length - 1);
+    const deleteToolCalls = args?.toolcalls === undefined || isTrueBoolean(args.toolcalls);
 
     //reject invalid args or no args
     if (!range) {
@@ -2828,12 +2829,16 @@ async function doMesCut(_, text) {
         return;
     }
 
-    let totalMesToCut = (range.end - range.start) + 1;
-    let mesIDToCut = range.start;
+    const messagesToCut = chat.slice(range.start, range.end + 1);
     let cutText = '';
 
-    for (let i = 0; i < totalMesToCut; i++) {
-        cutText += (chat[mesIDToCut]?.mes || '') + '\n';
+    for (const message of messagesToCut) {
+        const mesIDToCut = chat.indexOf(message);
+        if (mesIDToCut === -1) {
+            continue;
+        }
+
+        cutText += (message?.mes || '') + '\n';
         let mesToCut = $('#chat').find(`.mes[mesid=${mesIDToCut}]`);
 
         if (!mesToCut.length) {
@@ -2845,7 +2850,7 @@ async function doMesCut(_, text) {
         }
 
         setEditedMessageId(mesIDToCut);
-        await deleteMessage(mesIDToCut, null, false);
+        await deleteMessage(mesIDToCut, null, false, deleteToolCalls);
     }
 
     await saveChatConditional();
@@ -2853,7 +2858,7 @@ async function doMesCut(_, text) {
     return cutText;
 }
 
-async function doDelMode(_, text) {
+async function doDelMode(args, text) {
     //reject invalid args
     if (text && isNaN(text)) {
         toastr.warning('Must enter a number or nothing.');
@@ -2862,7 +2867,8 @@ async function doDelMode(_, text) {
 
     // Just enter the delete mode.
     if (!text) {
-        $('#option_delete_mes').trigger('click', { fromSlashCommand: true });
+        const deleteToolCalls = args?.toolcalls === undefined || isTrueBoolean(args.toolcalls);
+        $('#option_delete_mes').trigger('click', { fromSlashCommand: true, deleteToolCalls });
         return '';
     }
 
@@ -2879,7 +2885,7 @@ async function doDelMode(_, text) {
     }
 
     const range = `${chat.length - count}-${chat.length - 1}`;
-    return doMesCut(_, range);
+    return doMesCut(args, range);
 }
 
 function doResetPanels() {
@@ -4145,6 +4151,15 @@ jQuery(() => {
         name: 'del',
         callback: doDelMode,
         aliases: ['delete', 'delmode'],
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'toolcalls',
+                description: 'also delete associated tool-call messages',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'true',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
         unnamedArgumentList: [
             new SlashCommandArgument(
                 'optional number', [ARGUMENT_TYPE.NUMBER], false,
@@ -4157,6 +4172,15 @@ jQuery(() => {
         name: 'cut',
         callback: doMesCut,
         returns: 'the text of cut messages separated by a newline',
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'toolcalls',
+                description: 'also delete associated tool-call messages',
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'true',
+                enumList: commonEnumProviders.boolean('trueFalse')(),
+            }),
+        ],
         unnamedArgumentList: [
             SlashCommandArgument.fromProps({
                 description: 'number or range',

--- a/tests/frontend/DeleteToolCalls.e2e.js
+++ b/tests/frontend/DeleteToolCalls.e2e.js
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import { testSetup } from './frontent-test-utils.js';
+
+test.describe('deleting assistant messages with tool calls', () => {
+    test.beforeEach(testSetup.awaitST);
+
+    test('deletes preceding tool calls unless explicitly disabled', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const { addOneMessage, chat, deleteMessage, newAssistantChat } = await import('./script.js');
+            const commands = window.SillyTavern.getContext().SlashCommandParser.commands;
+            const testMessages = new Set(['Run a tool', 'Tool result', 'Done']);
+            const snapshot = () => chat
+                .filter(message => testMessages.has(message.mes))
+                .map(message => ({
+                    mes: message.mes,
+                    toolCall: Array.isArray(message.extra?.tool_invocations),
+                }));
+
+            const addMessages = async () => {
+                const messages = [
+                    { name: 'User', is_user: true, is_system: false, mes: 'Run a tool', extra: {} },
+                    {
+                        name: 'System',
+                        is_user: false,
+                        is_system: true,
+                        mes: 'Tool result',
+                        extra: { isSmallSys: true, tool_invocations: [{ id: 'call-1', name: 'lookup' }] },
+                    },
+                    { name: 'Assistant', is_user: false, is_system: false, mes: 'Done', extra: {} },
+                ];
+                for (const message of messages) {
+                    chat.push(message);
+                    await addOneMessage(message);
+                }
+            };
+
+            await newAssistantChat({ temporary: true });
+            await addMessages();
+            await deleteMessage(chat.length - 1, undefined, false);
+            const automatic = snapshot();
+
+            await newAssistantChat({ temporary: true });
+            await addMessages();
+            await commands.cut.callback({ toolcalls: 'false' }, String(chat.length - 1));
+            const disabled = snapshot();
+
+            await newAssistantChat({ temporary: true });
+            await addMessages();
+            chat.push({ name: 'Assistant', is_user: false, is_system: false, mes: 'Later', extra: {} });
+            await addOneMessage(chat.at(-1));
+            await commands.del.callback({ toolcalls: 'true' }, '2');
+            const range = chat
+                .filter(message => new Set([...testMessages, 'Later']).has(message.mes))
+                .map(message => message.mes);
+
+            await newAssistantChat({ temporary: true });
+            await addMessages();
+            document.querySelector('#option_delete_mes').click();
+            await new Promise(resolve => setTimeout(resolve, 200));
+            document.querySelector(`.mes[mesid="${chat.length - 1}"]`).click();
+            document.querySelector('#dialogue_del_mes_ok').click();
+            await new Promise(resolve => setTimeout(resolve, 50));
+            const deleteMode = snapshot();
+
+            return { automatic, deleteMode, disabled, range };
+        });
+
+        expect(result.automatic).toEqual([{ mes: 'Run a tool', toolCall: false }]);
+        expect(result.disabled).toEqual([
+            { mes: 'Run a tool', toolCall: false },
+            { mes: 'Tool result', toolCall: true },
+        ]);
+        expect(result.range).toEqual(['Run a tool']);
+        expect(result.deleteMode).toEqual([{ mes: 'Run a tool', toolCall: false }]);
+    });
+});


### PR DESCRIPTION
## Summary

- automatically remove consecutive tool-call system messages that precede a deleted assistant response
- apply the same behavior to message deletion mode and `/cut` / `/del`
- add `toolcalls=false` as an opt-out for slash-command deletions
- preserve range deletion behavior when associated tool-call messages are removed

Fixes #5613

## Testing

- `./node_modules/.bin/eslint public/script.js public/scripts/power-user.js tests/frontend/DeleteToolCalls.e2e.js`
- `ST_BASE_URL=http://127.0.0.1:8123 tests/node_modules/.bin/playwright test --config tests/playwright.config.js tests/frontend/DeleteToolCalls.e2e.js --reporter=line`

## Checklist

- [x] I have read the Contribution guidelines.
