### PR TITLE
Fix CORS proxy forwarding raw zstd-compressed bytes to the client

### DIFF
--- a/src/middleware/corsProxy.js
+++ b/src/middleware/corsProxy.js
@@ -26,6 +26,12 @@ export default async function corsProxyMiddleware(req, res) {
 
         headersToRemove.forEach(header => delete headers[header]);
 
+        // Force a set of encodings that node-fetch/undici can transparently decompress.
+        // Some origins (e.g. Cloudflare-fronted sites) will respond with zstd when a browser's
+        // full Accept-Encoding list is forwarded as-is; undici does not decode zstd, so the raw
+        // compressed bytes would otherwise be piped straight through to the client as garbage.
+        headers['accept-encoding'] = 'gzip, deflate, br';
+
         const bodyMethods = ['POST', 'PUT', 'PATCH'];
 
         const response = await fetch(url, {


### PR DESCRIPTION
undici (Node's fetch) transparently decompresses gzip, deflate, and br, but not zstd. When a browser's full Accept-Encoding header is forwarded as-is to the target origin, a Cloudflare-fronted server may respond with zstd, and corsProxyMiddleware pipes those still-compressed bytes straight through — the client receives garbage instead of the expected body (e.g. "SyntaxError: Unexpected token" when parsing JSON).

Cap the outgoing Accept-Encoding to the encodings undici can actually decode, so the target always responds with something we can forward correctly.

<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
