### PR TITLE
Add Claude Fable 5.1 and GPT-6 Astra support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3066,6 +3066,9 @@
                             <div>
                                 <h4 data-i18n="OpenAI Model">OpenAI Model</h4>
                                 <select id="model_openai_select">
+                                    <optgroup label="GPT-6">
+                                        <option value="gpt-6-astra">gpt-6-astra</option>
+                                    </optgroup>
                                     <optgroup label="GPT-5.6">
                                         <option value="gpt-5.6">gpt-5.6</option>
                                         <option value="gpt-5.6-sol">gpt-5.6-sol</option>
@@ -3183,6 +3186,7 @@
                                 <h4 data-i18n="Claude Model">Claude Model</h4>
                                 <select id="model_claude_select">
                                     <optgroup label="Versions">
+                                        <option value="claude-fable-5-1">claude-fable-5-1</option>
                                         <option value="claude-fable-5">claude-fable-5</option>
                                         <option value="claude-opus-5">claude-opus-5</option>
                                         <option value="claude-sonnet-5">claude-sonnet-5</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -54,6 +54,7 @@
                         <option data-type="cohere" value="c4ai-aya-vision-8b">c4ai-aya-vision-8b</option>
                         <option data-type="cohere" value="c4ai-aya-vision-32b">c4ai-aya-vision-32b</option>
                         <option data-type="cohere" value="command-a-vision-07-2025">command-a-vision-07-2025</option>
+                        <option data-type="openai" value="gpt-6-astra">gpt-6-astra</option>
                         <option data-type="openai" value="gpt-5.6">gpt-5.6</option>
                         <option data-type="openai" value="gpt-5.6-sol">gpt-5.6-sol</option>
                         <option data-type="openai" value="gpt-5.6-terra">gpt-5.6-terra</option>
@@ -96,6 +97,7 @@
                         <option data-type="openai" value="o3-2025-04-16">o3-2025-04-16</option>
                         <option data-type="openai" value="o4-mini">o4-mini</option>
                         <option data-type="openai" value="o4-mini-2025-04-16">o4-mini-2025-04-16</option>
+                        <option data-type="anthropic" value="claude-fable-5-1">claude-fable-5-1</option>
                         <option data-type="anthropic" value="claude-fable-5">claude-fable-5</option>
                         <option data-type="anthropic" value="claude-opus-5">claude-opus-5</option>
                         <option data-type="anthropic" value="claude-sonnet-5">claude-sonnet-5</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2632,6 +2632,10 @@ function getReasoningEffort(settings = null, model = null) {
                 return reasoning_effort_types.low;
             case reasoning_effort_types.max:
                 if ([chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source)
+                    && /^gpt-6-astra/.test(model)) {
+                    return reasoning_effort_types.max;
+                }
+                if ([chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source)
                     && /^gpt-5\.6/.test(model)) {
                     // GPT-5.6 reserves "max" effort for the Responses API.
                     return 'xhigh';
@@ -3088,6 +3092,15 @@ export async function createGenerationParameters(settings, model, type, messages
             delete generate_data.logit_bias;
             delete generate_data.stop;
         }
+    }
+
+    if (gptSources.includes(settings.chat_completion_source) && /gpt-6-astra/.test(model)) {
+        generate_data.max_completion_tokens = generate_data.max_tokens;
+        delete generate_data.max_tokens;
+        delete generate_data.temperature;
+        delete generate_data.top_p;
+        delete generate_data.logprobs;
+        delete generate_data.top_logprobs;
     }
 
     // Claude Fable / Claude 5 models removed sampling parameters and reject them with HTTP 400,
@@ -5079,6 +5092,7 @@ function getMaxContextOpenAI(value) {
 
     /** @type {[RegExp, number][]} */
     const contextMap = [
+        [/^gpt-6-astra/, max_1050k],
         [/^gpt-5\.6/, max_1050k],
         [/^gpt-5\.[45]/, max_1mil],
         [/^gpt-5/, max_400k],
@@ -6227,6 +6241,7 @@ export function isImageInliningSupported() {
         'gpt-4.1',
         'gpt-4.5-preview',
         'gpt-4o',
+        'gpt-6-astra',
         'gpt-5',
         'o1',
         'o3',

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -639,7 +639,7 @@ export function getTokenizerModel() {
     }
 
     if (oai_settings.chat_completion_source == chat_completion_sources.ELECTRONHUB && oai_settings.electronhub_model) {
-        if (oai_settings.electronhub_model.includes('gpt-4o') || oai_settings.electronhub_model.includes('gpt-5')) {
+        if (oai_settings.electronhub_model.includes('gpt-4o') || oai_settings.electronhub_model.includes('gpt-5') || oai_settings.electronhub_model.includes('gpt-6-astra')) {
             return gpt4oTokenizer;
         } else if (oai_settings.electronhub_model.includes('gpt-4.1') || oai_settings.electronhub_model.includes('gpt-4.5')) {
             return gpt4oTokenizer;

--- a/public/scripts/tool-calling.js
+++ b/public/scripts/tool-calling.js
@@ -619,6 +619,12 @@ export class ToolManager {
             return false;
         }
 
+        // GPT-6 Astra supports tool calling only through the Responses API.
+        if ([chat_completion_sources.OPENAI, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source)
+            && /^gpt-6-astra/.test(model)) {
+            return false;
+        }
+
         // Post-processing will forcefully remove past tool calls from the prompt, making them useless
         const { NONE, MERGE_TOOLS, SEMI_TOOLS, STRICT_TOOLS } = custom_prompt_post_processing_types;
         const allowedPromptPostProcessing = [NONE, MERGE_TOOLS, SEMI_TOOLS, STRICT_TOOLS];

--- a/src/constants.js
+++ b/src/constants.js
@@ -456,7 +456,7 @@ export const AZURE_OPENAI_KEYS = [
     'reasoning_effort',
 ];
 
-export const OPENAI_VERBOSITY_MODELS = /^gpt-5/;
+export const OPENAI_VERBOSITY_MODELS = /^(?:gpt-5|gpt-6-astra)/;
 
 export const OPENAI_REASONING_EFFORT_MODELS = [
     'o1',
@@ -491,6 +491,7 @@ export const OPENAI_REASONING_EFFORT_MODELS = [
     'gpt-5.6-sol',
     'gpt-5.6-terra',
     'gpt-5.6-luna',
+    'gpt-6-astra',
 ];
 
 export const OPENAI_REASONING_EFFORT_MAP = {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -250,6 +250,7 @@ async function sendClaudeRequest(request, response) {
         const convertedPrompt = convertClaudeMessages(request.body.messages, request.body.assistant_prefill, useSystemPrompt, useTools, getPromptNames(request));
         // Unanchored to also match prefixed ids passed through proxies, e.g. 'anthropic/claude-fable-5'
         const isFableModel = /claude-fable/.test(request.body.model);
+        const isFable51Model = /claude-fable-5-1/.test(request.body.model);
         const isClaude5Model = /claude-(opus-5|sonnet-5)/.test(request.body.model);
         const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel || isClaude5Model;
         const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|sonnet-4-6|opus-4-7)/.test(request.body.model) || isFableModel || isClaude5Model) && Boolean(request.body.enable_web_search);
@@ -298,15 +299,24 @@ async function sendClaudeRequest(request, response) {
             }
         }
 
-        // Structured output is a forced tool
+        // Fable 5.1 rejects forced tools, but supports native JSON outputs.
         if (request.body.json_schema) {
-            const jsonTool = {
-                name: request.body.json_schema.name,
-                description: request.body.json_schema.description || 'Well-formed JSON object',
-                input_schema: request.body.json_schema.value,
-            };
-            requestBody.tools = [...(requestBody.tools || []), jsonTool];
-            requestBody.tool_choice = { type: 'tool', name: request.body.json_schema.name };
+            if (isFable51Model) {
+                requestBody.output_config = {
+                    format: {
+                        type: 'json_schema',
+                        schema: request.body.json_schema.value,
+                    },
+                };
+            } else {
+                const jsonTool = {
+                    name: request.body.json_schema.name,
+                    description: request.body.json_schema.description || 'Well-formed JSON object',
+                    input_schema: request.body.json_schema.value,
+                };
+                requestBody.tools = [...(requestBody.tools || []), jsonTool];
+                requestBody.tool_choice = { type: 'tool', name: request.body.json_schema.name };
+            }
         }
 
         if (useWebSearch) {

--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -442,7 +442,7 @@ export function getTokenizerModel(requestModel) {
         return 'o1';
     }
 
-    if (requestModel.includes('gpt-5') || requestModel.includes('o3') || requestModel.includes('o4-mini')) {
+    if (requestModel.includes('gpt-5') || requestModel.includes('gpt-6-astra') || requestModel.includes('o3') || requestModel.includes('o4-mini')) {
         return 'o1';
     }
 


### PR DESCRIPTION
## Summary

Adds first-class support for `claude-fable-5-1` and `gpt-6-astra` to the Chat Completion and image caption model selectors.

The model-specific compatibility handling includes:

- 1M/1.05M context limits and vision support
- reasoning effort, verbosity, and tokenizer routing
- removal of Astra's unsupported sampling and logprob parameters
- native Claude JSON outputs for Fable 5.1, which no longer permits the forced tool choice used by older Claude models
- disabling native Astra function calling while SillyTavern uses Chat Completions, since Astra tools require the Responses API

Existing generic Claude Fable handling continues to cover adaptive thinking, assistant prefill removal, sampling restrictions, and web search.

## Verification

- Started SillyTavern locally; webpack compiled successfully.
- Sent four live requests from the Test User account:
  - GPT-6 Astra text completion returned successfully with `max_completion_tokens`, low reasoning effort, and the unsupported parameters removed.
  - Claude Fable 5.1 text completion returned successfully with adaptive thinking and low effort.
  - Claude Fable 5.1 structured output returned schema-valid `{"ready":true}` through `output_config.format`, without a forced tool choice.
  - GPT-6 Astra rejected a Chat Completions function-tool request with the provider's documented requirement to use the Responses API, confirming that native function calling must remain disabled for this model.
- `node --check` passed for every changed JavaScript file.
- ESLint passed for every changed JavaScript file.
- `git diff --check` passed.
