### PR TITLE
Export setGroupAutoMode() for programmatic group auto-mode control

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -2394,11 +2394,34 @@ export async function saveGroupBookmarkChat(groupId, name, metadata, mesId, chat
     }
 }
 
+/**
+ * Enable or disable group auto-mode.
+ * Keeps the internal flag and the UI checkbox in sync, and arms the stop handler
+ * the same way toggling the checkbox does.
+ * @param {boolean} enabled Desired state.
+ * @returns {boolean} The resulting state.
+ */
+export function setGroupAutoMode(enabled) {
+    const value = !!enabled;
+
+    if (value === is_group_automode_enabled) {
+        return value;
+    }
+
+    is_group_automode_enabled = value;
+    $('#rm_group_automode').prop('checked', value);
+
+    if (value) {
+        eventSource.once(event_types.GENERATION_STOPPED, stopAutoModeGeneration);
+    }
+
+    return value;
+}
+
 function onSendTextareaInput() {
     if (is_group_automode_enabled) {
         // Wait for current automode generation to finish
-        is_group_automode_enabled = false;
-        $('#rm_group_automode').prop('checked', false);
+        setGroupAutoMode(false);
     }
 }
 
@@ -2465,9 +2488,7 @@ jQuery(() => {
     $('#rm_group_submit').on('click', createGroup);
     $('#rm_group_scenario').on('click', setCharacterSettingsOverrides);
     $('#rm_group_automode').on('input', function () {
-        const value = $(this).prop('checked');
-        is_group_automode_enabled = value;
-        eventSource.once(event_types.GENERATION_STOPPED, stopAutoModeGeneration);
+        setGroupAutoMode($(this).prop('checked'));
     });
     $('#rm_group_hidemutedsprites').on('input', function () {
         const value = $(this).prop('checked');


### PR DESCRIPTION
Part of #5972.

### What

Factors the existing "set the auto-mode flag and sync the checkbox" logic into an
exported `setGroupAutoMode()`, and uses it at the two places that already did it inline.

`is_group_automode_enabled` is exported from `group-chats.js`, but as a `let` — ES
module bindings are read-only in the importing module, so extensions can read the flag
and assigning to it throws. There is no exported setter, which leaves clicking
`#rm_group_automode` in the DOM as the only external way to toggle group auto-mode.

This addresses part A of #5972. The optional turn limit (part B) is separate and not
included here.

### Changes

- Add `setGroupAutoMode(enabled)`, exported, next to `stopAutoModeGeneration()`.
  No-ops when already in the requested state; arms the `GENERATION_STOPPED` one-shot on
  enable, matching what the checkbox handler did.
- `onSendTextareaInput()` and the `#rm_group_automode` input handler now call it
  instead of duplicating the two statements.
- `stopAutoModeGeneration()` is deliberately unchanged — it must abort before clearing
  the flag.

The flag is now written in exactly three places: its declaration, the setter, and the
stop handler.

### Behaviour

Effectively unchanged, with one small difference worth calling out: the setter no-ops
when already in the requested state, so re-enabling auto-mode while it is already on no
longer arms an additional `GENERATION_STOPPED` listener. The previous handler registered
a fresh `eventSource.once(...)` on every `input` event. Happy to drop the guard if you'd
rather keep it byte-for-byte identical.

### Testing

- Toggling Auto Mode in the group panel enables and disables it as before.
- Typing in the send textarea while auto-mode is on still disables it.
- `import { setGroupAutoMode } from './group-chats.js'` — calling with `false` disables
  auto-mode and unchecks the box; calling with `true` enables it and arms the stop
  handler; calling with the current value is a no-op.

### Not included

`setGroupAutoMode` is not surfaced on `getContext()`. Happy to add that if you'd prefer
it on the context surface rather than as a module export only.
