### PR TITLE
Fix Quick Reply overwrite cancellation

### DIFF
--- a/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
@@ -381,7 +381,7 @@ export class SettingsUi {
         if (name && name.length > 0) {
             const oldQrs = QuickReplySet.get(name);
             if (oldQrs) {
-                const replace = Popup.show.confirm('Replace existing Quick Reply set', `A Quick Reply Set named "${name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
+                const replace = await Popup.show.confirm('Replace existing Quick Reply set', `A Quick Reply Set named "${name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
                 if (replace) {
                     const idx = QuickReplySet.list.indexOf(oldQrs);
                     await this.doDeleteQrSet(oldQrs);
@@ -444,7 +444,7 @@ export class SettingsUi {
                 qrs.init();
                 const oldQrs = QuickReplySet.get(props.name);
                 if (oldQrs) {
-                    const replace = Popup.show.confirm('Replace existing Quick Reply set', `A Quick Reply Set named "${name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
+                    const replace = await Popup.show.confirm('Replace existing Quick Reply set', `A Quick Reply Set named "${props.name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
                     if (replace) {
                         const idx = QuickReplySet.list.indexOf(oldQrs);
                         await this.doDeleteQrSet(oldQrs);

--- a/tests/frontend/QuickReplyOverwriteCancel.e2e.js
+++ b/tests/frontend/QuickReplyOverwriteCancel.e2e.js
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+import { testSetup } from './frontent-test-utils.js';
+
+test.describe('Quick Reply overwrite cancellation', () => {
+    test.beforeEach(testSetup.awaitST);
+
+    for (const operation of ['create', 'import']) {
+        test(`should keep the existing set when ${operation} overwrite is cancelled`, async ({ page }) => {
+            const result = await page.evaluate(async (operation) => {
+                const { Popup, POPUP_RESULT } = await import('./scripts/popup.js');
+                const { QuickReplySet } = await import('./scripts/extensions/quick-reply/src/QuickReplySet.js');
+                const { SettingsUi } = await import('./scripts/extensions/quick-reply/src/ui/SettingsUi.js');
+
+                const setName = 'STAGE_REPRO_OVERWRITE_CANCEL';
+                const existingSet = { name: setName };
+                const originalSets = QuickReplySet.list;
+                const originalInput = Popup.show.input;
+                const originalConfirm = Popup.show.confirm;
+                const originalFrom = QuickReplySet.from;
+                const originalAddQuickReply = QuickReplySet.prototype.addQuickReply;
+                let deleteCalls = 0;
+                let confirmMessage = '';
+
+                try {
+                    QuickReplySet.list = [existingSet];
+                    Popup.show.input = async () => setName;
+                    Popup.show.confirm = async (_title, message) => {
+                        confirmMessage = message;
+                        return POPUP_RESULT.NEGATIVE;
+                    };
+                    QuickReplySet.prototype.addQuickReply = () => {};
+                    QuickReplySet.from = props => ({
+                        ...props,
+                        qrList: [],
+                        init: () => {},
+                        save: async () => {},
+                    });
+
+                    const settingsUi = new SettingsUi({});
+                    settingsUi.currentSet = document.createElement('select');
+                    settingsUi.doDeleteQrSet = async () => deleteCalls++;
+                    settingsUi.rerender = () => {};
+                    settingsUi.onQrSetChange = () => {};
+                    settingsUi.prepareGlobalSetList = () => {};
+                    settingsUi.prepareChatSetList = () => {};
+                    settingsUi.prepareCharacterSetList = () => {};
+
+                    if (operation === 'create') {
+                        await settingsUi.addQrSet();
+                    } else {
+                        const file = {
+                            name: 'duplicate.json',
+                            text: async () => JSON.stringify({ version: 2, name: setName, qrList: [] }),
+                        };
+                        await settingsUi.importSingleQrSet(file);
+                    }
+
+                    return {
+                        confirmMessage,
+                        deleteCalls,
+                        setNames: QuickReplySet.list.map(set => set.name),
+                        setName,
+                    };
+                } finally {
+                    QuickReplySet.list = originalSets;
+                    Popup.show.input = originalInput;
+                    Popup.show.confirm = originalConfirm;
+                    QuickReplySet.from = originalFrom;
+                    QuickReplySet.prototype.addQuickReply = originalAddQuickReply;
+                }
+            }, operation);
+
+            expect(result.confirmMessage).toContain(`"${result.setName}"`);
+            expect(result.deleteCalls).toBe(0);
+            expect(result.setNames).toEqual([result.setName]);
+        });
+    }
+});


### PR DESCRIPTION
## Summary

- await the asynchronous replacement confirmation before deciding whether to overwrite a Quick Reply set
- show the imported set name in the duplicate-import confirmation
- add regression coverage for cancelled create and import replacements

## Root cause

Both overwrite paths treated the Promise returned by `Popup.show.confirm()` as the confirmation result. Because the Promise is truthy, choosing Cancel did not prevent the existing set from being deleted. The import path also interpolated `name` instead of `props.name`.

## Behavior after this change

Cancelling either confirmation preserves the existing Quick Reply set, while confirming still allows replacement.

## Testing

- `npm run lint`
- `cd tests && npm run lint` (passes with two pre-existing warnings)
- `cd tests && npm run test:unit -- --runInBand` (407 tests passed)
- `cd tests && ST_BASE_URL=http://127.0.0.1:8001 npx playwright test frontend/QuickReplyOverwriteCancel.e2e.js --config playwright.config.js --workers=1` (2 tests passed)

Fixes #6004

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).