### PR TITLE
Return a degraded preview instead of dropping a chat whose last line is unparseable

### DIFF
--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -487,12 +487,18 @@ export async function getChatInfo(pathToFile, additionalData = {}, withMetadata 
 
                     res(chatData);
                 } else {
-                    console.warn('Found an invalid or corrupted chat file:', pathToFile);
-                    res({});
+                    // The last line is unparseable or lacks known fields (e.g. a truncated write or an external edit).
+                    // Resolve a degraded preview from the stat data instead of hiding an otherwise intact chat
+                    // from the chat list, search and recents.
+                    console.warn('Found an invalid or corrupted last line in a chat file:', pathToFile);
+                    chatData.chat_items = Math.max(itemCounter - 1, 0);
+                    chatData.mes = '[The message is empty]';
+                    chatData.match = hasMatcher ? hasAnyMatch : true;
+                    res(chatData);
                 }
             } else {
-                // The file was truncated after the stat reported a non-zero size
-                res({});
+                // The file was truncated after the stat reported a non-zero size; treat it like an empty chat
+                res(chatData);
             }
         });
     });

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -491,7 +491,8 @@ export async function getChatInfo(pathToFile, additionalData = {}, withMetadata 
                     // Resolve a degraded preview from the stat data instead of hiding an otherwise intact chat
                     // from the chat list, search and recents.
                     console.warn('Found an invalid or corrupted last line in a chat file:', pathToFile);
-                    chatData.chat_items = Math.max(itemCounter - 1, 0);
+                    // Exclude both the metadata line and the unreadable trailing line.
+                    chatData.chat_items = Math.max(itemCounter - 2, 0);
                     chatData.mes = '[The message is empty]';
                     chatData.match = hasMatcher ? hasAnyMatch : true;
                     res(chatData);

--- a/tests/chat-info.test.js
+++ b/tests/chat-info.test.js
@@ -102,7 +102,7 @@ describe('getChatInfo', () => {
         const info = await chats.getChatInfo(chatFile);
         expect(info.file_id).toBe('chat');
         expect(info.file_name).toBe('chat.jsonl');
-        expect(info.chat_items).toBe(1);
+        expect(info.chat_items).toBe(0);
         expect(info.mes).toBe('[The message is empty]');
         expect(info.match).toBe(true);
     });
@@ -113,7 +113,7 @@ describe('getChatInfo', () => {
         const info = await chats.getChatInfo(chatFile);
         expect(info.file_id).toBe('chat');
         expect(info.file_name).toBe('chat.jsonl');
-        expect(info.chat_items).toBe(3);
+        expect(info.chat_items).toBe(2);
         expect(info.mes).toBe('[The message is empty]');
         expect(info.match).toBe(true);
     });

--- a/tests/chat-info.test.js
+++ b/tests/chat-info.test.js
@@ -85,7 +85,10 @@ describe('getChatInfo', () => {
         fs.writeFileSync(chatFile, '');
         jest.spyOn(fs.promises, 'stat').mockResolvedValue(/** @type {any} */({ size: 100, mtimeMs: 1_000_000 }));
         const info = await chats.getChatInfo(chatFile);
-        expect(info).toEqual({});
+        expect(info.file_name).toBe('chat.jsonl');
+        expect(info.chat_items).toBe(0);
+        expect(info.mes).toBe('[The chat is empty]');
+        expect(info.match).toBe(false);
     });
 
     test('rejects with the original error for non-ENOENT stat failures', async () => {
@@ -94,9 +97,34 @@ describe('getChatInfo', () => {
         await expect(chats.getChatInfo(chatFile)).rejects.toThrow('EACCES');
     });
 
-    test('resolves an empty object for a corrupted chat file', async () => {
+    test('resolves a degraded preview for a fully corrupted chat file', async () => {
         fs.writeFileSync(chatFile, 'not json at all\nstill not json');
         const info = await chats.getChatInfo(chatFile);
-        expect(info).toEqual({});
+        expect(info.file_id).toBe('chat');
+        expect(info.file_name).toBe('chat.jsonl');
+        expect(info.chat_items).toBe(1);
+        expect(info.mes).toBe('[The message is empty]');
+        expect(info.match).toBe(true);
+    });
+
+    test('resolves a degraded preview when only the last line is unparseable', async () => {
+        // e.g. a partially flushed write or an external edit truncated the final line
+        fs.writeFileSync(chatFile, makeChatJsonl() + '\n' + '{"name": "User", "is_user": true, "mes": "Trunc');
+        const info = await chats.getChatInfo(chatFile);
+        expect(info.file_id).toBe('chat');
+        expect(info.file_name).toBe('chat.jsonl');
+        expect(info.chat_items).toBe(3);
+        expect(info.mes).toBe('[The message is empty]');
+        expect(info.match).toBe(true);
+    });
+
+    test('matcher still applies to intact messages when the last line is unparseable', async () => {
+        fs.writeFileSync(chatFile, makeChatJsonl() + '\n' + '{"broken');
+        const matching = await chats.getChatInfo(chatFile, {}, false, lines => lines.some(l => l.includes('Second')));
+        expect(matching.match).toBe(true);
+        expect(matching.file_name).toBe('chat.jsonl');
+        const nonMatching = await chats.getChatInfo(chatFile, {}, false, lines => lines.some(l => l.includes('nope')));
+        expect(nonMatching.match).toBe(false);
+        expect(nonMatching.file_name).toBe('chat.jsonl');
     });
 });


### PR DESCRIPTION
### What

`getChatInfo()` resolved `{}` when the last line of a chat `.jsonl` failed to parse or had none of `name`/`character_name`/`chat_metadata`. All three consumers (chat list, search, recents) drop entries without a `file_name`, so an otherwise intact chat silently disappeared from the UI while still occupying its name for branch/checkpoint uniqueness checks.

### How

Per the direction discussed in the issue, the unparseable last line is now treated as a degraded preview rather than grounds for removal: the already-built `chatData` is resolved with stat-derived `file_id`, `file_name`, `file_size` and mtime-based `last_mes`, `chat_items` from the line count, and the existing `[The message is empty]` placeholder. Matcher results from the intact lines are preserved so search still works. The truncated-after-stat branch now returns the same defaults as an empty file instead of `{}`.

### Testing

Extended `tests/chat-info.test.js`: three new cases (fully corrupted file, valid chat with a truncated last line, matcher over intact lines with a broken last line) and updated the two that asserted the old `{}` behavior. Full unit suite passes (400/400), ESLint clean. To reproduce manually: truncate the final line of any chat `.jsonl`, then check the Manage chat files list, search, and welcome-screen recents; before this change the chat is absent from all three, after it appears with a placeholder preview and opens normally.

One judgment call for review: `chat_items` counts the broken trailing line as a message (parity with the success path's `itemCounter - 1`); excluding it would be `itemCounter - 2`.

Fixes #5940
