### PR TITLE
fix(chat): snapshot previous chat before confirmed overwrite

### DIFF
--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -531,6 +531,21 @@ export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false
     if (chatIntegritySlug && !await checkChatIntegrity(filePath, chatIntegritySlug)) {
         throw new IntegrityMismatchError(`Chat integrity check failed for "${filePath}". The expected integrity slug was "${chatIntegritySlug}".`);
     }
+
+    // A confirmed overwrite (skipIntegrityCheck === true) replaces the existing chat file,
+    // which would permanently destroy the previous content. Before the file is overwritten,
+    // snapshot its current bytes so the user can always restore the pre-overwrite state.
+    // This must run synchronously (bypassing the throttled backup function) to guarantee the
+    // snapshot is on disk before the overwrite below. The dedicated prefix keeps these
+    // snapshots separate from regular backups while still being listable and restorable
+    // through the backup browser (they start with the CHAT_BACKUPS_PREFIX guard).
+    if (skipIntegrityCheck) {
+        const previousContent = tryReadFileSync(filePath);
+        if (previousContent) {
+            backupChat(backupDirectory, cardName, previousContent, 'chat_pre_overwrite_');
+        }
+    }
+
     tryWriteFileSync(filePath, jsonlData);
     getBackupFunction(handle, cardName)(backupDirectory, cardName, jsonlData);
 }


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->
## Checklist:
- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## What this does

Implements #5929: before a confirmed/forced chat overwrite, snapshot the current chat file into the backups directory, so a user who confirms the OVERWRITE dialog can still recover the previous version.

## Why

`trySaveChat()` writes the new chat data with `tryWriteFileSync()` and only then backs up the freshly serialized data. When a save is forced after a failed integrity check (the OVERWRITE confirmation flow from #5928), the bytes that were on disk before the overwrite never make it into any backup — a user who confirms in a hurry, or misjudges which chat is which, permanently loses the previous file with no way back.

## Changes

In `src/endpoints/chats.js` `trySaveChat()`: when `skipIntegrityCheck` is true (the forced/confirmed overwrite path) and the target chat file exists and is non-empty, snapshot the existing file content via `backupChat()` with a dedicated `chat_pre_overwrite_` prefix **before** the overwrite takes place. The snapshot is written synchronously (direct call, bypassing the throttled backup function) so it is guaranteed to be on disk before the file is replaced.

## Notes

- Scoped to the risky path only: saves that pass the integrity check cleanly are unchanged and produce no extra backup.
- The `chat_pre_overwrite_` prefix starts with the existing `chat_` backup prefix, so the snapshot is listed and restorable through the regular backup browser with no changes to the backups API or UI.
- A failed snapshot never blocks the save (existing `backupChat` error handling is preserved).
