### PR TITLE
Respect "Character Names Behavior: None" in server-side prompt processing

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2820,6 +2820,7 @@ export async function createGenerationParameters(settings, model, type, messages
         'request_image_resolution': String(settings.request_image_resolution),
         'request_image_aspect_ratio': String(settings.request_image_aspect_ratio),
         'custom_prompt_post_processing': settings.custom_prompt_post_processing,
+        'names_behavior': settings.names_behavior,
         'verbosity': getVerbosity(settings),
     };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -184,6 +184,17 @@ export const VERTEX_SAFETY = [
     },
 ];
 
+/**
+ * Mirrors `character_names_behavior` in public/scripts/openai.js.
+ * Sent by the client as `names_behavior` with chat completion requests.
+ */
+export const CHARACTER_NAMES_BEHAVIOR = {
+    NONE: -1,
+    DEFAULT: 0,
+    COMPLETION: 1,
+    CONTENT: 2,
+};
+
 export const CHAT_COMPLETION_SOURCES = {
     OPENAI: 'openai',
     CLAUDE: 'claude',

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import { CHARACTER_NAMES_BEHAVIOR } from './constants.js';
 import { getConfigValue, tryParse } from './util.js';
 
 const PROMPT_PLACEHOLDER = getConfigValue('promptPlaceholder', 'Let\'s get started.');
@@ -47,9 +48,12 @@ const enableThoughtSignatures = !!getConfigValue('gemini.thoughtSignatures', tru
  * @returns {PromptNames} Prompt names
  */
 export function getPromptNames(request) {
+    // "Never add character name prefixes" also applies to the prefixes the
+    // server adds while converting or post-processing the prompt.
+    const addNames = Number(request.body.names_behavior) !== CHARACTER_NAMES_BEHAVIOR.NONE;
     return {
-        charName: String(request.body.char_name || ''),
-        userName: String(request.body.user_name || ''),
+        charName: addNames ? String(request.body.char_name || '') : '',
+        userName: addNames ? String(request.body.user_name || '') : '',
         groupNames: Array.isArray(request.body.group_names) ? request.body.group_names.map(String) : [],
         startsWithGroupName: function (message) {
             return this.groupNames.some(name => message.startsWith(`${name}: `));

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -24,6 +24,28 @@ function makeNames(charName = '', userName = '', groupNames = []) {
 }
 
 
+describe('postProcessPrompt single', () => {
+    const messages = () => [
+        { role: 'system', content: 'sys' },
+        { role: 'user', content: 'Test1' },
+        { role: 'assistant', content: 'Response 1' },
+        { role: 'user', content: 'Test2' },
+    ];
+
+    test('prefixes user and character names when names are provided', () => {
+        const result = mod.postProcessPrompt(messages(), 'single', makeNames('Bot', 'User'));
+        expect(result).toHaveLength(1);
+        expect(result[0].role).toBe('user');
+        expect(result[0].content).toBe('sys\n\nUser: Test1\n\nBot: Response 1\n\nUser: Test2');
+    });
+
+    test('adds no prefixes when the names are empty (names behavior NONE)', () => {
+        const result = mod.postProcessPrompt(messages(), 'single', makeNames('', ''));
+        expect(result).toHaveLength(1);
+        expect(result[0].content).toBe('sys\n\nTest1\n\nResponse 1\n\nTest2');
+    });
+});
+
 describe('addAssistantPrefix', () => {
     test('returns empty array unchanged', () => {
         expect(mod.addAssistantPrefix([], [], 'prefix')).toEqual([]);
@@ -782,6 +804,23 @@ describe('getPromptNames', () => {
         const request = { body: { group_names: [123, null] } };
         const names = mod.getPromptNames(request);
         expect(names.groupNames).toEqual(['123', 'null']);
+    });
+
+    test('omits the names when the client never wants name prefixes (#6011)', () => {
+        const request = { body: { char_name: 'Bot', user_name: 'User', group_names: ['Alice'], names_behavior: -1 } };
+        const names = mod.getPromptNames(request);
+        expect(names.charName).toBe('');
+        expect(names.userName).toBe('');
+        expect(names.groupNames).toEqual(['Alice']);
+    });
+
+    test('keeps the names for the other names behaviors', () => {
+        for (const behavior of [0, 1, 2, '2', undefined]) {
+            const request = { body: { char_name: 'Bot', user_name: 'User', names_behavior: behavior } };
+            const names = mod.getPromptNames(request);
+            expect(names.charName).toBe('Bot');
+            expect(names.userName).toBe('User');
+        }
     });
 });
 


### PR DESCRIPTION
Fixes #6011

**Problem:** the client sends `char_name` / `user_name` with every chat completion request, and `getPromptNames()` hands them to the server-side prompt processing regardless of the *Character Names Behavior* selected in the UI. With **None** ("Never add character name prefixes") the "Single user message" post-processing (and the backend converters for Claude, Google, Mistral, Cohere, AI21, xAI, which prefix example dialogue the same way) still added `{{user}}: ` / `{{char}}: ` prefixes, so the request contained the names the user had disabled.

**Change:**
- `public/scripts/openai.js` sends the selected `names_behavior` with the request.
- `src/constants.js` mirrors the client enum as `CHARACTER_NAMES_BEHAVIOR`.
- `getPromptNames()` returns empty `charName` / `userName` when the behavior is `NONE`, so none of the server-side prefixing paths add names. Group names are kept (they are only used to detect prefixes that are already present). Every other behavior, and clients that don't send the field, behave exactly as before.

**Tests:** `tests/prompt-converters.test.js` covers `getPromptNames` with `names_behavior: -1` (empty names, group names kept) and the other values (unchanged), plus `postProcessPrompt(..., 'single', …)` with and without names.

```
npx jest -c tests/jest.config.json tests/prompt-converters.test.js   # 157 passed
npx eslint <changed files>                                            # clean
```

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
