### PR TITLE
fix(chat): release the save lock if saveChat() never settles

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9409,6 +9409,13 @@ export async function saveMetadata() {
     return await saveChatConditional();
 }
 
+/**
+ * Hard ceiling on how long saveChatConditional() will hold the save lock, in ms.
+ * Guards against an await inside saveChat() that never settles.
+ * @type {number}
+ */
+const SAVE_CHAT_HARD_TIMEOUT = 60000;
+
 export async function saveChatConditional() {
     try {
         await waitUntilCondition(() => !isChatSaving, DEFAULT_SAVE_EDIT_TIMEOUT, 100);
@@ -9422,10 +9429,21 @@ export async function saveChatConditional() {
 
         isChatSaving = true;
 
-        if (selected_group) {
-            await saveGroupChat(selected_group, true);
-        } else {
-            await saveChat();
+        // saveChat() can await a promise that never settles - notably the chat
+        // integrity Popup.show.input(), which waits on user input with no timeout.
+        // If that never resolves, the finally block below never runs, isChatSaving
+        // stays true for the life of the page, and every subsequent call bails out
+        // at the guard above and silently returns without saving. Race it so the
+        // lock is always released.
+        const savePromise = selected_group ? saveGroupChat(selected_group, true) : saveChat();
+        let saveTimer;
+        const saveTimeout = new Promise((_, reject) => {
+            saveTimer = setTimeout(() => reject(new Error('saveChat did not settle within the timeout; releasing the save lock')), SAVE_CHAT_HARD_TIMEOUT);
+        });
+        try {
+            await Promise.race([savePromise, saveTimeout]);
+        } finally {
+            clearTimeout(saveTimer);
         }
 
         // Save token and prompts cache to IndexedDB storage


### PR DESCRIPTION
### Problem

`saveChatConditional()` guards saving with a module-scoped `isChatSaving` flag: it waits for the flag to clear, sets it, awaits `saveChat()`, and clears it in a `finally`.

`saveChat()` can await a promise that **never settles**. The clearest case is the chat integrity failure path, which calls `Popup.show.input()` and waits on user input with no timeout:

```js
const popupResult = await Popup.show.input(
    t`ERROR: Chat integrity check failed while saving the file.`, ...
);
```

If that popup is never answered — dismissed, missed, or covered by a high `z-index` overlay — the promise never resolves. The `finally` never runs, `isChatSaving` stays `true` for the life of the page, and **every subsequent save bails out at the guard and returns without saving**:

```js
try {
    await waitUntilCondition(() => !isChatSaving, DEFAULT_SAVE_EDIT_TIMEOUT, 100);
} catch {
    console.warn('Timeout waiting for chat to save');
    return;   // silently does not save
}
```

The only symptom is a `console.warn`. Generation keeps working, messages keep appearing in the UI, and nothing reaches disk. The user finds out on reload, by which point everything since the hang is gone.

### Evidence

I wrapped `window.fetch` to log every call to `/api/chats/save`. During a failure:

```
{"t":"…T12:39:34.933Z","ok":true,"status":200,"ms":566}
{"t":"…T12:39:39.052Z","ok":true,"status":200,"ms":621}
{"t":"…T12:44:55.851Z","ok":true,"status":200,"ms":584}
{"t":"…T12:45:02.605Z","ok":true,"status":200,"ms":643}
        ← log ends here. "Timeout waiting for chat to save" then repeats
          indefinitely, with no further fetch attempts at all.
```

Saves were healthy (~600 ms, HTTP 200) right up to the hang; afterwards the endpoint is never called again, because the guard returns first. Server side: no errors, plenty of disk, container healthy, chat file mtime frozen at the last successful save.

I also saw a torn line in the `.jsonl` once (two concatenated JSON objects on one line) from a write interrupted around the same time.

### Fix

Race the save against a hard timeout so the lock is always released:

```js
const savePromise = selected_group ? saveGroupChat(selected_group, true) : saveChat();
let saveTimer;
const saveTimeout = new Promise((_, reject) => {
    saveTimer = setTimeout(() => reject(new Error('saveChat did not settle within the timeout; releasing the save lock')), SAVE_CHAT_HARD_TIMEOUT);
});
try {
    await Promise.race([savePromise, saveTimeout]);
} finally {
    clearTimeout(saveTimer);
}
```

Worst case is one `console.error` after 60s instead of silent data loss for the rest of the session. Verified against a simulated never-settling `saveChat()`: the lock releases and subsequent saves succeed. Without the patch, all subsequent saves silently no-op.

### Possibly worth considering separately

- `saveChatConditional()` swallowing the failure as a `console.warn` is what makes this invisible. A toast would surface it immediately.
- `Popup.show.input()` inside `saveChat()` is unbounded; treating dismissal as an explicit cancel would make the promise always settle.
- `DEFAULT_SAVE_EDIT_TIMEOUT` is 1000 ms (`debounce_timeout.relaxed`). Large chats (~11 MB in my case) sit close to that on slower hosts, so genuine contention can also produce spurious "Timeout waiting for chat to save".
