### PR TITLE
fix(macros): ignore leading list separator after nesting

### DIFF
--- a/public/scripts/macros/definitions/core-macros.js
+++ b/public/scripts/macros/definitions/core-macros.js
@@ -409,9 +409,13 @@ export function registerCoreMacros() {
     /** @param {string} listString @return {string[]} */
     function readSingleArgsRandomList(listString) {
         // If it contains double colons, those will have precedence over comma-separated lists.
-        // This can only happen if the macro only had a single colon to introduce the list...
+        // This can happen if the macro only had a single colon to introduce the list...
         // like, {{random:a::b::c}}
         if (listString.includes('::')) {
+            // A leading separator can remain after nested macros resolve their scoped content.
+            if (listString.startsWith('::')) {
+                listString = listString.slice(2);
+            }
             return listString.split('::').map((/** @type {string} */ item) => item.trim());
         }
         // Otherwise, we fall back and split by commas that may be present

--- a/tests/frontend/MacroEngine.e2e.js
+++ b/tests/frontend/MacroEngine.e2e.js
@@ -745,6 +745,18 @@ test.describe('MacroEngine', () => {
             expect(options.includes(second)).toBeTruthy();
         });
 
+        test('should not treat a leading separator from resolved scoped arguments as a choice', async ({ page }) => {
+            await page.evaluate(async () => {
+                const { chat_metadata } = await import('./script.js');
+                chat_metadata.chat_id_hash = 1;
+            });
+
+            const input = '{{pick\n{{if 1}}::a{{/if}}\n{{if 1}}::b{{/if}}\n}}';
+            const output = await evaluateWithEngine(page, input);
+
+            expect(['a', 'b']).toContain(output);
+        });
+
         test('should use different seeds for identical picks at different positions', async ({ page }) => {
             await registerTestablePick(page);
 


### PR DESCRIPTION
Fixes #5976

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Summary

- remove the leading Macro 2.0 list separator that can remain after nested scoped arguments resolve
- preserve the existing `::` splitting behavior for the actual choices
- add a deterministic MacroEngine regression test for nested `{{if}}` arguments inside `{{pick}}`

## How to test

- `ST_BASE_URL=http://127.0.0.1:8011 playwright test frontend/MacroEngine.e2e.js -g "leading separator"`
- `ST_BASE_URL=http://127.0.0.1:8011 playwright test frontend/MacroEngine.e2e.js` (329 passed)
- ESLint on both changed files
