### PR TITLE
Update TavernAI link to version 1

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -75,7 +75,7 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU Affero General Public License for more details.**
 
-* [TavernAI](https://github.com/TavernAI/TavernAI) 1.2.8 by Humi: MIT License
+* [TavernAI](https://github.com/TavernAI/TavernAI-v1) 1.2.8 by Humi: MIT License
 * Portions of CncAnon's TavernAITurbo mod used with permission
 * Visual Novel Mode inspired by the work of PepperTaco (<https://github.com/peppertaco/Tavern/>)
 * Noto Sans font by Google (OFL license)


### PR DESCRIPTION
Update TavernAI link to version 1

<!-- Put X in the box below to confirm -->

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

TavernAI swapped the repos. so the url is now invalid (directs to version 2) i pushed a PR to correct this behavior. 
