### PR TITLE
Google AI Studio: Classify models for dynamic model selection

### DIFF
--- a/public/scripts/google-model.js
+++ b/public/scripts/google-model.js
@@ -1,0 +1,190 @@
+export const GoogleModelFamily = Object.freeze({
+    GEMINI: 'Gemini',
+    GEMMA: 'Gemma',
+    OTHER: 'Other',
+});
+
+export const GoogleModelTier = Object.freeze({
+    PRO: 'pro',
+    FLASH: 'flash',
+    FLASH_LITE: 'flash-lite',
+});
+
+export const GoogleModelBranch = Object.freeze({
+    STABLE: 'stable',
+    PREVIEW: 'preview',
+    EXPERIMENTAL: 'exp',
+    UNKNOWN: 'unknown',
+});
+
+export const GoogleModelPurpose = Object.freeze({
+    TEXT_GENERATION: 'TextGeneration',
+    IMAGE_GENERATION: 'ImageGeneration',
+    OTHER: 'Other',
+});
+
+const GEMINI_VERSION_PATTERN = /^gemini-(\d+)(?:\.(\d+))?(?:-|$)/;
+const IMAGE_MODEL_PATTERN = /(?:^|-)image(?:-|$)/;
+const SPECIALIZED_MODEL_PATTERN = /(?:^|-)(?:tts|transcribe|robotics|embedding|veo|lyria|omni|live|computer-use)(?:-|$)/;
+
+/**
+ * Tests whether a model ID contains a complete hyphen-delimited token.
+ *
+ * @param {string} modelId Lowercase model ID
+ * @param {string} token Token to find
+ * @returns {boolean} Whether the token is present
+ */
+function hasToken(modelId, token) {
+    return modelId === token || modelId.startsWith(`${token}-`) || modelId.endsWith(`-${token}`) || modelId.includes(`-${token}-`);
+}
+
+/**
+ * Identifies the model family and the normalized Gemini version.
+ *
+ * @param {string} modelId Lowercase model ID
+ * @returns {{ family: string, version: string | null }} Family classification and version
+ */
+function classifyFamily(modelId) {
+    const versionMatch = modelId.match(GEMINI_VERSION_PATTERN);
+    if (versionMatch) {
+        return {
+            family: GoogleModelFamily.GEMINI,
+            version: `${versionMatch[1]}.${versionMatch[2] ?? '0'}`,
+        };
+    }
+
+    if (modelId === 'gemma' || modelId.startsWith('gemma-')) {
+        return { family: GoogleModelFamily.GEMMA, version: null };
+    }
+
+    return { family: GoogleModelFamily.OTHER, version: null };
+}
+
+/**
+ * Identifies a performance tier from complete model ID tokens.
+ *
+ * @param {string} modelId Lowercase model ID
+ * @returns {string | null} Recognized tier or null
+ */
+function classifyTier(modelId) {
+    if (hasToken(modelId, GoogleModelTier.FLASH_LITE)) {
+        return GoogleModelTier.FLASH_LITE;
+    }
+    if (hasToken(modelId, GoogleModelTier.FLASH)) {
+        return GoogleModelTier.FLASH;
+    }
+    if (hasToken(modelId, GoogleModelTier.PRO)) {
+        return GoogleModelTier.PRO;
+    }
+
+    return null;
+}
+
+/**
+ * Identifies a release branch from complete model ID tokens.
+ *
+ * @param {string} modelId Lowercase model ID
+ * @returns {string} Recognized release branch
+ */
+function classifyBranch(modelId) {
+    const hasPreview = hasToken(modelId, GoogleModelBranch.PREVIEW);
+    const hasExperimental = hasToken(modelId, GoogleModelBranch.EXPERIMENTAL) || hasToken(modelId, 'experimental');
+    const hasLatest = hasToken(modelId, 'latest');
+    const markerCount = Number(hasPreview) + Number(hasExperimental) + Number(hasLatest);
+
+    if (markerCount > 1 || hasLatest) {
+        return GoogleModelBranch.UNKNOWN;
+    }
+    if (hasPreview) {
+        return GoogleModelBranch.PREVIEW;
+    }
+    if (hasExperimental) {
+        return GoogleModelBranch.EXPERIMENTAL;
+    }
+
+    return GoogleModelBranch.STABLE;
+}
+
+/**
+ * Identifies the primary model purpose using conservative model ID rules.
+ *
+ * @param {string} modelId Lowercase model ID
+ * @param {string} family Model family
+ * @returns {string} Recognized primary purpose
+ */
+function classifyPurpose(modelId, family) {
+    if (IMAGE_MODEL_PATTERN.test(modelId) || modelId.startsWith('imagen-') || modelId.startsWith('nano-banana-')) {
+        return GoogleModelPurpose.IMAGE_GENERATION;
+    }
+    if (SPECIALIZED_MODEL_PATTERN.test(modelId)) {
+        return GoogleModelPurpose.OTHER;
+    }
+    if (family === GoogleModelFamily.GEMINI || family === GoogleModelFamily.GEMMA) {
+        return GoogleModelPurpose.TEXT_GENERATION;
+    }
+    if (modelId.startsWith('gemini-') && hasToken(modelId, 'latest')) {
+        return GoogleModelPurpose.TEXT_GENERATION;
+    }
+
+    return GoogleModelPurpose.OTHER;
+}
+
+/**
+ * @typedef {object} ClassifiedGoogleModel
+ * @property {string} id Original model ID
+ * @property {string} family Gemini, Gemma, or Other
+ * @property {string | null} version Normalized Gemini version, or null for other families
+ * @property {string | null} tier Pro, Flash, Flash-Lite, or null when no tier is recognized
+ * @property {string} branch Stable, preview, experimental, or unknown release branch
+ * @property {string} purpose Text generation, image generation, or another specialized purpose
+ * @property {object} rawModel Original model object returned by the status endpoint
+ */
+
+/**
+ * Classifies Google AI Studio models returned in the `data` array of the
+ * chat-completions status response. Gemini IDs with a numeric version directly
+ * after the `gemini-` prefix are assigned to a normalized Gemini X.Y family;
+ * Gemma IDs are assigned to Gemma; all remaining IDs are assigned to Other.
+ * Complete ID tokens identify Pro, Flash, and Flash-Lite tiers and stable,
+ * preview, experimental, or unknown release branches. Purpose detection gives
+ * image-capable ID patterns precedence, treats known audio, transcription,
+ * robotics, embedding, video, live, and computer-use patterns as specialized
+ * models, and otherwise recognizes versioned Gemini, Gemini latest aliases,
+ * and Gemma as general text-generation models. Unrecognized purposes remain
+ * Other.
+ *
+ * The function rejects malformed input instead of omitting it, does not mutate
+ * the supplied array or its entries, and keeps each original entry available as
+ * `rawModel` for callers that need metadata not represented by the classifier.
+ *
+ * @param {object[]} models Raw models from the Google AI Studio status response
+ * @returns {ClassifiedGoogleModel[]} A new array of structured model records
+ * @throws {TypeError} When the input or a model ID is malformed
+ */
+export function classifyGoogleModels(models) {
+    if (!Array.isArray(models)) {
+        throw new TypeError('Expected Google models to be an array');
+    }
+
+    return models.map((rawModel, index) => {
+        if (rawModel === null || typeof rawModel !== 'object' || Array.isArray(rawModel)) {
+            throw new TypeError(`Google model at index ${index} must be an object`);
+        }
+        if (typeof rawModel.id !== 'string' || rawModel.id.trim().length === 0) {
+            throw new TypeError(`Google model at index ${index} must have a non-empty string id`);
+        }
+
+        const normalizedId = rawModel.id.toLowerCase();
+        const { family, version } = classifyFamily(normalizedId);
+
+        return {
+            id: rawModel.id,
+            family,
+            version,
+            tier: classifyTier(normalizedId),
+            branch: classifyBranch(normalizedId),
+            purpose: classifyPurpose(normalizedId, family),
+            rawModel,
+        };
+    });
+}

--- a/tests/google-model-catalog.test.js
+++ b/tests/google-model-catalog.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+    classifyGoogleModels,
+    GoogleModelBranch,
+    GoogleModelFamily,
+    GoogleModelPurpose,
+    GoogleModelTier,
+} from '../public/scripts/google-model.js';
+
+const F = GoogleModelFamily;
+const T = GoogleModelTier;
+const B = GoogleModelBranch;
+const P = GoogleModelPurpose;
+
+// Columns: id, family, version, tier, branch, purpose.
+const EXPECTED_MODELS = [
+    ['gemini-2.5-flash', F.GEMINI, '2.5', T.FLASH, B.STABLE, P.TEXT_GENERATION],
+    ['gemini-2.5-pro', F.GEMINI, '2.5', T.PRO, B.STABLE, P.TEXT_GENERATION],
+    ['gemini-2.5-flash-preview-tts', F.GEMINI, '2.5', T.FLASH, B.PREVIEW, P.OTHER],
+    ['gemini-2.5-pro-preview-tts', F.GEMINI, '2.5', T.PRO, B.PREVIEW, P.OTHER],
+    ['gemma-4-26b-a4b-it', F.GEMMA, null, null, B.STABLE, P.TEXT_GENERATION],
+    ['gemma-4-31b-it', F.GEMMA, null, null, B.STABLE, P.TEXT_GENERATION],
+    ['gemini-flash-latest', F.OTHER, null, T.FLASH, B.UNKNOWN, P.TEXT_GENERATION],
+    ['gemini-flash-lite-latest', F.OTHER, null, T.FLASH_LITE, B.UNKNOWN, P.TEXT_GENERATION],
+    ['gemini-pro-latest', F.OTHER, null, T.PRO, B.UNKNOWN, P.TEXT_GENERATION],
+    ['gemini-2.5-flash-lite', F.GEMINI, '2.5', T.FLASH_LITE, B.STABLE, P.TEXT_GENERATION],
+    ['gemini-2.5-flash-image', F.GEMINI, '2.5', T.FLASH, B.STABLE, P.IMAGE_GENERATION],
+    ['gemini-3-flash-preview', F.GEMINI, '3.0', T.FLASH, B.PREVIEW, P.TEXT_GENERATION],
+    ['gemini-3.1-pro-preview', F.GEMINI, '3.1', T.PRO, B.PREVIEW, P.TEXT_GENERATION],
+    ['gemini-3.1-pro-preview-customtools', F.GEMINI, '3.1', T.PRO, B.PREVIEW, P.TEXT_GENERATION],
+    ['gemini-3.1-flash-lite-preview', F.GEMINI, '3.1', T.FLASH_LITE, B.PREVIEW, P.TEXT_GENERATION],
+    ['gemini-3.1-flash-lite', F.GEMINI, '3.1', T.FLASH_LITE, B.STABLE, P.TEXT_GENERATION],
+    ['gemini-3-pro-image-preview', F.GEMINI, '3.0', T.PRO, B.PREVIEW, P.IMAGE_GENERATION],
+    ['gemini-3-pro-image', F.GEMINI, '3.0', T.PRO, B.STABLE, P.IMAGE_GENERATION],
+    ['nano-banana-pro-preview', F.OTHER, null, T.PRO, B.PREVIEW, P.IMAGE_GENERATION],
+    ['gemini-3.1-flash-image-preview', F.GEMINI, '3.1', T.FLASH, B.PREVIEW, P.IMAGE_GENERATION],
+    ['gemini-3.1-flash-image', F.GEMINI, '3.1', T.FLASH, B.STABLE, P.IMAGE_GENERATION],
+    ['gemini-3.1-flash-lite-image', F.GEMINI, '3.1', T.FLASH_LITE, B.STABLE, P.IMAGE_GENERATION],
+    ['gemini-3.5-flash', F.GEMINI, '3.5', T.FLASH, B.STABLE, P.TEXT_GENERATION],
+    ['gemini-3.5-flash-lite', F.GEMINI, '3.5', T.FLASH_LITE, B.STABLE, P.TEXT_GENERATION],
+    ['gemini-omni-flash-preview', F.OTHER, null, T.FLASH, B.PREVIEW, P.OTHER],
+    ['gemini-omni-1.1-flash', F.OTHER, null, T.FLASH, B.STABLE, P.OTHER],
+    ['gemini-3.5-transcribe', F.GEMINI, '3.5', null, B.STABLE, P.OTHER],
+    ['gemini-3.6-flash', F.GEMINI, '3.6', T.FLASH, B.STABLE, P.TEXT_GENERATION],
+    ['gemini-3.7-flash', F.GEMINI, '3.7', T.FLASH, B.STABLE, P.TEXT_GENERATION],
+    ['gemini-3.8-flash', F.GEMINI, '3.8', T.FLASH, B.STABLE, P.TEXT_GENERATION],
+    ['lyria-3-clip-preview', F.OTHER, null, null, B.PREVIEW, P.OTHER],
+    ['lyria-3-pro-preview', F.OTHER, null, T.PRO, B.PREVIEW, P.OTHER],
+    ['lyria-3.5', F.OTHER, null, null, B.STABLE, P.OTHER],
+    ['gemini-3.1-flash-tts-preview', F.GEMINI, '3.1', T.FLASH, B.PREVIEW, P.OTHER],
+    ['gemini-robotics-er-2-preview', F.OTHER, null, null, B.PREVIEW, P.OTHER],
+    ['gemini-2.5-computer-use-preview-10-2025', F.GEMINI, '2.5', null, B.PREVIEW, P.OTHER],
+    ['antigravity-preview-05-2026', F.OTHER, null, null, B.PREVIEW, P.OTHER],
+    ['deep-research-max-preview-04-2026', F.OTHER, null, null, B.PREVIEW, P.OTHER],
+    ['deep-research-preview-04-2026', F.OTHER, null, null, B.PREVIEW, P.OTHER],
+    ['deep-research-pro-preview-12-2025', F.OTHER, null, T.PRO, B.PREVIEW, P.OTHER],
+];
+
+describe('Google AI Studio model catalog classification', () => {
+    test('classifies the manually reviewed model catalog', () => {
+        const rawModels = EXPECTED_MODELS.map(([id]) => ({ id }));
+        const expected = EXPECTED_MODELS.map(([id, family, version, tier, branch, purpose], index) => ({
+            id,
+            family,
+            version,
+            tier,
+            branch,
+            purpose,
+            rawModel: rawModels[index],
+        }));
+
+        const actual = classifyGoogleModels(rawModels);
+
+        expect(actual).toEqual(expected);
+        actual.forEach((model, index) => expect(model.rawModel).toBe(rawModels[index]));
+    });
+});

--- a/tests/google-model.test.js
+++ b/tests/google-model.test.js
@@ -1,0 +1,124 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+    classifyGoogleModels,
+    GoogleModelBranch,
+    GoogleModelFamily,
+    GoogleModelPurpose,
+    GoogleModelTier,
+} from '../public/scripts/google-model.js';
+
+describe('Google AI Studio model classification', () => {
+    test('recognizes Gemini versions and tiers', () => {
+        const cases = [
+            ['gemini-2.0-flash', '2.0', GoogleModelTier.FLASH],
+            ['gemini-2.5-pro', '2.5', GoogleModelTier.PRO],
+            ['gemini-3-flash-preview', '3.0', GoogleModelTier.FLASH],
+            ['gemini-3.5-flash-lite', '3.5', GoogleModelTier.FLASH_LITE],
+            ['gemini-10.2-flash', '10.2', GoogleModelTier.FLASH],
+        ];
+
+        for (const [id, version, tier] of cases) {
+            const [model] = classifyGoogleModels([{ id }]);
+            expect(model).toMatchObject({
+                family: GoogleModelFamily.GEMINI,
+                version,
+                tier,
+            });
+        }
+    });
+
+    test('recognizes non-versioned families and tiers', () => {
+        const cases = [
+            ['gemma-3-27b-it', GoogleModelFamily.GEMMA, null],
+            ['gemini-flash-latest', GoogleModelFamily.OTHER, GoogleModelTier.FLASH],
+            ['gemini-robotics-er-2-preview', GoogleModelFamily.OTHER, null],
+            ['gemini-embedding-2', GoogleModelFamily.OTHER, null],
+            ['learnlm-2.0-flash-experimental', GoogleModelFamily.OTHER, GoogleModelTier.FLASH],
+        ];
+
+        for (const [id, family, tier] of cases) {
+            const [model] = classifyGoogleModels([{ id }]);
+            expect(model).toMatchObject({ family, tier, version: null });
+        }
+    });
+
+    test('recognizes release branches', () => {
+        const cases = [
+            ['gemini-2.5-pro', GoogleModelBranch.STABLE],
+            ['gemini-3.1-pro-preview', GoogleModelBranch.PREVIEW],
+            ['gemini-2.0-flash-thinking-exp', GoogleModelBranch.EXPERIMENTAL],
+            ['learnlm-2.0-flash-experimental', GoogleModelBranch.EXPERIMENTAL],
+            ['gemini-flash-latest', GoogleModelBranch.UNKNOWN],
+            ['gemini-3.0-flash-preview-exp', GoogleModelBranch.UNKNOWN],
+        ];
+
+        for (const [id, branch] of cases) {
+            const [model] = classifyGoogleModels([{ id }]);
+            expect(model.branch).toBe(branch);
+        }
+    });
+
+    test('recognizes primary purposes', () => {
+        const cases = [
+            ['gemini-2.5-flash', GoogleModelPurpose.TEXT_GENERATION],
+            ['gemini-2.5-pro', GoogleModelPurpose.TEXT_GENERATION],
+            ['gemini-flash-latest', GoogleModelPurpose.TEXT_GENERATION],
+            ['gemma-3-27b-it', GoogleModelPurpose.TEXT_GENERATION],
+            ['gemini-2.5-flash-image', GoogleModelPurpose.IMAGE_GENERATION],
+            ['nano-banana-pro-preview', GoogleModelPurpose.IMAGE_GENERATION],
+            ['gemini-3.1-flash-image', GoogleModelPurpose.IMAGE_GENERATION],
+            ['gemini-2.5-flash-image-preview-tts', GoogleModelPurpose.IMAGE_GENERATION],
+            ['imagen-4.0-generate', GoogleModelPurpose.IMAGE_GENERATION],
+            ['lyria-3-clip-preview', GoogleModelPurpose.OTHER],
+            ['lyria-3.5', GoogleModelPurpose.OTHER],
+            ['gemini-2.5-flash-preview-tts', GoogleModelPurpose.OTHER],
+            ['gemini-2.5-pro-preview-tts', GoogleModelPurpose.OTHER],
+            ['gemini-3.5-transcribe', GoogleModelPurpose.OTHER],
+            ['gemini-robotics-er-2-preview', GoogleModelPurpose.OTHER],
+            ['gemini-omni-1.1-flash', GoogleModelPurpose.OTHER],
+            ['veo-3.1-generate-preview', GoogleModelPurpose.OTHER],
+            ['gemini-embedding-2', GoogleModelPurpose.OTHER],
+            ['unrecognized-model', GoogleModelPurpose.OTHER],
+        ];
+
+        for (const [id, purpose] of cases) {
+            const [model] = classifyGoogleModels([{ id }]);
+            expect(model.purpose).toBe(purpose);
+        }
+    });
+
+    test('preserves the original model and does not mutate the input', () => {
+        const rawModel = Object.freeze({
+            id: 'gemini-2.5-flash',
+            displayName: 'Gemini 2.5 Flash',
+        });
+        const models = Object.freeze([rawModel]);
+
+        const result = classifyGoogleModels(models);
+
+        expect(result).toEqual([{
+            id: rawModel.id,
+            family: GoogleModelFamily.GEMINI,
+            version: '2.5',
+            tier: GoogleModelTier.FLASH,
+            branch: GoogleModelBranch.STABLE,
+            purpose: GoogleModelPurpose.TEXT_GENERATION,
+            rawModel,
+        }]);
+        expect(result[0].rawModel).toBe(rawModel);
+    });
+
+    test('rejects malformed input', () => {
+        const cases = [
+            [null, 'Expected Google models to be an array'],
+            [[null], 'Google model at index 0 must be an object'],
+            [[{}], 'Google model at index 0 must have a non-empty string id'],
+            [[{ id: 42 }], 'Google model at index 0 must have a non-empty string id'],
+            [[{ id: '   ' }], 'Google model at index 0 must have a non-empty string id'],
+        ];
+
+        for (const [input, message] of cases) {
+            expect(() => classifyGoogleModels(input)).toThrow(new TypeError(message));
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Add a reusable frontend utility for classifying Google AI Studio models returned by the chat-completions status endpoint.
- Produce structured model records containing:
    - Model family and normalized Gemini version.
    - Pro, Flash, or Flash-Lite tier.
    - Stable, preview, experimental, or unknown release branch.
    - Text generation, image generation, or other specialized purpose.
    - The original model object as `rawModel`.
- Reject malformed model arrays and invalid model IDs instead of silently omitting them.
- Add unit tests for individual classification rules and a manually reviewed catalog of 40 current Google models.

This is the foundation for a follow-up PR. That PR will use the classification utility to dynamically rebuild the Google AI Studio model dropdown from the status response, remove hardcoded models that are no longer returned by the API, group models under Gemini versions, Gemma, and Other, apply purpose and tier ordering, and provide a manual model ID input.

This PR is part of the work addressing #5873. To keep this PR small, it intentionally does not change the model-selection UI by itself, so it should not close the issue independently.

Although the total change exceeds the suggested 200-line limit, approximately half of the additional lines are unit tests and manually reviewed classification cases. The production code remains an isolated, dependency-free utility intended for reuse by the follow-up UI PR.

## Why

#5873 reports that the Google AI Studio model dropdown contains deprecated, unavailable, and specialized models, making it difficult to navigate and allowing users to select endpoints that may no longer work.

The requested dynamic list cannot be organized reliably using the model ID alone at each call site. A shared classification layer is needed before the frontend can consistently group and sort current and future Google models.

The Google models response also does not provide a single reliable field describing the primary output purpose of every model. This utility therefore uses explicit, conservative model ID rules. Unknown models and specialized models that cannot be identified as general text or image generation are classified as `Other`.

The original model object is preserved so later consumers can still inspect API metadata that is outside the normalized classification.

## Classification Rules

- `family`
    - `gemini-X.Y-*` is classified as `Gemini` with version `X.Y`.
    - `gemini-X-*` is normalized to version `X.0`.
    - A numeric version is recognized only when it immediately follows the `gemini-` prefix.
    - Non-versioned Gemini aliases and specialized families, such as `gemini-flash-latest`, Robotics, and Embedding, are classified as `Other`.
    - `gemma-*` is classified as `Gemma`.
    - All remaining models are classified as `Other`.
- `tier`
    - Complete hyphen-delimited tokens identify `pro`, `flash`, and `flash-lite`.
    - `flash-lite` is matched before `flash`.
    - Models without a recognized tier use `null`.
- `branch`
    - `preview` is classified as `preview`.
    - `exp` and `experimental` are classified as `exp`.
    - `latest`, conflicting markers, and branches that cannot be determined reliably are classified as `unknown`.
    - Models without a branch marker are classified as `stable`.
- `purpose`
    - Models containing a complete `image` token, or beginning with `imagen-` or `nano-banana-`, are classified as `ImageGeneration`.
    - TTS, transcription, Robotics, Embedding, Veo, Lyria, Omni, Live, and Computer Use models are classified as `Other`.
    - Remaining versioned Gemini models, Gemini `latest` aliases, and Gemma models are classified as `TextGeneration`.
    - Models whose purpose cannot be identified conservatively are classified as `Other`.
    - Image detection takes precedence over specialized-purpose detection because any model capable of image output belongs to `ImageGeneration`.

Concrete classifications for the reviewed model catalog are available in `tests/google-model-catalog.test.js`.

## Testing

- Added unit tests covering:
    - Gemini integer and decimal version recognition.
    - Future Gemini versions such as `gemini-10.2-*`.
    - Gemini, Gemma, and Other family classification.
    - Pro, Flash, and Flash-Lite tier recognition.
    - Stable, preview, experimental, latest, and conflicting branch markers.
    - Text generation, image generation, and specialized model purposes.
    - Image-purpose precedence.
    - TTS, transcription, Robotics, Embedding, Veo, Lyria, Omni, Live, and Computer Use models.
    - Preservation of the original model object.
    - Input immutability.
    - Malformed arrays, entries, and model IDs.
- Added a separate manually reviewed catalog test covering all 40 supplied Google model IDs.
- Ran the complete unit test suite successfully:
    - 20 test suites passed.
    - 414 tests passed.
- Ran the root project ESLint checks successfully.
- Ran the test project ESLint checks with no errors.
    - Two pre-existing warnings remain in unrelated Playwright tests.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).