### PR TITLE
World Info: add persona include/exclude filter

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7078,6 +7078,33 @@
                         </div>
                     </div>
                 </div>
+                <div class="flex-container wide100p flexGap10">
+                    <div class="flex4 flex-container flexFlowColumn flexNoGap">
+                        <div class="flex-container justifySpaceBetween">
+                            <small for="personaFilter" data-i18n="Filter to Personas">
+                                Filter to Personas
+                            </small>
+                            <label class="checkbox_label flexNoGap margin-r5" for="persona_exclusion">
+                                <input type="checkbox" name="persona_exclusion" />
+                                <span>
+                                    <small title="Switch the Persona filter around to exclude the listed personas from matching for this entry" data-i18n="[title]Switch the Persona filter around to exclude the listed personas from matching for this entry">
+                                        <span data-i18n="Exclude">Exclude</span>
+                                        <div class="fa-solid fa-circle-info opacity50p"></div>
+                                    </small>
+                                </span>
+                            </label>
+                        </div>
+                        <div class="range-block-range">
+                            <select name="personaFilter" multiple>
+                                <option value="" data-i18n="-- Personas not found --">
+                                    -- Personas not found --
+                                </option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="flex4">
+                    </div>
+                </div>
                 <div name="WIEntryBottomControls" class="flex-container flex1 justifySpaceBetween world_entry_form_horizontal">
                     <div class="flex-container flexFlowColumn flexNoGap  wi-enter-footer-text">
                         <label class="checkbox flex-container">

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2130,6 +2130,14 @@ function addMissingWorldInfoFields(data) {
                 tags: [],
             };
         }
+
+        // Ensure that the personaFilter is an object with the expected structure
+        if (!entry.personaFilter || typeof entry.personaFilter !== 'object' || Array.isArray(entry.personaFilter)) {
+            entry.personaFilter = {
+                isExclude: false,
+                personas: [],
+            };
+        }
     });
 
     return data;
@@ -3161,6 +3169,57 @@ function handleCharacterFilterChangeHelper({ characterFilter, data, entry, name 
         await saveWorldInfo(name, data);
     });
 }
+/** Init persona filter select2. */
+function initPersonaFilterSelect2Helper(personaFilter) {
+    if (!isMobile()) {
+        $(personaFilter).select2({
+            width: '100%',
+            placeholder: t`Tie this entry to specific personas`,
+            allowClear: true,
+            closeOnSelect: false,
+        });
+    }
+}
+
+/** Fill persona options (values are avatar ids, stable across renames). */
+function fillPersonaOptionsHelper({ personaFilter, entry }) {
+    Object.entries(power_user.personas).forEach(([avatarId, personaName]) => {
+        const option = document.createElement('option');
+        option.innerText = personaName;
+        option.value = avatarId;
+        option.selected = entry.personaFilter?.personas?.includes(avatarId);
+        option.setAttribute('data-type', 'persona');
+        personaFilter.append(option);
+    });
+}
+
+/** Persist persona filter selection. */
+function handlePersonaFilterChangeHelper({ personaFilter, data, entry, name }) {
+    personaFilter.on('mousedown change', async function (e) {
+        if (world_names.length === 0) {
+            e.preventDefault();
+            return;
+        }
+        const uid = $(this).data('uid');
+        const selected = $(this).find(':selected');
+        if ((!selected || selected?.length === 0) && !data.entries[uid].personaFilter?.isExclude) {
+            delete data.entries[uid].personaFilter;
+        } else {
+            const personas = selected.filter('[data-type="persona"]').map((_, e) => e instanceof HTMLOptionElement && e.value).toArray();
+            Object.assign(
+                data.entries[uid],
+                {
+                    personaFilter: {
+                        isExclude: data.entries[uid].personaFilter?.isExclude ?? false,
+                        personas: personas,
+                    },
+                },
+            );
+        }
+        setWIOriginalDataValue(data, uid, 'persona_filter', data.entries[uid].personaFilter);
+        await saveWorldInfo(name, data);
+    });
+}
 
 /**
  * Helper to handle probability input.
@@ -3664,6 +3723,41 @@ export async function getWorldEntry(name, data, entry) {
         initCharacterFilterSelect2Helper(characterFilter);
         fillCharacterAndTagOptionsHelper({ characterFilter, entry });
         handleCharacterFilterChangeHelper({ characterFilter, data, entry, name });
+
+        // Persona filter (small[for] matches the entry template markup)
+        const personaFilterLabel = editTemplate.find('small[for="personaFilter"]');
+        personaFilterLabel.text(entry.personaFilter?.isExclude ? 'Exclude Persona(s)' : 'Filter to Persona(s)');
+        const personaExclusionInput = editTemplate.find('input[name="persona_exclusion"]');
+        personaExclusionInput.data('uid', entry.uid);
+        personaExclusionInput.on('input', async function (_, { noSave = false } = {}) {
+            const uid = $(this).data('uid');
+            const value = $(this).prop('checked');
+            personaFilterLabel.text(value ? 'Exclude Persona(s)' : 'Filter to Persona(s)');
+            if (data.entries[uid].personaFilter) {
+                if (!value && data.entries[uid].personaFilter.personas.length === 0) {
+                    delete data.entries[uid].personaFilter;
+                } else {
+                    data.entries[uid].personaFilter.isExclude = value;
+                }
+            } else if (value) {
+                Object.assign(data.entries[uid], { personaFilter: { isExclude: true, personas: [] } });
+            }
+            if (data.entries[uid]?.personaFilter?.personas?.length > 0) {
+                for (const avatarId of [...data.entries[uid].personaFilter.personas]) {
+                    if (!power_user.personas[avatarId]) {
+                        data.entries[uid].personaFilter.personas = data.entries[uid].personaFilter.personas.filter(x => x !== avatarId);
+                    }
+                }
+            }
+            setWIOriginalDataValue(data, uid, 'persona_filter', data.entries[uid].personaFilter);
+            !noSave && await saveWorldInfo(name, data);
+        });
+        personaExclusionInput.prop('checked', entry.personaFilter?.isExclude ?? false).trigger('input', { noSave: true });
+        const personaFilter = editTemplate.find('select[name="personaFilter"]');
+        personaFilter.data('uid', entry.uid);
+        initPersonaFilterSelect2Helper(personaFilter);
+        fillPersonaOptionsHelper({ personaFilter, entry });
+        handlePersonaFilterChangeHelper({ personaFilter, data, entry, name });
 
         // Content
         const counter = editTemplate.find('.world_entry_form_token_counter');
@@ -4697,6 +4791,14 @@ function parseDecorators(content) {
     return [[], content];
 }
 
+/** Persona include/exclude check (avatar ids; missing/empty never filters). */
+export function isPersonaFiltered(entry, currentPersonaId) {
+    const personas = entry?.personaFilter?.personas;
+    if (!Array.isArray(personas) || personas.length === 0) return false;
+    const listed = personas.includes(currentPersonaId);
+    return entry.personaFilter.isExclude ? listed : !listed;
+}
+
 /**
  * Performs a scan on the chat and returns the world info activated.
  * @param {string[]} chat The chat messages to scan, in reverse order.
@@ -4840,6 +4942,12 @@ export async function checkWorldInfo(chat, maxContext, isDryRun, globalScanData 
                         }
                     }
                 }
+            }
+
+            // Check if this entry applies to the current persona or if it's excluded (#5595)
+            if (isPersonaFiltered(entry, user_avatar)) {
+                log('filtered out by persona');
+                continue;
             }
 
             const isSticky = timedEffects.isEffectActive('sticky', entry);

--- a/tests/frontend/WorldInfoPersonaFilter.e2e.js
+++ b/tests/frontend/WorldInfoPersonaFilter.e2e.js
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { testSetup } from './frontent-test-utils.js';
+
+test.describe('World Info Persona Filter (#5595)', () => {
+    test.beforeEach(testSetup.awaitST);
+    test('matcher: include/exclude/empty table', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const { isPersonaFiltered } = await import('./scripts/world-info.js');
+            const { user_avatar } = await import('./scripts/personas.js');
+            const stranger = '__st_5595_stranger__.png';
+            const listed = (isExclude) => ({ personaFilter: { isExclude, personas: [user_avatar] } });
+            return [
+                [listed(false), user_avatar, false],
+                [listed(false), stranger, true],
+                [listed(true), user_avatar, true],
+                [listed(true), stranger, false],
+                [{}, user_avatar, false],
+                [{ personaFilter: { isExclude: false, personas: [] } }, user_avatar, false],
+                [{ personaFilter: { isExclude: true, personas: [] } }, user_avatar, false],
+            ].map(([entry, persona, expected]) => isPersonaFiltered(entry, persona) === expected);
+        });
+        expect(result.every(Boolean)).toBe(true);
+    });
+    test('save/reload round-trip plus real editor DOM wiring', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const wi = await import('./scripts/world-info.js');
+            const { user_avatar } = await import('./scripts/personas.js');
+            const bookName = 'STAGE_REPRO_5595_PERSONA';
+            const out = {};
+            try {
+                if (wi.world_names?.includes(bookName)) await wi.deleteWorldInfo(bookName);
+                if (!await wi.createNewWorldInfo(bookName, { interactive: false })) throw new Error('create failed');
+                const data = await wi.loadWorldInfo(bookName);
+                const entry = wi.createWorldInfoEntry(bookName, data);
+                entry.comment = 'STAGE_REPRO_5595';
+                entry.personaFilter = { isExclude: true, personas: [user_avatar] };
+                await wi.saveWorldInfo(bookName, data, true);
+                wi.worldInfoCache.delete(bookName);
+                const reloaded = await wi.loadWorldInfo(bookName);
+                const runtimeEntry = Object.values(reloaded.entries).find((e) => e.comment === 'STAGE_REPRO_5595');
+                out.savedFilter = structuredClone(runtimeEntry.personaFilter);
+                out.listedFiltered = wi.isPersonaFiltered(runtimeEntry, user_avatar);
+                const rendered = await wi.getWorldEntry(bookName, reloaded, runtimeEntry);
+                rendered.find('.inline-drawer').trigger('inline-drawer-toggle');
+                const label = () => String(rendered[0].querySelector('small[for="personaFilter"]')?.textContent ?? '').trim();
+                const checkbox = rendered[0].querySelector('input[name="persona_exclusion"]');
+                if (!checkbox) throw new Error('persona checkbox not rendered');
+                out.excludeLabel = label();
+                out.checked = checkbox.checked;
+                window.$(checkbox).prop('checked', false).trigger('input', { noSave: true });
+                out.includeLabel = label();
+                out.flipped = reloaded.entries[runtimeEntry.uid].personaFilter.isExclude;
+            } finally {
+                await wi.deleteWorldInfo(bookName);
+            }
+            return out;
+        });
+        expect(result.savedFilter).toEqual({ isExclude: true, personas: expect.any(Array) });
+        expect(result.listedFiltered).toBe(true);
+        expect(result.checked).toBe(true);
+        expect(result.excludeLabel).toBe('Exclude Persona(s)');
+        expect(result.includeLabel).toBe('Filter to Persona(s)');
+        expect(result.flipped).toBe(false);
+    });
+});


### PR DESCRIPTION
## Problem
Lorebook entries can be filtered by characters or tags, but not by personas. When several personas share one lorebook (e.g. canonically related personas), entries keep triggering on the active persona's own name, doubling definitions from the persona and the lorebook entry. The only workaround is maintaining separate lorebooks per persona.

## What this changes
World Info entries gain a persona include/exclude filter that mirrors the existing character/tag filter:
- `personaFilter = { isExclude, personas: [avatarIds] }` per entry; avatar IDs are stable across persona renames.
- Scan skips non-matching entries the same way character/tag filtering does.
- Entry editor gets a persona selector plus an Exclude checkbox, reusing the established select2/checkbox wiring.

## Backward compatibility
Entries without a persona filter behave exactly as before (missing/empty filter never filters). No STscript surface added on purpose. No changes to character/tag behavior.

## Test evidence
- New focused e2e `tests/frontend/WorldInfoPersonaFilter.e2e.js`: save/reload round-trip, real editor DOM wiring (both label states), include/exclude matcher table, backward compatibility — 2/2 passed.
- `npm run test:unit`: 19 suites / 411 tests passed.
- ESLint on touched files: clean.
- Total diff: 200 insertions, 0 deletions across 3 files.

Closes #5595