### PR TITLE
feat: add NovelAI Diffusion V5 models

### DIFF
--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -4021,7 +4021,7 @@ function getNovelParams() {
     }
 
     if (extension_settings.sd.sampler === 'ddim' ||
-        ['nai-diffusion-4-curated-preview', 'nai-diffusion-4-full'].includes(extension_settings.sd.model)) {
+        ['nai-diffusion-4-curated-preview', 'nai-diffusion-4-full', 'nai-diffusion-5-full', 'nai-diffusion-5-curated'].includes(extension_settings.sd.model)) {
         sm = false;
         sm_dyn = false;
     }

--- a/public/scripts/extensions/stable-diffusion/index.js
+++ b/public/scripts/extensions/stable-diffusion/index.js
@@ -2457,6 +2457,14 @@ async function loadVladModels() {
 async function loadNovelModels() {
     return [
         {
+            value: 'nai-diffusion-5-full',
+            text: 'NAI Diffusion V5 (Full)',
+        },
+        {
+            value: 'nai-diffusion-5-curated',
+            text: 'NAI Diffusion V5 (Curated)',
+        },
+        {
             value: 'nai-diffusion-4-5-full',
             text: 'NAI Diffusion Anime V4.5 (Full)',
         },

--- a/src/endpoints/novelai.js
+++ b/src/endpoints/novelai.js
@@ -118,6 +118,11 @@ function getRepPenaltyWhitelist(model) {
 }
 
 function calculateSkipCfgAboveSigma(width, height, modelName) {
+    // Variety+ is not supported by V5 models
+    if (modelName?.startsWith('nai-diffusion-5')) {
+        return null;
+    }
+
     const magicConstant = modelName?.includes('nai-diffusion-4-5')
         ? SIGMA_MAGIC_NUMBER_V4_5
         : SIGMA_MAGIC_NUMBER;
@@ -323,7 +328,7 @@ router.post('/generate-image', async (request, response) => {
                 input: request.body.prompt ?? '',
                 model: request.body.model ?? 'nai-diffusion',
                 parameters: {
-                    params_version: 3,
+                    params_version: request.body.model?.startsWith('nai-diffusion-5') ? 4 : 3,
                     prefer_brownian: true,
                     negative_prompt: request.body.negative_prompt ?? '',
                     height: request.body.height ?? 512,

--- a/src/endpoints/novelai.js
+++ b/src/endpoints/novelai.js
@@ -316,6 +316,10 @@ router.post('/generate-image', async (request, response) => {
 
     try {
         console.debug('NAI Diffusion request:', request.body);
+
+        // V5 capability table (official web client): SMEA/SMEA DYN, Decrisper
+        // and non-karras noise schedules are disabled — force supported values.
+        const isV5Model = request.body.model?.startsWith('nai-diffusion-5');
         const generateUrl = `${IMAGE_NOVELAI}/ai/generate-image`;
         const generateResult = await fetch(generateUrl, {
             method: 'POST',
@@ -328,7 +332,7 @@ router.post('/generate-image', async (request, response) => {
                 input: request.body.prompt ?? '',
                 model: request.body.model ?? 'nai-diffusion',
                 parameters: {
-                    params_version: request.body.model?.startsWith('nai-diffusion-5') ? 4 : 3,
+                    params_version: isV5Model ? 4 : 3,
                     prefer_brownian: true,
                     negative_prompt: request.body.negative_prompt ?? '',
                     height: request.body.height ?? 512,
@@ -336,7 +340,7 @@ router.post('/generate-image', async (request, response) => {
                     scale: request.body.scale ?? 9,
                     seed: request.body.seed >= 0 ? request.body.seed : Math.floor(Math.random() * 9999999999),
                     sampler: request.body.sampler ?? 'k_dpmpp_2m',
-                    noise_schedule: request.body.scheduler ?? 'karras',
+                    noise_schedule: isV5Model ? 'karras' : (request.body.scheduler ?? 'karras'),
                     steps: request.body.steps ?? 28,
                     n_samples: 1,
                     // NAI handholding for prompts
@@ -345,11 +349,11 @@ router.post('/generate-image', async (request, response) => {
                     add_original_image: false,
                     controlnet_strength: 1,
                     deliberate_euler_ancestral_bug: false,
-                    dynamic_thresholding: request.body.decrisper ?? false,
+                    dynamic_thresholding: isV5Model ? false : (request.body.decrisper ?? false),
                     legacy: false,
                     legacy_v3_extend: false,
-                    sm: request.body.sm ?? false,
-                    sm_dyn: request.body.sm_dyn ?? false,
+                    sm: isV5Model ? false : (request.body.sm ?? false),
+                    sm_dyn: isV5Model ? false : (request.body.sm_dyn ?? false),
                     uncond_scale: 1,
                     skip_cfg_above_sigma: request.body.variety_boost
                         ? calculateSkipCfgAboveSigma(

--- a/tests/novelai.test.js
+++ b/tests/novelai.test.js
@@ -1,0 +1,172 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const fetchMock = jest.fn();
+jest.unstable_mockModule('node-fetch', () => ({ default: fetchMock }));
+jest.unstable_mockModule('../src/endpoints/secrets.js', () => ({
+    readSecret: jest.fn().mockReturnValue('test-token'),
+    SECRET_KEYS: { NOVEL: 'api_key_novel' },
+}));
+
+/** CRC-32 (IEEE 802.3) over a buffer. */
+function crc32(buffer) {
+    let crc = 0xFFFFFFFF;
+    for (const byte of buffer) {
+        crc ^= byte;
+        for (let i = 0; i < 8; i++) {
+            crc = (crc >>> 1) ^ (0xEDB88320 & -(crc & 1));
+        }
+    }
+    return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+/** Builds a minimal ZIP archive with a single STORE-method entry. */
+function buildZip(entryName, data) {
+    const name = Buffer.from(entryName, 'utf8');
+    const crc = crc32(data);
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(data.length, 18);
+    localHeader.writeUInt32LE(data.length, 22);
+    localHeader.writeUInt16LE(name.length, 26);
+    const centralDirectory = Buffer.alloc(46);
+    centralDirectory.writeUInt32LE(0x02014b50, 0);
+    centralDirectory.writeUInt16LE(20, 4);
+    centralDirectory.writeUInt16LE(20, 6);
+    centralDirectory.writeUInt32LE(crc, 16);
+    centralDirectory.writeUInt32LE(data.length, 20);
+    centralDirectory.writeUInt32LE(data.length, 24);
+    centralDirectory.writeUInt16LE(name.length, 28);
+    centralDirectory.writeUInt32LE(0, 42);
+    const endOfCentralDirectory = Buffer.alloc(22);
+    endOfCentralDirectory.writeUInt32LE(0x06054b50, 0);
+    endOfCentralDirectory.writeUInt16LE(1, 8);
+    endOfCentralDirectory.writeUInt16LE(1, 10);
+    endOfCentralDirectory.writeUInt32LE(centralDirectory.length + name.length, 12);
+    endOfCentralDirectory.writeUInt32LE(30 + name.length + data.length, 16);
+    return Buffer.concat([localHeader, name, data, centralDirectory, name, endOfCentralDirectory]);
+}
+
+describe('NovelAI image generation', () => {
+    /** @type {import('node:http').Server} */
+    let server;
+    let baseUrl;
+
+    beforeAll(async () => {
+        const { default: express } = await import('express');
+        const { router } = await import('../src/endpoints/novelai.js');
+        const app = express();
+        app.use(express.json());
+        app.use((req, _res, next) => {
+            req.user = { directories: {} };
+            next();
+        });
+        app.use(router);
+        server = app.listen(0, '127.0.0.1');
+        await new Promise(resolve => server.once('listening', resolve));
+        const address = server.address();
+        baseUrl = `http://127.0.0.1:${address.port}`;
+    });
+
+    afterAll(async () => {
+        await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    });
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+    });
+
+    function mockZipResponse() {
+        const png = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3]);
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            arrayBuffer: async () => Uint8Array.from(buildZip('image_0.png', png)).buffer,
+        });
+        return png;
+    }
+
+    function requestParameters() {
+        const [, options] = fetchMock.mock.calls[0];
+        return JSON.parse(options.body).parameters;
+    }
+
+    test('V5 models use params_version 4 and omit skip_cfg_above_sigma (Variety+ unsupported)', async () => {
+        for (const model of ['nai-diffusion-5-full', 'nai-diffusion-5-curated']) {
+            fetchMock.mockReset();
+            const png = mockZipResponse();
+
+            const response = await fetch(`${baseUrl}/generate-image`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    prompt: '1girl',
+                    model: model,
+                    width: 832,
+                    height: 1216,
+                    steps: 28,
+                    scale: 6,
+                    variety_boost: true,
+                    seed: 1234,
+                    upscale_ratio: 1,
+                }),
+            });
+
+            expect(response.status).toBe(200);
+            expect(await response.text()).toBe(png.toString('base64'));
+
+            const [url, options] = fetchMock.mock.calls[0];
+            expect(url).toBe('https://image.novelai.net/ai/generate-image');
+            expect(options.headers.Authorization).toBe('Bearer test-token');
+            const parameters = requestParameters();
+            expect(parameters.params_version).toBe(4);
+            expect(parameters.skip_cfg_above_sigma).toBeNull();
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        }
+    });
+
+    test('V4.5 keeps params_version 3 and applies the scaled Variety+ sigma', async () => {
+        mockZipResponse();
+
+        await fetch(`${baseUrl}/generate-image`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                prompt: '1girl',
+                model: 'nai-diffusion-4-5-full',
+                width: 832,
+                height: 1216,
+                variety_boost: true,
+                seed: 1234,
+                upscale_ratio: 1,
+            }),
+        });
+
+        const parameters = requestParameters();
+        expect(parameters.params_version).toBe(3);
+        // 832*1216 is the reference pixel count, so the multiplier applies unscaled
+        expect(parameters.skip_cfg_above_sigma).toBeCloseTo(58, 5);
+    });
+
+    test('V3 keeps params_version 3 and the base Variety+ sigma', async () => {
+        mockZipResponse();
+
+        await fetch(`${baseUrl}/generate-image`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                prompt: '1girl',
+                model: 'nai-diffusion-3',
+                width: 832,
+                height: 1216,
+                variety_boost: true,
+                seed: 1234,
+                upscale_ratio: 1,
+            }),
+        });
+
+        const parameters = requestParameters();
+        expect(parameters.params_version).toBe(3);
+        expect(parameters.skip_cfg_above_sigma).toBeCloseTo(19, 5);
+    });
+});

--- a/tests/novelai.test.js
+++ b/tests/novelai.test.js
@@ -148,6 +148,60 @@ describe('NovelAI image generation', () => {
         expect(parameters.skip_cfg_above_sigma).toBeCloseTo(58, 5);
     });
 
+    test('V5 forces karras and disables SMEA and Decrisper regardless of client settings', async () => {
+        mockZipResponse();
+
+        await fetch(`${baseUrl}/generate-image`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                prompt: '1girl',
+                model: 'nai-diffusion-5-full',
+                width: 832,
+                height: 1216,
+                scheduler: 'exponential',
+                sm: true,
+                sm_dyn: true,
+                decrisper: true,
+                seed: 1234,
+                upscale_ratio: 1,
+            }),
+        });
+
+        const parameters = requestParameters();
+        expect(parameters.noise_schedule).toBe('karras');
+        expect(parameters.sm).toBe(false);
+        expect(parameters.sm_dyn).toBe(false);
+        expect(parameters.dynamic_thresholding).toBe(false);
+    });
+
+    test('V4.5 passes through scheduler, SMEA and Decrisper settings', async () => {
+        mockZipResponse();
+
+        await fetch(`${baseUrl}/generate-image`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                prompt: '1girl',
+                model: 'nai-diffusion-4-5-full',
+                width: 832,
+                height: 1216,
+                scheduler: 'exponential',
+                sm: true,
+                sm_dyn: true,
+                decrisper: true,
+                seed: 1234,
+                upscale_ratio: 1,
+            }),
+        });
+
+        const parameters = requestParameters();
+        expect(parameters.noise_schedule).toBe('exponential');
+        expect(parameters.sm).toBe(true);
+        expect(parameters.sm_dyn).toBe(true);
+        expect(parameters.dynamic_thresholding).toBe(true);
+    });
+
     test('V3 keeps params_version 3 and the base Variety+ sigma', async () => {
         mockZipResponse();
 


### PR DESCRIPTION
## Summary

Adds support for the NovelAI Diffusion V5 models (`nai-diffusion-5-full` / `nai-diffusion-5-curated`, released 2026-08-21) to the NovelAI image generation source.

## Changes

**Frontend (`public/scripts/extensions/stable-diffusion/index.js`)**
- Add both V5 models to the NovelAI model dropdown
- Add the V5 ids to the SMEA-disable list in `getNovelParams()` (`sm`/`sm_dyn` are not supported by V4+ capability and `sm: true` returns HTTP 500)

**Server (`src/endpoints/novelai.js`)**
- `params_version: 4` for V5 (the value NovelAI's own web client sends; 3 is still accepted by the API)
- Gate V5 request params to NovelAI's official capability table:
  - force `noise_schedule: 'karras'` (V5 has no noise-schedule picker)
  - force `sm`/`sm_dyn: false` and `dynamic_thresholding: false` (SMEA / SMEA DYN / Decrisper unsupported)
  - omit `skip_cfg_above_sigma` (Variety+ is not supported by V5 models)
- V4.5 / V3 request bodies are unchanged (covered by regression tests)

## Verification

Model ids, `params_version`, and the capability gating were cross-checked against NovelAI's web frontend bundle and live API smoke tests, and match independent third-party integrations updated after the V5 launch (e.g. ComfyUI NAI API request node, NAIWeaver).

- `tests/novelai.test.js`: 5 unit tests covering params_version routing, Variety+ sigma handling for V4.5/V3, V5 parameter gating, and V4.5 passthrough (no regression)
- All tests pass via `npm run test:unit --prefix tests`

## Note on size

~250 changed lines total, of which 226 are the new test file — the production diff is ~30 lines across two files.