### PR TITLE
fix: resolve Pollinations TTS model aliases

### DIFF
--- a/src/endpoints/speech.js
+++ b/src/endpoints/speech.js
@@ -101,7 +101,7 @@ pollinations.post('/voices', async (req, res) => {
             throw new Error('Invalid data format received from Pollinations');
         }
 
-        const audioModelData = data.find(m => m.name === model);
+        const audioModelData = data.find(m => m.name === model || m.aliases?.includes(model));
         if (!audioModelData || !Array.isArray(audioModelData.voices)) {
             throw new Error('No voices found for the specified model');
         }

--- a/tests/pollinations.test.js
+++ b/tests/pollinations.test.js
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const fetchMock = jest.fn();
+jest.unstable_mockModule('node-fetch', () => ({ default: fetchMock }));
+jest.unstable_mockModule('../src/transformers.js', () => ({ getPipeline: jest.fn() }));
+jest.unstable_mockModule('../src/endpoints/secrets.js', () => ({
+    readSecret: jest.fn(),
+    SECRET_KEYS: {},
+}));
+
+describe('Pollinations TTS model aliases', () => {
+    /** @type {import('node:http').Server} */
+    let server;
+    let baseUrl;
+
+    beforeAll(async () => {
+        const { default: express } = await import('express');
+        const { router: speechRouter } = await import('../src/endpoints/speech.js');
+        const app = express();
+        app.use(express.json());
+        app.use('/speech', speechRouter);
+        server = app.listen(0, '127.0.0.1');
+        await new Promise(resolve => server.once('listening', resolve));
+        const address = server.address();
+        baseUrl = `http://127.0.0.1:${address.port}`;
+    });
+
+    afterAll(async () => {
+        await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+    });
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+    });
+
+    test.each([undefined, 'openai-audio', 'openai/gpt-audio-mini'])('looks up voices for %s', async (model) => {
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: async () => [{ name: 'openai/gpt-audio-mini', aliases: ['openai-audio'], voices: ['alloy', 'nova'] }],
+        });
+
+        const response = await fetch(`${baseUrl}/speech/pollinations/voices`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ model }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual(['alloy', 'nova']);
+    });
+
+    test('still accepts catalogs without aliases', async () => {
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: async () => [{ name: 'openai-audio', voices: ['alloy'] }],
+        });
+
+        const response = await fetch(`${baseUrl}/speech/pollinations/voices`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+        });
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual(['alloy']);
+    });
+});


### PR DESCRIPTION
Pollinations is [standardizing model IDs](https://github.com/pollinations/pollinations/pull/13076). Old names still work in requests, but the TTS voice lookup only checks the catalog name, so the default `openai-audio` would fail with HTTP 500.

- Match the requested model against its name or aliases.
- Keep the existing TTS default and generation requests unchanged.
- Add four regression cases; all 411 unit tests pass. Root and test ESLint pass (two existing test warnings).

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).