### PR TITLE
fix: use image.novelai.net for user/subscription status check

### DIFF
--- a/src/endpoints/novelai.js
+++ b/src/endpoints/novelai.js
@@ -140,7 +140,7 @@ router.post('/status', async function (req, res) {
     }
 
     try {
-        const response = await fetch(API_NOVELAI + '/user/subscription', {
+        const response = await fetch(IMAGE_NOVELAI + '/user/subscription', {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- NovelAI moved `GET /user/subscription` off `api.novelai.net`; that host now returns `400 Bad Request` for this route.
- This breaks the NovelAI connection status check on `release`: the key registers fine, but the UI always shows "No connection..." regardless of a valid key.
- Verified against `image.novelai.net`, which returns the expected subscription payload (tier, perks, etc.) with the same key.
- This exact fix is already merged to `staging` (3594fe224) but hasn't been backported to `release`.

## Test plan
- [x] Confirmed `api.novelai.net/user/subscription` returns 400 with a valid persistent API key
- [x] Confirmed `image.novelai.net/user/subscription` returns 200 with correct tier data for the same key
- [x] Applied the fix and confirmed the NovelAI panel shows the correct tier ("Opus") on Connect