### PR TITLE
Google AI Studio: Fetch all model pages

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -68,6 +68,7 @@ import {
 } from '../tokenizers.js';
 import { getVertexAIAuth, getProjectIdFromServiceAccount } from '../google.js';
 import { getCookieSecret } from '../../users.js';
+import { fetchGoogleModels, GoogleModelsHttpError } from './google-models.js';
 
 const API_OPENAI = 'https://api.openai.com/v1';
 const API_CLAUDE = 'https://api.anthropic.com/v1';
@@ -1908,26 +1909,15 @@ router.post('/status', async function (request, statusResponse) {
             }
 
             try {
-                const response = await fetch(modelsUrl);
-
-                if (response.ok) {
-                    /** @type {any} */
-                    const data = await response.json();
-                    // Transform Google AI Studio models to OpenAI format
-                    const models = data.models
-                        ?.filter(model => model.supportedGenerationMethods?.includes('generateContent'))
-                        ?.map(model => ({
-                            ...model,
-                            id: model.name.replace('models/', ''),
-                        })) || [];
-
-                    console.info('Available Google AI Studio models:', models.map(m => m.id));
-                    return statusResponse.send({ data: models });
-                } else {
-                    console.warn('Google AI Studio models endpoint failed:', response.status, response.statusText);
+                const models = await fetchGoogleModels(modelsUrl);
+                console.info('Available Google AI Studio models:', models.map(m => m.id));
+                return statusResponse.send({ data: models });
+            } catch (error) {
+                if (error instanceof GoogleModelsHttpError) {
+                    console.warn('Google AI Studio models endpoint failed:', error.status, error.statusText);
                     return statusResponse.send({ error: true, bypass: true, data: { data: [] } });
                 }
-            } catch (error) {
+
                 console.error('Error fetching Google AI Studio models:', error);
                 return statusResponse.send({ error: true, bypass: true, data: { data: [] } });
             }

--- a/src/endpoints/backends/google-models.js
+++ b/src/endpoints/backends/google-models.js
@@ -1,0 +1,99 @@
+import fetch from 'node-fetch';
+
+const GOOGLE_MODELS_PAGE_SIZE = 1000;
+
+export class GoogleModelsHttpError extends Error {
+    /**
+     * @param {number} status HTTP status code
+     * @param {string} statusText HTTP status text
+     */
+    constructor(status, statusText) {
+        super(`Google AI Studio models endpoint returned ${status} ${statusText}`.trim());
+        this.name = 'GoogleModelsHttpError';
+        this.status = status;
+        this.statusText = statusText;
+    }
+}
+
+export class GoogleModelsResponseError extends Error {
+    /**
+     * @param {string} message Error message
+     * @param {ErrorOptions} [options] Error options
+     */
+    constructor(message, options) {
+        super(message, options);
+        this.name = 'GoogleModelsResponseError';
+    }
+}
+
+/**
+ * Fetches every page of Google AI Studio models and converts supported models.
+ *
+ * @param {string | URL} modelsUrl Google AI Studio models endpoint
+ * @param {typeof fetch} [fetchImpl] Fetch implementation
+ * @returns {Promise<object[]>} Models that support content generation
+ */
+export async function fetchGoogleModels(modelsUrl, fetchImpl = fetch) {
+    const requestUrl = new URL(modelsUrl);
+    requestUrl.searchParams.set('pageSize', String(GOOGLE_MODELS_PAGE_SIZE));
+    requestUrl.searchParams.delete('pageToken');
+
+    const models = [];
+    const pageTokens = new Set();
+    let pageNumber = 1;
+
+    while (true) {
+        let response;
+
+        try {
+            response = await fetchImpl(requestUrl.toString());
+        } catch (cause) {
+            throw new GoogleModelsResponseError(`Failed to fetch Google AI Studio models page ${pageNumber}.`, { cause });
+        }
+
+        if (!response.ok) {
+            throw new GoogleModelsHttpError(response.status, response.statusText);
+        }
+
+        let data;
+        try {
+            data = await response.json();
+        } catch (cause) {
+            throw new GoogleModelsResponseError(`Failed to parse Google AI Studio models page ${pageNumber}.`, { cause });
+        }
+
+        if (!data || !Array.isArray(data.models)) {
+            throw new GoogleModelsResponseError(`Google AI Studio models page ${pageNumber} has an invalid models field.`);
+        }
+
+        models.push(...data.models);
+
+        const nextPageToken = data.nextPageToken;
+        if (nextPageToken === undefined || nextPageToken === '') {
+            break;
+        }
+        if (typeof nextPageToken !== 'string') {
+            throw new GoogleModelsResponseError(`Google AI Studio models page ${pageNumber} has an invalid nextPageToken.`);
+        }
+        if (pageTokens.has(nextPageToken)) {
+            throw new GoogleModelsResponseError(`Google AI Studio models pagination repeated token on page ${pageNumber}.`);
+        }
+
+        pageTokens.add(nextPageToken);
+        requestUrl.searchParams.set('pageToken', nextPageToken);
+        pageNumber++;
+    }
+
+    return models
+        .filter(model => model?.supportedGenerationMethods?.includes('generateContent'))
+        .map((model, index) => {
+            if (typeof model.name !== 'string') {
+                throw new GoogleModelsResponseError(`Google AI Studio model at index ${index} has an invalid name.`);
+            }
+
+            return {
+                ...model,
+                id: model.name.replace('models/', ''),
+            };
+        });
+}

--- a/tests/google-models.test.js
+++ b/tests/google-models.test.js
@@ -1,0 +1,123 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import {
+    fetchGoogleModels,
+    GoogleModelsHttpError,
+    GoogleModelsResponseError,
+} from '../src/endpoints/backends/google-models.js';
+
+function createResponse(data, overrides = {}) {
+    return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => data,
+        ...overrides,
+    };
+}
+
+describe('Google AI Studio model pagination', () => {
+    test('fetches every page and returns generateContent models', async () => {
+        const fetchMock = jest.fn()
+            .mockResolvedValueOnce(createResponse({
+                models: [
+                    {
+                        name: 'models/gemini-2.5-flash',
+                        supportedGenerationMethods: ['generateContent', 'countTokens'],
+                    },
+                    {
+                        name: 'models/gemini-embedding-001',
+                        supportedGenerationMethods: ['embedContent'],
+                    },
+                ],
+                nextPageToken: 'second-page',
+            }))
+            .mockResolvedValueOnce(createResponse({
+                models: [{
+                    name: 'models/gemini-2.5-pro',
+                    supportedGenerationMethods: ['generateContent'],
+                }],
+            }));
+
+        const models = await fetchGoogleModels('https://example.com/v1beta/models?key=secret', fetchMock);
+
+        expect(models).toEqual([
+            {
+                id: 'gemini-2.5-flash',
+                name: 'models/gemini-2.5-flash',
+                supportedGenerationMethods: ['generateContent', 'countTokens'],
+            },
+            {
+                id: 'gemini-2.5-pro',
+                name: 'models/gemini-2.5-pro',
+                supportedGenerationMethods: ['generateContent'],
+            },
+        ]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        const firstUrl = new URL(fetchMock.mock.calls[0][0]);
+        expect(firstUrl.searchParams.get('key')).toBe('secret');
+        expect(firstUrl.searchParams.get('pageSize')).toBe('1000');
+        expect(firstUrl.searchParams.has('pageToken')).toBe(false);
+
+        const secondUrl = new URL(fetchMock.mock.calls[1][0]);
+        expect(secondUrl.searchParams.get('key')).toBe('secret');
+        expect(secondUrl.searchParams.get('pageSize')).toBe('1000');
+        expect(secondUrl.searchParams.get('pageToken')).toBe('second-page');
+    });
+
+    test('preserves reverse proxy query parameters', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ models: [] }));
+
+        await fetchGoogleModels('https://proxy.example/v1beta/models?tenant=test', fetchMock);
+
+        const requestUrl = new URL(fetchMock.mock.calls[0][0]);
+        expect(requestUrl.searchParams.get('tenant')).toBe('test');
+        expect(requestUrl.searchParams.get('pageSize')).toBe('1000');
+    });
+
+    test('rejects an HTTP failure without returning partial models', async () => {
+        const fetchMock = jest.fn()
+            .mockResolvedValueOnce(createResponse({
+                models: [],
+                nextPageToken: 'second-page',
+            }))
+            .mockResolvedValueOnce(createResponse(null, {
+                ok: false,
+                status: 503,
+                statusText: 'Service Unavailable',
+            }));
+
+        await expect(fetchGoogleModels('https://example.com/v1beta/models', fetchMock))
+            .rejects.toEqual(expect.objectContaining({
+                name: GoogleModelsHttpError.name,
+                status: 503,
+                statusText: 'Service Unavailable',
+            }));
+    });
+
+    test('rejects a malformed models field', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({ models: null }));
+
+        await expect(fetchGoogleModels('https://example.com/v1beta/models', fetchMock))
+            .rejects.toThrow('invalid models field');
+    });
+
+    test('rejects a repeated page token', async () => {
+        const fetchMock = jest.fn()
+            .mockResolvedValueOnce(createResponse({ models: [], nextPageToken: 'repeated' }))
+            .mockResolvedValueOnce(createResponse({ models: [], nextPageToken: 'repeated' }));
+
+        await expect(fetchGoogleModels('https://example.com/v1beta/models', fetchMock))
+            .rejects.toBeInstanceOf(GoogleModelsResponseError);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    test('rejects a supported model without a valid name', async () => {
+        const fetchMock = jest.fn().mockResolvedValue(createResponse({
+            models: [{ supportedGenerationMethods: ['generateContent'] }],
+        }));
+
+        await expect(fetchGoogleModels('https://example.com/v1beta/models', fetchMock))
+            .rejects.toThrow('invalid name');
+    });
+});


### PR DESCRIPTION
## Summary

- Fetch all pages from the Google AI Studio models endpoint.
- Request up to 1,000 models per page and follow `nextPageToken` until the list is complete.
- Preserve API key and reverse proxy query parameters across paginated requests.
- Reject incomplete or malformed model lists instead of returning partial results.
- Keep filtering the response to models that support `generateContent`.

Although the total change exceeds the suggested 200-line limit, most of the additional lines are unit tests. The production change remains small and focused, while the tests cover pagination, response validation, filtering, and failure handling.

## Why

The Google Gemini `models.list` endpoint is paginated. According to the [official Google API documentation](https://ai.google.dev/api/models), it returns 50 models per page by default, accepts a maximum `pageSize` of 1,000, and provides `nextPageToken` when more pages are available.

The previous implementation fetched only the first page. This could omit supported models from the response. A complete list is especially important because the frontend might use it to determine which Google AI Studio models are available.

Partial results are not returned when a later page fails.

## Testing

- Added unit tests covering:
    - Multi-page aggregation.
    - `pageSize` and `pageToken` handling.
    - API key and reverse proxy query preservation.
    - `generateContent` filtering and model ID conversion.
    - HTTP failures on later pages.
    - Malformed responses.
    - Repeated pagination tokens.
    - Invalid model names.
- Ran the root project ESLint checks successfully.
- Ran the test project ESLint checks with no errors.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
