### PR TITLE
Fix: Avoid cpSync crash when renaming characters

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1081,6 +1081,8 @@ router.post('/rename', validateAvatarUrlMiddleware, async function (request, res
 
         // Rename chats folder
         if (fs.existsSync(oldChatsPath) && !fs.existsSync(newChatsPath)) {
+            // Supplying a filter avoids a Node.js Windows copyDir crash while preserving all entries.
+            // https://github.com/nodejs/node/issues/63970
             fs.cpSync(oldChatsPath, newChatsPath, { recursive: true, filter: () => true });
             fs.rmSync(oldChatsPath, { recursive: true, force: true });
         }

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -1081,7 +1081,7 @@ router.post('/rename', validateAvatarUrlMiddleware, async function (request, res
 
         // Rename chats folder
         if (fs.existsSync(oldChatsPath) && !fs.existsSync(newChatsPath)) {
-            fs.cpSync(oldChatsPath, newChatsPath, { recursive: true });
+            fs.cpSync(oldChatsPath, newChatsPath, { recursive: true, filter: () => true });
             fs.rmSync(oldChatsPath, { recursive: true, force: true });
         }
 


### PR DESCRIPTION
<!-- Put X in the box below to confirm -->

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).

## Problem

I originally reproduced this on SillyTavern 1.18.0 release (8172dcd0e), then confirmed that it is also reproducible on the latest `staging` branch.

Environment used for reproduction:

* Windows 11
* Node.js v22.17.0
* SillyTavern `staging`

Reproducible steps:

1. Create a character named `伊芙琳`.
2. Rename the character to `YiFuLin`.
3. Confirm the rename.
4. The SillyTavern Node.js process terminates completely
5. Windows Terminal shows "Press any key to continue ...".

There is no catchable JavaScript exception from the rename endpoint when this occurs because the process terminates in Node.js's native filesystem implementation.

Screen recording:

https://github.com/user-attachments/assets/e290a801-fd20-4701-a7a0-5ac84b2902ee


## Workaround

The issue appears to match the upstream Node.js bug:

* [nodejs/node#63970](https://github.com/nodejs/node/issues/63970) 

The upstream report affects Node.js v22.17.0 and later on Windows. A recursive `fs.cpSync()` call without a `filter` can use the native `copyDir` fast path, where certain filesystem failures may terminate the process instead of being converted into a JavaScript exception.

This PR adds a no-op filter:

```
fs.cpSync(oldChatsPath, newChatsPath, { recursive: true, filter: () => true });
```

The filter always returns true, so the intended copy behavior is unchanged, but it prevents Node.js from using the affected native copyDir fast path.

P.S. This workaround can potentially be revisited once the upstream Node.js fix is available.