### PR TITLE
fix: parse boolean values in env migrations

### DIFF
--- a/src/config-init.js
+++ b/src/config-init.js
@@ -4,7 +4,7 @@ import yaml from 'yaml';
 import color from 'chalk';
 import _ from 'lodash';
 import { serverDirectory } from './server-directory.js';
-import { keyToEnv, setConfigFilePath } from './util.js';
+import { keyToEnv, setConfigFilePath, stringToBool } from './util.js';
 
 const keyMigrationMap = [
     {
@@ -181,7 +181,7 @@ export function addMissingConfigValues(configPath) {
             const newEnvKey = keyToEnv(newKey);
             if (process.env[oldEnvKey] && !process.env[newEnvKey]) {
                 const oldValue = process.env[oldEnvKey];
-                const newValue = migrate(oldValue);
+                const newValue = migrate(stringToBool(oldValue));
                 process.env[newEnvKey] = newValue;
                 delete process.env[oldEnvKey];
                 console.warn(color.yellow(`Warning: Using a deprecated environment variable: ${oldEnvKey}. Please use ${newEnvKey} instead.`));

--- a/tests/config-init.test.js
+++ b/tests/config-init.test.js
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { addMissingConfigValues } from '../src/config-init.js';
+
+const oldEnvKey = 'SILLYTAVERN_DISABLETHUMBNAILS';
+const newEnvKey = 'SILLYTAVERN_THUMBNAILS_ENABLED';
+
+describe('addMissingConfigValues', () => {
+    let tempDirectory;
+    let configPath;
+
+    beforeEach(() => {
+        tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'sillytavern-config-'));
+        configPath = path.join(tempDirectory, 'config.yaml');
+        fs.writeFileSync(configPath, '{}\n');
+        delete process.env[oldEnvKey];
+        delete process.env[newEnvKey];
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        delete process.env[oldEnvKey];
+        delete process.env[newEnvKey];
+        fs.rmSync(tempDirectory, { recursive: true, force: true });
+        jest.restoreAllMocks();
+    });
+
+    test.each([
+        ['false', 'true'],
+        ['true', 'false'],
+    ])('migrates the boolean environment value %s to %s', (oldValue, newValue) => {
+        process.env[oldEnvKey] = oldValue;
+
+        addMissingConfigValues(configPath);
+
+        expect(process.env[newEnvKey]).toBe(newValue);
+        expect(process.env[oldEnvKey]).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

- parse legacy environment-variable booleans before applying config migrations
- preserve YAML migration behavior while fixing string truthiness for environment values
- add regression coverage for both `true` and `false` disable flags

## Testing

- focused Jest regression: 2 passed
- related config and utility tests: 116 passed
- `npm run lint`
- test-suite lint (two pre-existing Playwright warnings only)

## Checklist

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
