### PR TITLE
fix: preserve zero NovelAI Math1 temperature

### DIFF
--- a/public/scripts/nai-settings.js
+++ b/public/scripts/nai-settings.js
@@ -205,7 +205,7 @@ export function loadNovelPreset(preset) {
     nai_settings.logit_bias = preset.logit_bias || [];
     nai_settings.preamble = preset.preamble || default_preamble;
     nai_settings.min_p = preset.min_p || 0;
-    nai_settings.math1_temp = preset.math1_temp || 1;
+    nai_settings.math1_temp = preset.math1_temp ?? 1;
     nai_settings.math1_quad = preset.math1_quad || 0;
     nai_settings.math1_quad_entropy_scale = preset.math1_quad_entropy_scale || 0;
     nai_settings.extensions = preset.extensions || {};
@@ -259,7 +259,7 @@ export function loadNovelSettings(data, settings) {
     nai_settings.order = settings.order || default_order;
     nai_settings.logit_bias = settings.logit_bias || [];
     nai_settings.min_p = settings.min_p || 0;
-    nai_settings.math1_temp = settings.math1_temp || 1;
+    nai_settings.math1_temp = settings.math1_temp ?? 1;
     nai_settings.math1_quad = settings.math1_quad || 0;
     nai_settings.math1_quad_entropy_scale = settings.math1_quad_entropy_scale || 0;
     nai_settings.extensions = settings.extensions || {};

--- a/tests/nai-settings.test.js
+++ b/tests/nai-settings.test.js
@@ -1,0 +1,80 @@
+import { beforeAll, describe, expect, jest, test } from '@jest/globals';
+
+const jqueryElement = {
+    append: jest.fn(function () { return this; }),
+    children: jest.fn(() => ({ each: jest.fn() })),
+    detach: jest.fn(function () { return this; }),
+    empty: jest.fn(function () { return this; }),
+    find: jest.fn(function () { return this; }),
+    on: jest.fn(function () { return this; }),
+    prop: jest.fn(function () { return this; }),
+    trigger: jest.fn(function () { return this; }),
+    val: jest.fn(function () { return this; }),
+};
+
+global.$ = jest.fn(() => jqueryElement);
+
+jest.unstable_mockModule('../public/script.js', () => ({
+    abortStatusCheck: { signal: undefined },
+    event_types: {},
+    eventSource: { emit: jest.fn() },
+    getRequestHeaders: jest.fn(),
+    getStoppingStrings: jest.fn(),
+    resultCheckStatus: jest.fn(),
+    saveSettingsDebounced: jest.fn(),
+    setGenerationParamsFromPreset: jest.fn(),
+    setOnlineStatus: jest.fn(),
+    startStatusLoading: jest.fn(),
+}));
+jest.unstable_mockModule('../public/scripts/power-user.js', () => ({
+    MAX_CONTEXT_DEFAULT: 8192,
+    MAX_RESPONSE_DEFAULT: 150,
+    power_user: {},
+}));
+jest.unstable_mockModule('../public/scripts/tokenizers.js', () => ({
+    getTextTokens: jest.fn(),
+    tokenizers: { NONE: 0, NERD: 1, NERD2: 2, LLAMA3: 3 },
+}));
+jest.unstable_mockModule('../public/scripts/sse-stream.js', () => ({ getEventSourceStream: jest.fn() }));
+jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+    getSortableDelay: jest.fn(),
+    getStringHash: jest.fn(),
+    onlyUnique: jest.fn(),
+}));
+jest.unstable_mockModule('../public/scripts/logit-bias.js', () => ({
+    BIAS_CACHE: new Map(),
+    createNewLogitBiasEntry: jest.fn(),
+    displayLogitBias: jest.fn(),
+    getLogitBiasListResult: jest.fn(),
+}));
+jest.unstable_mockModule('../public/scripts/secrets.js', () => ({
+    SECRET_KEYS: {},
+    secret_state: {},
+    writeSecret: jest.fn(),
+}));
+
+let loadNovelPreset;
+let loadNovelSettings;
+let naiSettings;
+
+beforeAll(async () => {
+    ({
+        loadNovelPreset,
+        loadNovelSettings,
+        nai_settings: naiSettings,
+    } = await import('../public/scripts/nai-settings.js'));
+});
+
+describe('NovelAI settings', () => {
+    test('preserves a zero Math1 temperature when loading settings', () => {
+        loadNovelSettings(
+            { novelai_setting_names: [], novelai_settings: [] },
+            { ...naiSettings, math1_temp: 0 },
+        );
+        expect(naiSettings.math1_temp).toBe(0);
+
+        naiSettings.math1_temp = 1;
+        loadNovelPreset({ ...naiSettings, genamt: 150, math1_temp: 0 });
+        expect(naiSettings.math1_temp).toBe(0);
+    });
+});


### PR DESCRIPTION
## What changed

Preserve a valid zero Math1 Linear temperature when loading NovelAI presets and saved settings.

The Math1 temperature controls allow values from 0 to 1.5, but the previous `|| 1` fallback replaced `0` with `1`. Nullish fallback now applies only when the setting is absent.

A regression test covers both preset loading and saved-settings loading.

## Testing

- `npm run test:unit -- --runInBand nai-settings.test.js`
- `npm run lint -- --quiet`
- `npm run lint -- --quiet` from `tests/`