### PR TITLE
Make OpenRouter provider list dynamic 

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4385,7 +4385,7 @@ function loadOpenAISettings(data, settings) {
     setToolReasoningControls();
     ToolManager.RECURSE_LIMIT = oai_settings.tool_call_recurse_limit;
 
-    $('#openrouter_providers_chat').trigger('change');
+    syncOpenRouterProvidersForModel(oai_settings.openrouter_model, '#openrouter_providers_chat', oai_settings.openrouter_providers);
     $('#openrouter_quantizations_chat').trigger('change');
     $('#nanogpt_provider').trigger('change');
     $('#chat_completion_source').trigger('change');
@@ -5054,7 +5054,7 @@ function onSettingsPresetChange() {
         // These cannot be changed via preset if unbound to connection
         if (oai_settings.bind_preset_to_connection) {
             $('#chat_completion_source').trigger('change');
-            $('#openrouter_providers_chat').trigger('change');
+            syncOpenRouterProvidersForModel(oai_settings.openrouter_model, '#openrouter_providers_chat', oai_settings.openrouter_providers);
             $('#openrouter_quantizations_chat').trigger('change');
             $('#nanogpt_provider').trigger('change');
         }
@@ -5486,7 +5486,7 @@ async function onModelChange() {
 
         console.log('OpenRouter model changed to', value);
         oai_settings.openrouter_model = value;
-        syncOpenRouterProvidersForModel(value, '#openrouter_providers_chat');
+        syncOpenRouterProvidersForModel(value, '#openrouter_providers_chat', oai_settings.openrouter_providers);
     }
 
     if ($(this).is('#model_ai21_select')) {
@@ -7246,12 +7246,13 @@ export function initOpenAI() {
     }
 
     $('#openrouter_providers_chat').on('change', function () {
-        const selectedProviders = $(this).val();
-
-        // Not a multiple select?
-        if (!Array.isArray(selectedProviders)) {
+        // Options still loading from OpenRouter — do not wipe saved slugs.
+        if ($(this).find('option').length === 0) {
             return;
         }
+
+        // Include disabled leftovers; $(this).val() omits them.
+        const selectedProviders = $(this).find('option:selected').map(function () { return this.value; }).get();
 
         oai_settings.openrouter_providers = selectedProviders;
 

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -21,98 +21,6 @@ let llamacppModels = [];
 export let openRouterModels = [];
 
 /**
- * List of OpenRouter providers.
- * @type {string[]}
- */
-const OPENROUTER_PROVIDERS = [
-    // Providers endpoint: https://openrouter.ai/api/v1/providers
-    // The list should resemble the sidebar from https://openrouter.ai/models
-    // Their docs no longer displays the list, which had "super dead" ones at top, thankfully gone from /v1/providers
-    'AI21',
-    'AionLabs',
-    'Alibaba',
-    'AkashML',
-    'Amazon Bedrock',
-    'Amazon Nova',
-    'Ambient',
-    'Anthropic',
-    'Arcee AI',
-    'AtlasCloud',
-    'Avian',
-    'Azure',
-    'Baidu',
-    'BaseTen',
-    'Black Forest Labs',
-    'Cerebras',
-    'Chutes',
-    'Cirrascale',
-    'Clarifai',
-    'Cloudflare',
-    'Cohere',
-    'Crucible',
-    'Crusoe',
-    'DeepInfra',
-    'DeepSeek',
-    'DekaLLM',
-    'FakeProvider',
-    'Featherless',
-    'Fireworks',
-    'Friendli',
-    'GMICloud',
-    'Google',
-    'Google AI Studio',
-    'Groq',
-    'Hyperbolic',
-    'Inception',
-    'Inceptron',
-    'InferenceNet',
-    'Infermatic',
-    'Inflection',
-    'Io Net',
-    'Ionstream',
-    'Liquid',
-    'Mancer 2',
-    'Mara',
-    'Minimax',
-    'Mistral',
-    'ModelRun',
-    'Modular',
-    'Moonshot AI',
-    'Morph',
-    'NCompass',
-    'Nebius',
-    'Nex AGI',
-    'NextBit',
-    'Novita',
-    'Nvidia',
-    'OpenAI',
-    'OpenInference',
-    'Parasail',
-    'Perceptron',
-    'Perplexity',
-    'Phala',
-    'Poolside',
-    'Recraft',
-    'Reka',
-    'Relace',
-    'SambaNova',
-    'Seed',
-    'SiliconFlow',
-    'Sourceful',
-    'Stealth',
-    'StepFun',
-    'StreamLake',
-    'Switchpoint',
-    'Together',
-    'Upstage',
-    'Venice',
-    'WandB',
-    'xAI',
-    'Xiaomi',
-    'Z.AI',
-];
-
-/**
  * List of NanoGPT providers.
  * Providers endpoint: https://nano-gpt.com/api/models/providers
  * @type {{id: string, label: string}[]}
@@ -347,6 +255,9 @@ const OPENROUTER_PROVIDER_WARNING_SELECTORS = {
     },
 };
 
+/** @type {Map<string, number>} */
+const openRouterProviderSyncSeq = new Map();
+
 export function updateOpenRouterProvidersWarning(providersSelector) {
     const $providers = $(providersSelector);
 
@@ -367,49 +278,163 @@ export function updateOpenRouterProvidersWarning(providersSelector) {
     $warning.toggleClass('displayNone', !showWarning);
 }
 
-export async function syncOpenRouterProvidersForModel(modelId, providersSelector) {
+/**
+ * Normalize API provider rows (objects or legacy strings) to { slug, name, label }.
+ * @param {any[]} providers
+ * @returns {{ slug: string, name: string, label: string }[]}
+ */
+function normalizeOpenRouterProviderRows(providers) {
+    if (!Array.isArray(providers)) {
+        return [];
+    }
+
+    return providers.map(provider => {
+        if (typeof provider === 'string') {
+            return { slug: provider, name: provider, label: provider };
+        }
+        const slug = provider?.slug || '';
+        const name = provider?.name || slug;
+        const label = provider?.label || name;
+        return { slug, name, label };
+    }).filter(provider => provider.slug);
+}
+
+/**
+ * Map saved display names to routing slugs. Drops unknown display names.
+ * @param {string[]} saved
+ * @param {{ slug: string, name: string }[]} providers
+ * @returns {string[]}
+ */
+export function migrateOpenRouterProviderSelection(saved, providers) {
+    if (!Array.isArray(saved)) {
+        return [];
+    }
+
+    const bySlug = new Map();
+    const byName = new Map();
+    for (const provider of providers) {
+        if (provider.slug) {
+            bySlug.set(String(provider.slug).toLowerCase(), provider.slug);
+        }
+        if (provider.name) {
+            const nameKey = String(provider.name).toLowerCase();
+            if (!byName.has(nameKey) || !provider.slug.includes('/')) {
+                byName.set(nameKey, provider.slug);
+            }
+        }
+    }
+
+    const migrated = [];
+    for (const raw of saved) {
+        if (typeof raw !== 'string' || !raw) {
+            continue;
+        }
+        const key = raw.toLowerCase();
+        if (bySlug.has(key)) {
+            migrated.push(bySlug.get(key));
+            continue;
+        }
+        if (byName.has(key)) {
+            migrated.push(byName.get(key));
+            continue;
+        }
+        // Keep unknown slug-like values (e.g. fireworks/fast saved from another model).
+        if (!/\s/.test(raw) && /^[a-z0-9._-]+(?:\/[a-z0-9._-]+)*$/i.test(raw)) {
+            migrated.push(raw);
+        }
+    }
+
+    return [...new Set(migrated)];
+}
+
+export async function syncOpenRouterProvidersForModel(modelId, providersSelector, savedProviders = null) {
     const $providers = $(providersSelector);
+    const seq = (openRouterProviderSyncSeq.get(providersSelector) || 0) + 1;
+    openRouterProviderSyncSeq.set(providersSelector, seq);
+
+    const isCurrent = () => openRouterProviderSyncSeq.get(providersSelector) === seq;
 
     const refreshWarningState = () => {
         updateOpenRouterProvidersWarning(providersSelector);
     };
 
-    if (!modelId || !modelId.includes('/')) {
-        $providers.find('option').prop('disabled', false);
+    const selectedSource = Array.isArray(savedProviders)
+        ? savedProviders
+        : $providers.find('option:selected').map(function () { return this.value; }).get();
+
+    const applyProviders = (providers) => {
+        const rows = normalizeOpenRouterProviderRows(providers);
+        const migrated = migrateOpenRouterProviderSelection(selectedSource, rows);
+        const selected = new Set(migrated);
+        const present = new Set();
+
+        $providers.empty();
+        for (const provider of rows) {
+            $providers.append($('<option>', {
+                value: provider.slug,
+                text: provider.label,
+                selected: selected.has(provider.slug),
+            }));
+            present.add(provider.slug);
+        }
+
+        for (const slug of migrated) {
+            if (!present.has(slug)) {
+                $providers.append($('<option>', {
+                    value: slug,
+                    text: slug,
+                    selected: true,
+                    disabled: true,
+                }));
+            }
+        }
+
+        // Reorder selected options to match saved priority order
+        for (const slug of migrated) {
+            $providers.append($providers.find(`option[value="${CSS.escape(slug)}"]`).detach());
+        }
+
+        $providers.trigger('change');
         $providers.trigger('change.select2');
         refreshWarningState();
-        return;
-    }
+    };
 
-    try {
-        const response = await fetch('/api/openrouter/models/providers', {
+    const fetchProviders = async (url, body) => {
+        const response = await fetch(url, {
             method: 'POST',
             headers: getRequestHeaders(),
-            body: JSON.stringify({ model: modelId }),
+            body: JSON.stringify(body),
         });
-
         if (!response.ok) {
+            return [];
+        }
+        const providers = await response.json();
+        return Array.isArray(providers) ? providers : [];
+    };
+
+    try {
+        let providers = [];
+        if (modelId) {
+            providers = await fetchProviders('/api/openrouter/models/providers', { model: modelId });
+            if (!isCurrent()) {
+                return;
+            }
+        }
+        if (providers.length === 0) {
+            providers = await fetchProviders('/api/openrouter/providers', {});
+            if (!isCurrent()) {
+                return;
+            }
+        }
+        if (providers.length === 0) {
             refreshWarningState();
             return;
         }
-
-        const providerNames = await response.json();
-
-        if (!Array.isArray(providerNames) || providerNames.length === 0) {
-            $providers.find('option').prop('disabled', false);
-            $providers.trigger('change.select2');
-            refreshWarningState();
-            return;
-        }
-
-        $providers.find('option').each(function () {
-            const isAvailable = providerNames.includes($(this).val());
-            $(this).prop('disabled', !isAvailable);
-        });
-
-        $providers.trigger('change.select2');
-        refreshWarningState();
+        applyProviders(providers);
     } catch (error) {
+        if (!isCurrent()) {
+            return;
+        }
         console.error('Failed to fetch OpenRouter providers for model', error);
         refreshWarningState();
     }
@@ -717,7 +742,7 @@ export async function loadOpenRouterModels(data) {
 
     // Calculate the cost of the selected model + update on settings change
     calculateOpenRouterCost();
-    syncOpenRouterProvidersForModel(textgen_settings.openrouter_model, '#openrouter_providers_text');
+    syncOpenRouterProvidersForModel(textgen_settings.openrouter_model, '#openrouter_providers_text', textgen_settings.openrouter_providers);
 }
 
 export async function loadVllmModels(data) {
@@ -1085,7 +1110,7 @@ function onOpenRouterModelSelect() {
     textgen_settings.openrouter_model = modelId;
     $('#api_button_textgenerationwebui').trigger('click');
     const model = openRouterModels.find(x => x.id === modelId);
-    syncOpenRouterProvidersForModel(modelId, '#openrouter_providers_text');
+    syncOpenRouterProvidersForModel(modelId, '#openrouter_providers_text', textgen_settings.openrouter_providers);
     setGenerationParamsFromPreset({ max_length: model.context_length });
 }
 
@@ -1401,12 +1426,6 @@ export function initTextGenModels() {
     $('#featherless_model').on('change', () => onFeatherlessModelSelect(String($('#featherless_model').val())));
 
     const providersSelect = $('.openrouter_providers');
-    for (const provider of OPENROUTER_PROVIDERS) {
-        providersSelect.append($('<option>', {
-            value: provider,
-            text: provider,
-        }));
-    }
 
     const nanoGptProvidersSelect = $('#nanogpt_provider');
     for (const provider of NANOGPT_PROVIDERS) {

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -23,7 +23,7 @@ import { power_user, registerDebugFunction } from './power-user.js';
 import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
-import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, updateOpenRouterProvidersWarning } from './textgen-models.js';
+import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, syncOpenRouterProvidersForModel, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { ENCODE_TOKENIZERS, TEXTGEN_TOKENIZERS, TOKENIZER_SUPPORTED_KEY, getTextTokens, getTokenizerBestMatch, tokenizers } from './tokenizers.js';
 import { AbortReason } from './util/AbortReason.js';
 import { getSortableDelay, onlyUnique, arraysEqual, isObject } from './utils.js';
@@ -591,7 +591,7 @@ export async function loadTextGenSettings(data, loadedSettings) {
     }
 
     $('#textgen_type').val(textgenerationwebui_settings.type);
-    $('#openrouter_providers_text').val(textgenerationwebui_settings.openrouter_providers).trigger('change');
+    syncOpenRouterProvidersForModel(textgenerationwebui_settings.openrouter_model, '#openrouter_providers_text', textgenerationwebui_settings.openrouter_providers);
     $('#openrouter_quantizations_text').val(textgenerationwebui_settings.openrouter_quantizations).trigger('change');
     showSamplerControls(textgenerationwebui_settings.type);
     BIAS_CACHE.delete(BIAS_KEY);
@@ -1061,12 +1061,13 @@ export function initTextGenSettings() {
     $('#textgen_logit_bias_new_entry').on('click', () => createNewLogitBiasEntry(textgenerationwebui_settings.logit_bias, BIAS_KEY));
 
     $('#openrouter_providers_text').on('change', function () {
-        const selectedProviders = $(this).val();
-
-        // Not a multiple select?
-        if (!Array.isArray(selectedProviders)) {
+        // Options still loading from OpenRouter — do not wipe saved slugs.
+        if ($(this).find('option').length === 0) {
             return;
         }
+
+        // Include disabled leftovers; $(this).val() omits them.
+        const selectedProviders = $(this).find('option:selected').map(function () { return this.value; }).get();
 
         textgenerationwebui_settings.openrouter_providers = selectedProviders;
 

--- a/src/endpoints/openrouter.js
+++ b/src/endpoints/openrouter.js
@@ -7,6 +7,65 @@ import { OPENROUTER_HEADERS } from '../constants.js';
 export const router = express.Router();
 const API_OPENROUTER = 'https://openrouter.ai/api/v1';
 
+/** Quantization suffixes that already have their own OpenRouter picker. */
+const QUANTIZATION_SUFFIXES = new Set([
+    'int4', 'int8', 'fp4', 'mxfp4', 'nvfp4', 'fp6', 'fp8', 'mxfp8', 'fp16', 'bf16', 'fp32', 'unknown',
+]);
+
+/**
+ * Turn an endpoint tag into an OpenRouter routing slug.
+ * Strips trailing quantization segments; keeps region/tier suffixes.
+ * @param {string} tag
+ * @param {string} [providerName]
+ * @returns {string}
+ */
+function routingSlugFromTag(tag, providerName = '') {
+    if (typeof tag === 'string' && tag.trim()) {
+        const parts = tag.trim().split('/').filter(Boolean);
+        if (parts.length > 1 && QUANTIZATION_SUFFIXES.has(parts[parts.length - 1].toLowerCase())) {
+            parts.pop();
+        }
+        return parts.join('/');
+    }
+
+    return String(providerName || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+/**
+ * @param {string} name
+ * @param {string} slug
+ * @returns {string}
+ */
+function labelForProvider(name, slug) {
+    const slash = String(slug || '').indexOf('/');
+    if (slash === -1) {
+        return name || slug;
+    }
+    return `${name} / ${slug.slice(slash + 1)}`;
+}
+
+/**
+ * @param {{ slug: string, name: string, label: string }[]} items
+ * @returns {{ slug: string, name: string, label: string }[]}
+ */
+function uniqueSortedProviders(items) {
+    const bySlug = new Map();
+    for (const item of items) {
+        if (!item?.slug || bySlug.has(item.slug)) {
+            continue;
+        }
+        bySlug.set(item.slug, item);
+    }
+    return [...bySlug.values()].sort((a, b) => {
+        const byName = (a.name || '').localeCompare(b.name || '');
+        return byName || a.slug.localeCompare(b.slug);
+    });
+}
+
 router.post('/models/providers', async (req, res) => {
     try {
         const { model } = req.body;
@@ -24,9 +83,46 @@ router.post('/models/providers', async (req, res) => {
         /** @type {any} */
         const data = await response.json();
         const endpoints = data?.data?.endpoints || [];
-        const providerNames = endpoints.map(e => e.provider_name);
+        const providers = uniqueSortedProviders(endpoints.map(endpoint => {
+            const name = endpoint.provider_name || '';
+            const slug = routingSlugFromTag(endpoint.tag, name);
+            return {
+                slug,
+                name,
+                label: labelForProvider(name, slug),
+            };
+        }));
 
-        return res.json(providerNames);
+        return res.json(providers);
+    } catch (error) {
+        console.error(error);
+        return res.sendStatus(500);
+    }
+});
+
+router.post('/providers', async (_req, res) => {
+    try {
+        const response = await fetch(`${API_OPENROUTER}/providers`, {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            return res.json([]);
+        }
+
+        /** @type {any} */
+        const data = await response.json();
+        const list = Array.isArray(data?.data) ? data.data : [];
+        const providers = uniqueSortedProviders(list.map(provider => ({
+            slug: provider.slug,
+            name: provider.name,
+            label: provider.name,
+        })));
+
+        return res.json(providers);
     } catch (error) {
         console.error(error);
         return res.sendStatus(500);


### PR DESCRIPTION
**Description**

The provider dropdowns used a hardcoded list of display names, new providers were missing and region/tier variants (`fireworks/fast`, `fireworks/us`, `deepinfra/turbo`) could not be selected. Both Chat Completion and Text Completion pickers are now built from OpenRouter endpoint tags.

Quantization suffixes (`/fp8`, `/bf16`) are stripped and stay on the existing quantizations picker. Saved display names (`Together`, `Fireworks`) migrate to slugs.

Also:

- Models with no endpoints (`openrouter/auto`) fall back to the provider catalog instead of an empty list
- Saved slugs that the current model does not list stay selected and disabled, so the 404 warning still works
- Chat presets run the same sync/migrate path instead of `.val()` on old names, which wiped the selection
- Overlapping model syncs ignore stale responses

## Checklist:

- [X] I have read the [Contribution guidelines](https://github.com/SillyTavern/SillyTavern/blob/release/CONTRIBUTING.md).
