### PR TITLE
feat: Adding OAI_PRESET_SAVED event

### DIFF
--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -38,6 +38,7 @@ export const event_types = {
     OAI_PRESET_CHANGED_AFTER: 'oai_preset_changed_after',
     OAI_PRESET_EXPORT_READY: 'oai_preset_export_ready',
     OAI_PRESET_IMPORT_READY: 'oai_preset_import_ready',
+    OAI_PRESET_SAVED: 'oai_preset_saved',
     WORLDINFO_SETTINGS_UPDATED: 'worldinfo_settings_updated',
     WORLDINFO_UPDATED: 'worldinfo_updated',
     CHARACTER_EDITOR_OPENED: 'character_editor_opened',

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4598,6 +4598,7 @@ async function saveOpenAIPreset(name, settings, triggerUi = true) {
             option.innerText = data.name;
             if (triggerUi) $('#settings_preset_openai').append(option).trigger('change');
         }
+        eventSource.emit(event_types.OAI_PRESET_SAVED, { data: presetBody, presetName: data.name });
     } else {
         toastr.error(t`Failed to save preset`);
         throw new Error('Failed to save preset');


### PR DESCRIPTION
#### Description
This simply adds a new event that is emitted after a chat completion preset is saved: `OAI_PRESET_SAVED` .

#### Motivation
This is mainly for extensions to perform actions when a CC preset is saved. The existing events `OAI_PRESET_CHANGED_BEFORE` and `OAI_PRESET_CHANGED_AFTER` are only emitted when switching presets, not when a preset is saved. This is in contrast to TC which emits the `PRESET_CHANGED` event in both cases.

I thought about instead just having the `OAI_PRESET_CHANGED_BEFORE` and `OAI_PRESET_CHANGED_AFTER` events emit when saving a preset to be more in line with `PRESET_CHANGED`, but I felt that might be unexpected if extensions currently use those hooks. Though let me know if you feel that option is more appropriate.

#### Testing
This can be verified by clicking the "save" button in a CC preset and observing the event emitted.

#### Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
