### PR TITLE
Vectors: allow retrieval of hidden messages when "Include hidden messages" is enabled

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -822,7 +822,15 @@ async function rearrangeChat(chat, _contextSize, _abort, type) {
         const insertedHashes = new Set();
         const retainMessages = chat.slice(-settings.protect);
 
-        for (const message of chat) {
+        // The interceptor receives a copy of the chat with hidden messages filtered out.
+        // If hidden messages were vectorized, they must be matched against the full chat,
+        // otherwise their vectors can never be inserted.
+        const fullChat = getContext().chat;
+        const hiddenMessages = settings.keep_hidden && Array.isArray(fullChat)
+            ? fullChat.filter(x => x.is_system && !fullChat.slice(-settings.protect).includes(x))
+            : [];
+
+        for (const message of [...chat, ...hiddenMessages]) {
             if (retainMessages.includes(message) || !message.mes) {
                 continue;
             }


### PR DESCRIPTION
## What

`rearrangeChat` in the Vector Storage extension only inserts a retrieved
chunk if the source message is present in the chat array passed to the
generation interceptor. That array is `coreChat`, which already has
`is_system` messages filtered out (`script.js`, `Generate`). So with
"Include hidden messages" (`keep_hidden`) enabled, hidden messages are
vectorized but can never be inserted: the query returns their hashes,
the loop over `chat` finds no match, and the extension logs
"No relevant messages found".

This is very visible with extensions that hide summarised messages
(MemoryBooks, Summarize with hide, manual `/hide`): the store fills up,
`View Stats` shows hundreds of hashes, and the prompt itemization shows
`Vector Storage (Chats): 0` on every generation.

## Fix

When `keep_hidden` is on, take the hidden messages from `getContext().chat`
(minus the last `protect` messages) and append them to the candidate list
that query hashes are matched against. Visible messages keep using the
`coreChat` copies, so the existing dedupe/splice logic is unchanged.
Retrieved hidden messages are formatted through the same template as
before.

When `keep_hidden` is off, behaviour is identical to the current code.

## Testing

- Chat with ~300 hidden messages (MemoryBooks) and 14 visible, Ollama
  `mxbai-embed-large`, Retain 5, Insert 3, In-chat @ Depth 2.
- Before: `View Stats` 316 unique hashes, `Vector Storage (Chats): 0`.
- After: hidden scenes are inserted as "Past events", visible messages
  in the retained tail are still excluded.
- `keep_hidden` off: no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
