### PR TITLE
Fix /api/chats/get return on internal errors (#5941) 

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -288,6 +288,7 @@ import { addChatBackupsBrowser } from './scripts/chat-backups.js';
 import { onboardingExperimentalMacroEngine } from './scripts/macros/engine/MacroDiagnostics.js';
 import { compressRequest, setRequestCompressionConfig } from './scripts/request-compression.js';
 import { canJumpToSwipeForMessage, canOpenSwipePickerForMessage, initSwipePicker } from './scripts/swipe-picker.js';
+import { parseChatResponse } from './scripts/chat-response.js';
 
 // API OBJECT FOR EXTERNAL WIRING
 globalThis.SillyTavern = {
@@ -7319,37 +7320,35 @@ async function renamePastChats(oldAvatar, newAvatar, newName) {
                 cache: 'no-cache',
             });
 
-            if (getChatResponse.ok) {
-                const currentChat = await getChatResponse.json();
+            const currentChat = await parseChatResponse(getChatResponse);
 
-                for (const message of currentChat) {
-                    if (message.is_user || message.is_system || message.extra?.type == system_message_types.NARRATOR) {
-                        continue;
-                    }
-
-                    if (message.name !== undefined) {
-                        message.name = newName;
-                    }
+            for (const message of currentChat) {
+                if (message.is_user || message.is_system || message.extra?.type == system_message_types.NARRATOR) {
+                    continue;
                 }
 
-                await eventSource.emit(event_types.CHARACTER_RENAMED_IN_PAST_CHAT, currentChat, oldAvatar, newAvatar);
-
-                const saveChatRequest = await compressRequest({
-                    method: 'POST',
-                    headers: getRequestHeaders(),
-                    body: JSON.stringify({
-                        ch_name: newName,
-                        file_name: fileNameWithoutExtension,
-                        chat: currentChat,
-                        avatar_url: newAvatar,
-                    }),
-                    cache: 'no-cache',
-                });
-                const saveChatResponse = await fetch('/api/chats/save', saveChatRequest);
-
-                if (!saveChatResponse.ok) {
-                    throw new Error('Could not save chat');
+                if (message.name !== undefined) {
+                    message.name = newName;
                 }
+            }
+
+            await eventSource.emit(event_types.CHARACTER_RENAMED_IN_PAST_CHAT, currentChat, oldAvatar, newAvatar);
+
+            const saveChatRequest = await compressRequest({
+                method: 'POST',
+                headers: getRequestHeaders(),
+                body: JSON.stringify({
+                    ch_name: newName,
+                    file_name: fileNameWithoutExtension,
+                    chat: currentChat,
+                    avatar_url: newAvatar,
+                }),
+                cache: 'no-cache',
+            });
+            const saveChatResponse = await fetch('/api/chats/save', saveChatRequest);
+
+            if (!saveChatResponse.ok) {
+                throw new Error('Could not save chat');
             }
         } catch (error) {
             toastr.error(t`Past chat could not be updated: ${file_name}`);
@@ -7646,11 +7645,7 @@ export async function getChat() {
             }),
         });
 
-        if (!response.ok) {
-            throw new Error('Chat could not be loaded');
-        }
-
-        const data = await response.json();
+        const data = await parseChatResponse(response);
         if (Array.isArray(data) && data.length > 0) {
             /** @type {ChatHeader} */
             const chatHeader = data.shift();
@@ -7658,7 +7653,7 @@ export async function getChat() {
             chat.splice(0, chat.length, ...data);
             chat.forEach(ensureMessageMediaIsArray);
         } else {
-            // An empty/corrupted chat file
+            // An empty chat file
             chat.splice(0, chat.length);
             chat_metadata = {};
         }
@@ -7676,8 +7671,15 @@ export async function getChat() {
             $('#send_textarea').trigger('click').trigger('focus');
         });
     } catch (error) {
-        await getChatResult();
-        console.log(error);
+        console.error('Chat could not be loaded:', error);
+        try {
+            await Popup.show.text(
+                t`Chat could not be loaded`,
+                t`Something went wrong while loading the chat. The page will be reloaded to prevent data corruption.`,
+            );
+        } finally {
+            window.location.reload();
+        }
     }
 }
 
@@ -8468,19 +8470,14 @@ export async function getChatsFromFiles(data, isGroupChat) {
                     cache: 'no-cache',
                 });
 
-                if (!chatResponse.ok) {
-                    return res();
-                    // continue;
-                }
-
-                const currentChat = await chatResponse.json();
+                const currentChat = await parseChatResponse(chatResponse);
                 if (!isGroupChat) {
                     // remove the first message, which is metadata, only for individual chats
                     currentChat.shift();
                 }
                 chat_dict[file_name] = currentChat;
             } catch (error) {
-                console.error(error);
+                console.error(`Chat file could not be loaded: ${file_name}`, error);
             }
 
             return res();

--- a/public/scripts/chat-response.js
+++ b/public/scripts/chat-response.js
@@ -1,0 +1,59 @@
+/**
+ * An error returned while loading a chat from the server.
+ */
+export class ChatLoadError extends Error {
+    /**
+     * @param {string} message Error message.
+     * @param {object} [options] Error details.
+     * @param {number} [options.status] HTTP response status.
+     * @param {string} [options.serverMessage] Stable error message returned by the server.
+     * @param {unknown} [options.cause] Original parsing error.
+     */
+    constructor(message, { status, serverMessage, cause } = {}) {
+        super(message, { cause });
+        this.name = 'ChatLoadError';
+        this.status = status;
+        this.serverMessage = serverMessage;
+    }
+}
+
+/**
+ * Parses and validates a chat endpoint response.
+ * Successful chat responses must contain a JSON array. Error responses use a
+ * JSON `error` string when available and otherwise fall back to HTTP status data.
+ * @param {Response} response Chat endpoint response.
+ * @returns {Promise<Array>} Parsed chat records.
+ * @throws {ChatLoadError} If the request failed or the success body is not a JSON array.
+ */
+export async function parseChatResponse(response) {
+    let data;
+    try {
+        data = await response.json();
+    } catch (error) {
+        const serverMessage = response.statusText || `HTTP ${response.status}`;
+        throw new ChatLoadError(`Chat response was not valid JSON: ${response.status} ${serverMessage}`, {
+            status: response.status,
+            serverMessage,
+            cause: error,
+        });
+    }
+
+    if (!response.ok) {
+        const serverMessage = typeof data?.error === 'string' && data.error
+            ? data.error
+            : response.statusText || `HTTP ${response.status}`;
+        throw new ChatLoadError(`Chat could not be loaded: ${response.status} ${serverMessage}`, {
+            status: response.status,
+            serverMessage,
+        });
+    }
+
+    if (!Array.isArray(data)) {
+        throw new ChatLoadError(`Chat response was not an array: HTTP ${response.status}`, {
+            status: response.status,
+            serverMessage: 'Invalid chat response.',
+        });
+    }
+
+    return data;
+}

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -87,6 +87,7 @@ import { POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { compressRequest } from './request-compression.js';
+import { parseChatResponse } from './chat-response.js';
 
 export {
     selected_group,
@@ -199,15 +200,7 @@ async function loadGroupChat(chatId) {
         body: JSON.stringify({ id: chatId }),
     });
 
-    if (response.ok) {
-        const data = await response.json();
-        if (!Array.isArray(data)) {
-            return [];
-        }
-        return data;
-    }
-
-    return [];
+    return await parseChatResponse(response);
 }
 
 /**
@@ -264,7 +257,21 @@ export async function getGroupChat(groupId, reload = false) {
     await unshallowGroupMembers(groupId);
 
     const chat_id = group.chat_id;
-    const data = await loadGroupChat(chat_id);
+    let data;
+    try {
+        data = await loadGroupChat(chat_id);
+    } catch (error) {
+        console.error('Group chat could not be loaded:', error);
+        try {
+            await Popup.show.text(
+                t`Group chat could not be loaded`,
+                t`Something went wrong while loading the group chat. The page will be reloaded to prevent data corruption.`,
+            );
+        } finally {
+            window.location.reload();
+        }
+        return;
+    }
     const metadata = data?.[0]?.chat_metadata ?? {};
     const freshChat = !metadata.tainted && (!Array.isArray(data) || !data.length);
 

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -18,7 +18,6 @@ import {
     removeOldBackups,
     formatBytes,
     tryWriteFileSync,
-    tryReadFileSync,
     tryDeleteFile,
     readFirstLine,
     isPathUnderParent,
@@ -563,42 +562,67 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
 });
 
 /**
- * Gets the chat as an object.
+ * Gets the chat as an array of JSONL records.
+ * Missing and empty files return an empty array. Other read errors and malformed
+ * non-empty JSONL lines are reported to the caller.
  * @param {string} chatFilePath The full chat file path.
- * @returns {Array}} If the chatFilePath cannot be read, this will return [].
+ * @returns {Array} Parsed chat records.
+ * @throws {Error} If the file cannot be read or a non-empty line cannot be parsed.
  */
 export function getChatData(chatFilePath) {
-    let chatData = [];
+    let chatJSON;
+    try {
+        chatJSON = fs.readFileSync(chatFilePath, 'utf8');
+    } catch (error) {
+        // If the file does not exist, return an empty array
+        if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+            return [];
+        }
 
-    const chatJSON = tryReadFileSync(chatFilePath) ?? '';
-    if (chatJSON.length > 0) {
-        const lines = chatJSON.split('\n');
-        // Iterate through the array of strings and parse each line as JSON
-        chatData = lines.map(line => tryParse(line)).filter(x => x);
-    } else {
-        console.warn(`File not found: ${chatFilePath}. The chat does not exist or is empty.`);
+        throw new Error(`Could not read chat file "${chatFilePath}".`, { cause: error });
+    }
+
+    const chatData = [];
+    for (const [index, rawLine] of chatJSON.split('\n').entries()) {
+        // Process Unicode BOM
+        const line = index === 0 ? rawLine.replace(/^\uFEFF/, '') : rawLine;
+        if (!line.trim()) {
+            continue;
+        }
+
+        try {
+            chatData.push(JSON.parse(line));
+        } catch (error) {
+            throw new SyntaxError(`Could not parse chat file "${chatFilePath}" at line ${index + 1}.`, { cause: error });
+        }
     }
 
     return chatData;
 }
 
+/**
+ * Loads a character chat.
+ * Returns a JSON array for successful reads, including missing and empty chats.
+ * Invalid requests return 400; read and parse failures return 500 with a JSON error.
+ */
 router.post('/get', validateAvatarUrlMiddleware, function (request, response) {
     try {
         const dirName = String(request.body.avatar_url).replace('.png', '');
         const directoryPath = path.join(request.user.directories.chats, dirName);
         if (!isPathUnderParent(request.user.directories.chats, directoryPath)) {
-            return response.sendStatus(400);
+            return response.status(400).send({ error: 'Invalid chat path.' });
         }
+
+        if (!request.body.file_name) {
+            return response.status(400).send({ error: 'The request\'s body.file_name is required.' });
+        }
+
         const chatDirExists = fs.existsSync(directoryPath);
 
         //if no chat dir for the character is found, make one with the character name
         if (!chatDirExists) {
             fs.mkdirSync(directoryPath);
-            return response.send({});
-        }
-
-        if (!request.body.file_name) {
-            return response.send({});
+            return response.send([]);
         }
 
         const chatFileName = `${String(request.body.file_name)}.jsonl`;
@@ -606,8 +630,8 @@ router.post('/get', validateAvatarUrlMiddleware, function (request, response) {
 
         return response.send(getChatData(chatFilePath));
     } catch (error) {
-        console.error(error);
-        return response.send({});
+        console.error('Could not load character chat:', error);
+        return response.status(500).send({ error: 'Chat could not be loaded.' });
     }
 });
 
@@ -862,15 +886,25 @@ router.post('/import', validateAvatarUrlMiddleware, function (request, response)
     }
 });
 
+/**
+ * Loads a group chat.
+ * Returns a JSON array for successful reads, including missing and empty chats.
+ * Invalid requests return 400; read and parse failures return 500 with a JSON error.
+ */
 router.post('/group/get', (request, response) => {
-    if (!request.body || !request.body.id) {
-        return response.sendStatus(400);
+    try {
+        if (!request.body || !request.body.id) {
+            return response.status(400).send({ error: 'The request\'s body.id is required.' });
+        }
+
+        const id = request.body.id;
+        const chatFilePath = path.join(request.user.directories.groupChats, sanitize(`${id}.jsonl`));
+
+        return response.send(getChatData(chatFilePath));
+    } catch (error) {
+        console.error('Could not load group chat:', error);
+        return response.status(500).send({ error: 'Chat could not be loaded.' });
     }
-
-    const id = request.body.id;
-    const chatFilePath = path.join(request.user.directories.groupChats, sanitize(`${id}.jsonl`));
-
-    return response.send(getChatData(chatFilePath));
 });
 
 router.post('/group/info', async (request, response) => {

--- a/tests/chat-get.test.js
+++ b/tests/chat-get.test.js
@@ -1,0 +1,190 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+process.env.SILLYTAVERN_BACKUPS_CHAT_ENABLED = 'false';
+process.env.SILLYTAVERN_BACKUPS_CHAT_MAXTOTALBACKUPS = '-1';
+process.env.SILLYTAVERN_BACKUPS_CHAT_THROTTLEINTERVAL = '0';
+process.env.SILLYTAVERN_BACKUPS_CHAT_CHECKINTEGRITY = 'true';
+
+/** @type {import('../src/endpoints/chats.js')} */
+let chats;
+/** @type {import('node:http').Server} */
+let server;
+let baseUrl;
+let tmpDir;
+let characterChatsDir;
+let groupChatsDir;
+
+beforeAll(async () => {
+    const { default: express } = await import('express');
+    chats = await import('../src/endpoints/chats.js');
+
+    const app = express();
+    app.use(express.json());
+    app.use((request, _response, next) => {
+        request.user = {
+            profile: { handle: 'test-user' },
+            directories: {
+                chats: characterChatsDir,
+                groupChats: groupChatsDir,
+            },
+        };
+        next();
+    });
+    app.use('/api/chats', chats.router);
+
+    server = app.listen(0, '127.0.0.1');
+    await new Promise(resolve => server.once('listening', resolve));
+    const address = server.address();
+    baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+    if (server?.listening) {
+        await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    }
+});
+
+beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'st-chat-get-'));
+    characterChatsDir = path.join(tmpDir, 'chats');
+    groupChatsDir = path.join(tmpDir, 'group-chats');
+    fs.mkdirSync(characterChatsDir);
+    fs.mkdirSync(groupChatsDir);
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    if (tmpDir) {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+});
+
+function makeChatJsonl() {
+    return [
+        JSON.stringify({ chat_metadata: { integrity: 'test-integrity' } }),
+        JSON.stringify({ name: 'Character', mes: 'Hello' }),
+    ].join('\n');
+}
+
+async function post(endpoint, body) {
+    return await fetch(`${baseUrl}${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+describe('getChatData', () => {
+    test('returns an empty array for a missing or empty file', () => {
+        const missingFile = path.join(tmpDir, 'missing.jsonl');
+        const emptyFile = path.join(tmpDir, 'empty.jsonl');
+        fs.writeFileSync(emptyFile, ' \n\t');
+
+        expect(chats.getChatData(missingFile)).toEqual([]);
+        expect(chats.getChatData(emptyFile)).toEqual([]);
+    });
+
+    test('parses valid records while tolerating a BOM and blank lines', () => {
+        const chatFile = path.join(tmpDir, 'valid.jsonl');
+        fs.writeFileSync(chatFile, `\uFEFF${makeChatJsonl().replace('\n', '\n\n')}\n`);
+
+        expect(chats.getChatData(chatFile)).toEqual([
+            { chat_metadata: { integrity: 'test-integrity' } },
+            { name: 'Character', mes: 'Hello' },
+        ]);
+    });
+
+    test('rejects the entire chat when any non-empty line is malformed', () => {
+        const chatFile = path.join(tmpDir, 'corrupted.jsonl');
+        fs.writeFileSync(chatFile, `${makeChatJsonl()}\nnot-json`);
+
+        expect(() => chats.getChatData(chatFile)).toThrow(/line 3/);
+    });
+
+    test('propagates non-ENOENT read failures with the original cause', () => {
+        const chatFile = path.join(tmpDir, 'unreadable.jsonl');
+        const readError = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+        const realReadFileSync = fs.readFileSync;
+        jest.spyOn(fs, 'readFileSync').mockImplementation((filePath, ...args) => {
+            if (filePath === chatFile) {
+                throw readError;
+            }
+            return realReadFileSync(filePath, ...args);
+        });
+
+        let caughtError;
+        try {
+            chats.getChatData(chatFile);
+        } catch (error) {
+            caughtError = error;
+        }
+        expect(caughtError?.message).toContain(chatFile);
+        expect(caughtError?.cause).toBe(readError);
+    });
+});
+
+describe('chat get endpoints', () => {
+    test('returns an array for a character chat and creates a missing character directory', async () => {
+        const missingDirectoryResponse = await post('/api/chats/get', {
+            avatar_url: 'New Character.png',
+            file_name: 'new-chat',
+        });
+        expect(missingDirectoryResponse.status).toBe(200);
+        expect(await missingDirectoryResponse.json()).toEqual([]);
+        expect(fs.existsSync(path.join(characterChatsDir, 'New Character'))).toBe(true);
+
+        const characterDir = path.join(characterChatsDir, 'Character');
+        fs.mkdirSync(characterDir);
+        const missingFileResponse = await post('/api/chats/get', {
+            avatar_url: 'Character.png',
+            file_name: 'missing-chat',
+        });
+        expect(missingFileResponse.status).toBe(200);
+        expect(await missingFileResponse.json()).toEqual([]);
+
+        fs.writeFileSync(path.join(characterDir, 'chat.jsonl'), makeChatJsonl());
+        const response = await post('/api/chats/get', {
+            avatar_url: 'Character.png',
+            file_name: 'chat',
+        });
+        expect(response.status).toBe(200);
+        expect(await response.json()).toHaveLength(2);
+    });
+
+    test('returns JSON 400 errors for invalid character and group requests', async () => {
+        const missingFileName = await post('/api/chats/get', { avatar_url: 'Character.png' });
+        expect(missingFileName.status).toBe(400);
+        expect(await missingFileName.json()).toEqual({ error: 'The request\'s body.file_name is required.' });
+
+        const invalidPath = await post('/api/chats/get', { avatar_url: '..', file_name: 'chat' });
+        expect(invalidPath.status).toBe(400);
+        expect(await invalidPath.json()).toEqual({ error: 'Invalid chat path.' });
+
+        const missingGroupId = await post('/api/chats/group/get', {});
+        expect(missingGroupId.status).toBe(400);
+        expect(await missingGroupId.json()).toEqual({ error: 'The request\'s body.id is required.' });
+    });
+
+    test('returns the same fixed JSON 500 error for corrupted character and group chats', async () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const characterDir = path.join(characterChatsDir, 'Character');
+        fs.mkdirSync(characterDir);
+        fs.writeFileSync(path.join(characterDir, 'broken.jsonl'), 'not-json');
+        fs.writeFileSync(path.join(groupChatsDir, 'broken-group.jsonl'), 'not-json');
+
+        const characterResponse = await post('/api/chats/get', {
+            avatar_url: 'Character.png',
+            file_name: 'broken',
+        });
+        const groupResponse = await post('/api/chats/group/get', { id: 'broken-group' });
+
+        expect(characterResponse.status).toBe(500);
+        expect(await characterResponse.json()).toEqual({ error: 'Chat could not be loaded.' });
+        expect(groupResponse.status).toBe(500);
+        expect(await groupResponse.json()).toEqual({ error: 'Chat could not be loaded.' });
+        expect(consoleError).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/chat-response.test.js
+++ b/tests/chat-response.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { ChatLoadError, parseChatResponse } from '../public/scripts/chat-response.js';
+
+function jsonResponse(body, status = 200, statusText = '') {
+    return new Response(JSON.stringify(body), {
+        status,
+        statusText,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+describe('parseChatResponse', () => {
+    test('returns non-empty and empty chat arrays', async () => {
+        await expect(parseChatResponse(jsonResponse([{ chat_metadata: {} }]))).resolves.toEqual([{ chat_metadata: {} }]);
+        await expect(parseChatResponse(jsonResponse([]))).resolves.toEqual([]);
+    });
+
+    test('rejects a non-array successful response', async () => {
+        await expect(parseChatResponse(jsonResponse({}))).rejects.toMatchObject({
+            name: 'ChatLoadError',
+            status: 200,
+            serverMessage: 'Invalid chat response.',
+        });
+    });
+
+    test('uses a JSON error message for an unsuccessful response', async () => {
+        await expect(parseChatResponse(jsonResponse({ error: 'Chat could not be loaded.' }, 500, 'Internal Server Error')))
+            .rejects.toMatchObject({
+                name: 'ChatLoadError',
+                status: 500,
+                serverMessage: 'Chat could not be loaded.',
+            });
+    });
+
+    test('falls back to HTTP status data for a non-JSON response', async () => {
+        const response = new Response('Internal Server Error', { status: 500, statusText: 'Internal Server Error' });
+
+        let caughtError;
+        try {
+            await parseChatResponse(response);
+        } catch (error) {
+            caughtError = error;
+        }
+        expect(caughtError).toBeInstanceOf(ChatLoadError);
+        expect(caughtError).toMatchObject({ status: 500, serverMessage: 'Internal Server Error' });
+        expect(caughtError?.cause).toMatchObject({ name: 'SyntaxError' });
+    });
+});

--- a/tests/frontend/ChatLoadFailure.e2e.js
+++ b/tests/frontend/ChatLoadFailure.e2e.js
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { testSetup } from './frontent-test-utils.js';
+
+test.describe('chat load failures fail closed', () => {
+    test.beforeEach(testSetup.awaitST);
+
+    test('does not save a character chat after a failed read', async ({ page }) => {
+        let saveRequests = 0;
+        page.on('request', request => {
+            if (request.method() === 'POST' && new URL(request.url()).pathname === '/api/chats/save') {
+                saveRequests++;
+            }
+        });
+        await page.route('**/api/chats/get', route => route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'Chat could not be loaded.' }),
+        }));
+
+        await page.evaluate(async () => {
+            const script = await import('./script.js');
+            const characterId = script.characters.push({
+                name: 'Load Failure Test',
+                avatar: 'load-failure.png',
+                chat: 'load-failure',
+                first_mes: 'This greeting must not be saved.',
+            }) - 1;
+            script.chat.splice(0, script.chat.length);
+            script.setCharacterId(characterId);
+            void script.getChat();
+        });
+
+        const errorDialog = page.getByRole('dialog').filter({
+            has: page.getByRole('heading', { name: 'Chat could not be loaded', exact: true }),
+        });
+        await expect(errorDialog).toBeVisible();
+        await new Promise(resolve => setTimeout(resolve, 200));
+        expect(saveRequests).toBe(0);
+
+        const navigation = page.waitForEvent('framenavigated', frame => frame === page.mainFrame());
+        await errorDialog.locator('.popup-button-ok').click();
+        await navigation;
+        expect(saveRequests).toBe(0);
+    });
+
+    test('does not save a group chat after a failed read', async ({ page }) => {
+        let saveRequests = 0;
+        page.on('request', request => {
+            if (request.method() === 'POST' && new URL(request.url()).pathname === '/api/chats/group/save') {
+                saveRequests++;
+            }
+        });
+        await page.route('**/api/chats/group/get', route => route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'Chat could not be loaded.' }),
+        }));
+
+        await page.evaluate(async () => {
+            const script = await import('./script.js');
+            const groupChats = await import('./scripts/group-chats.js');
+            groupChats.groups.push({
+                id: 'load-failure-group',
+                name: 'Load Failure Group',
+                chat_id: 'load-failure-chat',
+                chats: ['load-failure-chat'],
+                members: [],
+                disabled_members: [],
+            });
+            script.chat.splice(0, script.chat.length);
+            void groupChats.getGroupChat('load-failure-group');
+        });
+
+        const errorDialog = page.getByRole('dialog').filter({
+            has: page.getByRole('heading', { name: 'Group chat could not be loaded', exact: true }),
+        });
+        await expect(errorDialog).toBeVisible();
+        await new Promise(resolve => setTimeout(resolve, 200));
+        expect(saveRequests).toBe(0);
+
+        const navigation = page.waitForEvent('framenavigated', frame => frame === page.mainFrame());
+        await errorDialog.locator('.popup-button-ok').click();
+        await navigation;
+        expect(saveRequests).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

- Return structured `4xx`/`5xx` errors when character or group chats cannot be loaded.
- Preserve HTTP 200 array responses for successful reads, including `[]` for missing or genuinely empty chat files.
- Reject files containing malformed non-empty JSONL records instead of returning partial data.
- Handle failed character and group chat loads as terminal frontend errors, preventing cleared or incomplete state from being saved over existing files.
- Validate chat responses through a shared frontend parser, including non-2xx responses, invalid JSON, and legacy ambiguous `{}` responses.
- Preserve existing best-effort behavior for batch operations while logging individual read failures.

Fixes #5941 

This PR contains 574 changed lines: 498 insertions and 76 deletions. The production implementation accounts for 249 changed lines; the remaining 325 lines are tests.

Splitting the backend and frontend changes into separate PRs would leave an unsafe intermediate state. A backend-only change would return non-200 responses correctly, but the existing frontend could still treat failed reads incorrectly or allow the user to continue from cleared state. Later save requests could then become inconsistent with the chat stored on the server. The server contract and frontend fail-closed behavior therefore need to land together.

Separating the tests from the implementation would also make the data-safety contract harder to review and would allow behavior changes to land without their regression coverage, so the tests are included in the same PR.

## Why

`POST /api/chats/get` previously returned HTTP 200 with `{}` for several error paths, including unexpected internal failures. `getChatData()` also silently discarded malformed JSONL records and could return an empty or partial array for a corrupted file.

The frontend could not distinguish a successful empty chat from a failed read. In the character chat flow, an ambiguous response cleared the in-memory chat and metadata before continuing through the normal empty-chat initialization path. This could generate a new integrity identifier, add the greeting, and save that state over the original file. Chats without an existing integrity identifier were especially vulnerable because the server-side integrity check was skipped.

The new contract distinguishes successful reads from failures:

- A missing chat file or an empty chat remains a successful HTTP 200 response containing `[]`.
- Missing required identifiers and endpoint-owned validation failures return HTTP 400 with `{ "error": "..." }`.
- File read failures and malformed non-empty JSONL records return HTTP 500 with `{ "error": "Chat could not be loaded." }`.
- Detailed file paths and underlying error causes are logged only on the server.

The group chat endpoint follows the same failure contract so both chat types have consistent read behavior.

## Design decisions

- `getChatData()` performs the strict read locally:
    - Only `ENOENT` is treated as a missing chat and converted to `[]`.
    - Other filesystem errors are propagated with their original cause.
    - Blank lines are ignored.
    - A UTF-8 BOM on the first line is accepted.
    - Any malformed non-empty JSONL record rejects the entire read.
- Partial records are not returned after a parse failure. Returning a truncated chat would still allow a later save to overwrite valid records that were not loaded.
- `tryReadFileSync()` was not changed. Although `getChatData()` is its only caller inside the SillyTavern repository, it is an exported generic helper and its contract may be used by plugins or other external code. Changing its error-swallowing behavior could therefore introduce compatibility issues outside the repository.
- Shared avatar-validation middleware was not changed because it is used by other endpoints. Error-response changes are limited to the chat endpoints to avoid expanding the scope of this PR.
- Character chat loading now validates the response before mutating chat state. On failure, it displays an error and ask for reloading the page without invoking the save path.
- Group chat loading uses the same terminal failure behavior. Throwing from `loadGroupChat()` alone would not be sufficient because some selection flows clear existing state before loading completes.
- `renamePastChats()` continues processing other files after an individual failure, but a failed read is never passed to the save path.
- `getChatsFromFiles()` retains its existing best-effort partial aggregation behavior for extension compatibility, while failed items are now logged instead of being silently skipped.
- Existing per-group failure isolation in `renameGroupMember()` is preserved; this PR does not change its batch semantics.

## Testing

- Added server tests covering:
    - Missing and empty chat files.
    - Blank lines and a first-line UTF-8 BOM.
    - Malformed JSONL records, including corruption after valid records.
    - Non-`ENOENT` filesystem failures and preservation of their causes.
    - Character and group endpoint status codes and error bodies.
- Added frontend parser tests covering:
    - Successful array responses.
    - Non-2xx JSON error responses.
    - Non-JSON error responses.
    - Invalid successful payloads, including the previous `{}` response.
- Added browser regression tests covering:
    - Chat load failures.
    - Group chat load failures.
    - Error notification and page reload behavior.
    - Verification that no chat save is issued after the failed load.
- Ran the complete Jest suite successfully: 18 suites and 409 tests passed.
- Ran the targeted Playwright suite successfully: 2 tests passed.
- Ran the root project ESLint checks successfully.
- Ran the test project ESLint checks with no errors.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
