### PR TITLE
Add X-AIMLAPI-Source attribution header to the aimlapi chat-completion source

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -367,6 +367,7 @@ export const OPENROUTER_HEADERS = {
 export const AIMLAPI_HEADERS = {
     'HTTP-Referer': 'https://sillytavern.app',
     'X-Title': 'SillyTavern',
+    'X-AIMLAPI-Source': 'agent/sillytavern',
 };
 
 export const FEATHERLESS_HEADERS = {


### PR DESCRIPTION
### What is the reason for this change?

The `AIMLAPI_HEADERS` constant (`src/constants.js`) was a leftover copy of
`OPENROUTER_HEADERS` — it only carried `HTTP-Referer` and `X-Title`. Every
request sent through the `aimlapi` chat-completion source (both chat
endpoints, model listing, and image generation all read from this one
constant) was missing the header AIMLAPI uses to identify traffic coming
from a specific integration.

### What did you do to achieve this?

Added `X-AIMLAPI-Source: agent/sillytavern` to `AIMLAPI_HEADERS`, alongside
the existing `HTTP-Referer`/`X-Title` pair. One constant, one place, all
four call sites pick it up automatically.

### How would a reviewer test this?

Set the chat completion source to AI/ML API with a valid key and send a
message; inspect the outgoing request to `api.aimlapi.com` and confirm the
`X-AIMLAPI-Source` header is present (e.g. via a proxy/devtools, or a quick
`console.log` of the headers object locally).
