### PR TITLE
Add OpenRouter service tier selector to chat completions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3260,6 +3260,12 @@
                                     <option data-i18n="Unknown" value="unknown">Unknown</option>
                                 </select>
                             </div>
+                            <div>
+                                <h4 data-i18n="Service Tier">Service Tier</h4>
+                                <select id="openrouter_service_tier" class="text_pole">
+                                    <option value="">Default</option>
+                                </select>
+                            </div>
                         </form>
                         <form id="ai21_form" data-source="ai21" action="javascript:void(null);" method="post" enctype="multipart/form-data">
                             <h4 data-i18n="AI21 API Key">AI21 API Key</h4>

--- a/public/locales/ar-sa.json
+++ b/public/locales/ar-sa.json
@@ -1454,5 +1454,8 @@
     "Deleting chat…": "جارٍ حذف المحادثة…",
     "Loading chat…": "جارٍ تحميل المحادثة…",
     "Bulk Delete": "حذف جماعي",
-    "Deleting ${0} character(s)…": "جارٍ حذف ${0} شخصية (شخصيات)…"
+    "Deleting ${0} character(s)…": "جارٍ حذف ${0} شخصية (شخصيات)…",
+    "Service Tier": "مستوى الخدمة",
+    "Flex (cheap, slower)": "Flex (رخيص، أبطأ)",
+    "Priority (fast, expensive)": "Priority (سريع، مكلف)"
 }

--- a/public/locales/de-de.json
+++ b/public/locales/de-de.json
@@ -1454,5 +1454,8 @@
     "Deleting chat…": "Chat wird gelöscht…",
     "Loading chat…": "Chat wird geladen…",
     "Bulk Delete": "Massenlöschung",
-    "Deleting ${0} character(s)…": "${0} Charakter(e) werden gelöscht…"
+    "Deleting ${0} character(s)…": "${0} Charakter(e) werden gelöscht…",
+    "Service Tier": "Service-Stufe",
+    "Flex (cheap, slower)": "Flex (günstig, langsamer)",
+    "Priority (fast, expensive)": "Priority (schnell, teuer)"
 }

--- a/public/locales/es-es.json
+++ b/public/locales/es-es.json
@@ -1561,5 +1561,8 @@
     "Deleting chat…": "Eliminando chat…",
     "Loading chat…": "Cargando chat…",
     "Bulk Delete": "Eliminación masiva",
-    "Deleting ${0} character(s)…": "Eliminando ${0} personaje(s)…"
+    "Deleting ${0} character(s)…": "Eliminando ${0} personaje(s)…",
+    "Service Tier": "Nivel de servicio",
+    "Flex (cheap, slower)": "Flex (barato, más lento)",
+    "Priority (fast, expensive)": "Priority (rápido, caro)"
 }

--- a/public/locales/fr-fr.json
+++ b/public/locales/fr-fr.json
@@ -2062,5 +2062,8 @@
     "Deleting chat…": "Suppression de la discussion…",
     "Loading chat…": "Chargement de la discussion…",
     "Bulk Delete": "Suppression groupée",
-    "Deleting ${0} character(s)…": "Suppression de ${0} personnage(s)…"
+    "Deleting ${0} character(s)…": "Suppression de ${0} personnage(s)…",
+    "Service Tier": "Niveau de service",
+    "Flex (cheap, slower)": "Flex (moins cher, plus lent)",
+    "Priority (fast, expensive)": "Priority (rapide, coûteux)"
 }

--- a/public/locales/is-is.json
+++ b/public/locales/is-is.json
@@ -1452,5 +1452,8 @@
     "Deleting chat…": "Eyði spjalli…",
     "Loading chat…": "Hleð spjalli…",
     "Bulk Delete": "Fjöldaeyðing",
-    "Deleting ${0} character(s)…": "Eyði ${0} persónu(m)…"
+    "Deleting ${0} character(s)…": "Eyði ${0} persónu(m)…",
+    "Service Tier": "Þjónustustig",
+    "Flex (cheap, slower)": "Flex (ódýr, hægari)",
+    "Priority (fast, expensive)": "Priority (hratt, dýrt)"
 }

--- a/public/locales/it-it.json
+++ b/public/locales/it-it.json
@@ -1454,5 +1454,8 @@
     "Deleting chat…": "Eliminazione chat…",
     "Loading chat…": "Caricamento chat…",
     "Bulk Delete": "Eliminazione multipla",
-    "Deleting ${0} character(s)…": "Eliminazione di ${0} personaggio/i…"
+    "Deleting ${0} character(s)…": "Eliminazione di ${0} personaggio/i…",
+    "Service Tier": "Livello di servizio",
+    "Flex (cheap, slower)": "Flex (economico, più lento)",
+    "Priority (fast, expensive)": "Priority (veloce, costoso)"
 }

--- a/public/locales/ja-jp.json
+++ b/public/locales/ja-jp.json
@@ -1459,5 +1459,8 @@
     "Deleting chat…": "チャットを削除中…",
     "Loading chat…": "チャットを読み込み中…",
     "Bulk Delete": "一括削除",
-    "Deleting ${0} character(s)…": "${0}人のキャラクターを削除中…"
+    "Deleting ${0} character(s)…": "${0}人のキャラクターを削除中…",
+    "Service Tier": "サービスティア",
+    "Flex (cheap, slower)": "Flex（安い、遅い）",
+    "Priority (fast, expensive)": "Priority（速い、高い）"
 }

--- a/public/locales/ko-kr.json
+++ b/public/locales/ko-kr.json
@@ -1633,5 +1633,8 @@
     "Deleting chat…": "채팅 삭제 중…",
     "Loading chat…": "채팅 불러오는 중…",
     "Bulk Delete": "대량 삭제",
-    "Deleting ${0} character(s)…": "${0}개 캐릭터 삭제 중…"
+    "Deleting ${0} character(s)…": "${0}개 캐릭터 삭제 중…",
+    "Service Tier": "서비스 등급",
+    "Flex (cheap, slower)": "Flex(저렴, 느림)",
+    "Priority (fast, expensive)": "Priority(빠름, 비쌈)"
 }

--- a/public/locales/nl-nl.json
+++ b/public/locales/nl-nl.json
@@ -1450,5 +1450,8 @@
     "Deleting chat…": "Chat verwijderen…",
     "Loading chat…": "Chat laden…",
     "Bulk Delete": "Bulkverwijdering",
-    "Deleting ${0} character(s)…": "${0} personage(s) verwijderen…"
+    "Deleting ${0} character(s)…": "${0} personage(s) verwijderen…",
+    "Service Tier": "Serviceniveau",
+    "Flex (cheap, slower)": "Flex (goedkoop, langzamer)",
+    "Priority (fast, expensive)": "Priority (snel, duur)"
 }

--- a/public/locales/pt-pt.json
+++ b/public/locales/pt-pt.json
@@ -1452,5 +1452,8 @@
     "Deleting chat…": "A eliminar chat…",
     "Loading chat…": "A carregar chat…",
     "Bulk Delete": "Eliminação em massa",
-    "Deleting ${0} character(s)…": "A eliminar ${0} personagem(ns)…"
+    "Deleting ${0} character(s)…": "A eliminar ${0} personagem(ns)…",
+    "Service Tier": "Nível de serviço",
+    "Flex (cheap, slower)": "Flex (barato, mais lento)",
+    "Priority (fast, expensive)": "Priority (rápido, caro)"
 }

--- a/public/locales/ru-ru.json
+++ b/public/locales/ru-ru.json
@@ -2754,5 +2754,8 @@
     "Deleting chat…": "Удаление чата…",
     "Loading chat…": "Загрузка чата…",
     "Bulk Delete": "Массовое удаление",
-    "Deleting ${0} character(s)…": "Удаление ${0} персонажа(ей)…"
+    "Deleting ${0} character(s)…": "Удаление ${0} персонажа(ей)…",
+    "Service Tier": "Уровень обслуживания",
+    "Flex (cheap, slower)": "Flex (дешевле, медленнее)",
+    "Priority (fast, expensive)": "Priority (быстро, дорого)"
 }

--- a/public/locales/th-th.json
+++ b/public/locales/th-th.json
@@ -1471,5 +1471,8 @@
     "Deleting chat…": "กำลังลบแชท…",
     "Loading chat…": "กำลังโหลดแชท…",
     "Bulk Delete": "ลบจำนวนมาก",
-    "Deleting ${0} character(s)…": "กำลังลบ ${0} ตัวละคร…"
+    "Deleting ${0} character(s)…": "กำลังลบ ${0} ตัวละคร…",
+  "Service Tier": "ระดับบริการ",
+  "Flex (cheap, slower)": "Flex (ถูก, ช้ากว่า)",
+  "Priority (fast, expensive)": "Priority (เร็ว, แพง)"
 }

--- a/public/locales/uk-ua.json
+++ b/public/locales/uk-ua.json
@@ -1452,5 +1452,8 @@
     "Deleting chat…": "Видалення чату…",
     "Loading chat…": "Завантаження чату…",
     "Bulk Delete": "Масове видалення",
-    "Deleting ${0} character(s)…": "Видалення ${0} персонажа(ів)…"
+    "Deleting ${0} character(s)…": "Видалення ${0} персонажа(ів)…",
+    "Service Tier": "Рівень обслуговування",
+    "Flex (cheap, slower)": "Flex (дешевше, повільніше)",
+    "Priority (fast, expensive)": "Priority (швидко, дорого)"
 }

--- a/public/locales/vi-vn.json
+++ b/public/locales/vi-vn.json
@@ -1452,5 +1452,8 @@
     "Deleting chat…": "Đang xóa cuộc trò chuyện…",
     "Loading chat…": "Đang tải cuộc trò chuyện…",
     "Bulk Delete": "Xóa hàng loạt",
-    "Deleting ${0} character(s)…": "Đang xóa ${0} nhân vật…"
+    "Deleting ${0} character(s)…": "Đang xóa ${0} nhân vật…",
+    "Service Tier": "Cấp độ dịch vụ",
+    "Flex (cheap, slower)": "Flex (rẻ, chậm hơn)",
+    "Priority (fast, expensive)": "Priority (nhanh, đắt)"
 }

--- a/public/locales/zh-cn.json
+++ b/public/locales/zh-cn.json
@@ -3643,5 +3643,8 @@
     "Deleting chat…": "正在删除聊天…",
     "Loading chat…": "正在加载聊天…",
     "Bulk Delete": "批量删除",
-    "Deleting ${0} character(s)…": "正在删除 ${0} 个角色…"
+    "Deleting ${0} character(s)…": "正在删除 ${0} 个角色…",
+    "Service Tier": "服务档位",
+    "Flex (cheap, slower)": "Flex（低价，较慢）",
+    "Priority (fast, expensive)": "Priority（快，但贵）"
 }

--- a/public/locales/zh-tw.json
+++ b/public/locales/zh-tw.json
@@ -2774,5 +2774,8 @@
     "Deleting chat…": "正在刪除聊天…",
     "Loading chat…": "正在載入聊天…",
     "Bulk Delete": "批次刪除",
-    "Deleting ${0} character(s)…": "正在刪除 ${0} 個角色…"
+    "Deleting ${0} character(s)…": "正在刪除 ${0} 個角色…",
+    "Service Tier": "服務檔位",
+    "Flex (cheap, slower)": "Flex（低價，較慢）",
+    "Priority (fast, expensive)": "Priority（快，但貴）"
 }

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -322,6 +322,7 @@ export const settingsToUpdate = {
     openrouter_providers: ['#openrouter_providers_chat', 'openrouter_providers', false, true],
     openrouter_quantizations: ['#openrouter_quantizations_chat', 'openrouter_quantizations', false, true],
     openrouter_allow_fallbacks: ['#openrouter_allow_fallbacks', 'openrouter_allow_fallbacks', true, true],
+    openrouter_service_tier: ['#openrouter_service_tier', 'openrouter_service_tier', false, true],
     openrouter_middleout: ['#openrouter_middleout', 'openrouter_middleout', false, true],
     tool_reasoning_mode: ['#tool_reasoning_mode', 'tool_reasoning_mode', false, false],
     ai21_model: ['#model_ai21_select', 'ai21_model', false, true],
@@ -481,6 +482,7 @@ const default_settings = {
     openrouter_providers: [],
     openrouter_quantizations: [],
     openrouter_allow_fallbacks: true,
+    openrouter_service_tier: '',
     openrouter_middleout: openrouter_middleout_types.ON,
     tool_reasoning_mode: tool_reasoning_modes.DISABLED,
     reverse_proxy: '',
@@ -2873,6 +2875,9 @@ export async function createGenerationParameters(settings, model, type, messages
         generate_data.quantizations = settings.openrouter_quantizations;
         generate_data.allow_fallbacks = settings.openrouter_allow_fallbacks;
         generate_data.middleout = settings.openrouter_middleout;
+        if (settings.openrouter_service_tier) {
+            generate_data.service_tier = settings.openrouter_service_tier;
+        }
     }
 
     if (settings.chat_completion_source === chat_completion_sources.NANOGPT) {
@@ -5472,7 +5477,7 @@ async function onModelChange() {
 
         console.log('OpenRouter model changed to', value);
         oai_settings.openrouter_model = value;
-        syncOpenRouterProvidersForModel(value, '#openrouter_providers_chat');
+        syncOpenRouterProvidersForModel(value, '#openrouter_providers_chat', '#openrouter_service_tier', oai_settings.openrouter_service_tier);
     }
 
     if ($(this).is('#model_ai21_select')) {
@@ -7251,6 +7256,11 @@ export function initOpenAI() {
 
         oai_settings.openrouter_quantizations = selectedQuantizations;
 
+        saveSettingsDebounced();
+    });
+
+    $('#openrouter_service_tier').on('change', function () {
+        oai_settings.openrouter_service_tier = String($(this).val());
         saveSettingsDebounced();
     });
 

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -367,16 +367,26 @@ export function updateOpenRouterProvidersWarning(providersSelector) {
     $warning.toggleClass('displayNone', !showWarning);
 }
 
-export async function syncOpenRouterProvidersForModel(modelId, providersSelector) {
+export async function syncOpenRouterProvidersForModel(modelId, providersSelector, tiersSelector = null, preferredTier = null) {
     const $providers = $(providersSelector);
 
     const refreshWarningState = () => {
         updateOpenRouterProvidersWarning(providersSelector);
     };
 
+    const resetTiers = () => {
+        if (!tiersSelector) return;
+        const $tiers = $(tiersSelector);
+        if ($tiers.length === 0) return;
+        $tiers.find('option').not(':first').remove();
+        $tiers.children('option:first').attr('value', '').text(t`Default`);
+        $tiers.trigger('change');
+    };
+
     if (!modelId || !modelId.includes('/')) {
         $providers.find('option').prop('disabled', false);
         $providers.trigger('change.select2');
+        resetTiers();
         refreshWarningState();
         return;
     }
@@ -393,11 +403,14 @@ export async function syncOpenRouterProvidersForModel(modelId, providersSelector
             return;
         }
 
-        const providerNames = await response.json();
+        const data = await response.json();
+        const providerNames = Array.isArray(data) ? data : data?.providers;
+        const tiers = Array.isArray(data) ? [] : data?.tiers;
 
         if (!Array.isArray(providerNames) || providerNames.length === 0) {
             $providers.find('option').prop('disabled', false);
             $providers.trigger('change.select2');
+            resetTiers();
             refreshWarningState();
             return;
         }
@@ -409,6 +422,29 @@ export async function syncOpenRouterProvidersForModel(modelId, providersSelector
 
         $providers.trigger('change.select2');
         refreshWarningState();
+
+        if (tiersSelector && Array.isArray(tiers)) {
+            const $tiers = $(tiersSelector);
+            if ($tiers.length > 0) {
+                const labels = {
+                    flex: t`Flex (cheap, slower)`,
+                    standard: t`Default`,
+                    priority: t`Priority (fast, expensive)`,
+                };
+                const current = $tiers.val();
+                $tiers.find('option').not(':first').remove();
+                $tiers.children('option:first').attr('value', '').text(labels.standard);
+                tiers.forEach((tier) => {
+                    if (tier === 'standard') return;
+                    if ($tiers.find(`option[value="${tier}"]`).length === 0) {
+                        $tiers.append($(`<option value="${tier}">${labels[tier] ?? tier}</option>`));
+                    }
+                });
+                const restore = [preferredTier, current].find(v => v && $tiers.find(`option[value="${v}"]`).length > 0);
+                $tiers.val(restore ?? '');
+                $tiers.trigger('change');
+            }
+        }
     } catch (error) {
         console.error('Failed to fetch OpenRouter providers for model', error);
         refreshWarningState();

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2335,6 +2335,10 @@ router.post('/generate', async function (request, response) {
                 bodyParams['route'] = 'fallback';
             }
 
+            if (request.body.service_tier) {
+                bodyParams['service_tier'] = request.body.service_tier;
+            }
+
             if (request.body.reasoning_effort) {
                 bodyParams['reasoning']['effort'] = request.body.reasoning_effort;
             }

--- a/src/endpoints/openrouter.js
+++ b/src/endpoints/openrouter.js
@@ -26,7 +26,13 @@ router.post('/models/providers', async (req, res) => {
         const endpoints = data?.data?.endpoints || [];
         const providerNames = endpoints.map(e => e.provider_name);
 
-        return res.json(providerNames);
+        const getTier = (tag) => tag?.endsWith('/flex') ? 'flex'
+            : tag?.endsWith('/priority') ? 'priority'
+                : 'standard';
+
+        const tiers = [...new Set(endpoints.filter(e => e.status === 0).map(e => getTier(e.tag)))];
+
+        return res.json({ providers: providerNames, tiers });
     } catch (error) {
         console.error(error);
         return res.sendStatus(500);


### PR DESCRIPTION
Adds a Service Tier dropdown (flex/default/priority) to the OpenRouter chat settings. Options are derived dynamically from the model's OpenRouter endpoints. Selecting flex/priority sends the service_tier param; default (standard tier) sends nothing, preserving current behavior. Includes i18n strings across all locales.

This is mainly for saving costs when using OpenRouter, flex tier typically saves 50% cost.

Setting can be saved. 

The setting is in "API Connections" menu, "Service Tiers" setting. Can be verified via console log and OpenRouter log. 
E.g. on terminal that ran `start.sh`:
```
  reasoning: { exclude: false },
  min_p: 0,
  top_a: 0,
  repetition_penalty: 1,
  service_tier: 'flex',
  safety_settings: [
    { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'OFF' },
    { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'OFF' },

```

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
