### PR TITLE
fix: close race window that lets duplicate generations start on rapid send

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1712,6 +1712,10 @@ export async function sendTextareaMessage() {
     if (is_send_press) return;
     if (isExecutingCommandsFromChatInput) return;
 
+    // Claim the send lock synchronously (no await above this line) to close the race window where
+    // two rapid triggers (e.g. double Enter) both pass the is_send_press check before Generate() sets it.
+    is_send_press = true;
+
     hideSwipeButtons(); //Swipe buttons must be hidden now, otherwise concurrent generations are possible.
 
     let generateType = 'normal';


### PR DESCRIPTION
## Summary

Fixes #5977.

`sendTextareaMessage()` guards against duplicate sends with the module-level `is_send_press` flag, but the flag was only actually set to `true` deep inside `Generate()`, after five separate `await`s (`unshallowCharacter`, two `eventSource.emit` calls, `processCommands`, `pingServer`). During that window `is_send_press` remained `false`, so a second trigger (most easily reproduced by pressing Enter twice quickly, since the Enter-key hotkey path calls `sendTextareaMessage()` directly and isn't covered by the `SimpleMutex` wrapping the `#send_but` click handler) could pass the same guard check and start a second, concurrent `Generate()` call.

Once two generations run concurrently, each `StreamingProcessor` resolves its target message index via `chat.length - 1` after an `await saveReply(...)`. If the second generation pushes its own message while the first is still awaiting inside `saveReply`, the first generation's streaming loop ends up writing into the second generation's message slot, corrupting/mixing the streamed content.

## Fix

Claim `is_send_press` synchronously in `sendTextareaMessage()`, immediately after the existing guard checks and before any `await`, so the check-and-set is atomic and no second call can slip through the gap.

All of `Generate()`'s existing early-exit paths already call `unblockGeneration()` (or set `is_send_press = false` directly) on failure, so moving the set earlier doesn't leave the flag stuck on any error path.

## Test plan

- [x] `node --check public/script.js`
- [ ] Manually reproduce: rapidly press Enter twice (or Enter immediately followed by clicking Send) with a message typed — confirm only one generation starts and the resulting message is not corrupted.
- [ ] Regression check: normal single send, swipe, regenerate, continue, and impersonate still work as before.