### PR TITLE
Stop the keyboard and a11y observers from scanning every added <option>

### DIFF
--- a/public/scripts/a11y.js
+++ b/public/scripts/a11y.js
@@ -89,14 +89,23 @@ const a11yRules = {
  * @param {Element} element Element to process.
  */
 function applyA11yRules(element) {
+    // <option> and <optgroup> match no rule and contain no element that could
+    if (element instanceof HTMLOptionElement || element instanceof HTMLOptGroupElement) {
+        return;
+    }
     try {
+        // Childless elements (e.g. the tens of thousands of <option>s of a large model
+        // list) have no descendants to query, so only match the element itself.
+        const hasChildren = Boolean(element.firstElementChild);
         for (const [selector, rule] of Object.entries(a11yRules)) {
             // Apply if the element directly matches the selector
             if (element.matches(selector)) {
                 rule(element);
             }
             // Apply the rule to descendants
-            element.querySelectorAll(selector).forEach(rule);
+            if (hasChildren) {
+                element.querySelectorAll(selector).forEach(rule);
+            }
         }
     } catch (error) {
         console.error('Error applying accessibility rules to element:', element, error);

--- a/public/scripts/keyboard.js
+++ b/public/scripts/keyboard.js
@@ -33,6 +33,13 @@ if (CSS.supports('selector(:has(*))')) {
     interactableSelectors.push('#extensionsMenu div:has(.extensionsMenuExtensionButton)');
 }
 
+/**
+ * All interactable selectors joined into one selector list, so a node is matched or
+ * queried once instead of once per selector. Rebuilt when a type is registered.
+ * @type {string}
+ */
+let interactableSelectorList = interactableSelectors.join(', ');
+
 export const INTERACTABLE_CONTROL_CLASS = 'interactable';
 export const CUSTOM_INTERACTABLE_CONTROL_CLASS = 'custom_interactable';
 
@@ -63,17 +70,28 @@ const observer = new MutationObserver(mutations => {
  */
 function handleNodeChange(node) {
     if (node.nodeType === Node.ELEMENT_NODE && node instanceof Element) {
+        // <option> and <optgroup> are never interactables and never contain any
+        if (node instanceof HTMLOptionElement || node instanceof HTMLOptGroupElement) {
+            return;
+        }
+
         // Handle keyboard interactables
         if (isKeyboardInteractable(node)) {
             makeKeyboardInteractable(node);
         }
-        initializeInteractables(node);
 
         // Handle scroll reset containers
         if (node.classList.contains('scroll-reset-container')) {
             applyScrollResetBehavior(node);
         }
-        initializeScrollResetBehaviors(node);
+
+        // Descendant queries only make sense for nodes that have descendants. A huge
+        // model list adds tens of thousands of childless <option> elements, and running
+        // the full selector list against each of them froze the UI for a minute.
+        if (node.firstElementChild) {
+            initializeInteractables(node);
+            initializeScrollResetBehaviors(node);
+        }
     }
 }
 
@@ -87,9 +105,11 @@ function handleNodeChange(node) {
  * @param {boolean} [options.notFocusableByDefault=false] - Whether interactables of this class should not be focusable by default
  */
 export function registerInteractableType(interactableSelector, { disabledByDefault = false, notFocusableByDefault = false } = {}) {
-    interactableSelectors.push(interactableSelector);
-
+    // Query first: an invalid selector throws here, before it can poison the combined list.
     const interactables = document.querySelectorAll(interactableSelector);
+
+    interactableSelectors.push(interactableSelector);
+    interactableSelectorList = interactableSelectors.join(', ');
 
     if (disabledByDefault || notFocusableByDefault) {
         interactables.forEach(interactable => {
@@ -109,7 +129,7 @@ export function registerInteractableType(interactableSelector, { disabledByDefau
  */
 export function isKeyboardInteractable(control) {
     // Check if this control matches any of the selectors
-    return interactableSelectors.some(selector => control.matches(selector));
+    return control.matches(interactableSelectorList);
 }
 
 /**
@@ -175,8 +195,7 @@ function initializeInteractables(element = document) {
  * @returns {HTMLElement[]} An array containing all the interactables that match the given selectors
  */
 function getAllInteractables(element) {
-    // Query each selector individually and combine all to a big array to return
-    return [].concat(...interactableSelectors.map(selector => Array.from(element.querySelectorAll(`${selector}`))));
+    return Array.from(element.querySelectorAll(interactableSelectorList));
 }
 
 /**


### PR DESCRIPTION
Fixes #6018

**Problem:** with Featherless selected, `#model_custom_select` holds ~22k `<option>` elements (~46k on the whole page). `keyboard.js` observes `document.body` and, for every added node, ran `getAllInteractables(node)`, i.e. one `querySelectorAll()` per entry of `interactableSelectors` (~29), plus `isKeyboardInteractable(node)` with one `matches()` per selector. `a11y.js` did the same with seven rules. For the option list alone that is over a million selector queries that can never match, which is the 44 s of `querySelectorAll` self time in the issue's profile.

**Change:**
- `keyboard.js`: the interactable selectors are joined into one selector list, so a node is matched or queried once instead of ~29 times. `registerInteractableType()` rebuilds the list; it still runs the query before adding the selector, so an invalid selector throws exactly as before and never poisons the combined list. `getAllInteractables()` now returns each element once (previously an element matching several selectors was returned several times; `makeKeyboardInteractable` is idempotent, so this only removes redundant work).
- Both observers skip `<option>` / `<optgroup>` nodes outright (they are never interactables or a11y targets and never contain any) and skip descendant queries for nodes without element children.

**Measured** with jsdom appending 20,000 options to a `<select>` after `initKeyboard()` / `initAccessibility()` (script not committed): observer work dropped from ~5.8 s to ~50 ms (2,000 options: 593 ms → 8 ms). A `.menu_button` added afterwards still receives `tabindex="0"`, `role="button"` and the `interactable` class, so the normal path is unchanged.

`npx eslint public/scripts/keyboard.js public/scripts/a11y.js` is clean.

## Checklist:

- [x] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
